### PR TITLE
ROK-369: Add missing bot permissions for EP-11 stories

### DIFF
--- a/api/src/discord-bot/discord-bot-client.service.spec.ts
+++ b/api/src/discord-bot/discord-bot-client.service.spec.ts
@@ -67,10 +67,12 @@ jest.mock('discord.js', () => {
     PermissionsBitField: {
       Flags: {
         ManageRoles: BigInt(1),
+        ManageChannels: BigInt(32),
+        CreateInstantInvite: BigInt(64),
+        ViewChannel: BigInt(16),
         SendMessages: BigInt(2),
         EmbedLinks: BigInt(4),
         ReadMessageHistory: BigInt(8),
-        ViewChannel: BigInt(16),
       },
     },
   };
@@ -454,7 +456,7 @@ describe('DiscordBotClientService', () => {
     it('should return all false when no client exists', () => {
       const results = service.checkPermissions();
 
-      expect(results).toHaveLength(5);
+      expect(results).toHaveLength(7);
       results.forEach((r) => expect(r.granted).toBe(false));
     });
 
@@ -464,7 +466,7 @@ describe('DiscordBotClientService', () => {
 
       const results = service.checkPermissions();
 
-      expect(results).toHaveLength(5);
+      expect(results).toHaveLength(7);
       results.forEach((r) => expect(r.granted).toBe(false));
     });
 
@@ -477,7 +479,7 @@ describe('DiscordBotClientService', () => {
 
       const results = service.checkPermissions();
 
-      expect(results).toHaveLength(5);
+      expect(results).toHaveLength(7);
       results.forEach((r) => expect(r.granted).toBe(false));
     });
 
@@ -491,7 +493,7 @@ describe('DiscordBotClientService', () => {
 
       const results = service.checkPermissions();
 
-      expect(results).toHaveLength(5);
+      expect(results).toHaveLength(7);
       results.forEach((r) => expect(r.granted).toBe(false));
     });
 
@@ -513,7 +515,7 @@ describe('DiscordBotClientService', () => {
 
       const results = service.checkPermissions();
 
-      expect(results).toHaveLength(5);
+      expect(results).toHaveLength(7);
       const manageRoles = results.find((r) => r.name === 'Manage Roles');
       expect(manageRoles?.granted).toBe(false);
       const sendMessages = results.find((r) => r.name === 'Send Messages');

--- a/api/src/discord-bot/discord-bot-client.service.ts
+++ b/api/src/discord-bot/discord-bot-client.service.ts
@@ -27,13 +27,18 @@ export interface PermissionCheckResult {
  */
 const REQUIRED_PERMISSIONS: { label: string; flag: bigint }[] = [
   { label: 'Manage Roles', flag: PermissionsBitField.Flags.ManageRoles },
+  { label: 'Manage Channels', flag: PermissionsBitField.Flags.ManageChannels },
+  {
+    label: 'Create Instant Invite',
+    flag: PermissionsBitField.Flags.CreateInstantInvite,
+  },
+  { label: 'View Channels', flag: PermissionsBitField.Flags.ViewChannel },
   { label: 'Send Messages', flag: PermissionsBitField.Flags.SendMessages },
   { label: 'Embed Links', flag: PermissionsBitField.Flags.EmbedLinks },
   {
     label: 'Read Message History',
     flag: PermissionsBitField.Flags.ReadMessageHistory,
   },
-  { label: 'View Channels', flag: PermissionsBitField.Flags.ViewChannel },
 ];
 
 @Injectable()

--- a/web/src/components/admin/DiscordBotForm.tsx
+++ b/web/src/components/admin/DiscordBotForm.tsx
@@ -116,7 +116,9 @@ export function DiscordBotForm() {
                 <ul className="text-xs text-secondary space-y-0.5 list-disc list-inside ml-2">
                     <li>Go to the <strong>OAuth2 → URL Generator</strong> tab</li>
                     <li>Under <strong>Scopes</strong>, check <strong>bot</strong> and <strong>applications.commands</strong></li>
-                    <li>A <strong>Bot Permissions</strong> section will appear — enable: <em>Manage Roles</em>, <em>Send Messages</em>, <em>Embed Links</em>, <em>Read Message History</em>, and <em>View Channels</em></li>
+                    <li>A <strong>Bot Permissions</strong> section will appear — enable these permissions:</li>
+                    <li className="ml-4"><strong>General:</strong> <em>Manage Roles</em>, <em>Manage Channels</em>, <em>Create Instant Invite</em>, <em>View Channels</em></li>
+                    <li className="ml-4"><strong>Text:</strong> <em>Send Messages</em>, <em>Embed Links</em>, <em>Read Message History</em></li>
                     <li>Copy the generated URL, open it in your browser, and select your server</li>
                 </ul>
             </div>


### PR DESCRIPTION
## Summary
- Adds `ManageChannels` and `CreateInstantInvite` to `REQUIRED_PERMISSIONS` array (5 → 7 permissions)
- Updates admin setup instructions to list all 7 permissions grouped by General and Text
- Updates test assertions to reflect expanded permission set

## Story
[ROK-369](https://linear.app/roknua-projects/issue/ROK-369/add-missing-bot-permissions-to-setup-instructions-and-permission-check)

## Changes
- `api/src/discord-bot/discord-bot-client.service.ts` — 2 new permissions added
- `web/src/components/admin/DiscordBotForm.tsx` — Setup instructions updated
- `api/src/discord-bot/discord-bot-client.service.spec.ts` — Test mocks/assertions updated

## Test Plan
- [x] TypeScript compiles clean
- [x] Lint passes
- [x] All 26 discord-bot-client tests pass
- [ ] Manual smoke test on staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)