### PR TITLE
ROK-309: Fix WoW Classic and GW2 Twitch category IDs

### DIFF
--- a/api/seeds/games-seed.json
+++ b/api/seeds/games-seed.json
@@ -87,7 +87,7 @@
         "min": 1,
         "max": 40
       },
-      "twitchGameId": "510218",
+      "twitchGameId": "18122",
       "crossplay": false
     },
     {
@@ -170,7 +170,7 @@
         "min": 1,
         "max": 50
       },
-      "twitchGameId": "30921",
+      "twitchGameId": "19357",
       "crossplay": false
     },
     {


### PR DESCRIPTION
## Summary
- Fixed WoW Classic `twitchGameId` from `510218` (Among Us) to `18122` (World of Warcraft)
- Fixed Guild Wars 2 `twitchGameId` from `30921` (Rocket League) to `19357` (Guild Wars 2)
- Audited all 40 game entries — no other mismatches found

## Story
[ROK-309](https://linear.app/roknua-projects/issue/ROK-309)

## Changes
- `api/seeds/games-seed.json` — corrected two `twitchGameId` values

## Test Plan
- [ ] Re-seed database: `npm run db:seed:games -w api`
- [ ] WoW Classic game page shows WoW streams (not Among Us)
- [ ] Guild Wars 2 game page shows GW2 streams (not Rocket League)
- [ ] Other game pages unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)