### PR TITLE
ROK-206: Remove star badge from character cards

### DIFF
--- a/web/src/components/characters/character-card-compact.tsx
+++ b/web/src/components/characters/character-card-compact.tsx
@@ -9,7 +9,6 @@ interface CharacterCardCompactProps {
     id: string;
     name: string;
     avatarUrl?: string | null;
-    isMain?: boolean;
     faction?: string | null;
     level?: number | null;
     race?: string | null;
@@ -33,7 +32,6 @@ export function CharacterCardCompact({
     id,
     name,
     avatarUrl,
-    isMain,
     faction,
     level,
     race,
@@ -63,9 +61,6 @@ export function CharacterCardCompact({
             <div className="min-w-0">
                 <div className="flex items-center gap-2">
                     <span className="font-medium text-foreground truncate">{name}</span>
-                    {isMain && (
-                        <span className="text-yellow-400" title="Main character">⭐</span>
-                    )}
                     {faction && (
                         <span className={`px-1.5 py-0.5 rounded text-xs font-medium border ${FACTION_STYLES[faction] ?? 'bg-faint text-muted'}`}>
                             {faction.charAt(0).toUpperCase() + faction.slice(1)}

--- a/web/src/components/profile/CharacterCard.tsx
+++ b/web/src/components/profile/CharacterCard.tsx
@@ -67,11 +67,6 @@ export function CharacterCard({ character, onEdit }: CharacterCardProps) {
                         <span className="font-medium text-foreground truncate">
                             {character.name}
                         </span>
-                        {character.isMain && (
-                            <span className="text-yellow-400" title="Main character">
-                                ⭐
-                            </span>
-                        )}
                         {/* Faction badge (ROK-234) */}
                         {character.faction && (
                             <span

--- a/web/src/pages/event-detail-page.tsx
+++ b/web/src/pages/event-detail-page.tsx
@@ -440,7 +440,6 @@ export function EventDetailPage() {
                                                 id={signup.character.id}
                                                 name={signup.character.name}
                                                 avatarUrl={signup.character.avatarUrl}
-                                                isMain={signup.character.isMain}
                                                 faction={signup.character.faction}
                                                 level={signup.character.level}
                                                 race={signup.character.race}

--- a/web/src/pages/user-profile-page.tsx
+++ b/web/src/pages/user-profile-page.tsx
@@ -38,9 +38,6 @@ function PublicCharacterCard({ character }: { character: CharacterDto }) {
             <div className="min-w-0">
                 <div className="flex items-center gap-2">
                     <span className="font-medium text-foreground truncate">{character.name}</span>
-                    {character.isMain && (
-                        <span className="text-yellow-400" title="Main character">⭐</span>
-                    )}
                     {character.faction && (
                         <span className={`px-1.5 py-0.5 rounded text-xs font-medium border ${FACTION_STYLES[character.faction] ?? 'bg-faint text-muted'}`}>
                             {character.faction.charAt(0).toUpperCase() + character.faction.slice(1)}


### PR DESCRIPTION
## Summary
- Removed star/main badge from all character card components (CharacterCard, CharacterCardCompact, PublicCharacterCard)
- Star on character detail page header preserved (reviewer confirmed it's correct)
- Cleaned up unused `isMain` prop from CharacterCardCompact interface

## Story
[ROK-206](https://linear.app/roknua-projects/issue/ROK-206/enforce-single-main-character-per-player)

## Changes
- `web/src/components/characters/character-card-compact.tsx` — Removed star emoji + `isMain` prop
- `web/src/components/profile/CharacterCard.tsx` — Removed star emoji next to name
- `web/src/pages/user-profile-page.tsx` — Removed star from PublicCharacterCard
- `web/src/pages/event-detail-page.tsx` — Removed `isMain` prop passed to CharacterCardCompact

## Test Plan
- [ ] TypeScript compiles clean
- [ ] Character cards in profile, event detail, and roster views show no star
- [ ] Character detail page still shows star next to name for main character
- [ ] No regressions in character list/grid views

🤖 Generated with [Claude Code](https://claude.com/claude-code)