### PR TITLE
fix: auto-derive CORS_ORIGIN in all-in-one Docker image

### DIFF
--- a/Dockerfile.allinone
+++ b/Dockerfile.allinone
@@ -7,6 +7,7 @@
 # Environment Variables:
 #   PORT           - External port (default: 80)
 #   ADMIN_PASSWORD - Set a specific admin password on first run (default: random)
+#   CORS_ORIGIN    - Allowed CORS origin (default: auto-derived from RENDER_EXTERNAL_URL or localhost)
 #
 # Data is persisted under /data (PostgreSQL + Redis). Mount a volume to
 # retain data across container updates (e.g. Watchtower).
@@ -196,6 +197,17 @@ until redis-cli -s /tmp/redis.sock ping > /dev/null 2>&1; do
 done
 echo "✅ Redis is ready"
 
+# Auto-derive CORS_ORIGIN for all-in-one image if not explicitly set.
+# Render provides RENDER_EXTERNAL_URL; local Docker falls back to localhost.
+if [ -z "$CORS_ORIGIN" ] || [ "$CORS_ORIGIN" = "auto" ]; then
+  if [ -n "$RENDER_EXTERNAL_URL" ]; then
+    export CORS_ORIGIN="$RENDER_EXTERNAL_URL"
+  else
+    export CORS_ORIGIN="http://localhost:${NGINX_PORT:-80}"
+  fi
+  echo "🌐 CORS_ORIGIN auto-derived: $CORS_ORIGIN"
+fi
+
 # Run entrypoint (migrations, admin bootstrap, seeding)
 cd /app
 exec /usr/local/bin/docker-entrypoint.sh node /app/dist/src/main.js
@@ -259,7 +271,7 @@ ENV DATABASE_URL=postgresql://raid_ledger:raid_ledger@localhost:5432/raid_ledger
 ENV REDIS_URL=/tmp/redis.sock
 ENV JWT_SECRET=raid-ledger-default-secret-change-in-production
 ENV DOTENV_CONFIG_QUIET=true
-ENV CORS_ORIGIN=*
+ENV CORS_ORIGIN=auto
 ENV CLIENT_URL=
 ENV ADMIN_PASSWORD=
 


### PR DESCRIPTION
## Summary
- The security-hardening PR (#94) added a production check rejecting `CORS_ORIGIN=*`, but `Dockerfile.allinone` still defaulted to `*` — crashing the Render deploy on startup
- Changed the default to `auto`, which the start script resolves at runtime from Render's `RENDER_EXTERNAL_URL` or falls back to `http://localhost:<port>` for local Docker
- Self-hosters can still override `CORS_ORIGIN` explicitly via `-e CORS_ORIGIN=https://my-domain.com`

## Test plan
- [ ] Verify Render deploy starts successfully (no CORS crash)
- [ ] Verify local `docker run` still works with auto-derived localhost origin
- [ ] Verify explicit `CORS_ORIGIN=https://example.com` override still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)