### PR TITLE
feat(ROK-354): consolidate dual hamburger menus on mobile

### DIFF
--- a/web/src/components/admin/admin-nav-data.tsx
+++ b/web/src/components/admin/admin-nav-data.tsx
@@ -1,0 +1,103 @@
+import type { PluginInfoDto } from '@raid-ledger/contract';
+
+/** Status info for integration sidebar items */
+export type IntegrationStatus = 'online' | 'offline' | 'loading';
+
+export interface NavItem {
+    to: string;
+    label: string;
+    /** When true, the item shows a "New" badge via useNewBadge */
+    newBadgeKey?: string;
+    /** Integration status shown as a small pill badge */
+    status?: IntegrationStatus;
+    /** Source plugin name for plugin-installed integrations (e.g. "World of Warcraft") */
+    pluginSource?: string;
+}
+
+export interface NavSection {
+    id: string;
+    label: string;
+    icon: React.ReactNode;
+    children: NavItem[];
+}
+
+const GeneralIcon = (<svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.75} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" /><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.75} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" /></svg>);
+const IntegrationsIcon = (<svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.75} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" /></svg>);
+const PluginsIcon = (<svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.75} d="M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z" /></svg>);
+const AppearanceIcon = (<svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.75} d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01" /></svg>);
+
+/** Build core integration nav items with live status from hooks */
+export function buildCoreIntegrationItems(statuses: {
+    discord: { configured: boolean; loading: boolean };
+    discordBot: { connected: boolean; configured: boolean; loading: boolean };
+    igdb: { configured: boolean; loading: boolean };
+}): NavItem[] {
+    return [
+        {
+            to: '/admin/settings/integrations',
+            label: 'Discord OAuth',
+            status: statuses.discord.loading ? 'loading'
+                : statuses.discord.configured ? 'online' : 'offline',
+        },
+        {
+            to: '/admin/settings/integrations/discord-bot',
+            label: 'Discord Bot',
+            status: statuses.discordBot.loading ? 'loading'
+                : statuses.discordBot.connected ? 'online' : 'offline',
+        },
+        {
+            to: '/admin/settings/integrations/igdb',
+            label: 'IGDB / Twitch',
+            status: statuses.igdb.loading ? 'loading'
+                : statuses.igdb.configured ? 'online' : 'offline',
+        },
+    ];
+}
+
+/** Build integration nav items from active plugins. Plugin-installed integrations get a "New" badge key. */
+export function buildPluginIntegrationItems(plugins: PluginInfoDto[]): NavItem[] {
+    const items: NavItem[] = [];
+    for (const plugin of plugins) {
+        if (plugin.status !== 'active') continue;
+        for (const integration of plugin.integrations) {
+            items.push({
+                to: `/admin/settings/integrations/plugin/${plugin.slug}/${integration.key}`,
+                label: integration.name,
+                newBadgeKey: `integration-nav-seen:${plugin.slug}:${integration.key}`,
+                status: integration.configured ? 'online' : 'offline',
+                pluginSource: plugin.name,
+            });
+        }
+    }
+    return items;
+}
+
+/** Build the full sections list, merging core and plugin integrations */
+export function buildNavSections(coreIntegrations: NavItem[], pluginIntegrations: NavItem[]): NavSection[] {
+    return [
+        {
+            id: 'general', label: 'General', icon: GeneralIcon, children: [
+                { to: '/admin/settings/general', label: 'Site Settings' },
+                { to: '/admin/settings/general/roles', label: 'Role Management' },
+                { to: '/admin/settings/general/data', label: 'Demo Data' },
+                { to: '/admin/settings/general/cron-jobs', label: 'Scheduled Jobs' },
+            ]
+        },
+        {
+            id: 'integrations', label: 'Integrations', icon: IntegrationsIcon, children: [
+                ...coreIntegrations,
+                ...pluginIntegrations,
+            ]
+        },
+        {
+            id: 'plugins', label: 'Plugins', icon: PluginsIcon, children: [
+                { to: '/admin/settings/plugins', label: 'Manage Plugins' },
+            ]
+        },
+        {
+            id: 'appearance', label: 'Appearance', icon: AppearanceIcon, children: [
+                { to: '/admin/settings/appearance', label: 'Branding' },
+            ]
+        },
+    ];
+}

--- a/web/src/components/admin/admin-settings-layout.tsx
+++ b/web/src/components/admin/admin-settings-layout.tsx
@@ -1,37 +1,17 @@
-import { useState, useEffect, useCallback } from 'react';
 import { Outlet, Navigate, useLocation, useNavigate } from 'react-router-dom';
 import { useAuth, isAdmin as isAdminCheck } from '../../hooks/use-auth';
 import { AdminSidebar } from './admin-sidebar';
