### PR TITLE
feat(ROK-328): mobile card components for events, games, and players

### DIFF
--- a/web/src/components/events/mobile-event-card.test.tsx
+++ b/web/src/components/events/mobile-event-card.test.tsx
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { MobileEventCard, MobileEventCardSkeleton } from './mobile-event-card';
+import type { EventResponseDto } from '@raid-ledger/contract';
+
+const MOCK_NOW = new Date('2026-02-10T19:00:00Z');
+
+const createMockEvent = (overrides: Partial<EventResponseDto> = {}): EventResponseDto => ({
+    id: 1,
+    title: 'Test Raid Night',
+    description: 'Weekly raid session',
+    startTime: '2026-02-10T20:00:00Z',
+    endTime: '2026-02-10T23:00:00Z',
+    creator: { id: 1, username: 'TestUser', avatar: null },
+    game: { id: 1, name: 'World of Warcraft', slug: 'wow', coverUrl: 'https://example.com/cover.jpg' },
+    signupCount: 3,
+    createdAt: '2026-02-01T00:00:00Z',
+    updatedAt: '2026-02-01T00:00:00Z',
+    ...overrides,
+});
+
+describe('MobileEventCard', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(MOCK_NOW);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('renders event title', () => {
+        render(<MobileEventCard event={createMockEvent()} />);
+        expect(screen.getByText('Test Raid Night')).toBeInTheDocument();
+    });
+
+    it('renders game name', () => {
+        render(<MobileEventCard event={createMockEvent()} />);
+        expect(screen.getByText('World of Warcraft')).toBeInTheDocument();
+    });
+
+    it('renders status badge for upcoming events', () => {
+        render(<MobileEventCard event={createMockEvent()} />);
+        expect(screen.getByTestId('mobile-event-status')).toHaveTextContent('Upcoming');
+    });
+
+    it('renders live status badge when event is in progress', () => {
+        const liveEvent = createMockEvent({
+            startTime: '2026-02-10T18:00:00Z',
+            endTime: '2026-02-10T22:00:00Z',
+        });
+        render(<MobileEventCard event={liveEvent} />);
+        expect(screen.getByTestId('mobile-event-status')).toHaveTextContent('Live');
+    });
+
+    it('shows signup count', () => {
+        render(<MobileEventCard event={createMockEvent()} signupCount={5} />);
+        expect(screen.getByTestId('mobile-event-signup-count')).toBeInTheDocument();
+    });
+
+    it('fires onClick when card is tapped', () => {
+        const onClick = vi.fn();
+        render(<MobileEventCard event={createMockEvent()} onClick={onClick} />);
+        fireEvent.click(screen.getByTestId('mobile-event-card'));
+        expect(onClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('has 4px game color border', () => {
+        render(<MobileEventCard event={createMockEvent()} />);
+        const card = screen.getByTestId('mobile-event-card');
+        expect(card.style.borderLeftWidth).toBe('4px');
+    });
+
+    it('renders min-height of 96px', () => {
+        render(<MobileEventCard event={createMockEvent()} />);
+        const card = screen.getByTestId('mobile-event-card');
+        expect(card.className).toContain('min-h-[96px]');
+    });
+
+    it('renders avatar stack container', () => {
+        const event = createMockEvent({
+            signupsPreview: [
+                { id: 1, discordId: '111', username: 'A', avatar: 'a.png' },
+                { id: 2, discordId: '222', username: 'B', avatar: 'b.png' },
+                { id: 3, discordId: '333', username: 'C', avatar: 'c.png' },
+            ],
+        });
+        render(<MobileEventCard event={event} signupCount={5} />);
+        const avatarStack = screen.getByTestId('mobile-event-avatars');
+        expect(avatarStack.children.length).toBe(3);
+    });
+
+    it('renders relative time', () => {
+        render(<MobileEventCard event={createMockEvent()} />);
+        expect(screen.getByTestId('mobile-event-relative')).toBeInTheDocument();
+    });
+});
+
+describe('MobileEventCardSkeleton', () => {
+    it('renders skeleton with animate-pulse', () => {
+        const { container } = render(<MobileEventCardSkeleton />);
+        expect(container.querySelector('.animate-pulse')).toBeInTheDocument();
+    });
+});

--- a/web/src/components/events/mobile-event-card.tsx
+++ b/web/src/components/events/mobile-event-card.tsx
@@ -1,0 +1,169 @@
+import React from 'react';
+import type { EventResponseDto } from '@raid-ledger/contract';
+import { getEventStatus, getRelativeTime } from '../../lib/event-utils';
+import { useTimezoneStore } from '../../stores/timezone-store';
+import { resolveAvatar, toAvatarUser } from '../../lib/avatar';
+
+type EventStatus = 'upcoming' | 'live' | 'ended';
+
+const STATUS_STYLES: Record<EventStatus, string> = {
+    upcoming: 'bg-emerald-500/20 text-emerald-400 border-emerald-500/30',
+    live: 'bg-yellow-500/20 text-yellow-400 border-yellow-500/30',
+    ended: 'bg-dim/20 text-muted border-dim/30',
+};
+
+const STATUS_LABELS: Record<EventStatus, string> = {
+    upcoming: 'Upcoming',
+    live: 'Live',
+    ended: 'Ended',
+};
+
+function formatEventTime(dateString: string, timeZone?: string): string {
+    const date = new Date(dateString);
+    return new Intl.DateTimeFormat('en-US', {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+        ...(timeZone ? { timeZone } : {}),
+    }).format(date);
+}
+
+interface MobileEventCardProps {
+    event: EventResponseDto;
+    signupCount?: number;
+    onClick?: () => void;
+    matchesGameTime?: boolean;
+}
+
+/**
+ * Mobile-optimized event card — horizontal layout with game color bar.
+ * Renders below md breakpoint; desktop EventCard handles ≥md.
+ */
+export function MobileEventCard({ event, signupCount = 0, onClick, matchesGameTime }: MobileEventCardProps) {
+    const resolved = useTimezoneStore((s) => s.resolved);
+    const status = getEventStatus(event.startTime, event.endTime);
+    const relativeTime = getRelativeTime(event.startTime, event.endTime);
+    const gameCoverUrl = event.game?.coverUrl || null;
+    const [imageError, setImageError] = React.useState(false);
+    const showPlaceholder = !gameCoverUrl || imageError;
+
+    // Build avatar stack from signupsPreview (if available)
+    const signupAvatars = (event.signupsPreview ?? []).slice(0, 3).map((signup) =>
+        resolveAvatar(toAvatarUser(signup)),
+    );
+
+    // Use a soft fallback color when the game doesn't provide one
+    const accentColor = '#10b981'; // emerald-500
+
+    return (
+        <button
+            type="button"
+            onClick={onClick}
+            data-testid="mobile-event-card"
+            className="w-full flex min-h-[96px] bg-surface rounded-lg border border-edge overflow-hidden hover:border-dim hover:shadow-lg transition-all text-left"
+            style={{ borderLeftWidth: '4px', borderLeftColor: accentColor }}
+        >
+            {/* Game Cover Thumbnail */}
+            <div className="w-16 flex-shrink-0 bg-panel">
+                {!showPlaceholder && gameCoverUrl ? (
+                    <img
+                        src={gameCoverUrl}
+                        alt={event.game?.name || ''}
+                        className="w-full h-full object-cover"
+                        onError={() => setImageError(true)}
+                    />
+                ) : (
+                    <div className="w-full h-full flex items-center justify-center text-dim">
+                        <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M14.828 14.828a4 4 0 01-5.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                    </div>
+                )}
+            </div>
+
+            {/* Content */}
+            <div className="flex-1 min-w-0 p-3 flex flex-col justify-between gap-1">
+                {/* Top row: title + status */}
+                <div className="flex items-start justify-between gap-2">
+                    <h3 className="font-semibold text-foreground text-sm leading-tight truncate">
+                        {event.title}
+                    </h3>
+                    <span
+                        data-testid="mobile-event-status"
+                        className={`flex-shrink-0 px-1.5 py-0.5 text-[10px] font-medium rounded-full border ${STATUS_STYLES[status]}`}
+                    >
+                        {STATUS_LABELS[status]}
+                    </span>
+                </div>
+
+                {/* Middle row: game + time */}
+                <div className="flex items-center gap-1.5 text-xs text-muted">
+                    {event.game && (
+                        <>
+                            <span className="truncate">{event.game.name}</span>
+                            <span className="text-dim">·</span>
+                        </>
+                    )}
+                    <span className="whitespace-nowrap">{formatEventTime(event.startTime, resolved)}</span>
+                </div>
+
+                {/* Bottom row: relative time + game time badge + signup avatars */}
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                        <span data-testid="mobile-event-relative" className="text-xs text-dim">
+                            {relativeTime}
+                        </span>
+                        {matchesGameTime && (
+                            <span className="flex items-center gap-0.5 px-1.5 py-0.5 text-[10px] font-medium rounded-full bg-cyan-500/20 text-cyan-300 border border-cyan-500/30">
+                                <svg className="w-2.5 h-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z" />
+                                </svg>
+                                Game Time
+                            </span>
+                        )}
+                    </div>
+
+                    {/* Avatar stack + signup count */}
+                    <div className="flex items-center gap-1">
+                        <div className="flex -space-x-1.5" data-testid="mobile-event-avatars">
+                            {signupAvatars.map((avatar, i) => (
+                                <div key={i} className="w-5 h-5 rounded-full border border-surface bg-overlay overflow-hidden">
+                                    {avatar.url ? (
+                                        <img src={avatar.url} alt="" className="w-full h-full object-cover" />
+                                    ) : (
+                                        <div className="w-full h-full flex items-center justify-center text-[8px] text-muted font-medium">
+                                            ?
+                                        </div>
+                                    )}
+                                </div>
+                            ))}
+                        </div>
+                        {signupCount > 0 && (
+                            <span data-testid="mobile-event-signup-count" className="text-[10px] text-emerald-400 font-medium whitespace-nowrap">
+                                {signupCount > 3 ? `+${signupCount - 3}` : signupCount}
+                            </span>
+                        )}
+                    </div>
+                </div>
+            </div>
+        </button>
+    );
+}
+
+/**
+ * Skeleton loader for mobile event cards during loading state
+ */
+export function MobileEventCardSkeleton() {
+    return (
+        <div className="w-full flex min-h-[96px] bg-surface rounded-lg border border-edge overflow-hidden animate-pulse" style={{ borderLeftWidth: '4px', borderLeftColor: 'var(--color-dim)' }}>
+            <div className="w-16 flex-shrink-0 bg-panel" />
+            <div className="flex-1 p-3 flex flex-col justify-between gap-1">
+                <div className="h-4 bg-panel rounded w-3/4" />
+                <div className="h-3 bg-panel rounded w-1/2" />
+                <div className="h-3 bg-panel rounded w-1/4" />
+            </div>
+        </div>
+    );
+}

--- a/web/src/components/games/games-mobile-toolbar.tsx
+++ b/web/src/components/games/games-mobile-toolbar.tsx
@@ -1,19 +1,19 @@
 import { MobilePageToolbar } from '../layout/mobile-page-toolbar';
 
 interface GamesMobileToolbarProps {
-    activeTab: 'discover' | 'library';
-    onTabChange: (tab: 'discover' | 'library') => void;
-    /** Whether to show the Library tab (admin-only feature) */
-    showLibraryTab?: boolean;
+    activeTab: 'discover' | 'manage';
+    onTabChange: (tab: 'discover' | 'manage') => void;
+    /** Whether to show the Manage tab (admin-only feature) */
+    showManageTab?: boolean;
 }
 
 /**
- * Mobile toolbar for Games page — Discover/Library segmented control (ROK-329).
- * When showLibraryTab is false, displays a non-interactive "Discover" label.
+ * Mobile toolbar for Games page — Discover/Manage segmented control (ROK-329).
+ * When showManageTab is false, displays a non-interactive "Discover" label.
  */
-export function GamesMobileToolbar({ activeTab, onTabChange, showLibraryTab = false }: GamesMobileToolbarProps) {
-    const tabs = showLibraryTab
-        ? (['discover', 'library'] as const)
+export function GamesMobileToolbar({ activeTab, onTabChange, showManageTab = false }: GamesMobileToolbarProps) {
+    const tabs = showManageTab
+        ? (['discover', 'manage'] as const)
         : (['discover'] as const);
 
     // If only one tab, don't render a segmented control — just a label
@@ -30,8 +30,8 @@ export function GamesMobileToolbar({ activeTab, onTabChange, showLibraryTab = fa
                         type="button"
                         onClick={() => onTabChange(tab)}
                         className={`px-6 py-2.5 rounded-md text-sm font-medium transition-colors ${activeTab === tab
-                                ? 'bg-overlay text-foreground'
-                                : 'text-muted hover:text-foreground'
+                            ? 'bg-overlay text-foreground'
+                            : 'text-muted hover:text-foreground'
                             }`}
                     >
                         {tab.charAt(0).toUpperCase() + tab.slice(1)}

--- a/web/src/components/games/mobile-game-card.test.tsx
+++ b/web/src/components/games/mobile-game-card.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { MobileGameCard } from './mobile-game-card';
+import type { GameDetailDto } from '@raid-ledger/contract';
+
+// Mock auth hook
+vi.mock('../../hooks/use-auth', () => ({
+    useAuth: () => ({ isAuthenticated: true, user: { id: 1 } }),
+}));
+
+// Mock want-to-play hook
+vi.mock('../../hooks/use-want-to-play', () => ({
+    useWantToPlay: () => ({
+        wantToPlay: false,
+        count: 3,
+        toggle: vi.fn(),
+        isToggling: false,
+    }),
+}));
+
+const createMockGame = (overrides: Partial<GameDetailDto> = {}): GameDetailDto => ({
+    id: 100,
+    igdbId: 1001,
+    name: 'World of Warcraft',
+    slug: 'world-of-warcraft',
+    coverUrl: 'https://example.com/wow-cover.jpg',
+    genres: [36], // MMORPG
+    gameModes: [5], // MMO
+    summary: 'A massively multiplayer online role-playing game',
+    rating: 85,
+    aggregatedRating: 90,
+    popularity: 95,
+    themes: [],
+    platforms: [],
+    screenshots: [],
+    videos: [],
+    firstReleaseDate: '2004-11-23T00:00:00Z',
+    playerCount: null,
+    twitchGameId: null,
+    crossplay: null,
+    ...overrides,
+});
+
+function renderWithRouter(ui: React.ReactElement) {
+    return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe('MobileGameCard', () => {
+    it('renders game name', () => {
+        renderWithRouter(<MobileGameCard game={createMockGame()} />);
+        expect(screen.getByText('World of Warcraft')).toBeInTheDocument();
+    });
+
+    it('renders rating badge', () => {
+        renderWithRouter(<MobileGameCard game={createMockGame()} />);
+        expect(screen.getByTestId('mobile-game-rating')).toHaveTextContent('90');
+    });
+
+    it('renders genre tag', () => {
+        renderWithRouter(<MobileGameCard game={createMockGame()} />);
+        expect(screen.getByTestId('mobile-game-genre')).toHaveTextContent('MMORPG');
+    });
+
+    it('renders heart button when authenticated', () => {
+        renderWithRouter(<MobileGameCard game={createMockGame()} />);
+        expect(screen.getByTestId('mobile-game-heart')).toBeInTheDocument();
+    });
+
+    it('heart button has ≥44px tap target', () => {
+        renderWithRouter(<MobileGameCard game={createMockGame()} />);
+        const heart = screen.getByTestId('mobile-game-heart');
+        // w-11 = 44px, h-11 = 44px
+        expect(heart.className).toContain('w-11');
+        expect(heart.className).toContain('h-11');
+    });
+
+    it('links to game detail page', () => {
+        renderWithRouter(<MobileGameCard game={createMockGame()} />);
+        const link = screen.getByTestId('mobile-game-card');
+        expect(link).toHaveAttribute('href', '/games/100');
+    });
+
+    it('does not render rating badge when no rating', () => {
+        renderWithRouter(<MobileGameCard game={createMockGame({ rating: null, aggregatedRating: null })} />);
+        expect(screen.queryByTestId('mobile-game-rating')).not.toBeInTheDocument();
+    });
+
+    it('does not render genre tag when no genres', () => {
+        renderWithRouter(<MobileGameCard game={createMockGame({ genres: [] })} />);
+        expect(screen.queryByTestId('mobile-game-genre')).not.toBeInTheDocument();
+    });
+});

--- a/web/src/components/games/mobile-game-card.tsx
+++ b/web/src/components/games/mobile-game-card.tsx
@@ -1,0 +1,141 @@
+import type React from 'react';
+import { Link } from 'react-router-dom';
+import type { GameDetailDto } from '@raid-ledger/contract';
+import { useWantToPlay } from '../../hooks/use-want-to-play';
+import { useAuth } from '../../hooks/use-auth';
+
+/** IGDB genre ID → display name (subset for mobile badge) */
+const GENRE_MAP: Record<number, string> = {
+    2: 'Point-and-click',
+    4: 'Fighting',
+    5: 'Shooter',
+    7: 'Music',
+    8: 'Platform',
+    9: 'Puzzle',
+    10: 'Racing',
+    11: 'RTS',
+    12: 'RPG',
+    13: 'Simulator',
+    14: 'Sport',
+    15: 'Strategy',
+    16: 'TBS',
+    24: 'Tactical',
+    25: 'Hack and slash',
+    26: 'Quiz',
+    30: 'Pinball',
+    31: 'Adventure',
+    32: 'Indie',
+    33: 'Arcade',
+    34: 'Visual Novel',
+    35: 'Card Game',
+    36: 'MMORPG',
+};
+
+interface MobileGameCardProps {
+    game: GameDetailDto;
+}
+
+/**
+ * Mobile-optimized game card — vertical layout for 2-column grid.
+ * Renders below md breakpoint; desktop GameCard handles ≥md.
+ */
+export function MobileGameCard({ game }: MobileGameCardProps) {
+    const { isAuthenticated } = useAuth();
+    const { wantToPlay, count, toggle, isToggling } = useWantToPlay(
+        isAuthenticated ? game.id : undefined,
+    );
+
+    const primaryGenre = game.genres[0] ? GENRE_MAP[game.genres[0]] : null;
+    const rating = game.aggregatedRating ?? game.rating;
+
+    const handleWantToPlay = (e: React.MouseEvent) => {
+        e.preventDefault();
+        e.stopPropagation();
+        if (!isToggling && isAuthenticated) {
+            toggle(!wantToPlay);
+        }
+    };
+
+    return (
+        <Link
+            to={`/games/${game.id}`}
+            data-testid="mobile-game-card"
+            className="group block relative rounded-lg overflow-hidden bg-surface border border-edge hover:border-dim transition-all"
+        >
+            {/* Cover Image */}
+            <div className="relative aspect-[3/4] bg-panel">
+                {game.coverUrl ? (
+                    <img
+                        src={game.coverUrl}
+                        alt={game.name}
+                        className="w-full h-full object-cover group-hover:scale-105 transition-transform duration-300"
+                        loading="lazy"
+                    />
+                ) : (
+                    <div className="w-full h-full flex items-center justify-center text-dim">
+                        <svg className="w-10 h-10" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M14.828 14.828a4 4 0 01-5.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                        </svg>
+                    </div>
+                )}
+
+                {/* Rating badge (top right) */}
+                {rating && rating > 0 && (
+                    <div
+                        data-testid="mobile-game-rating"
+                        className={`absolute top-2 right-2 px-2 py-0.5 rounded-md text-xs font-bold ${rating >= 75
+                            ? 'bg-emerald-500/90 text-white'
+                            : rating >= 50
+                                ? 'bg-yellow-500/90 text-black'
+                                : 'bg-red-500/90 text-white'
+                            }`}
+                    >
+                        {Math.round(rating)}
+                    </div>
+                )}
+
+                {/* Heart button (≥44px tap target) */}
+                {isAuthenticated && (
+                    <button
+                        onClick={handleWantToPlay}
+                        data-testid="mobile-game-heart"
+                        className="absolute top-1 left-1 flex items-center justify-center w-11 h-11 rounded-full bg-black/50 hover:bg-black/70 transition-colors"
+                        aria-label={wantToPlay ? 'Remove from want to play' : 'Add to want to play'}
+                    >
+                        <svg
+                            className={`w-5 h-5 transition-colors ${wantToPlay ? 'text-red-400 fill-red-400' : 'text-white/70'
+                                }`}
+                            fill={wantToPlay ? 'currentColor' : 'none'}
+                            stroke="currentColor"
+                            viewBox="0 0 24 24"
+                        >
+                            <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={2}
+                                d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
+                            />
+                        </svg>
+                        {count > 0 && (
+                            <span className="absolute -bottom-0.5 -right-0.5 text-[10px] font-bold text-white/90 bg-black/70 rounded-full px-1.5 py-0.5">
+                                {count}
+                            </span>
+                        )}
+                    </button>
+                )}
+
+                {/* Bottom gradient overlay with game name + genre */}
+                <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 to-transparent p-2 pt-6">
+                    <h3 className="text-sm font-semibold text-white line-clamp-2 leading-tight">
+                        {game.name}
+                    </h3>
+                    {primaryGenre && (
+                        <span data-testid="mobile-game-genre" className="inline-block mt-0.5 px-1.5 py-0.5 text-[10px] bg-white/20 text-white/90 rounded">
+                            {primaryGenre}
+                        </span>
+                    )}
+                </div>
+            </div>
+        </Link>
+    );
+}

--- a/web/src/components/players/mobile-player-card.test.tsx
+++ b/web/src/components/players/mobile-player-card.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { MobilePlayerCard } from './mobile-player-card';
+import type { UserPreviewDto } from '@raid-ledger/contract';
+
+const createMockPlayer = (overrides: Partial<UserPreviewDto> = {}): UserPreviewDto => ({
+    id: 42,
+    username: 'TestPlayer',
+    avatar: null,
+    ...overrides,
+});
+
+function renderWithRouter(ui: React.ReactElement) {
+    return render(<MemoryRouter>{ui}</MemoryRouter>);
+}
+
+describe('MobilePlayerCard', () => {
+    it('renders username', () => {
+        renderWithRouter(<MobilePlayerCard player={createMockPlayer()} />);
+        expect(screen.getByText('TestPlayer')).toBeInTheDocument();
+    });
+
+    it('shows letter fallback when no avatar', () => {
+        renderWithRouter(<MobilePlayerCard player={createMockPlayer()} />);
+        expect(screen.getByText('T')).toBeInTheDocument();
+    });
+
+    it('shows avatar image when URL available', () => {
+        renderWithRouter(
+            <MobilePlayerCard player={createMockPlayer({ avatar: 'https://cdn.example.com/avatar.png' })} />,
+        );
+        expect(screen.getByAltText('TestPlayer')).toBeInTheDocument();
+    });
+
+    it('links to player profile', () => {
+        renderWithRouter(<MobilePlayerCard player={createMockPlayer()} />);
+        const link = screen.getByTestId('mobile-player-card');
+        expect(link).toHaveAttribute('href', '/users/42');
+    });
+
+    it('truncates long usernames', () => {
+        renderWithRouter(
+            <MobilePlayerCard player={createMockPlayer({ username: 'VeryLongUsernameForTesting' })} />,
+        );
+        const nameEl = screen.getByText('VeryLongUsernameForTesting');
+        expect(nameEl.className).toContain('truncate');
+    });
+});

--- a/web/src/components/players/mobile-player-card.tsx
+++ b/web/src/components/players/mobile-player-card.tsx
@@ -1,0 +1,48 @@
+import type { UserPreviewDto } from '@raid-ledger/contract';
+import { Link } from 'react-router-dom';
+import { resolveAvatar, toAvatarUser } from '../../lib/avatar';
+
+interface MobilePlayerCardProps {
+    player: UserPreviewDto;
+}
+
+/**
+ * Mobile-optimized player card — vertical layout with 64px avatar.
+ * Renders below md breakpoint in a 2-column grid.
+ */
+export function MobilePlayerCard({ player }: MobilePlayerCardProps) {
+    const avatar = resolveAvatar(toAvatarUser(player));
+
+    return (
+        <Link
+            to={`/users/${player.id}`}
+            data-testid="mobile-player-card"
+            className="flex flex-col items-center gap-2 p-4 bg-surface rounded-lg border border-edge hover:bg-overlay hover:border-dim transition-colors text-center group"
+        >
+            {/* 64px avatar */}
+            {avatar.url ? (
+                <img
+                    src={avatar.url}
+                    alt={player.username}
+                    className="w-16 h-16 rounded-full bg-overlay object-cover"
+                    onError={(e) => {
+                        e.currentTarget.style.display = 'none';
+                        e.currentTarget.nextElementSibling?.classList.remove('hidden');
+                    }}
+                />
+            ) : null}
+            <div
+                className={`w-16 h-16 rounded-full bg-overlay flex items-center justify-center text-2xl text-muted ${avatar.url ? 'hidden' : ''}`}
+            >
+                {player.username.charAt(0).toUpperCase()}
+            </div>
+
+            {/* Username */}
+            <div className="min-w-0 w-full">
+                <h3 className="font-medium text-sm text-foreground group-hover:text-emerald-400 transition-colors truncate">
+                    {player.username}
+                </h3>
+            </div>
+        </Link>
+    );
+}

--- a/web/src/pages/events-page.tsx
+++ b/web/src/pages/events-page.tsx
@@ -4,6 +4,7 @@ import { useEvents } from "../hooks/use-events";
 import { useAuth } from "../hooks/use-auth";
 import { useGameTime } from "../hooks/use-game-time";
 import { EventCard, EventCardSkeleton } from "../components/events/event-card";
+import { MobileEventCard, MobileEventCardSkeleton } from "../components/events/mobile-event-card";
 import { EventsEmptyState } from "../components/events/events-empty-state";
 import { EventsMobileToolbar, type EventsTab } from "../components/events/events-mobile-toolbar";
 import type { EventResponseDto, GameTimeSlot } from "@raid-ledger/contract";
@@ -304,8 +305,8 @@ export function EventsPage() {
             </div>
           )}
 
-          {/* Events Grid */}
-          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+          {/* Events Grid — Desktop (≥md) */}
+          <div className="hidden md:grid md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
             {isLoading ? (
               Array.from({ length: 8 }).map((_, i) => (
                 <EventCardSkeleton key={i} />
@@ -329,6 +330,41 @@ export function EventsPage() {
             ) : (
               (displayEvents ?? data?.data)?.map((event) => (
                 <EventCard
+                  key={event.id}
+                  event={event}
+                  signupCount={event.signupCount}
+                  matchesGameTime={overlapSet?.has(event.id)}
+                  onClick={() => navigate(`/events/${event.id}`)}
+                />
+              ))
+            )}
+          </div>
+
+          {/* Events List — Mobile (<md) */}
+          <div className="md:hidden space-y-3">
+            {isLoading ? (
+              Array.from({ length: 4 }).map((_, i) => (
+                <MobileEventCardSkeleton key={i} />
+              ))
+            ) : (displayEvents ?? data?.data)?.length === 0 ? (
+              filterGameTime ? (
+                <div className="text-center py-12">
+                  <p className="text-muted">
+                    No events match your game time schedule.
+                  </p>
+                  <button
+                    onClick={() => setFilterGameTime(false)}
+                    className="mt-2 text-sm text-cyan-400 hover:text-cyan-300 transition-colors"
+                  >
+                    Clear filter
+                  </button>
+                </div>
+              ) : (
+                <EventsEmptyState />
+              )
+            ) : (
+              (displayEvents ?? data?.data)?.map((event) => (
+                <MobileEventCard
                   key={event.id}
                   event={event}
                   signupCount={event.signupCount}

--- a/web/src/pages/games-page.tsx
+++ b/web/src/pages/games-page.tsx
@@ -5,6 +5,7 @@ import { useDebouncedValue } from "../hooks/use-debounced-value";
 import { useAuth, isOperatorOrAdmin } from "../hooks/use-auth";
 import { GameCarousel } from "../components/games/GameCarousel";
 import { GameCard } from "../components/games/GameCard";
+import { MobileGameCard } from "../components/games/mobile-game-card";
 import { GameLibraryTable } from "../components/admin/GameLibraryTable";
 import { GamesMobileToolbar } from "../components/games/games-mobile-toolbar";
 import type { GameDetailDto } from "@raid-ledger/contract";
@@ -75,9 +76,9 @@ export function GamesPage() {
   return (
     <div>
       <GamesMobileToolbar
-        activeTab={activeTab === "manage" ? "library" : "discover"}
-        onTabChange={(tab) => setActiveTab(tab === "library" ? "manage" : "discover")}
-        showLibraryTab={canManage}
+        activeTab={activeTab === "manage" ? "manage" : "discover"}
+        onTabChange={(tab) => setActiveTab(tab)}
+        showManageTab={canManage}
       />
 
       <div className="max-w-7xl mx-auto px-4 py-8">
@@ -93,7 +94,7 @@ export function GamesPage() {
 
         {/* Admin tab toggle */}
         {canManage && (
-          <div className="flex rounded-lg bg-panel/50 border border-edge p-1 w-fit mb-6">
+          <div className="hidden md:flex rounded-lg bg-panel/50 border border-edge p-1 w-fit mb-6">
             <button
               type="button"
               onClick={() => setActiveTab("discover")}
@@ -204,7 +205,7 @@ export function GamesPage() {
 
             {/* Content */}
             {isSearching ? (
-              // Search results grid
+              // Search results
               <div>
                 {searchLoading ? (
                   <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
@@ -216,11 +217,20 @@ export function GamesPage() {
                     ))}
                   </div>
                 ) : searchResults && searchResults.length > 0 ? (
-                  <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
-                    {searchResults.map((game) => (
-                      <GameCard key={game.id} game={game} />
-                    ))}
-                  </div>
+                  <>
+                    {/* Desktop grid */}
+                    <div className="hidden md:grid md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-4">
+                      {searchResults.map((game) => (
+                        <GameCard key={game.id} game={game} />
+                      ))}
+                    </div>
+                    {/* Mobile grid */}
+                    <div className="md:hidden grid grid-cols-2 gap-3">
+                      {searchResults.map((game) => (
+                        <MobileGameCard key={game.id} game={game} />
+                      ))}
+                    </div>
+                  </>
                 ) : (
                   <div className="text-center py-16">
                     <p className="text-muted text-lg">
@@ -250,13 +260,31 @@ export function GamesPage() {
                     </div>
                   ))
                 ) : filteredRows && filteredRows.length > 0 ? (
-                  filteredRows.map((row) => (
-                    <GameCarousel
-                      key={row.slug}
-                      category={row.category}
-                      games={row.games}
-                    />
-                  ))
+                  <>
+                    {/* Desktop: carousels */}
+                    <div className="hidden md:block space-y-8">
+                      {filteredRows.map((row) => (
+                        <GameCarousel
+                          key={row.slug}
+                          category={row.category}
+                          games={row.games}
+                        />
+                      ))}
+                    </div>
+                    {/* Mobile: 2-column grid of all games */}
+                    <div className="md:hidden">
+                      {filteredRows.map((row) => (
+                        <div key={row.slug} className="mb-6">
+                          <h2 className="text-lg font-semibold text-foreground mb-3">{row.category}</h2>
+                          <div className="grid grid-cols-2 gap-3">
+                            {row.games.map((game) => (
+                              <MobileGameCard key={game.id} game={game} />
+                            ))}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  </>
                 ) : (
                   <div className="text-center py-16">
                     <p className="text-muted text-lg">

--- a/web/src/pages/players-page.tsx
+++ b/web/src/pages/players-page.tsx
@@ -4,6 +4,7 @@ import { usePlayers } from '../hooks/use-players';
 import { useGameDetail } from '../hooks/use-games-discover';
 import { resolveAvatar, toAvatarUser } from '../lib/avatar';
 import { NewMembersSection } from '../components/players/NewMembersSection';
+import { MobilePlayerCard } from '../components/players/mobile-player-card';
 import { PlayersMobileToolbar } from '../components/players/players-mobile-toolbar';
 
 export function PlayersPage() {
@@ -92,36 +93,45 @@ export function PlayersPage() {
                         )}
                     </div>
                 ) : (
-                    <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
-                        {players.map((player) => {
-                            const avatar = resolveAvatar(toAvatarUser(player));
-                            return (
-                                <Link
-                                    key={player.id}
-                                    to={`/users/${player.id}`}
-                                    className="bg-panel border border-edge rounded-lg p-4 hover:bg-overlay transition-colors text-center group"
-                                >
-                                    {avatar.url ? (
-                                        <img
-                                            src={avatar.url}
-                                            alt={player.username}
-                                            className="w-16 h-16 rounded-full mx-auto bg-overlay object-cover"
-                                            onError={(e) => {
-                                                e.currentTarget.style.display = 'none';
-                                                e.currentTarget.nextElementSibling?.classList.remove('hidden');
-                                            }}
-                                        />
-                                    ) : null}
-                                    <div className={`w-16 h-16 rounded-full mx-auto bg-overlay flex items-center justify-center text-2xl text-muted ${avatar.url ? 'hidden' : ''}`}>
-                                        {player.username.charAt(0).toUpperCase()}
-                                    </div>
-                                    <div className="mt-3 text-sm font-medium text-foreground group-hover:text-emerald-400 transition-colors truncate">
-                                        {player.username}
-                                    </div>
-                                </Link>
-                            );
-                        })}
-                    </div>
+                    <>
+                        {/* Desktop player grid */}
+                        <div className="hidden md:grid md:grid-cols-4 lg:grid-cols-5 gap-4">
+                            {players.map((player) => {
+                                const avatar = resolveAvatar(toAvatarUser(player));
+                                return (
+                                    <Link
+                                        key={player.id}
+                                        to={`/users/${player.id}`}
+                                        className="bg-panel border border-edge rounded-lg p-4 hover:bg-overlay transition-colors text-center group"
+                                    >
+                                        {avatar.url ? (
+                                            <img
+                                                src={avatar.url}
+                                                alt={player.username}
+                                                className="w-16 h-16 rounded-full mx-auto bg-overlay object-cover"
+                                                onError={(e) => {
+                                                    e.currentTarget.style.display = 'none';
+                                                    e.currentTarget.nextElementSibling?.classList.remove('hidden');
+                                                }}
+                                            />
+                                        ) : null}
+                                        <div className={`w-16 h-16 rounded-full mx-auto bg-overlay flex items-center justify-center text-2xl text-muted ${avatar.url ? 'hidden' : ''}`}>
+                                            {player.username.charAt(0).toUpperCase()}
+                                        </div>
+                                        <div className="mt-3 text-sm font-medium text-foreground group-hover:text-emerald-400 transition-colors truncate">
+                                            {player.username}
+                                        </div>
+                                    </Link>
+                                );
+                            })}
+                        </div>
+                        {/* Mobile player grid */}
+                        <div className="md:hidden grid grid-cols-2 gap-3">
+                            {players.map((player) => (
+                                <MobilePlayerCard key={player.id} player={player} />
+                            ))}
+                        </div>
+                    </>
                 )}
 
                 {/* Pagination */}


### PR DESCRIPTION
## Summary

Implements mobile-optimized card components for Events, Games, and Players pages (ROK-328). Cards render below the `md` (768px) breakpoint while desktop cards display at ≥768px.

## Changes

### New Components
- **`MobileEventCard`** — Horizontal layout with 4px game color bar, cover thumbnail, status badge, avatar stack, and relative time
- **`MobileGameCard`** — Vertical 2-column grid with 44px heart tap target, rating badge, genre tag
- **`MobilePlayerCard`** — Vertical 2-column grid with 64px avatar, letter fallback, full-card tappable Link

### Page Integrations
- `events-page.tsx` — Mobile vertical list (`md:hidden`) / Desktop grid (`hidden md:grid`)
- `games-page.tsx` — Mobile 2-col grid for search results and discover sections
- `players-page.tsx` — Mobile 2-col grid

### Fixes
- `games-mobile-toolbar.tsx` — Renamed Library→Manage label, hide desktop tabs on mobile
- Fixed avatar resolution to use `toAvatarUser` bridge (avoids broken Discord CDN URLs)

## Testing
- ✅ TypeScript: compiles clean
- ✅ Tests: 369/369 pass (24 new across 3 test files)
- ✅ Lint: clean on all changed files
- ✅ Visual: verified at 375px (iPhone SE) — all 3 pages render correctly