### PR TITLE
fix(ROK-379): rename Voice Monitor to Event Announcements in channel binding labels

### DIFF
--- a/api/src/discord-bot/commands/bind.command.ts
+++ b/api/src/discord-bot/commands/bind.command.ts
@@ -122,7 +122,7 @@ export class BindCommand
       const behaviorLabel =
         behavior === 'game-announcements'
           ? 'Event Announcements'
-          : 'Voice Monitor';
+          : 'Event Announcements';
 
       const description = [
         `**#${channelName}** bound for **${behaviorLabel}**`,

--- a/api/src/discord-bot/commands/bindings.command.spec.ts
+++ b/api/src/discord-bot/commands/bindings.command.spec.ts
@@ -213,7 +213,7 @@ describe('BindingsCommand', () => {
       );
     });
 
-    it('should label game-voice-monitor bindings as "Voice Monitor"', async () => {
+    it('should label game-voice-monitor bindings as "Event Announcements"', async () => {
       bindingsService.getBindings.mockResolvedValue([
         makeBinding({ bindingPurpose: 'game-voice-monitor', gameId: null }),
       ]);

--- a/api/src/discord-bot/commands/bindings.command.ts
+++ b/api/src/discord-bot/commands/bindings.command.ts
@@ -87,7 +87,7 @@ export class BindingsCommand
           binding.bindingPurpose === 'game-announcements'
             ? 'Announcements'
             : binding.bindingPurpose === 'game-voice-monitor'
-              ? 'Voice Monitor'
+              ? 'Event Announcements'
               : binding.bindingPurpose;
 
         return `<#${binding.channelId}> → ${gameName} (${behaviorLabel})`;

--- a/web/src/components/admin/BindingConfigForm.test.tsx
+++ b/web/src/components/admin/BindingConfigForm.test.tsx
@@ -69,7 +69,7 @@ describe('BindingConfigForm', () => {
     expect(screen.getByRole('button', { name: 'Cancel' })).toBeInTheDocument();
   });
 
-  // ── Voice monitor mode (shows all config fields) ──────────────
+  // ── Event Announcements mode (shows all config fields) ────────
 
   it('shows voice monitor fields when bindingPurpose is game-voice-monitor', () => {
     render(

--- a/web/src/components/admin/ChannelBindingList.test.tsx
+++ b/web/src/components/admin/ChannelBindingList.test.tsx
@@ -127,7 +127,7 @@ describe('ChannelBindingList', () => {
     expect(screen.getByText('Announcements')).toBeInTheDocument();
   });
 
-  it('shows "Voice Monitor" badge for game-voice-monitor binding', () => {
+  it('shows "Event Announcements" badge for game-voice-monitor binding', () => {
     render(
       <ChannelBindingList
         bindings={[makeBinding({ bindingPurpose: 'game-voice-monitor' })]}
@@ -138,7 +138,7 @@ describe('ChannelBindingList', () => {
       />,
     );
 
-    expect(screen.getByText('Voice Monitor')).toBeInTheDocument();
+    expect(screen.getByText('Event Announcements')).toBeInTheDocument();
   });
 
   it('shows "General Lobby" badge for general-lobby binding', () => {

--- a/web/src/components/admin/ChannelBindingList.tsx
+++ b/web/src/components/admin/ChannelBindingList.tsx
@@ -4,7 +4,7 @@ import { BindingConfigForm } from './BindingConfigForm';
 
 const BEHAVIOR_LABELS: Record<string, string> = {
   'game-announcements': 'Event Announcements',
-  'game-voice-monitor': 'Voice Monitor',
+  'game-voice-monitor': 'Event Announcements',
   'general-lobby': 'General Lobby',
 };
 
@@ -14,7 +14,7 @@ const BEHAVIOR_BADGES: Record<string, { label: string; className: string }> = {
     className: 'bg-cyan-500/15 text-cyan-400',
   },
   'game-voice-monitor': {
-    label: 'Voice Monitor',
+    label: 'Event Announcements',
     className: 'bg-purple-500/15 text-purple-400',
   },
   'general-lobby': {


### PR DESCRIPTION
## Summary
- Renamed all user-facing "Voice Monitor" labels to "Event Announcements" in Discord bot commands and web admin panel
- Internal enum value `game-voice-monitor` unchanged — display-label-only fix, no migration needed

## Changes
- `bind.command.ts` — confirmation embed label
- `bindings.command.ts` — bindings list label
- `ChannelBindingList.tsx` — badge + tooltip labels
- Updated 3 test files to match new labels

## Test plan
- [x] TypeScript clean (api + web)
- [x] ESLint clean (api + web)  
- [x] 1026 API tests pass
- [x] 1461 web tests pass
- [x] All 3 affected test suites updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)