### PR TITLE
feat(ROK-330): z-index constants & pattern library spec fixes

### DIFF
--- a/web/src/components/admin/admin-settings-layout.tsx
+++ b/web/src/components/admin/admin-settings-layout.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { Outlet, Navigate, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth, isAdmin as isAdminCheck } from '../../hooks/use-auth';
 import { AdminSidebar } from './admin-sidebar';
+import { Z_INDEX } from '../../lib/z-index';
 
 /**
  * Admin Settings layout — sidebar + content area with nested <Outlet />.
@@ -103,7 +104,8 @@ export function AdminSettingsLayout() {
             </div>
 
             <div
-                className={`fixed inset-0 z-50 md:hidden ${mobileOpen ? 'visible' : 'invisible pointer-events-none'}`}
+                className={`fixed inset-0 md:hidden ${mobileOpen ? 'visible' : 'invisible pointer-events-none'}`}
+                style={{ zIndex: Z_INDEX.MODAL }}
                 aria-hidden={!mobileOpen}
             >
                 {/* Backdrop */}

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -7,6 +7,7 @@ import { NotificationBell } from '../notifications';
 import { useAuth } from '../../hooks/use-auth';
 import { useSystemStatus } from '../../hooks/use-system-status';
 import { API_BASE_URL } from '../../lib/config';
+import { Z_INDEX } from '../../lib/z-index';
 
 /**
  * Site header with logo, navigation, and user menu (ROK-271 branding).
@@ -32,7 +33,7 @@ export function Header() {
 
     return (
         <>
-            <header className="sticky top-0 z-40 bg-backdrop/95 backdrop-blur-sm border-b border-edge-subtle">
+            <header className="sticky top-0 bg-backdrop/95 backdrop-blur-sm border-b border-edge-subtle" style={{ zIndex: Z_INDEX.HEADER }}>
                 <div className="max-w-7xl mx-auto px-4 h-16 flex items-center justify-between">
                     {/* Logo (ROK-271: custom branding) */}
                     <Link

--- a/web/src/components/layout/MobileNav.tsx
+++ b/web/src/components/layout/MobileNav.tsx
@@ -6,6 +6,7 @@ import { useThemeStore } from '../../stores/theme-store';
 import { API_BASE_URL } from '../../lib/config';
 import { resolveAvatar, toAvatarUser } from '../../lib/avatar';
 import { DiscordIcon } from '../icons/DiscordIcon';
+import { Z_INDEX } from '../../lib/z-index';
 
 interface MobileNavProps {
     isOpen: boolean;
@@ -81,7 +82,8 @@ export function MobileNav({ isOpen, onClose }: MobileNavProps) {
 
     return (
         <div
-            className={`fixed inset-0 z-50 md:hidden ${isOpen ? 'visible' : 'invisible pointer-events-none'}`}
+            className={`fixed inset-0 md:hidden ${isOpen ? 'visible' : 'invisible pointer-events-none'}`}
+            style={{ zIndex: Z_INDEX.MODAL }}
             aria-hidden={!isOpen}
         >
             {/* Backdrop */}

--- a/web/src/components/profile/profile-layout.tsx
+++ b/web/src/components/profile/profile-layout.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { Outlet, Navigate, useLocation, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../../hooks/use-auth';
+import { Z_INDEX } from '../../lib/z-index';
 
 import { ProfileSidebar } from './profile-sidebar';
 import { toast } from '../../lib/toast';
@@ -105,7 +106,8 @@ export function ProfileLayout() {
                 </div>
 
                 <div
-                    className={`fixed inset-0 z-50 md:hidden ${mobileOpen ? 'visible' : 'invisible pointer-events-none'}`}
+                    className={`fixed inset-0 md:hidden ${mobileOpen ? 'visible' : 'invisible pointer-events-none'}`}
+                    style={{ zIndex: Z_INDEX.MODAL }}
                     aria-hidden={!mobileOpen}
                 >
                     <div

--- a/web/src/lib/z-index.ts
+++ b/web/src/lib/z-index.ts
@@ -1,0 +1,35 @@
+/**
+ * Z-index hierarchy for Raid-Ledger UI.
+ * Based on EP-10 mobile design spec (ROK-330).
+ *
+ * Stack order (bottom → top):
+ *   DEFAULT → DROPDOWN → TOOLBAR/FAB → HEADER/TAB_BAR → BOTTOM_SHEET → MODAL → TOAST
+ */
+export const Z_INDEX = {
+    /** Base content layer */
+    DEFAULT: 0,
+
+    /** Dropdowns, popovers, autocomplete lists */
+    DROPDOWN: 10,
+
+    /** Sticky per-page toolbars, calendar toolbar, filter bars */
+    TOOLBAR: 30,
+
+    /** Floating action buttons (Create Event, Jump to Today) */
+    FAB: 30,
+
+    /** Site header (sticky) */
+    HEADER: 40,
+
+    /** Bottom tab bar (mobile, Strategy 2/3) */
+    TAB_BAR: 40,
+
+    /** Bottom sheets (game filter, settings) */
+    BOTTOM_SHEET: 45,
+
+    /** Modals, drawers, overlays, MobileNav */
+    MODAL: 50,
+
+    /** Toast notifications (highest layer) */
+    TOAST: 60,
+} as const;


### PR DESCRIPTION
## Summary

- **Z-index constants**: Created `web/src/lib/z-index.ts` with the full layer hierarchy (DEFAULT → DROPDOWN → TOOLBAR/FAB → HEADER/TAB_BAR → BOTTOM_SHEET → MODAL → TOAST)
- **Component migrations**: Migrated 4 components from hardcoded Tailwind `z-*` classes to `Z_INDEX` constants with inline styles:
  - `Header.tsx`: `z-40` → `Z_INDEX.HEADER`
  - `MobileNav.tsx`: `z-50` → `Z_INDEX.MODAL`
  - `profile-layout.tsx`: `z-50` → `Z_INDEX.MODAL`
  - `admin-settings-layout.tsx`: `z-50` → `Z_INDEX.MODAL`

## Verification

- ✅ TypeScript compilation — no errors
- ✅ All 335 tests pass (31 test files)
- ✅ Browser visual check at 375px — drawer layering correct
- ✅ Adversarial code review passed (1 issue auto-fixed)

## Story

Closes ROK-330