### PR TITLE
feat(ROK-333): scroll-aware navigation — hide header and tab bar on scroll-down

### DIFF
--- a/web/src/components/layout/Header.test.tsx
+++ b/web/src/components/layout/Header.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { Header } from './Header';
+
+// Mock heavy child components to avoid pulling in their dependency trees
+vi.mock('./UserMenu', () => ({ UserMenu: () => <div data-testid="user-menu" /> }));
+vi.mock('./ThemeToggle', () => ({ ThemeToggle: () => <div data-testid="theme-toggle" /> }));
+vi.mock('../notifications', () => ({ NotificationBell: () => <div data-testid="notification-bell" /> }));
+
+// Mock hooks
+vi.mock('../../hooks/use-auth', () => ({
+    useAuth: () => ({ user: null }),
+}));
+
+vi.mock('../../hooks/use-system-status', () => ({
+    useSystemStatus: () => ({ data: null }),
+}));
+
+// Scroll direction mock — default to null, overridden per-test via mockReturnValue
+const mockUseScrollDirection = vi.fn().mockReturnValue(null);
+vi.mock('../../hooks/use-scroll-direction', () => ({
+    useScrollDirection: (...args: unknown[]) => mockUseScrollDirection(...args),
+}));
+
+function renderHeader() {
+    return render(
+        <MemoryRouter>
+            <Header onMenuClick={vi.fn()} />
+        </MemoryRouter>,
+    );
+}
+
+describe('Header', () => {
+    it('renders the community name', () => {
+        renderHeader();
+        expect(screen.getByText('Raid Ledger')).toBeInTheDocument();
+    });
+
+    it('has sticky positioning at top-0', () => {
+        renderHeader();
+        const header = document.querySelector('header')!;
+        expect(header).toHaveClass('sticky', 'top-0');
+    });
+
+    it('applies z-index from Z_INDEX.HEADER (40)', () => {
+        renderHeader();
+        const header = document.querySelector('header')!;
+        expect(header).toHaveStyle({ zIndex: 40 });
+    });
+
+    it('has inline transition style for scroll-aware animation', () => {
+        renderHeader();
+        const header = document.querySelector('header')!;
+        expect(header).toHaveStyle({ transition: 'transform 300ms ease-in-out' });
+    });
+
+    it('has translate-y-0 when scroll direction is null (initial)', () => {
+        mockUseScrollDirection.mockReturnValue(null);
+        renderHeader();
+        const header = document.querySelector('header')!;
+        expect(header).toHaveClass('translate-y-0');
+        expect(header).not.toHaveClass('-translate-y-full');
+    });
+
+    it('has -translate-y-full when scrolling down', () => {
+        mockUseScrollDirection.mockReturnValue('down');
+        renderHeader();
+        const header = document.querySelector('header')!;
+        expect(header).toHaveClass('-translate-y-full');
+    });
+
+    it('has translate-y-0 when scrolling up', () => {
+        mockUseScrollDirection.mockReturnValue('up');
+        renderHeader();
+        const header = document.querySelector('header')!;
+        expect(header).toHaveClass('translate-y-0');
+        expect(header).not.toHaveClass('-translate-y-full');
+    });
+
+    it('forces translate-y-0 on desktop via md:translate-y-0', () => {
+        mockUseScrollDirection.mockReturnValue('down');
+        renderHeader();
+        const header = document.querySelector('header')!;
+        // Even when hidden on mobile, md:translate-y-0 overrides on desktop
+        expect(header).toHaveClass('md:translate-y-0');
+    });
+
+    it('has will-change-transform with md:will-change-auto for desktop reset', () => {
+        renderHeader();
+        const header = document.querySelector('header')!;
+        expect(header).toHaveClass('will-change-transform', 'md:will-change-auto');
+    });
+
+    it('renders hamburger button for mobile', () => {
+        renderHeader();
+        expect(screen.getByLabelText('Open menu')).toBeInTheDocument();
+    });
+});

--- a/web/src/components/layout/Header.tsx
+++ b/web/src/components/layout/Header.tsx
@@ -4,6 +4,7 @@ import { ThemeToggle } from './ThemeToggle';
 import { NotificationBell } from '../notifications';
 import { useAuth } from '../../hooks/use-auth';
 import { useSystemStatus } from '../../hooks/use-system-status';
+import { useScrollDirection } from '../../hooks/use-scroll-direction';
 import { API_BASE_URL } from '../../lib/config';
 import { Z_INDEX } from '../../lib/z-index';
 
