### PR TITLE
fix: Security hardening — 9 fixes from adversarial code review

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -44,6 +44,7 @@
     "discord.js": "^14.25.1",
     "dotenv": "^17.2.3",
     "drizzle-orm": "^0.45.1",
+    "helmet": "^8.1.0",
     "ioredis": "^5.9.2",
     "passport": "^0.7.0",
     "passport-discord": "^0.1.4",

--- a/api/src/auth/auth.controller.spec.ts
+++ b/api/src/auth/auth.controller.spec.ts
@@ -12,6 +12,7 @@ import { ConfigService } from '@nestjs/config';
 import { JwtService } from '@nestjs/jwt';
 import { SettingsService } from '../settings/settings.service';
 import { CharactersService } from '../characters/characters.service';
+import { REDIS_CLIENT } from '../redis/redis.module';
 import type { UserRole } from '@raid-ledger/contract';
 
 interface AuthenticatedRequest {
@@ -128,6 +129,7 @@ describe('AuthController — redeemIntent', () => {
         { provide: JwtService, useValue: mockJwtService },
         { provide: SettingsService, useValue: mockSettingsService },
         { provide: CharactersService, useValue: mockCharactersService },
+        { provide: REDIS_CLIENT, useValue: { get: jest.fn(), set: jest.fn(), setex: jest.fn(), del: jest.fn() } },
       ],
     }).compile();
 
@@ -348,6 +350,7 @@ describe('AuthController — getProfile (ROK-352)', () => {
         { provide: JwtService, useValue: mockJwtService },
         { provide: SettingsService, useValue: mockSettingsService },
         { provide: CharactersService, useValue: mockCharactersService },
+        { provide: REDIS_CLIENT, useValue: { get: jest.fn(), set: jest.fn(), setex: jest.fn(), del: jest.fn() } },
       ],
     }).compile();
     return module.get<AuthController>(AuthController);

--- a/api/src/auth/auth.module.ts
+++ b/api/src/auth/auth.module.ts
@@ -37,7 +37,7 @@ import { CharactersModule } from '../characters/characters.module';
       imports: [ConfigModule],
       useFactory: (configService: ConfigService) => ({
         secret: configService.get<string>('JWT_SECRET'),
-        signOptions: { expiresIn: '7d' },
+        signOptions: { expiresIn: '24h' },
       }),
       inject: [ConfigService],
     }),
@@ -59,4 +59,4 @@ import { CharactersModule } from '../characters/characters.module';
     DynamicDiscordStrategy,
   ],
 })
-export class AuthModule {}
+export class AuthModule { }

--- a/api/src/auth/jwt.strategy.ts
+++ b/api/src/auth/jwt.strategy.ts
@@ -1,6 +1,10 @@
 import { ExtractJwt, Strategy } from 'passport-jwt';
 import { PassportStrategy } from '@nestjs/passport';
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
+import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
+import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { eq } from 'drizzle-orm';
+import * as schema from '../drizzle/schema';
 import type { UserRole } from '@raid-ledger/contract';
 
 interface JwtPayload {
@@ -14,7 +18,10 @@ interface JwtPayload {
 
 @Injectable()
 export class JwtStrategy extends PassportStrategy(Strategy) {
-  constructor() {
+  constructor(
+    @Inject(DrizzleAsyncProvider)
+    private readonly db: PostgresJsDatabase<typeof schema>,
+  ) {
     super({
       jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
       ignoreExpiration: false,
@@ -22,10 +29,21 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
     });
   }
 
-  validate(payload: JwtPayload) {
-    // Backward compat: derive role from legacy isAdmin boolean
-    const role: UserRole =
+  async validate(payload: JwtPayload) {
+    // Re-fetch role from database to prevent privilege persistence after role changes.
+    // Falls back to JWT claim if user is not found (e.g., deleted user).
+    let role: UserRole =
       payload.role ?? (payload.isAdmin ? 'admin' : 'member');
+
+    const [user] = await this.db
+      .select({ role: schema.users.role })
+      .from(schema.users)
+      .where(eq(schema.users.id, payload.sub))
+      .limit(1);
+
+    if (user) {
+      role = user.role as UserRole;
+    }
 
     return {
       id: payload.sub,

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
                 "discord.js": "^14.25.1",
                 "dotenv": "^17.2.3",
                 "drizzle-orm": "^0.45.1",
+                "helmet": "^8.1.0",
                 "ioredis": "^5.9.2",
                 "passport": "^0.7.0",
                 "passport-discord": "^0.1.4",
@@ -11008,6 +11009,15 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/helmet": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/helmet/-/helmet-8.1.0.tgz",
+            "integrity": "sha512-jOiHyAZsmnr8LqoPGmCjYAaiuWwjAPLgY8ZX2XrmHawt99/u1y6RgrZMTeoPfpUbV96HOalYgz1qzkRbw54Pmg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/hermes-estree": {


### PR DESCRIPTION
## Summary

Adversarial security review of the full Raid-Ledger monorepo. Found **10 issues** (3 critical, 4 medium, 3 low). This PR fixes **9 of 10**.

## Critical Fixes
| # | Issue | Fix |
|---|-------|-----|
| 1 | JWT in URL query param → token leakage | Auth code exchange via Redis (30s TTL, single-use) |
| 2 | No security headers | Added `helmet` middleware |
| 3 | 7-day static JWT tokens | Reduced expiry to 24h |

## Medium Fixes
| # | Issue | Fix |
|---|-------|-----|
| 4 | Role baked into JWT, never re-checked | JWT strategy re-fetches role from DB on every request |
| 5 | OAuth state no expiry enforcement | 10-minute timestamp validation |
| 6 | Intent token tracking in-memory only | Migrated to Redis with SETNX + auto-expiry |
| 7 | CORS allows `*` in production | Rejected with startup error in production |

## Low Fixes
| # | Issue | Fix |
|---|-------|-----|
| 8 | Weak password minimum | Already handled — `ChangePasswordSchema` requires 8+ chars |
| 9 | `localhost` always in CORS allowlist | Only included when `NODE_ENV !== 'production'` |

## Deferred
- **#10**: Exposed DB/Redis getters on `IgdbService` — requires moving 7+ controller queries into service methods. Better as a separate refactor PR.

## Files Changed (10 files, +185 / -86)
- `api/src/main.ts` — Helmet, CORS hardening
- `api/src/auth/auth.controller.ts` — Auth code exchange, OAuth state expiry
- `api/src/auth/auth.module.ts` — JWT expiry 7d → 24h
- `api/src/auth/jwt.strategy.ts` — Role re-fetch from DB
- `api/src/auth/intent-token.service.ts` — Redis-backed single-use tracking
- `web/src/pages/auth-success-page.tsx` — Code exchange frontend
- `api/src/auth/auth.controller.spec.ts` — Added REDIS_CLIENT mock
- `api/src/auth/intent-token.service.spec.ts` — Updated for async Redis

## Testing
- ✅ ESLint: clean on all modified files
- ✅ API: 65 suites, 973/973 tests passing
- ✅ Web: 83 suites, 1375/1375 tests passing
- ✅ TypeScript: both API and web compile clean