### PR TITLE
chore: remove remaining staging branch references

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -11,4 +11,4 @@
 - [ ] TypeScript compiles clean (`npx tsc --noEmit`)
 - [ ] Lint passes (`npm run lint`)
 - [ ] Unit tests pass (`npm run test`)
-- [ ] Manual smoke test on staging
+- [ ] Manual smoke test (`deploy_dev.sh --branch <feature-branch>`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - staging
   pull_request:
     branches:
       - main

--- a/scripts/deploy_dev.sh
+++ b/scripts/deploy_dev.sh
@@ -10,7 +10,7 @@
 #   ./scripts/deploy_dev.sh --rebuild        # Rebuild contract package, then start
 #   ./scripts/deploy_dev.sh --fresh          # Reset DB, new admin password, restart
 #   ./scripts/deploy_dev.sh --reset-password # Reset admin password (no data loss)
-#   ./scripts/deploy_dev.sh --branch staging # Switch to staging branch, then start
+#   ./scripts/deploy_dev.sh --branch rok-123 # Switch to feature branch, then start
 #   ./scripts/deploy_dev.sh --down           # Stop everything
 #   ./scripts/deploy_dev.sh --status         # Show process/container status
 #   ./scripts/deploy_dev.sh --logs           # Tail API and web logs
@@ -62,10 +62,9 @@ check_branch_for_testing() {
     local current_branch
     current_branch=$(get_current_branch)
 
-    # Warn if not on staging or main (common testing branches)
-    if [ "$current_branch" != "staging" ] && [ "$current_branch" != "main" ]; then
+    # Warn if not on main (feature branches are fine for testing)
+    if [ "$current_branch" != "main" ]; then
         print_warning "⚠️  BRANCH WARNING: Deploying from branch '$current_branch'"
-        print_warning "    For operator testing, you usually want 'staging'"
         print_warning "    For post-merge verification, you usually want 'main'"
         echo ""
         echo -e "  ${YELLOW}Press Ctrl+C to cancel, or wait 5 seconds to continue...${NC}"
@@ -372,7 +371,7 @@ case "${1:-}" in
         echo "  --help            Show this help message"
         echo ""
         echo "Examples:"
-        echo "  $0 --branch staging    # Switch to staging and deploy"
+        echo "  $0 --branch rok-123    # Switch to feature branch and deploy"
         echo "  $0 --rebuild           # Rebuild contract and start"
         ;;
     *)


### PR DESCRIPTION
## Summary
- Completes staging branch retirement started in PR #105
- Removes last references from CI, PR template, and deploy script
- Remote `staging` branch and its protection rule have been deleted

## Changes
- `.github/workflows/ci.yml` — removed `staging` from push triggers
- `.github/pull_request_template.md` — updated smoke test to reference `deploy_dev.sh --branch`
- `scripts/deploy_dev.sh` — updated branch warnings and help examples

## Test Plan
- [x] No staging references remain in CI, templates, or scripts
- [x] Remote branch deleted, protection rule removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)