-import { Z_INDEX } from '../../lib/z-index';
 
 /**
  * Admin Settings layout — sidebar + content area with nested <Outlet />.
  * Desktop: fixed sidebar on the left, content scrolls independently.
- * Mobile: hamburger button opens a slide-over drawer.
+ * Mobile: navigation is handled by the MoreDrawer accordion (ROK-354).
  * ROK-281: Always-expanded sidebar navigation with dynamic plugin integrations.
  */
 export function AdminSettingsLayout() {
     const { user, isLoading } = useAuth();
     const location = useLocation();
     const navigate = useNavigate();
-    const [mobileOpen, setMobileOpen] = useState(false);
-
-    const closeMobile = useCallback(() => setMobileOpen(false), []);
-
-    // Close mobile drawer on Escape and lock body scroll
-    useEffect(() => {
-        if (!mobileOpen) return;
-        function handleEscape(e: KeyboardEvent) {
-            if (e.key === 'Escape') setMobileOpen(false);
-        }
-        document.addEventListener('keydown', handleEscape);
-        document.body.style.overflow = 'hidden';
-        return () => {
-            document.removeEventListener('keydown', handleEscape);
-            document.body.style.overflow = '';
-        };
-    }, [mobileOpen]);
-
 
     // Redirect bare /admin/settings to /admin/settings/general
     if (location.pathname === '/admin/settings') {
@@ -71,22 +51,10 @@ export function AdminSettingsLayout() {
 
     return (
         <div className="max-w-6xl mx-auto px-4 py-6">
-            {/* Header row with mobile hamburger */}
-            <div className="flex items-center gap-3 mb-6">
-                <button
-                    type="button"
-                    className="md:hidden p-2 -ml-2 rounded-lg text-muted hover:text-foreground hover:bg-overlay/30 transition-colors"
-                    onClick={() => setMobileOpen(true)}
-                    aria-label="Open settings menu"
-                >
-                    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-                    </svg>
-                </button>
-                <div>
-                    <h1 className="text-2xl font-bold text-foreground">Admin Settings</h1>
-                    <p className="text-sm text-muted mt-0.5">Manage your community configuration</p>
-                </div>
+            {/* Header */}
+            <div className="mb-6">
+                <h1 className="text-2xl font-bold text-foreground">Admin Settings</h1>
+                <p className="text-sm text-muted mt-0.5">Manage your community configuration</p>
             </div>
 
             <div className="flex gap-6">
@@ -101,36 +69,6 @@ export function AdminSettingsLayout() {
                 <main className="flex-1 min-w-0">
                     <Outlet />
                 </main>
-            </div>
-
-            <div
-                className={`fixed inset-0 md:hidden ${mobileOpen ? 'visible' : 'invisible pointer-events-none'}`}
-                style={{ zIndex: Z_INDEX.MODAL }}
-                aria-hidden={!mobileOpen}
-            >
-                {/* Backdrop */}
-                <div
-                    className={`absolute inset-0 bg-black/60 backdrop-blur-sm transition-opacity duration-200 ${mobileOpen ? 'opacity-100' : 'opacity-0'}`}
-                    onClick={closeMobile}
-                    aria-hidden="true"
-                />
-                {/* Drawer */}
-                <div className={`absolute top-0 right-0 w-72 h-full bg-surface border-l border-edge-subtle shadow-2xl transform transition-transform duration-200 ease-out ${mobileOpen ? 'translate-x-0' : 'translate-x-full'}`}>
-                    <div className="flex items-center justify-between px-4 py-3 border-b border-edge-subtle">
-                        <span className="font-semibold text-foreground text-sm">Settings</span>
-                        <button
-                            type="button"
-                            onClick={closeMobile}
-                            className="flex items-center justify-center min-w-[44px] min-h-[44px] rounded-lg text-muted hover:text-foreground hover:bg-overlay/30 transition-colors"
-                            aria-label="Close settings menu"
-                        >
-                            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                            </svg>
-                        </button>
-                    </div>
-                    <AdminSidebar onNavigate={closeMobile} />
-                </div>
             </div>
         </div>
     );

--- a/web/src/components/admin/admin-sidebar.tsx
+++ b/web/src/components/admin/admin-sidebar.tsx
@@ -3,109 +3,8 @@ import { usePluginAdmin } from '../../hooks/use-plugin-admin';
 import { useAdminSettings } from '../../hooks/use-admin-settings';
 import { useNewBadge } from '../../hooks/use-new-badge';
 import { NewBadge } from '../ui/new-badge';
-import type { PluginInfoDto } from '@raid-ledger/contract';
-
-/** Status info for integration sidebar items */
-type IntegrationStatus = 'online' | 'offline' | 'loading';
-
-interface NavItem {
-    to: string;
-    label: string;
-    /** When true, the item shows a "New" badge via useNewBadge */
-    newBadgeKey?: string;
-    /** Integration status shown as a small pill badge */
-    status?: IntegrationStatus;
-    /** Source plugin name for plugin-installed integrations (e.g. "World of Warcraft") */
-    pluginSource?: string;
-}
-
-interface NavSection {
-    id: string;
-    label: string;
-    icon: React.ReactNode;
-    children: NavItem[];
-}
-
-const GeneralIcon = (<svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.75} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" /><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.75} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" /></svg>);
-const IntegrationsIcon = (<svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.75} d="M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1" /></svg>);
-const PluginsIcon = (<svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.75} d="M11 4a2 2 0 114 0v1a1 1 0 001 1h3a1 1 0 011 1v3a1 1 0 01-1 1h-1a2 2 0 100 4h1a1 1 0 011 1v3a1 1 0 01-1 1h-3a1 1 0 01-1-1v-1a2 2 0 10-4 0v1a1 1 0 01-1 1H7a1 1 0 01-1-1v-3a1 1 0 00-1-1H4a2 2 0 110-4h1a1 1 0 001-1V7a1 1 0 011-1h3a1 1 0 001-1V4z" /></svg>);
-const AppearanceIcon = (<svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.75} d="M7 21a4 4 0 01-4-4V5a2 2 0 012-2h4a2 2 0 012 2v12a4 4 0 01-4 4zm0 0h12a2 2 0 002-2v-4a2 2 0 00-2-2h-2.343M11 7.343l1.657-1.657a2 2 0 012.828 0l2.829 2.829a2 2 0 010 2.828l-8.486 8.485M7 17h.01" /></svg>);
-
-/** Build core integration nav items with live status from hooks */
-function buildCoreIntegrationItems(statuses: {
-    discord: { configured: boolean; loading: boolean };
-    discordBot: { connected: boolean; configured: boolean; loading: boolean };
-    igdb: { configured: boolean; loading: boolean };
-}): NavItem[] {
-    return [
-        {
-            to: '/admin/settings/integrations',
-            label: 'Discord OAuth',
-            status: statuses.discord.loading ? 'loading'
-                : statuses.discord.configured ? 'online' : 'offline',
-        },
-        {
-            to: '/admin/settings/integrations/discord-bot',
-            label: 'Discord Bot',
-            status: statuses.discordBot.loading ? 'loading'
-                : statuses.discordBot.connected ? 'online' : 'offline',
-        },
-        {
-            to: '/admin/settings/integrations/igdb',
-            label: 'IGDB / Twitch',
-            status: statuses.igdb.loading ? 'loading'
-                : statuses.igdb.configured ? 'online' : 'offline',
-        },
-    ];
-}
-
-/** Build integration nav items from active plugins. Plugin-installed integrations get a "New" badge key. */
-function buildPluginIntegrationItems(plugins: PluginInfoDto[]): NavItem[] {
-    const items: NavItem[] = [];
-    for (const plugin of plugins) {
-        if (plugin.status !== 'active') continue;
-        for (const integration of plugin.integrations) {
-            items.push({
-                to: `/admin/settings/integrations/plugin/${plugin.slug}/${integration.key}`,
-                label: integration.name,
-                newBadgeKey: `integration-nav-seen:${plugin.slug}:${integration.key}`,
-                status: integration.configured ? 'online' : 'offline',
-                pluginSource: plugin.name,
-            });
-        }
-    }
-    return items;
-}
-
-/** Build the full sections list, merging core and plugin integrations */
-function buildNavSections(coreIntegrations: NavItem[], pluginIntegrations: NavItem[]): NavSection[] {
-    return [
-        {
-            id: 'general', label: 'General', icon: GeneralIcon, children: [
-                { to: '/admin/settings/general', label: 'Site Settings' },
-                { to: '/admin/settings/general/roles', label: 'Role Management' },
-                { to: '/admin/settings/general/data', label: 'Demo Data' },
-                { to: '/admin/settings/general/cron-jobs', label: 'Scheduled Jobs' },
-            ]
-        },
-        {
-            id: 'integrations', label: 'Integrations', icon: IntegrationsIcon, children: [
-                ...coreIntegrations,
-                ...pluginIntegrations,
-            ]
-        },
-        {
-            id: 'plugins', label: 'Plugins', icon: PluginsIcon, children: [
-                { to: '/admin/settings/plugins', label: 'Manage Plugins' },
-            ]
-        },
-        {
-            id: 'appearance', label: 'Appearance', icon: AppearanceIcon, children: [
-                { to: '/admin/settings/appearance', label: 'Branding' },
-            ]
-        },
-    ];
-}
+import type { IntegrationStatus, NavItem } from './admin-nav-data';
+import { buildCoreIntegrationItems, buildPluginIntegrationItems, buildNavSections } from './admin-nav-data';
 
 interface AdminSidebarProps { isOpen?: boolean; onNavigate?: () => void; }
 
