### PR TITLE
feat(mobile): ROK-326 Breakpoint Standardization & Drawer Direction Fix

### DIFF
--- a/web/src/components/admin/admin-settings-layout.tsx
+++ b/web/src/components/admin/admin-settings-layout.tsx
@@ -17,15 +17,20 @@ export function AdminSettingsLayout() {
 
     const closeMobile = useCallback(() => setMobileOpen(false), []);
 
-    // Close mobile drawer on Escape
+    // Close mobile drawer on Escape and lock body scroll
     useEffect(() => {
         if (!mobileOpen) return;
         function handleEscape(e: KeyboardEvent) {
             if (e.key === 'Escape') setMobileOpen(false);
         }
         document.addEventListener('keydown', handleEscape);
-        return () => document.removeEventListener('keydown', handleEscape);
+        document.body.style.overflow = 'hidden';
+        return () => {
+            document.removeEventListener('keydown', handleEscape);
+            document.body.style.overflow = '';
+        };
     }, [mobileOpen]);
+
 
     // Redirect bare /admin/settings to /admin/settings/general
     if (location.pathname === '/admin/settings') {
@@ -69,7 +74,7 @@ export function AdminSettingsLayout() {
             <div className="flex items-center gap-3 mb-6">
                 <button
                     type="button"
-                    className="lg:hidden p-2 -ml-2 rounded-lg text-muted hover:text-foreground hover:bg-overlay/30 transition-colors"
+                    className="md:hidden p-2 -ml-2 rounded-lg text-muted hover:text-foreground hover:bg-overlay/30 transition-colors"
                     onClick={() => setMobileOpen(true)}
                     aria-label="Open settings menu"
                 >
@@ -85,7 +90,7 @@ export function AdminSettingsLayout() {
 
             <div className="flex gap-6">
                 {/* Desktop sidebar */}
-                <aside className="hidden lg:block w-56 flex-shrink-0">
+                <aside className="hidden md:block w-56 flex-shrink-0">
                     <div className="sticky top-24">
                         <AdminSidebar />
                     </div>
@@ -97,33 +102,34 @@ export function AdminSettingsLayout() {
                 </main>
             </div>
 
-            {/* Mobile drawer overlay */}
-            {mobileOpen && (
-                <div className="fixed inset-0 z-50 lg:hidden">
-                    {/* Backdrop */}
-                    <div
-                        className="absolute inset-0 bg-black/60 backdrop-blur-sm"
-                        onClick={closeMobile}
-                    />
-                    {/* Drawer */}
-                    <div className="absolute inset-y-0 left-0 w-72 bg-surface border-r border-edge shadow-2xl">
-                        <div className="flex items-center justify-between px-4 py-3 border-b border-edge">
-                            <span className="font-semibold text-foreground text-sm">Settings</span>
-                            <button
-                                type="button"
-                                onClick={closeMobile}
-                                className="p-1 rounded-lg text-muted hover:text-foreground hover:bg-overlay/30 transition-colors"
-                                aria-label="Close settings menu"
-                            >
-                                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                                </svg>
-                            </button>
-                        </div>
-                        <AdminSidebar onNavigate={closeMobile} />
+            <div
+                className={`fixed inset-0 z-50 md:hidden ${mobileOpen ? 'visible' : 'invisible pointer-events-none'}`}
+                aria-hidden={!mobileOpen}
+            >
+                {/* Backdrop */}
+                <div
+                    className={`absolute inset-0 bg-black/60 backdrop-blur-sm transition-opacity duration-200 ${mobileOpen ? 'opacity-100' : 'opacity-0'}`}
+                    onClick={closeMobile}
+                    aria-hidden="true"
+                />
+                {/* Drawer */}
+                <div className={`absolute top-0 right-0 w-72 h-full bg-surface border-l border-edge-subtle shadow-2xl transform transition-transform duration-200 ease-out ${mobileOpen ? 'translate-x-0' : 'translate-x-full'}`}>
+                    <div className="flex items-center justify-between px-4 py-3 border-b border-edge-subtle">
+                        <span className="font-semibold text-foreground text-sm">Settings</span>
+                        <button
+                            type="button"
+                            onClick={closeMobile}
+                            className="p-1 rounded-lg text-muted hover:text-foreground hover:bg-overlay/30 transition-colors"
+                            aria-label="Close settings menu"
+                        >
+                            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                            </svg>
+                        </button>
                     </div>
+                    <AdminSidebar onNavigate={closeMobile} />
                 </div>
-            )}
+            </div>
         </div>
     );
 }

--- a/web/src/components/profile/profile-layout.tsx
+++ b/web/src/components/profile/profile-layout.tsx
@@ -38,8 +38,13 @@ export function ProfileLayout() {
             if (e.key === 'Escape') setMobileOpen(false);
         }
         document.addEventListener('keydown', handleEscape);
-        return () => document.removeEventListener('keydown', handleEscape);
+        document.body.style.overflow = 'hidden';
+        return () => {
+            document.removeEventListener('keydown', handleEscape);
+            document.body.style.overflow = '';
+        };
     }, [mobileOpen]);
+
 
     if (location.pathname === '/profile' || location.pathname === '/profile/') {
         return <Navigate to="/profile/identity" replace />;
@@ -73,7 +78,7 @@ export function ProfileLayout() {
             <div className="profile-page__stars" />
 
             <div className="relative z-10 max-w-6xl mx-auto pt-6">
-                <div className="flex items-center gap-3 mb-6 lg:hidden">
+                <div className="flex items-center gap-3 mb-6 md:hidden">
                     <button
                         type="button"
                         className="p-2 -ml-2 rounded-lg text-muted hover:text-foreground hover:bg-overlay/30 transition-colors"
@@ -88,7 +93,7 @@ export function ProfileLayout() {
                 </div>
 
                 <div className="flex gap-6">
-                    <aside className="hidden lg:block w-56 flex-shrink-0">
+                    <aside className="hidden md:block w-56 flex-shrink-0">
                         <div className="sticky top-8">
                             <ProfileSidebar />
                         </div>
@@ -99,30 +104,32 @@ export function ProfileLayout() {
                     </main>
                 </div>
 
-                {mobileOpen && (
-                    <div className="fixed inset-0 z-50 lg:hidden">
-                        <div
-                            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
-                            onClick={closeMobile}
-                        />
-                        <div className="absolute inset-y-0 left-0 w-72 bg-surface border-r border-edge shadow-2xl">
-                            <div className="flex items-center justify-between px-4 py-3 border-b border-edge">
-                                <span className="font-semibold text-foreground text-sm">Profile</span>
-                                <button
-                                    type="button"
-                                    onClick={closeMobile}
-                                    className="p-1 rounded-lg text-muted hover:text-foreground hover:bg-overlay/30 transition-colors"
-                                    aria-label="Close profile menu"
-                                >
-                                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                                    </svg>
-                                </button>
-                            </div>
-                            <ProfileSidebar onNavigate={closeMobile} />
+                <div
+                    className={`fixed inset-0 z-50 md:hidden ${mobileOpen ? 'visible' : 'invisible pointer-events-none'}`}
+                    aria-hidden={!mobileOpen}
+                >
+                    <div
+                        className={`absolute inset-0 bg-black/60 backdrop-blur-sm transition-opacity duration-200 ${mobileOpen ? 'opacity-100' : 'opacity-0'}`}
+                        onClick={closeMobile}
+                        aria-hidden="true"
+                    />
+                    <div className={`absolute top-0 right-0 w-72 h-full bg-surface border-l border-edge-subtle shadow-2xl transform transition-transform duration-200 ease-out ${mobileOpen ? 'translate-x-0' : 'translate-x-full'}`}>
+                        <div className="flex items-center justify-between px-4 py-3 border-b border-edge-subtle">
+                            <span className="font-semibold text-foreground text-sm">Profile</span>
+                            <button
+                                type="button"
+                                onClick={closeMobile}
+                                className="p-1 rounded-lg text-muted hover:text-foreground hover:bg-overlay/30 transition-colors"
+                                aria-label="Close profile menu"
+                            >
+                                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                                </svg>
+                            </button>
                         </div>
+                        <ProfileSidebar onNavigate={closeMobile} />
                     </div>
-                )}
+                </div>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary

Standardizes all responsive layouts to use `md:` (768px) breakpoint instead of `lg:` (1024px) and ensures all mobile drawers open consistently from the **RIGHT** side.

## Changes

### Breakpoint Standardization
- Replace all `lg:` (1024px) breakpoints with `md:` (768px) in Profile and Admin layouts
- Eliminates the visual "dead zone" between 768-1024px
- Consistent with Header navigation which already uses `md:`

### Drawer Direction Fix
- Refactored mobile drawers to slide from **RIGHT** (matching MobileNav pattern)
- Added 200ms ease-out slide animation with `translate-x-full` → `translate-x-0` transition
- Added backdrop blur with opacity transition
- Changed border from `border-r` to `border-l` for right-side positioning

### Accessibility & UX Improvements (Code Review)
- Body scroll lock when drawer is open (`document.body.style.overflow`)
- `aria-hidden` on backdrop and drawer wrapper
- Consistent `border-edge-subtle` token throughout

## Files Modified
- `web/src/components/profile/profile-layout.tsx`
- `web/src/components/admin/admin-settings-layout.tsx`

## Testing
- ✅ `tsc --noEmit` — clean
- ✅ `eslint` — clean
- ✅ Browser tested at 375px, 767px, 768px, 1280px
- ✅ Admin drawer: slides from right with backdrop blur
- ✅ Profile drawer: slides from right with backdrop blur
- ✅ Sidebar visibility toggles at exactly 768px

## Blocks
- ROK-329 (Sticky Per-Page Toolbars)
- ROK-331 (Bottom Tab Bar Component)

## Linear Issue
ROK-326