@@ -21,6 +22,8 @@ export function Header({ onMenuClick }: HeaderProps) {
     const location = useLocation();
     const { user } = useAuth();
     const { data: systemStatus } = useSystemStatus();
+    const scrollDirection = useScrollDirection();
+    const isHidden = scrollDirection === 'down';
 
     const communityName = systemStatus?.communityName || 'Raid Ledger';
     const communityLogoUrl = systemStatus?.communityLogoUrl
@@ -35,7 +38,11 @@ export function Header({ onMenuClick }: HeaderProps) {
     ];
 
     return (
-        <header className="sticky top-0 bg-backdrop/95 backdrop-blur-sm border-b border-edge-subtle" style={{ zIndex: Z_INDEX.HEADER }}>
+        <header
+            className={`sticky top-0 bg-backdrop/95 backdrop-blur-sm border-b border-edge-subtle will-change-transform md:will-change-auto md:translate-y-0 ${isHidden ? '-translate-y-full' : 'translate-y-0'
+                }`}
+            style={{ zIndex: Z_INDEX.HEADER, transition: 'transform 300ms ease-in-out' }}
+        >
             <div className="max-w-7xl mx-auto px-4 h-16 flex items-center justify-between">
                 {/* Logo (ROK-271: custom branding) */}
                 <Link

--- a/web/src/components/layout/bottom-tab-bar.test.tsx
+++ b/web/src/components/layout/bottom-tab-bar.test.tsx
@@ -83,4 +83,10 @@ describe('BottomTabBar', () => {
         const gamesLink = screen.getByText('Games').closest('a')!;
         expect(gamesLink).toHaveAttribute('href', '/games');
     });
+
+    it('has inline transition style for scroll-aware animation', () => {
+        renderWithRouter(<BottomTabBar />);
+        const nav = screen.getByRole('navigation', { name: 'Main navigation' });
+        expect(nav).toHaveStyle({ transition: 'transform 300ms ease-in-out' });
+    });
 });

--- a/web/src/components/layout/bottom-tab-bar.tsx
+++ b/web/src/components/layout/bottom-tab-bar.tsx
@@ -5,6 +5,7 @@ import {
     UserGroupIcon,
     PuzzlePieceIcon,
 } from '@heroicons/react/24/outline';