@@ -168,7 +67,7 @@ export function AdminSidebar({ isOpen = true, onNavigate }: AdminSidebarProps) {
 }
 
 /** Small status pill for integration sidebar items */
-function StatusPill({ status }: { status: IntegrationStatus }) {
+export function StatusPill({ status }: { status: IntegrationStatus }) {
     if (status === 'loading') return null;
 
     const config = {
@@ -186,7 +85,7 @@ function StatusPill({ status }: { status: IntegrationStatus }) {
 }
 
 /** Individual nav link. Renders status pills for integrations and "New" badges for plugin items. */
-function SidebarNavItem({
+export function SidebarNavItem({
     item,
     isActive,
     onNavigate,

--- a/web/src/components/layout/more-drawer.tsx
+++ b/web/src/components/layout/more-drawer.tsx
@@ -7,6 +7,16 @@ import { Z_INDEX } from '../../lib/z-index';
 import { useQuery } from '@tanstack/react-query';
 import { getAuthToken } from '../../hooks/use-auth';
 import { API_BASE_URL } from '../../lib/config';
+import { SECTIONS as PROFILE_SECTIONS } from '../profile/profile-nav-data';
+import { useResetOnboarding } from '../../hooks/use-onboarding-fte';
+import { usePluginAdmin } from '../../hooks/use-plugin-admin';
+import { useAdminSettings } from '../../hooks/use-admin-settings';
+import {
+    buildCoreIntegrationItems,
+    buildPluginIntegrationItems,
+    buildNavSections,
+} from '../admin/admin-nav-data';
+import { SidebarNavItem } from '../admin/admin-sidebar';
 
 interface MoreDrawerProps {
     isOpen: boolean;
@@ -66,6 +76,24 @@ export function MoreDrawer({ isOpen, onClose, onFeedbackClick }: MoreDrawerProps
     const [impersonateSearch, setImpersonateSearch] = useState('');
     const impersonateSearchRef = useRef<HTMLInputElement>(null);
 
+    // Accordion state for profile and admin submenus.
+    // Uses React's "adjust state during render" pattern (prev-value in state) to
+    // reset accordion state when the drawer transitions from closed → open,
+    // avoiding both useEffect+setState and ref-during-render lint violations.
+    const [profileExpanded, setProfileExpanded] = useState(() => location.pathname.startsWith('/profile'));
+    const [adminExpanded, setAdminExpanded] = useState(() => location.pathname.startsWith('/admin/settings'));
+    const [prevIsOpen, setPrevIsOpen] = useState(isOpen);
+
+    if (isOpen !== prevIsOpen) {
+        setPrevIsOpen(isOpen);
+        if (isOpen) {
+            setProfileExpanded(location.pathname.startsWith('/profile'));
+            setAdminExpanded(location.pathname.startsWith('/admin/settings'));
+            setAvatarError(false);
+        }
+    }
+
+
     // Fetch users for impersonation (admin/operator only)
     const { data: impersonateUsers } = useQuery<{ id: number; username: string; avatar: string | null; discordId: string | null; customAvatarUrl: string | null }[]>({
         queryKey: ['auth', 'users'],
@@ -93,12 +121,6 @@ export function MoreDrawer({ isOpen, onClose, onFeedbackClick }: MoreDrawerProps
         onClose();
         await exitImpersonation();
     };
-
-    const navLinks = [
-        ...(isAdmin(user)
-            ? [{ to: '/admin/settings', icon: '⚙️', label: 'Admin Settings' }]
-            : []),
-    ];
 
     // Theme mode icon
     const themeIcon =
@@ -136,7 +158,7 @@ export function MoreDrawer({ isOpen, onClose, onFeedbackClick }: MoreDrawerProps
 
             {/* Drawer panel — full-screen, slides from left */}
             <div
-                className={`absolute inset-0 bg-surface transform transition-transform duration-300 ${isOpen ? 'translate-x-0' : '-translate-x-full'}`}
+                className={`absolute inset-0 bg-surface flex flex-col transform transition-transform duration-300 ${isOpen ? 'translate-x-0' : '-translate-x-full'}`}
                 style={{ transitionTimingFunction: 'var(--spring-smooth)' }}
                 data-testid="more-drawer-panel"
                 role="dialog"
@@ -157,191 +179,329 @@ export function MoreDrawer({ isOpen, onClose, onFeedbackClick }: MoreDrawerProps
                     </button>
                 </div>
 
-                {/* User info — taps through to Profile */}
-                {isAuthenticated && user && (
-                    <Link
-                        to="/profile"
-                        onClick={onClose}
-                        className="flex items-center gap-3 p-4 border-b border-edge-subtle hover:bg-overlay/20 transition-colors"
-                    >
-                        {avatarUrl && !avatarError ? (
-                            <img
-                                src={avatarUrl}
-                                alt={user.username}
-                                className="w-12 h-12 rounded-full bg-overlay"
-                                onError={() => setAvatarError(true)}
-                            />
-                        ) : (
-                            <div className="w-12 h-12 rounded-full bg-overlay flex items-center justify-center text-sm font-semibold text-muted">
-                                {user.username.charAt(0).toUpperCase()}
-                            </div>
-                        )}
-                        <span className="flex-1 text-foreground font-medium">{user.username}</span>
-                        <svg className="w-4 h-4 text-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                        </svg>
-                    </Link>
-                )}
+                {/* Scrollable content area */}
+                <div className="flex-1 overflow-y-auto">
 
-                {navLinks.length > 0 && (
-                    <nav className="py-4" data-testid="more-drawer-nav">
-                        {navLinks.map(({ to, icon, label }) => (
-                            <Link
-                                key={to}
-                                to={to}
-                                onClick={onClose}
-                                className="flex items-center gap-3 px-4 py-3 text-foreground hover:bg-overlay/20 transition-colors"
+                    {/* User info — profile accordion */}
+                    {isAuthenticated && user && (
+                        <div className="border-b border-edge-subtle">
+                            <button
+                                onClick={() => setProfileExpanded((prev) => !prev)}
+                                className="flex items-center gap-3 p-4 w-full hover:bg-overlay/20 transition-colors"
+                                data-testid="more-drawer-profile-toggle"
+                                aria-expanded={profileExpanded}
                             >
-                                <span className="text-2xl w-8 text-center">{icon}</span>
-                                <span className="flex-1 font-medium">{label}</span>
-                                <svg className="w-4 h-4 text-muted" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+                                {avatarUrl && !avatarError ? (
+                                    <img
+                                        src={avatarUrl}
+                                        alt={user.username}
+                                        className="w-12 h-12 rounded-full bg-overlay"
+                                        onError={() => setAvatarError(true)}
+                                    />
+                                ) : (
+                                    <div className="w-12 h-12 rounded-full bg-overlay flex items-center justify-center text-sm font-semibold text-muted">
+                                        {user.username.charAt(0).toUpperCase()}
+                                    </div>
+                                )}
+                                <span className="flex-1 text-left text-foreground font-medium">{user.username}</span>
+                                <svg
+                                    className={`w-4 h-4 text-muted transition-transform duration-200 ${profileExpanded ? 'rotate-180' : ''}`}
+                                    fill="none"
+                                    stroke="currentColor"
+                                    viewBox="0 0 24 24"
+                                    data-testid="profile-chevron"
+                                >
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
                                 </svg>
+                            </button>
+
+                            {profileExpanded && (
+                                <ProfileSubmenuContent pathname={location.pathname} onClose={onClose} />
+                            )}
+                        </div>
+                    )}
+
+                    {/* Admin Settings accordion (admin only) */}
+                    {isAdmin(user) && (
+                        <div className="border-b border-edge-subtle">
+                            <button
+                                onClick={() => setAdminExpanded((prev) => !prev)}
+                                className="flex items-center gap-3 px-4 py-3 w-full text-foreground hover:bg-overlay/20 transition-colors"
+                                data-testid="more-drawer-admin-toggle"
+                                aria-expanded={adminExpanded}
+                            >
+                                <span className="text-2xl w-8 text-center">⚙️</span>
+                                <span className="flex-1 text-left font-medium">Admin Settings</span>
+                                <svg
+                                    className={`w-4 h-4 text-muted transition-transform duration-200 ${adminExpanded ? 'rotate-180' : ''}`}
+                                    fill="none"
+                                    stroke="currentColor"
+                                    viewBox="0 0 24 24"
+                                    data-testid="admin-chevron"
+                                >
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                                </svg>
+                            </button>
+
+                            {adminExpanded && (
+                                <AdminSubmenuContent pathname={location.pathname} onClose={onClose} />
+                            )}
+                        </div>
+                    )}
+
+                    {/* Controls section */}
+                    <div className="px-4 py-4 border-t border-edge-subtle">
+                        {/* Theme cycling */}
+                        <button
+                            onClick={cycleTheme}
+                            className="flex items-center gap-3 w-full px-4 py-3 rounded-lg font-medium text-foreground hover:bg-overlay/20 transition-colors"
+                            data-testid="more-drawer-theme-toggle"
+                        >
+                            {themeIcon}
+                            <span className="flex-1 text-left">{themeLabel}</span>
+                        </button>
+
+                        {/* Send Feedback */}
+                        {onFeedbackClick && (
+                            <button
+                                onClick={() => {
+                                    onClose();
+                                    onFeedbackClick();
+                                }}
+                                className="flex items-center gap-3 w-full px-4 py-3 rounded-lg font-medium text-foreground hover:bg-overlay/20 transition-colors"
+                                data-testid="more-drawer-feedback"
+                            >
+                                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
+                                </svg>
+                                <span className="flex-1 text-left">Send Feedback</span>
+                            </button>
+                        )}
+                    </div>
+
+                    {/* Impersonation section (admin/operator only) */}
+                    {isOperatorOrAdmin(user) && !isImpersonating && (
+                        <div className="px-4 py-4 border-t border-edge-subtle">
+                            <button
+                                onClick={() => {
+                                    const next = !showImpersonateMenu;
+                                    setShowImpersonateMenu(next);
+                                    if (!next) setImpersonateSearch('');
+                                    else setTimeout(() => impersonateSearchRef.current?.focus(), 0);
+                                }}
+                                className="flex items-center gap-3 w-full px-4 py-3 rounded-lg font-medium text-foreground hover:bg-overlay/20 transition-colors"
+                            >
+                                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+                                </svg>
+                                <span className="flex-1 text-left">Impersonate</span>
+                                <svg
+                                    className={`w-4 h-4 text-muted transition-transform ${showImpersonateMenu ? 'rotate-180' : ''}`}
+                                    fill="none"
+                                    stroke="currentColor"
+                                    viewBox="0 0 24 24"
+                                >
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                                </svg>
+                            </button>
+
+                            {showImpersonateMenu && (
+                                <div className="mt-2 rounded-lg bg-panel/50 overflow-hidden">
+                                    <div className="p-3">
+                                        <input
+                                            ref={impersonateSearchRef}
+                                            type="text"
+                                            value={impersonateSearch}
+                                            onChange={(e) => setImpersonateSearch(e.target.value)}
+                                            placeholder="Search users..."
+                                            className="w-full px-3 py-2 text-sm bg-surface/50 border border-edge rounded-lg text-foreground placeholder:text-dim focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                                        />
+                                    </div>
+                                    <div className="max-h-48 overflow-y-auto">
+                                        {(() => {
+                                            const filtered = (impersonateUsers ?? []).filter((u) =>
+                                                u.username.toLowerCase().includes(impersonateSearch.toLowerCase())
+                                            );
+                                            return filtered.length > 0 ? (
+                                                filtered.map((u) => {
+                                                    const impAvatar = resolveAvatar(toAvatarUser(u));
+                                                    return (
+                                                        <button
+                                                            key={u.id}
+                                                            onClick={() => handleImpersonate(u.id)}
+                                                            className="flex items-center gap-3 w-full px-4 py-2.5 text-sm text-muted hover:bg-overlay/30 hover:text-foreground transition-colors"
+                                                        >
+                                                            {impAvatar.url ? (
+                                                                <img
+                                                                    src={impAvatar.url}
+                                                                    alt={u.username}
+                                                                    className="w-6 h-6 rounded-full bg-faint object-cover"
+                                                                    onError={(e) => {
+                                                                        e.currentTarget.style.display = 'none';
+                                                                        e.currentTarget.nextElementSibling?.classList.remove('hidden');
+                                                                    }}
+                                                                />
+                                                            ) : null}
+                                                            <div className={`w-6 h-6 rounded-full bg-faint flex items-center justify-center text-xs font-semibold text-muted ${impAvatar.url ? 'hidden' : ''}`}>
+                                                                {u.username.charAt(0).toUpperCase()}
+                                                            </div>
+                                                            {u.username}
+                                                        </button>
+                                                    );
+                                                })
+                                            ) : (
+                                                <p className="px-4 py-3 text-xs text-dim">
+                                                    {impersonateSearch ? 'No matches' : 'No users available'}
+                                                </p>
+                                            );
+                                        })()}
+                                    </div>
+                                </div>
+                            )}
+                        </div>
+                    )}
+
+                    {/* Exit Impersonation */}
+                    {isImpersonating && (
+                        <div className="px-4 py-4 border-t border-edge-subtle">
+                            <button
+                                onClick={handleExitImpersonation}
+                                className="flex items-center gap-3 w-full px-4 py-3 rounded-lg font-medium text-amber-400 bg-amber-500/10 hover:bg-amber-500/20 transition-colors"
+                            >
+                                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 15l-3-3m0 0l3-3m-3 3h8M3 12a9 9 0 1118 0 9 9 0 01-18 0z" />
+                                </svg>
+                                <span className="flex-1 text-left">Exit Impersonation</span>
+                            </button>
+                        </div>
+                    )}
+
+                    {/* Logout */}
+                    {isAuthenticated && (
+                        <div className="px-4 py-6 border-t border-edge-subtle">
+                            <button
+                                onClick={handleLogout}
+                                className="w-full px-4 py-3 bg-red-500/15 text-red-400 font-medium rounded-lg hover:bg-red-500/25 transition-colors"
+                                data-testid="more-drawer-logout"
+                            >
+                                Logout
+                            </button>
+                        </div>
+                    )}
+                </div>{/* end scrollable content area */}
+            </div>
+        </div>
+    );
+}
+
+/** Profile submenu — renders profile nav sections inline in the MoreDrawer */
+function ProfileSubmenuContent({ pathname, onClose }: { pathname: string; onClose: () => void }) {
+    const navigate = useNavigate();
+    const resetOnboarding = useResetOnboarding();
+
+    const handleRerunWizard = () => {
+        resetOnboarding.mutate(undefined, {
+            onSuccess: () => {
+                navigate('/onboarding?rerun=1');
+            },
+        });
+    };
+
+    return (
+        <div className="px-4 pb-3 space-y-3" data-testid="profile-submenu">
+            {PROFILE_SECTIONS.map((section) => (
+                <div key={section.id}>
+                    <div className="flex items-center gap-2 px-3 py-1.5 text-secondary">
+                        <span className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider">
+                            {section.icon}
+                            {section.label}
+                        </span>
+                    </div>
+                    <div className="mt-1 space-y-0.5">
+                        {section.children.map((child) => (
+                            <Link
+                                key={child.to}
+                                to={child.to}
+                                onClick={onClose}
+                                className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors ${pathname === child.to
+                                    ? 'text-emerald-400 bg-emerald-500/10 font-medium'
+                                    : 'text-muted hover:text-foreground hover:bg-overlay/20'
+                                    }`}
+                            >
+                                <span className="truncate min-w-0 flex-1">{child.label}</span>
                             </Link>
                         ))}
-                    </nav>
-                )}
-
-                {/* Controls section */}
-                <div className="px-4 py-4 border-t border-edge-subtle">
-                    {/* Theme cycling */}
-                    <button
-                        onClick={cycleTheme}
-                        className="flex items-center gap-3 w-full px-4 py-3 rounded-lg font-medium text-foreground hover:bg-overlay/20 transition-colors"
-                        data-testid="more-drawer-theme-toggle"
-                    >
-                        {themeIcon}
-                        <span className="flex-1 text-left">{themeLabel}</span>
-                    </button>
-
-                    {/* Send Feedback */}
-                    {onFeedbackClick && (
-                        <button
-                            onClick={() => {
-                                onClose();
-                                onFeedbackClick();
-                            }}
-                            className="flex items-center gap-3 w-full px-4 py-3 rounded-lg font-medium text-foreground hover:bg-overlay/20 transition-colors"
-                            data-testid="more-drawer-feedback"
-                        >
-                            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 10h.01M12 10h.01M16 10h.01M9 16H5a2 2 0 01-2-2V6a2 2 0 012-2h14a2 2 0 012 2v8a2 2 0 01-2 2h-5l-5 5v-5z" />
-                            </svg>
-                            <span className="flex-1 text-left">Send Feedback</span>
-                        </button>
-                    )}
+                    </div>
                 </div>
+            ))}
 
-                {/* Impersonation section (admin/operator only) */}
-                {isOperatorOrAdmin(user) && !isImpersonating && (
-                    <div className="px-4 py-4 border-t border-edge-subtle">
-                        <button
-                            onClick={() => {
-                                const next = !showImpersonateMenu;
-                                setShowImpersonateMenu(next);
-                                if (!next) setImpersonateSearch('');
-                                else setTimeout(() => impersonateSearchRef.current?.focus(), 0);
-                            }}
-                            className="flex items-center gap-3 w-full px-4 py-3 rounded-lg font-medium text-foreground hover:bg-overlay/20 transition-colors"
-                        >
-                            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-                            </svg>
-                            <span className="flex-1 text-left">Impersonate</span>
-                            <svg
-                                className={`w-4 h-4 text-muted transition-transform ${showImpersonateMenu ? 'rotate-180' : ''}`}
-                                fill="none"
-                                stroke="currentColor"
-                                viewBox="0 0 24 24"
-                            >
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                            </svg>
-                        </button>
-
-                        {showImpersonateMenu && (
-                            <div className="mt-2 rounded-lg bg-panel/50 overflow-hidden">
-                                <div className="p-3">
-                                    <input
-                                        ref={impersonateSearchRef}
-                                        type="text"
-                                        value={impersonateSearch}
-                                        onChange={(e) => setImpersonateSearch(e.target.value)}
-                                        placeholder="Search users..."
-                                        className="w-full px-3 py-2 text-sm bg-surface/50 border border-edge rounded-lg text-foreground placeholder:text-dim focus:outline-none focus:ring-1 focus:ring-emerald-500"
-                                    />
-                                </div>
-                                <div className="max-h-48 overflow-y-auto">
-                                    {(() => {
-                                        const filtered = (impersonateUsers ?? []).filter((u) =>
-                                            u.username.toLowerCase().includes(impersonateSearch.toLowerCase())
-                                        );
-                                        return filtered.length > 0 ? (
-                                            filtered.map((u) => {
-                                                const impAvatar = resolveAvatar(toAvatarUser(u));
-                                                return (
-                                                    <button
-                                                        key={u.id}
-                                                        onClick={() => handleImpersonate(u.id)}
-                                                        className="flex items-center gap-3 w-full px-4 py-2.5 text-sm text-muted hover:bg-overlay/30 hover:text-foreground transition-colors"
-                                                    >
-                                                        {impAvatar.url ? (
-                                                            <img
-                                                                src={impAvatar.url}
-                                                                alt={u.username}
-                                                                className="w-6 h-6 rounded-full bg-faint object-cover"
-                                                                onError={(e) => {
-                                                                    e.currentTarget.style.display = 'none';
-                                                                    e.currentTarget.nextElementSibling?.classList.remove('hidden');
-                                                                }}
-                                                            />
-                                                        ) : null}
-                                                        <div className={`w-6 h-6 rounded-full bg-faint flex items-center justify-center text-xs font-semibold text-muted ${impAvatar.url ? 'hidden' : ''}`}>
-                                                            {u.username.charAt(0).toUpperCase()}
-                                                        </div>
-                                                        {u.username}
-                                                    </button>
-                                                );
-                                            })
-                                        ) : (
-                                            <p className="px-4 py-3 text-xs text-dim">
-                                                {impersonateSearch ? 'No matches' : 'No users available'}
-                                            </p>
-                                        );
-                                    })()}
-                                </div>
-                            </div>
-                        )}
-                    </div>
-                )}
-
-                {/* Exit Impersonation */}
-                {isImpersonating && (
-                    <div className="px-4 py-4 border-t border-edge-subtle">
-                        <button
-                            onClick={handleExitImpersonation}
-                            className="flex items-center gap-3 w-full px-4 py-3 rounded-lg font-medium text-amber-400 bg-amber-500/10 hover:bg-amber-500/20 transition-colors"
-                        >
-                            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 15l-3-3m0 0l3-3m-3 3h8M3 12a9 9 0 1118 0 9 9 0 01-18 0z" />
-                            </svg>
-                            <span className="flex-1 text-left">Exit Impersonation</span>
-                        </button>
-                    </div>
-                )}
-
-                {/* Logout */}
-                {isAuthenticated && (
-                    <div className="px-4 py-6 border-t border-edge-subtle">
-                        <button
-                            onClick={handleLogout}
-                            className="w-full px-4 py-3 bg-red-500/15 text-red-400 font-medium rounded-lg hover:bg-red-500/25 transition-colors"
-                            data-testid="more-drawer-logout"
-                        >
-                            Logout
-                        </button>
-                    </div>
-                )}
+            {/* Setup Wizard re-run */}
+            <div className="border-t border-edge/30 pt-3">
+                <button
+                    onClick={handleRerunWizard}
+                    disabled={resetOnboarding.isPending}
+                    className="flex items-center gap-2 px-3 py-2 rounded-lg text-sm text-muted hover:text-foreground hover:bg-overlay/20 transition-colors w-full"
+                >
+                    <svg className="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.75} d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
+                    </svg>
+                    <span className="truncate min-w-0 flex-1">
+                        {resetOnboarding.isPending ? 'Resetting...' : 'Re-run Setup Wizard'}
+                    </span>
+                </button>
             </div>
+        </div>
+    );
+}
+
+/**
+ * Admin submenu — conditionally rendered so hooks only fire when expanded.
+ * Uses the same builder functions and SidebarNavItem from admin-sidebar.
+ */
+function AdminSubmenuContent({ pathname, onClose }: { pathname: string; onClose: () => void }) {
+    const { plugins } = usePluginAdmin();
+    const { oauthStatus, igdbStatus, discordBotStatus } = useAdminSettings();
+
+    const coreIntegrations = buildCoreIntegrationItems({
+        discord: {
+            configured: oauthStatus.data?.configured ?? false,
+            loading: oauthStatus.isLoading,
+        },
+        discordBot: {
+            connected: discordBotStatus.data?.connected ?? false,
+            configured: discordBotStatus.data?.configured ?? false,
+            loading: discordBotStatus.isLoading,
+        },
+        igdb: {
+            configured: igdbStatus.data?.configured ?? false,
+            loading: igdbStatus.isLoading,
+        },
+    });
+    const pluginIntegrations = buildPluginIntegrationItems(plugins.data ?? []);
+    const sections = buildNavSections(coreIntegrations, pluginIntegrations);
+
+    return (
+        <div className="px-4 pb-3 space-y-3" data-testid="admin-submenu">
+            {sections.map((section) => (
+                <div key={section.id}>
+                    <div className="flex items-center gap-2.5 px-3 py-1.5 text-secondary">
+                        <span className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wider">
+                            {section.icon}
+                            {section.label}
+                        </span>
+                    </div>
+                    <div className="mt-1 space-y-0.5">
+                        {section.children.map((child) => (
+                            <SidebarNavItem
+                                key={child.to}
+                                item={child}
+                                isActive={pathname === child.to}
+                                onNavigate={onClose}
+                            />
+                        ))}
+                    </div>
+                </div>
+            ))}
         </div>
     );
 }

--- a/web/src/components/profile/profile-layout.tsx
+++ b/web/src/components/profile/profile-layout.tsx
@@ -1,7 +1,6 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { Outlet, Navigate, useLocation, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../../hooks/use-auth';
-import { Z_INDEX } from '../../lib/z-index';
 
 import { ProfileSidebar } from './profile-sidebar';
 import { toast } from '../../lib/toast';
@@ -11,9 +10,6 @@ export function ProfileLayout() {
     const { user, isLoading: authLoading, isAuthenticated, refetch } = useAuth();
     const location = useLocation();
     const [searchParams, setSearchParams] = useSearchParams();
-    const [mobileOpen, setMobileOpen] = useState(false);
-
-    const closeMobile = useCallback(() => setMobileOpen(false), []);
 
     // Handle Discord link callback search params (?linked=success/error)
     const processedRef = useRef(false);
@@ -32,20 +28,6 @@ export function ProfileLayout() {
             setSearchParams({});
         }
     }, [searchParams, setSearchParams, refetch]);
-
-    useEffect(() => {
-        if (!mobileOpen) return;
-        function handleEscape(e: KeyboardEvent) {
-            if (e.key === 'Escape') setMobileOpen(false);
-        }
-        document.addEventListener('keydown', handleEscape);
-        document.body.style.overflow = 'hidden';
-        return () => {
-            document.removeEventListener('keydown', handleEscape);
-            document.body.style.overflow = '';
-        };
-    }, [mobileOpen]);
-
 
     if (location.pathname === '/profile' || location.pathname === '/profile/') {
         return <Navigate to="/profile/identity" replace />;
@@ -79,19 +61,7 @@ export function ProfileLayout() {
             <div className="profile-page__stars" />
 
             <div className="relative z-10 max-w-6xl mx-auto pt-6">
-                <div className="flex items-center gap-3 mb-6 md:hidden">
-                    <button
-                        type="button"
-                        className="p-2 -ml-2 rounded-lg text-muted hover:text-foreground hover:bg-overlay/30 transition-colors"
-                        onClick={() => setMobileOpen(true)}
-                        aria-label="Open profile menu"
-                    >
-                        <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
-                        </svg>
-                    </button>
-                    <h1 className="text-lg font-bold text-foreground">My Profile</h1>
-                </div>
+                <h1 className="text-lg font-bold text-foreground mb-6 md:hidden">My Profile</h1>
 
                 <div className="flex gap-6">
                     <aside className="hidden md:block w-56 flex-shrink-0">
@@ -103,34 +73,6 @@ export function ProfileLayout() {
                     <main className="flex-1 min-w-0">
                         <Outlet />
                     </main>
-                </div>
-
-                <div
-                    className={`fixed inset-0 md:hidden ${mobileOpen ? 'visible' : 'invisible pointer-events-none'}`}
-                    style={{ zIndex: Z_INDEX.MODAL }}
-                    aria-hidden={!mobileOpen}
-                >
-                    <div
-                        className={`absolute inset-0 bg-black/60 backdrop-blur-sm transition-opacity duration-200 ${mobileOpen ? 'opacity-100' : 'opacity-0'}`}
-                        onClick={closeMobile}
-                        aria-hidden="true"
-                    />
-                    <div className={`absolute top-0 right-0 w-72 h-full bg-surface border-l border-edge-subtle shadow-2xl transform transition-transform duration-200 ease-out ${mobileOpen ? 'translate-x-0' : 'translate-x-full'}`}>
-                        <div className="flex items-center justify-between px-4 py-3 border-b border-edge-subtle">
-                            <span className="font-semibold text-foreground text-sm">Profile</span>
-                            <button
-                                type="button"
-                                onClick={closeMobile}
-                                className="flex items-center justify-center min-w-[44px] min-h-[44px] rounded-lg text-muted hover:text-foreground hover:bg-overlay/30 transition-colors"
-                                aria-label="Close profile menu"
-                            >
-                                <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
-                                </svg>
-                            </button>
-                        </div>
-                        <ProfileSidebar onNavigate={closeMobile} />
-                    </div>
                 </div>
             </div>
         </div>

--- a/web/src/components/profile/profile-nav-data.tsx
+++ b/web/src/components/profile/profile-nav-data.tsx
@@ -1,0 +1,62 @@
+export interface NavItem {
+    to: string;
+    label: string;
+}
+
+export interface NavSection {
+    id: string;
+    label: string;
+    icon: React.ReactNode;
+    children: NavItem[];
+}
+
+const IdentityIcon = (
+    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.75} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
+    </svg>
+);
+
+const PreferencesIcon = (
+    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.75} d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
+    </svg>
+);
+
+const GamingIcon = (
+    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.75} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.75} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+    </svg>
+);
+
+export const SECTIONS: NavSection[] = [
+    {
+        id: 'identity',
+        label: 'Identity',
+        icon: IdentityIcon,
+        children: [
+            { to: '/profile/identity', label: 'My Profile' },
+            { to: '/profile/identity/discord', label: 'Discord' },
+            { to: '/profile/identity/avatar', label: 'Avatar' },
+        ],
+    },
+    {
+        id: 'preferences',
+        label: 'Preferences',
+        icon: PreferencesIcon,
+        children: [
+            { to: '/profile/preferences/appearance', label: 'Appearance' },
+            { to: '/profile/preferences/timezone', label: 'Timezone' },
+            { to: '/profile/preferences/notifications', label: 'Notifications' },
+        ],
+    },
+    {
+        id: 'gaming',
+        label: 'Gaming',
+        icon: GamingIcon,
+        children: [
+            { to: '/profile/gaming/game-time', label: 'Game Time' },
+            { to: '/profile/gaming/characters', label: 'Characters' },
+        ],
+    },
+];

--- a/web/src/components/profile/profile-sidebar.tsx
+++ b/web/src/components/profile/profile-sidebar.tsx
@@ -1,68 +1,6 @@
 import { Link, useLocation, useNavigate } from 'react-router-dom';
 import { useResetOnboarding } from '../../hooks/use-onboarding-fte';
-
-interface NavItem {
-    to: string;
-    label: string;
-}
-
-interface NavSection {
-    id: string;
-    label: string;
-    icon: React.ReactNode;
-    children: NavItem[];
-}
-
-const IdentityIcon = (
-    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.75} d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-    </svg>
-);
-
-const PreferencesIcon = (
-    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.75} d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4" />
-    </svg>
-);
-
-const GamingIcon = (
-    <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.75} d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z" />
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.75} d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-    </svg>
-);
-
-const SECTIONS: NavSection[] = [
-    {
-        id: 'identity',
-        label: 'Identity',
-        icon: IdentityIcon,
-        children: [
-            { to: '/profile/identity', label: 'My Profile' },
-            { to: '/profile/identity/discord', label: 'Discord' },
-            { to: '/profile/identity/avatar', label: 'Avatar' },
-        ],
-    },
-    {
-        id: 'preferences',
-        label: 'Preferences',
-        icon: PreferencesIcon,
-        children: [
-            { to: '/profile/preferences/appearance', label: 'Appearance' },
-            { to: '/profile/preferences/timezone', label: 'Timezone' },
-            { to: '/profile/preferences/notifications', label: 'Notifications' },
-        ],
-    },
-    {
-        id: 'gaming',
-        label: 'Gaming',
-        icon: GamingIcon,
-        children: [
-            { to: '/profile/gaming/game-time', label: 'Game Time' },
-            { to: '/profile/gaming/characters', label: 'Characters' },
-        ],
-    },
-];
+import { SECTIONS } from './profile-nav-data';
 
 interface ProfileSidebarProps {
     onNavigate?: () => void;
@@ -99,11 +37,10 @@ export function ProfileSidebar({ onNavigate }: ProfileSidebarProps) {
                                     key={child.to}
                                     to={child.to}
                                     onClick={onNavigate}
-                                    className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors ${
-                                        location.pathname === child.to
-                                            ? 'text-emerald-400 bg-emerald-500/10 font-medium'
-                                            : 'text-muted hover:text-foreground hover:bg-overlay/20'
-                                    }`}
+                                    className={`flex items-center gap-2 px-3 py-2 rounded-lg text-sm transition-colors ${location.pathname === child.to
+                                        ? 'text-emerald-400 bg-emerald-500/10 font-medium'
+                                        : 'text-muted hover:text-foreground hover:bg-overlay/20'
+                                        }`}
                                 >
                                     <span className="truncate min-w-0 flex-1">{child.label}</span>
                                 </Link>


### PR DESCRIPTION
## Summary

Eliminate the dual-hamburger problem on Profile and Admin Settings pages by folding page-level sidebar navigation into the MoreDrawer as expandable accordion submenus. Desktop layout is untouched.

## Changes

### MoreDrawer Accordion (`more-drawer.tsx`)
- Profile row (avatar + username) and Admin Settings row become expandable accordion toggles
- Auto-expand matching submenu based on current route when drawer opens
- Chevron rotation animation for expand/collapse state
- `aria-expanded` for accessibility
- Scrollable content area (`flex-col` + `overflow-y-auto`)
- Conditional rendering of `AdminSubmenuContent` so hooks only fire when expanded
- `onClose` threaded through submenu components for explicit drawer close on navigation

### Nav Data Extraction
- **`profile-nav-data.tsx`** [NEW]: Types, icons, and `SECTIONS` constant extracted from profile-sidebar
- **`admin-nav-data.tsx`** [NEW]: Types, icons, and builder functions extracted from admin-sidebar
- Both sidebar component files now import from their respective data files (satisfies `react-refresh/only-export-components`)

### Mobile Hamburger Removal
- **`profile-layout.tsx`**: Removed mobile hamburger button, right-sliding drawer overlay, and associated state
- **`admin-settings-layout.tsx`**: Removed mobile hamburger button, right-sliding drawer overlay, and associated state
- Desktop sidebar behavior completely preserved on both pages

## Testing

| Check | Result |
|---|---|
| TypeScript compilation | ✅ Zero errors |
| Unit tests | ✅ 565/565 pass (35 MoreDrawer tests including 7 new) |
| ESLint | ✅ Zero errors on all changed files |

### New Tests Added
- Profile accordion: expand/collapse, auto-expand, chevron rotation, active item highlighting, Re-run Setup Wizard, aria-expanded
- Admin accordion (admin user): toggle, auto-expand, chevron, aria-expanded