### PR TITLE
fix: Blizzard character auto-sync job — schedule + manual trigger (ROK-398)

### DIFF
--- a/api/src/plugins/plugin-host/cron-manager.service.spec.ts
+++ b/api/src/plugins/plugin-host/cron-manager.service.spec.ts
@@ -8,28 +8,38 @@ import type { CronRegistrar } from './extension-points';
 describe('CronManagerService', () => {
   let service: CronManagerService;
   const createdJobs: CronJob[] = [];
+  let registeredJobNames: Set<string>;
   let mockSchedulerRegistry: {
     addCronJob: jest.Mock;
     deleteCronJob: jest.Mock;
     getCronJobs: jest.Mock;
+    getCronJob: jest.Mock;
   };
   let mockPluginRegistry: {
     getAdapter: jest.Mock;
+    getAdaptersForExtensionPoint: jest.Mock;
   };
 
   beforeEach(async () => {
+    registeredJobNames = new Set();
     mockSchedulerRegistry = {
-      addCronJob: jest
-        .fn()
-        .mockImplementation((_name: string, job: CronJob) => {
-          createdJobs.push(job);
-        }),
-      deleteCronJob: jest.fn(),
+      addCronJob: jest.fn().mockImplementation((name: string, job: CronJob) => {
+        registeredJobNames.add(name);
+        createdJobs.push(job);
+      }),
+      deleteCronJob: jest.fn().mockImplementation((name: string) => {
+        registeredJobNames.delete(name);
+      }),
       getCronJobs: jest.fn().mockReturnValue(new Map()),
+      getCronJob: jest.fn().mockImplementation((name: string) => {
+        if (registeredJobNames.has(name)) return {};
+        throw new Error(`No Cron Job was found with the given name (${name})`);
+      }),
     };
 
     mockPluginRegistry = {
       getAdapter: jest.fn(),
+      getAdaptersForExtensionPoint: jest.fn().mockReturnValue(new Map()),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -124,6 +134,58 @@ describe('CronManagerService', () => {
     });
   });
 
+  describe('onApplicationBootstrap()', () => {
+    it('should register cron jobs for all active plugins at startup', () => {
+      const adapter: CronRegistrar = {
+        getCronJobs: () => [
+          { name: 'sync', cronExpression: '0 */6 * * *', handler: jest.fn() },
+        ],
+      };
+
+      mockPluginRegistry.getAdaptersForExtensionPoint.mockReturnValue(
+        new Map([['blizzard', adapter]]),
+      );
+
+      service.onApplicationBootstrap();
+
+      expect(mockSchedulerRegistry.addCronJob).toHaveBeenCalledTimes(1);
+      expect(mockSchedulerRegistry.addCronJob).toHaveBeenCalledWith(
+        'blizzard:sync',
+        expect.any(CronJob),
+      );
+    });
+
+    it('should handle no active plugins gracefully', () => {
+      mockPluginRegistry.getAdaptersForExtensionPoint.mockReturnValue(
+        new Map(),
+      );
+
+      expect(() => service.onApplicationBootstrap()).not.toThrow();
+      expect(mockSchedulerRegistry.addCronJob).not.toHaveBeenCalled();
+    });
+
+    it('should skip jobs already in SchedulerRegistry (idempotent)', () => {
+      const adapter: CronRegistrar = {
+        getCronJobs: () => [
+          { name: 'sync', cronExpression: '0 */6 * * *', handler: jest.fn() },
+        ],
+      };
+
+      mockPluginRegistry.getAdaptersForExtensionPoint.mockReturnValue(
+        new Map([['blizzard', adapter]]),
+      );
+      mockPluginRegistry.getAdapter.mockReturnValue(adapter);
+
+      // Bootstrap registers the job
+      service.onApplicationBootstrap();
+      expect(mockSchedulerRegistry.addCronJob).toHaveBeenCalledTimes(1);
+
+      // ACTIVATED event fires — should skip because job is already registered
+      service.handlePluginActivated({ slug: 'blizzard' });
+      expect(mockSchedulerRegistry.addCronJob).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('handlePluginDeactivated()', () => {
     it('should remove cron jobs with matching plugin prefix', () => {
       const jobs = new Map([
@@ -159,6 +221,35 @@ describe('CronManagerService', () => {
       expect(() =>
         service.handlePluginDeactivated({ slug: 'wow-plugin' }),
       ).not.toThrow();
+    });
+
+    it('should allow re-registration after deactivation + re-activation', () => {
+      const adapter: CronRegistrar = {
+        getCronJobs: () => [
+          { name: 'sync', cronExpression: '0 */6 * * *', handler: jest.fn() },
+        ],
+      };
+
+      mockPluginRegistry.getAdaptersForExtensionPoint.mockReturnValue(
+        new Map([['blizzard', adapter]]),
+      );
+      mockPluginRegistry.getAdapter.mockReturnValue(adapter);
+
+      // Bootstrap registers the job
+      service.onApplicationBootstrap();
+      expect(mockSchedulerRegistry.addCronJob).toHaveBeenCalledTimes(1);
+
+      // Deactivate removes it
+      const jobs = new Map([['blizzard:sync', { stop: jest.fn() }]]);
+      mockSchedulerRegistry.getCronJobs.mockReturnValue(jobs);
+      service.handlePluginDeactivated({ slug: 'blizzard' });
+      expect(mockSchedulerRegistry.deleteCronJob).toHaveBeenCalledWith(
+        'blizzard:sync',
+      );
+
+      // Re-activate re-registers it
+      service.handlePluginActivated({ slug: 'blizzard' });
+      expect(mockSchedulerRegistry.addCronJob).toHaveBeenCalledTimes(2);
     });
   });
 });


### PR DESCRIPTION
## Summary
- **Root cause:** Plugin cron jobs only registered on `ACTIVATED` event, which never fires for plugins already active at boot. `CronManagerService` now implements `OnApplicationBootstrap` to register all active plugin jobs at startup.
- **Manual trigger tracking:** `triggerJob()` now routes plugin jobs through `executeWithTracking()` so execution history is recorded in the DB (previously fire-and-forget via `fireOnTick()`).
- **Tests:** 4 new tests covering bootstrap registration, no-plugins edge case, idempotent skip, and deactivate+re-activate lifecycle.

## Test plan
- [x] `character-auto-sync` job appears in SchedulerRegistry after startup (confirmed in logs)
- [x] Manual trigger from admin UI executes successfully
- [x] Execution history shows "completed" status with duration
- [x] All 1078 API tests pass
- [x] TypeScript clean, ESLint clean
- [x] Code review: APPROVED (0 critical issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)