### PR TITLE
fix: roster update validation for PUG users with missing userId (ROK-401)

### DIFF
--- a/web/src/hooks/use-roster.ts
+++ b/web/src/hooks/use-roster.ts
@@ -93,12 +93,14 @@ export function buildRosterUpdate(
     assignments: RosterAssignmentResponse[],
 ): UpdateRosterDto {
     return {
-        assignments: assignments.map((a) => ({
-            userId: a.userId,
-            signupId: a.signupId,
-            slot: a.slot,
-            position: a.position,
-            isOverride: a.isOverride,
-        })),
+        assignments: assignments
+            .filter((a) => a.userId > 0)
+            .map((a) => ({
+                userId: a.userId,
+                signupId: a.signupId,
+                slot: a.slot,
+                position: a.position,
+                isOverride: a.isOverride,
+            })),
     };
 }


### PR DESCRIPTION
## Summary
- Filters out PUG slot entries with `userId: 0` in `buildRosterUpdate()` before sending the PATCH request
- Anonymous PUG signups (from invite links) have no linked user account, so `userId` defaults to 0 in the roster response
- When an admin modifies any roster slot, ALL remaining assignments are serialized — including these invalid entries — causing Zod validation to reject the request

## Fix
One-line filter in `web/src/hooks/use-roster.ts`: `.filter((a) => a.userId > 0)` before mapping assignments to the PATCH body.

## Test plan
- [x] All 1079 API tests pass, all 1487 web tests pass
- [x] TypeScript clean, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)