### PR TITLE
ROK-294: App Version Footer & Update Check — Cron + Admin Banner

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -24,6 +24,7 @@ import { RateLimitModule } from './throttler/throttler.module';
 import { QueueModule } from './queue/queue.module';
 import { RelayModule } from './relay/relay.module';
 import { FeedbackModule } from './feedback/feedback.module';
+import { VersionModule } from './version/version.module';
 
 @Module({
   imports: [
@@ -49,6 +50,7 @@ import { FeedbackModule } from './feedback/feedback.module';
     WowCommonModule,
     RelayModule,
     FeedbackModule,
+    VersionModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/api/src/drizzle/schema/app-settings.ts
+++ b/api/src/drizzle/schema/app-settings.ts
@@ -36,6 +36,9 @@ export const SETTING_KEYS = {
   ONBOARDING_COMPLETED: 'onboarding_completed',
   ONBOARDING_CURRENT_STEP: 'onboarding_current_step',
   DEFAULT_TIMEZONE: 'default_timezone',
+  LATEST_VERSION: 'latest_version',
+  VERSION_CHECK_LAST_RUN: 'version_check_last_run',
+  UPDATE_AVAILABLE: 'update_available',
 } as const;
 
 export type SettingKey = (typeof SETTING_KEYS)[keyof typeof SETTING_KEYS];

--- a/api/src/version/version-check.service.ts
+++ b/api/src/version/version-check.service.ts
@@ -1,0 +1,181 @@
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { SettingsService } from '../settings/settings.service';
+import { SETTING_KEYS } from '../drizzle/schema/app-settings';
+
+interface GitHubRelease {
+  tag_name: string;
+}
+
+/**
+ * Scheduled service that checks GitHub for new Raid Ledger releases (ROK-294).
+ *
+ * - Runs once on startup (after 10s delay) and every 24 hours thereafter.
+ * - Stores results in app_settings: latest_version, version_check_last_run, update_available.
+ * - Handles GitHub API unreachability and rate limits gracefully.
+ */
+@Injectable()
+export class VersionCheckService implements OnModuleInit {
+  private readonly logger = new Logger(VersionCheckService.name);
+  private readonly currentVersion: string;
+
+  constructor(private readonly settingsService: SettingsService) {
+    // Read version from root package.json at startup
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const rootPkg = require('../../../../package.json') as { version: string };
+    this.currentVersion = rootPkg.version;
+  }
+
+  onModuleInit() {
+    // Run initial check after a short delay so it doesn't block startup
+    setTimeout(() => {
+      this.checkForUpdates().catch((err) => {
+        this.logger.warn('Initial version check failed:', err);
+      });
+    }, 10_000);
+  }
+
+  /**
+   * Get the running instance version.
+   */
+  getVersion(): string {
+    return this.currentVersion;
+  }
+
+  /**
+   * Cron: run every day at midnight.
+   */
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT)
+  async handleCron() {
+    await this.checkForUpdates();
+  }
+
+  /**
+   * Check GitHub for the latest release and compare against current version.
+   */
+  async checkForUpdates(): Promise<void> {
+    this.logger.debug('Checking for updates...');
+
+    try {
+      const latestVersion = await this.fetchLatestVersion();
+
+      if (!latestVersion) {
+        this.logger.debug('Could not determine latest version from GitHub');
+        return;
+      }
+
+      const updateAvailable = this.isNewer(latestVersion, this.currentVersion);
+
+      await Promise.all([
+        this.settingsService.set(SETTING_KEYS.LATEST_VERSION, latestVersion),
+        this.settingsService.set(
+          SETTING_KEYS.VERSION_CHECK_LAST_RUN,
+          new Date().toISOString(),
+        ),
+        this.settingsService.set(
+          SETTING_KEYS.UPDATE_AVAILABLE,
+          updateAvailable ? 'true' : 'false',
+        ),
+      ]);
+
+      this.logger.debug(
+        `Version check complete: current=${this.currentVersion}, latest=${latestVersion}, updateAvailable=${updateAvailable}`,
+      );
+    } catch (error) {
+      this.logger.warn(
+        'Version check failed (will retry next cycle):',
+        error instanceof Error ? error.message : error,
+      );
+    }
+  }
+
+  /**
+   * Fetch the latest version string from GitHub releases, falling back to tags.
+   */
+  private async fetchLatestVersion(): Promise<string | null> {
+    const headers: Record<string, string> = {
+      Accept: 'application/vnd.github.v3+json',
+      'User-Agent': 'RaidLedger-VersionCheck',
+    };
+
+    // Try releases first
+    try {
+      const response = await fetch(
+        'https://api.github.com/repos/sjdodge123/Raid-Ledger/releases/latest',
+        { headers, signal: AbortSignal.timeout(10_000) },
+      );
+
+      if (response.ok) {
+        const data = (await response.json()) as GitHubRelease;
+        return this.normalizeVersion(data.tag_name);
+      }
+
+      // 404 means no releases exist yet — fall back to tags
+      if (response.status === 404) {
+        return this.fetchLatestTag(headers);
+      }
+
+      // Rate limited or other error
+      if (response.status === 403 || response.status === 429) {
+        this.logger.warn('GitHub API rate limited, skipping version check');
+        return null;
+      }
+
+      this.logger.warn(`GitHub releases API returned ${response.status}`);
+      return null;
+    } catch (error) {
+      this.logger.warn(
+        'Failed to reach GitHub API:',
+        error instanceof Error ? error.message : error,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Fallback: fetch latest tag if no releases exist.
+   */
+  private async fetchLatestTag(
+    headers: Record<string, string>,
+  ): Promise<string | null> {
+    try {
+      const response = await fetch(
+        'https://api.github.com/repos/sjdodge123/Raid-Ledger/tags?per_page=1',
+        { headers, signal: AbortSignal.timeout(10_000) },
+      );
+
+      if (!response.ok) return null;
+
+      const tags = (await response.json()) as Array<{ name: string }>;
+      if (tags.length === 0) return null;
+
+      return this.normalizeVersion(tags[0].name);
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Strip leading 'v' from version strings for comparison.
+   */
+  private normalizeVersion(version: string): string {
+    return version.replace(/^v/i, '');
+  }
+
+  /**
+   * Simple semver comparison: returns true if remote > local.
+   */
+  private isNewer(remote: string, local: string): boolean {
+    const remoteParts = remote.split('.').map(Number);
+    const localParts = local.split('.').map(Number);
+
+    for (let i = 0; i < Math.max(remoteParts.length, localParts.length); i++) {
+      const r = remoteParts[i] ?? 0;
+      const l = localParts[i] ?? 0;
+      if (r > l) return true;
+      if (r < l) return false;
+    }
+
+    return false;
+  }
+}

--- a/api/src/version/version.controller.ts
+++ b/api/src/version/version.controller.ts
@@ -1,0 +1,58 @@
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { AdminGuard } from '../auth/admin.guard';
+import { VersionCheckService } from './version-check.service';
+import { SettingsService } from '../settings/settings.service';
+import { SETTING_KEYS } from '../drizzle/schema/app-settings';
+import type { VersionInfoDto, UpdateStatusDto } from '@raid-ledger/contract';
+
+/**
+ * Version endpoints (ROK-294).
+ *
+ * - GET /system/version — public, returns current version and relay hub status.
+ * - GET /admin/update-status — admin-only, returns update check results.
+ */
+@Controller()
+export class VersionController {
+  constructor(
+    private readonly versionCheck: VersionCheckService,
+    private readonly settingsService: SettingsService,
+  ) {}
+
+  /**
+   * GET /system/version
+   * Public endpoint returning current app version and relay hub feature flag.
+   */
+  @Get('system/version')
+  async getVersion(): Promise<VersionInfoDto> {
+    const relayEnabled = await this.settingsService.get(
+      SETTING_KEYS.RELAY_ENABLED,
+    );
+
+    return {
+      version: this.versionCheck.getVersion(),
+      relayHubEnabled: relayEnabled === 'true',
+    };
+  }
+
+  /**
+   * GET /admin/update-status
+   * Admin-only endpoint returning version check results.
+   */
+  @Get('admin/update-status')
+  @UseGuards(AuthGuard('jwt'), AdminGuard)
+  async getUpdateStatus(): Promise<UpdateStatusDto> {
+    const [latestVersion, lastChecked, updateAvailable] = await Promise.all([
+      this.settingsService.get(SETTING_KEYS.LATEST_VERSION),
+      this.settingsService.get(SETTING_KEYS.VERSION_CHECK_LAST_RUN),
+      this.settingsService.get(SETTING_KEYS.UPDATE_AVAILABLE),
+    ]);
+
+    return {
+      currentVersion: this.versionCheck.getVersion(),
+      latestVersion,
+      updateAvailable: updateAvailable === 'true',
+      lastChecked,
+    };
+  }
+}

--- a/api/src/version/version.module.ts
+++ b/api/src/version/version.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { VersionController } from './version.controller';
+import { VersionCheckService } from './version-check.service';
+import { SettingsModule } from '../settings/settings.module';
+
+/**
+ * Version module (ROK-294).
+ * Provides version info endpoints and scheduled update checks.
+ */
+@Module({
+  imports: [SettingsModule],
+  controllers: [VersionController],
+  providers: [VersionCheckService],
+  exports: [VersionCheckService],
+})
+export class VersionModule {}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
     "name": "raid-ledger",
+    "version": "1.0.0",
     "private": true,
     "workspaces": [
         "api",

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -63,3 +63,6 @@ export * from './pug.schema.js';
 
 // Admin Onboarding Wizard (ROK-204)
 export * from './onboarding.schema.js';
+
+// Version & Update Check (ROK-294)
+export * from './version.schema.js';

--- a/packages/contract/src/version.schema.ts
+++ b/packages/contract/src/version.schema.ts
@@ -1,0 +1,25 @@
+import { z } from 'zod';
+
+/**
+ * Public version info response (ROK-294)
+ * GET /api/system/version
+ */
+export const VersionInfoSchema = z.object({
+    version: z.string(),
+    relayHubEnabled: z.boolean(),
+});
+
+export type VersionInfoDto = z.infer<typeof VersionInfoSchema>;
+
+/**
+ * Admin update status response (ROK-294)
+ * GET /api/admin/update-status
+ */
+export const UpdateStatusSchema = z.object({
+    currentVersion: z.string(),
+    latestVersion: z.string().nullable(),
+    updateAvailable: z.boolean(),
+    lastChecked: z.string().nullable(),
+});
+
+export type UpdateStatusDto = z.infer<typeof UpdateStatusSchema>;

--- a/web/src/components/admin/UpdateBanner.tsx
+++ b/web/src/components/admin/UpdateBanner.tsx
@@ -1,0 +1,62 @@
+import { useState } from 'react';
+import { useUpdateStatus } from '../../hooks/use-version';
+
+/**
+ * Admin update banner (ROK-294).
+ * Shows a warning when a newer version is available on GitHub.
+ * Dismissible per page load (returns on next navigation).
+ */
+export function UpdateBanner({ enabled }: { enabled: boolean }) {
+    const { data } = useUpdateStatus(enabled);
+    const [dismissed, setDismissed] = useState(false);
+
+    if (!data?.updateAvailable || dismissed) return null;
+
+    return (
+        <div className="bg-amber-500/10 border border-amber-500/30 rounded-lg p-4 flex items-start justify-between gap-3">
+            <div className="flex items-start gap-3">
+                <svg
+                    className="w-5 h-5 text-amber-400 mt-0.5 flex-shrink-0"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                >
+                    <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4.5c-.77-.833-2.694-.833-3.464 0L3.34 16.5c-.77.833.192 2.5 1.732 2.5z"
+                    />
+                </svg>
+                <div>
+                    <p className="text-sm text-amber-300 font-medium">
+                        A new version of Raid Ledger is available (v{data.latestVersion}).
+                        You are running v{data.currentVersion}.
+                    </p>
+                    <a
+                        href="https://github.com/sjdodge123/Raid-Ledger/Releases"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-sm text-amber-400 hover:text-amber-300 underline underline-offset-2 mt-1 inline-block"
+                    >
+                        View releases on GitHub
+                    </a>
+                </div>
+            </div>
+            <button
+                onClick={() => setDismissed(true)}
+                className="text-amber-400/60 hover:text-amber-300 transition-colors flex-shrink-0"
+                aria-label="Dismiss update banner"
+            >
+                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M6 18L18 6M6 6l12 12"
+                    />
+                </svg>
+            </button>
+        </div>
+    );
+}

--- a/web/src/components/layout/Footer.tsx
+++ b/web/src/components/layout/Footer.tsx
@@ -1,18 +1,50 @@
+import { useVersionInfo } from '../../hooks/use-version';
+
 /**
- * Footer component with copyright and optional links.
+ * Footer component with copyright, version display, and relay hub indicator (ROK-294).
  */
 export function Footer() {
     const currentYear = new Date().getFullYear();
+    const { data: versionInfo } = useVersionInfo();
 
     return (
         <footer className="bg-surface border-t border-edge-subtle py-6 px-4">
             <div className="max-w-7xl mx-auto flex flex-col sm:flex-row items-center justify-between gap-4">
                 <p className="text-dim text-sm">
-                    © {currentYear} Raid Ledger. All rights reserved.
+                    &copy; {currentYear} Raid Ledger. All rights reserved.
                 </p>
                 <div className="flex items-center gap-6">
+                    {/* Version + Relay Hub indicator */}
+                    <div className="flex items-center gap-2">
+                        {versionInfo && (
+                            <span className="text-dim text-xs">
+                                v{versionInfo.version}
+                            </span>
+                        )}
+                        <span
+                            className="relative group"
+                            aria-label="Relay Hub - Coming Soon"
+                        >
+                            <svg
+                                className="w-3.5 h-3.5 text-dim/40"
+                                fill="none"
+                                stroke="currentColor"
+                                viewBox="0 0 24 24"
+                            >
+                                <path
+                                    strokeLinecap="round"
+                                    strokeLinejoin="round"
+                                    strokeWidth={2}
+                                    d="M8.111 16.404a5.5 5.5 0 017.778 0M12 20h.01m-7.08-7.071c3.904-3.905 10.236-3.905 14.14 0M1.394 9.393c5.857-5.858 15.355-5.858 21.213 0"
+                                />
+                            </svg>
+                            <span className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2 py-1 text-xs text-foreground bg-panel border border-edge rounded shadow-lg whitespace-nowrap opacity-0 pointer-events-none group-hover:opacity-100 transition-opacity">
+                                Relay Hub &mdash; Coming Soon
+                            </span>
+                        </span>
+                    </div>
                     <a
-                        href="https://github.com"
+                        href="https://github.com/sjdodge123/Raid-Ledger"
                         target="_blank"
                         rel="noopener noreferrer"
                         className="text-dim hover:text-secondary transition-colors text-sm"

--- a/web/src/globals.d.ts
+++ b/web/src/globals.d.ts
@@ -1,0 +1,2 @@
+/** Injected by Vite at build time from root package.json version */
+declare const __APP_VERSION__: string;

--- a/web/src/hooks/use-version.ts
+++ b/web/src/hooks/use-version.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchApi } from '../lib/api-client';
+import type { VersionInfoDto, UpdateStatusDto } from '@raid-ledger/contract';
+
+/**
+ * Fetch public version info (ROK-294).
+ * Cached for 5 minutes since version rarely changes.
+ */
+export function useVersionInfo() {
+    return useQuery<VersionInfoDto>({
+        queryKey: ['system', 'version'],
+        queryFn: () => fetchApi<VersionInfoDto>('/system/version'),
+        staleTime: 5 * 60 * 1000,
+    });
+}
+
+/**
+ * Fetch admin update status (ROK-294).
+ * Only enabled when a token is present.
+ */
+export function useUpdateStatus(enabled: boolean) {
+    return useQuery<UpdateStatusDto>({
+        queryKey: ['admin', 'update-status'],
+        queryFn: () => fetchApi<UpdateStatusDto>('/admin/update-status'),
+        staleTime: 60 * 1000,
+        enabled,
+    });
+}

--- a/web/src/pages/admin-settings-page.tsx
+++ b/web/src/pages/admin-settings-page.tsx
@@ -15,6 +15,7 @@ import { RoleManagementCard } from '../components/admin/RoleManagementCard';
 import { NewBadge } from '../components/ui/new-badge';
 import { Modal } from '../components/ui/modal';
 import { PluginSlot } from '../plugins';
+import { UpdateBanner } from '../components/admin/UpdateBanner';
 import type { PluginInfoDto } from '@raid-ledger/contract';
 
 // Discord icon
@@ -131,6 +132,9 @@ export function AdminSettingsPage() {
 
     return (
         <div className="max-w-2xl mx-auto px-4 py-8 space-y-6">
+            {/* Update available banner (ROK-294) */}
+            <UpdateBanner enabled={isAdminCheck(user)} />
+
             <div>
                 <h1 className="text-3xl font-bold text-foreground mb-2">Plugins</h1>
                 <p className="text-muted">

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,8 +1,17 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+
+const rootPkg = JSON.parse(
+  readFileSync(resolve(__dirname, '../package.json'), 'utf-8'),
+) as { version: string }
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react(), tailwindcss()],
+  define: {
+    __APP_VERSION__: JSON.stringify(rootPkg.version),
+  },
 })


### PR DESCRIPTION
## Summary
- Version footer on all pages showing `vX.Y.Z` + greyed-out relay hub indicator ("Coming Soon")
- NestJS cron job checks GitHub releases every 24h (+ on startup) for update availability
- Admin-only warning banner on settings page when a newer version is detected
- Two new API endpoints: `GET /system/version` (public) and `GET /admin/update-status` (admin-only)

## Story
[ROK-294](https://linear.app/roknua-projects/issue/ROK-294)

## Changes
- `packages/contract/src/version.schema.ts` — new Zod schemas
- `api/src/version/` — new module (cron service, controller)
- `web/src/components/layout/Footer.tsx` — version display
- `web/src/components/admin/UpdateBanner.tsx` — admin warning banner
- `web/vite.config.ts` — inject version at build time

## Test Plan
- [ ] TypeScript compiles clean
- [ ] Lint passes
- [ ] Footer shows version on all pages
- [ ] Admin settings shows update banner (when update available)
- [ ] Cron doesn't crash when GitHub is unreachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)