+import { useScrollDirection } from '../../hooks/use-scroll-direction';
 import { Z_INDEX } from '../../lib/z-index';
 
 const tabs = [
@@ -22,15 +23,19 @@ const tabs = [
  */
 export function BottomTabBar() {
     const location = useLocation();
+    const scrollDirection = useScrollDirection();
+    const isHidden = scrollDirection === 'down';
 
     const isActive = (path: string) => location.pathname.startsWith(path);
 
     return (
         <nav
-            className="fixed bottom-0 inset-x-0 md:hidden bg-surface/95 backdrop-blur-sm border-t border-edge-subtle"
+            className={`fixed bottom-0 inset-x-0 md:hidden bg-surface/95 backdrop-blur-sm border-t border-edge-subtle will-change-transform md:will-change-auto ${isHidden ? 'translate-y-full' : 'translate-y-0'
+                }`}
             style={{
                 zIndex: Z_INDEX.TAB_BAR,
                 paddingBottom: 'env(safe-area-inset-bottom)',
+                transition: 'transform 300ms ease-in-out',
             }}
             aria-label="Main navigation"
         >

--- a/web/src/components/layout/mobile-page-toolbar.test.tsx
+++ b/web/src/components/layout/mobile-page-toolbar.test.tsx
@@ -64,4 +64,16 @@ describe('MobilePageToolbar', () => {
         render(<MobilePageToolbar>Test</MobilePageToolbar>);
         expect(screen.getByRole('toolbar')).toBeInTheDocument();
     });
+
+    it('has inline transition style for scroll-aware animation', () => {
+        render(<MobilePageToolbar>Test</MobilePageToolbar>);
+        const toolbar = screen.getByRole('toolbar');
+        expect(toolbar).toHaveStyle({ transition: 'top 300ms ease-in-out' });
+    });
+
+    it('defaults to top-16 when scroll direction is null', () => {
+        render(<MobilePageToolbar>Test</MobilePageToolbar>);
+        const toolbar = screen.getByRole('toolbar');
+        expect(toolbar).toHaveClass('top-16');
+    });
 });

--- a/web/src/components/layout/mobile-page-toolbar.tsx
+++ b/web/src/components/layout/mobile-page-toolbar.tsx
@@ -1,3 +1,4 @@
+import { useScrollDirection } from '../../hooks/use-scroll-direction';
 import { Z_INDEX } from '../../lib/z-index';
 
 interface MobilePageToolbarProps {
@@ -11,14 +12,20 @@ interface MobilePageToolbarProps {
  * Sticky toolbar wrapper for mobile per-page controls (ROK-329).
  * Sits below the 64px header, only visible on mobile (<768px).
  * Frosted glass effect with backdrop blur.
+ *
+ * When the header hides (scroll-down), the toolbar slides up to top-0.
  */
 export function MobilePageToolbar({ children, className = '', 'aria-label': ariaLabel = 'Page toolbar' }: MobilePageToolbarProps) {
+    const scrollDirection = useScrollDirection();
+    const headerHidden = scrollDirection === 'down';
+
     return (
         <div
             role="toolbar"
             aria-label={ariaLabel}
-            className="sticky top-16 md:hidden bg-surface/95 backdrop-blur-sm border-b border-edge"
-            style={{ zIndex: Z_INDEX.TOOLBAR }}
+            className={`sticky md:hidden bg-surface/95 backdrop-blur-sm border-b border-edge will-change-transform md:will-change-auto ${headerHidden ? 'top-0' : 'top-16'
+                }`}
+            style={{ zIndex: Z_INDEX.TOOLBAR, transition: 'top 300ms ease-in-out' }}
         >
             <div className={`px-4 py-3 ${className}`}>
                 {children}

--- a/web/src/hooks/use-scroll-direction.test.ts
+++ b/web/src/hooks/use-scroll-direction.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useScrollDirection } from './use-scroll-direction';
+
+/* ────────────────────────────────────────────────────────── */
+/*  Helpers                                                   */
+/* ────────────────────────────────────────────────────────── */
+
+let matchMediaMatches = true; // true = mobile viewport
+
+beforeEach(() => {
+    matchMediaMatches = true;
+
+    // Stub rAF to fire synchronously (via vi.stubGlobal, NOT a jsdom default)
+    vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+        cb(0);
+        return 0;
+    });
+
+    // Stub matchMedia
+    vi.stubGlobal('matchMedia', vi.fn().mockImplementation(() => ({
+        matches: matchMediaMatches,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+    })));
+
+    // Reset scrollY
+    Object.defineProperty(window, 'scrollY', { value: 0, writable: true, configurable: true });
+});
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+function simulateScroll(y: number) {
+    Object.defineProperty(window, 'scrollY', { value: y, writable: true, configurable: true });
+    window.dispatchEvent(new Event('scroll'));
+}
+
+/* ────────────────────────────────────────────────────────── */
+/*  Tests                                                     */
+/* ────────────────────────────────────────────────────────── */
+
+describe('useScrollDirection', () => {
+    it('returns null initially', () => {
+        const { result } = renderHook(() => useScrollDirection());
+        expect(result.current).toBeNull();
+    });
+
+    it('returns "down" after scrolling past threshold (100px)', () => {
+        const { result } = renderHook(() => useScrollDirection());
+
+        act(() => {
+            simulateScroll(50);
+        });
+        // Still below threshold
+        expect(result.current).toBeNull();
+
+        act(() => {
+            simulateScroll(150);
+        });
+        expect(result.current).toBe('down');
+    });
+
+    it('returns "up" on any upward scroll', () => {
+        const { result } = renderHook(() => useScrollDirection());
+
+        act(() => {
+            simulateScroll(200);
+        });
+        expect(result.current).toBe('down');
+
+        act(() => {
+            simulateScroll(180);
+        });
+        expect(result.current).toBe('up');
+    });
+
+    it('does not attach listener on desktop (matchMedia does not match)', () => {
+        matchMediaMatches = false;
+        // Re-stub so the hook gets the new value
+        vi.stubGlobal('matchMedia', vi.fn().mockImplementation(() => ({
+            matches: false,
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+        })));
+
+        const addSpy = vi.spyOn(window, 'addEventListener');
+        renderHook(() => useScrollDirection());
+
+        const scrollCalls = addSpy.mock.calls.filter(([event]) => event === 'scroll');
+        expect(scrollCalls).toHaveLength(0);
+    });
+
+    it('cleans up scroll listener on unmount', () => {
+        const removeSpy = vi.spyOn(window, 'removeEventListener');
+        const { unmount } = renderHook(() => useScrollDirection());
+
+        unmount();
+
+        const scrollCalls = removeSpy.mock.calls.filter(([event]) => event === 'scroll');
+        expect(scrollCalls.length).toBeGreaterThanOrEqual(1);
+    });
+});

--- a/web/src/hooks/use-scroll-direction.ts
+++ b/web/src/hooks/use-scroll-direction.ts
@@ -1,0 +1,120 @@
+import { useSyncExternalStore } from 'react';
+
+export type ScrollDirection = 'up' | 'down' | null;
+
+/** Minimum scroll distance from top before we report "down". */
+const SCROLL_THRESHOLD = 100;
+
+/** Breakpoint above which scroll-hiding is disabled (desktop). */
+const DESKTOP_MIN_WIDTH = 768;
+
+/* ──────────────────────────────────────────────────────────
+   Singleton scroll-direction store
+   All callers share ONE scroll listener and ONE rAF loop.
+   ────────────────────────────────────────────────────────── */
+
+let direction: ScrollDirection = null;
+let lastScrollY = 0;
+let ticking = false;
+let listenerAttached = false;
+let subscriberCount = 0;
+const subscribers = new Set<() => void>();
+
+function notify() {
+    subscribers.forEach((cb) => cb());
+}
+
+function update() {
+    const currentY = window.scrollY;
+
+    if (currentY > lastScrollY && currentY > SCROLL_THRESHOLD) {
+        if (direction !== 'down') {
+            direction = 'down';
+            notify();
+        }
+    } else if (currentY < lastScrollY) {
+        if (direction !== 'up') {
+            direction = 'up';
+            notify();
+        }
+    }
+
+    lastScrollY = currentY;
+    ticking = false;
+}
+
+function onScroll() {
+    if (!ticking) {
+        ticking = true;
+        requestAnimationFrame(update);
+    }
+}
+
+function attach() {
+    if (listenerAttached) return;
+    const mql = window.matchMedia(`(max-width: ${DESKTOP_MIN_WIDTH - 1}px)`);
+    if (!mql.matches) return;
+
+    lastScrollY = window.scrollY;
+    window.addEventListener('scroll', onScroll, { passive: true });
+    listenerAttached = true;
+
+    // Handle viewport resize (e.g. rotating device)
+    mql.addEventListener('change', onMediaChange);
+}
+
+function detach() {
+    window.removeEventListener('scroll', onScroll);
+    const mql = window.matchMedia(`(max-width: ${DESKTOP_MIN_WIDTH - 1}px)`);
+    mql.removeEventListener('change', onMediaChange);
+    listenerAttached = false;
+    if (direction !== null) {
+        direction = null;
+        notify();
+    }
+}
+
+function onMediaChange(e: MediaQueryListEvent) {
+    if (e.matches) {
+        attach();
+    } else {
+        detach();
+    }
+}
+
+function subscribe(cb: () => void) {
+    subscribers.add(cb);
+    subscriberCount++;
+    if (subscriberCount === 1) {
+        attach();
+    }
+    return () => {
+        subscribers.delete(cb);
+        subscriberCount--;
+        if (subscriberCount === 0) {
+            detach();
+        }
+    };
+}
+
+function getSnapshot(): ScrollDirection {
+    return direction;
+}
+
+/**
+ * Reports the user's scroll direction on mobile viewports.
+ *
+ * Uses a passive scroll listener throttled via `requestAnimationFrame`.
+ * Returns `'down'` once the user has scrolled past {@link SCROLL_THRESHOLD}
+ * and is moving downward, `'up'` on any upward movement, or `null` before
+ * any scroll activity (or on desktop).
+ *
+ * Internally backed by a singleton store — multiple callers share ONE
+ * scroll listener regardless of how many components use the hook.
+ *
+ * The listener is only attached when ≥ 1 subscriber exists and is
+ * cleaned up when all subscribers unmount.
+ */
+export function useScrollDirection(): ScrollDirection {
+    return useSyncExternalStore(subscribe, getSnapshot);
+}


### PR DESCRIPTION
## Summary

Hide header and tab bar on scroll-down, show on scroll-up to reclaim 120px of vertical space on mobile. Desktop is unaffected.

## Changes

### New Files
- **`use-scroll-direction.ts`** — Singleton scroll direction hook using `useSyncExternalStore`. All callers share ONE passive scroll listener with rAF throttle, 100px threshold, and desktop guard via `matchMedia`.
- **`Header.test.tsx`** — 10 tests for Header scroll behavior
- **`use-scroll-direction.test.ts`** — 5 tests for the hook

### Modified Files
- **`Header.tsx`** — Hides via `-translate-y-full` on scroll-down, `md:translate-y-0` keeps desktop visible
- **`bottom-tab-bar.tsx`** — Hides via `translate-y-full` on scroll-down
- **`mobile-page-toolbar.tsx`** — Slides from `top-16` to `top-0` when header hides
- **`bottom-tab-bar.test.tsx`** — Added transition style test
- **`mobile-page-toolbar.test.tsx`** — Added transition + default position tests

### Key Design Decisions
- **Singleton store** via `useSyncExternalStore` — 3 components share 1 listener instead of each creating its own
- **Inline transition styles** — Override global `* { transition-duration: 150ms }` rule in `index.css` that was blocking Tailwind's `duration-300`
- **`md:will-change-auto`** — Reset GPU layer promotion on desktop where transforms never fire

## Testing
- ✅ TypeScript: compiles clean
- ✅ Tests: 418/418 passing
- ✅ Lint: clean on changed files
- ✅ Browser verified: smooth 300ms animation on mobile