### PR TITLE
fix: derive CLIENT_URL from app_settings (ROK-408)

### DIFF
--- a/api/src/discord-bot/listeners/event.listener.spec.ts
+++ b/api/src/discord-bot/listeners/event.listener.spec.ts
@@ -111,6 +111,7 @@ describe('DiscordEventListener', () => {
               communityLogoPath: null,
               communityAccentColor: null,
             }),
+            getClientUrl: jest.fn().mockResolvedValue(null),
           },
         },
       ],

--- a/api/src/discord-bot/listeners/event.listener.ts
+++ b/api/src/discord-bot/listeners/event.listener.ts
@@ -310,10 +310,13 @@ export class DiscordEventListener {
    * Build shared embed context from settings.
    */
   private async buildContext(): Promise<EmbedContext> {
-    const branding = await this.settingsService.getBranding();
+    const [branding, clientUrl] = await Promise.all([
+      this.settingsService.getBranding(),
+      this.settingsService.getClientUrl(),
+    ]);
     return {
       communityName: branding.communityName,
-      clientUrl: process.env.CLIENT_URL ?? null,
+      clientUrl,
     };
   }
 }

--- a/api/src/discord-bot/processors/embed-sync.processor.ts
+++ b/api/src/discord-bot/processors/embed-sync.processor.ts
@@ -283,10 +283,13 @@ export class EmbedSyncProcessor extends WorkerHost {
    * Build shared embed context from settings.
    */
   private async buildContext(): Promise<EmbedContext> {
-    const branding = await this.settingsService.getBranding();
+    const [branding, clientUrl] = await Promise.all([
+      this.settingsService.getBranding(),
+      this.settingsService.getClientUrl(),
+    ]);
     return {
       communityName: branding.communityName,
-      clientUrl: process.env.CLIENT_URL ?? null,
+      clientUrl,
     };
   }
 }

--- a/api/src/discord-bot/services/pug-invite.service.spec.ts
+++ b/api/src/discord-bot/services/pug-invite.service.spec.ts
@@ -175,6 +175,7 @@ describe('PugInviteService', () => {
               communityLogoPath: null,
               communityAccentColor: null,
             }),
+            getClientUrl: jest.fn().mockResolvedValue('http://localhost:5173'),
           },
         },
       ],

--- a/api/src/discord-bot/services/pug-invite.service.ts
+++ b/api/src/discord-bot/services/pug-invite.service.ts
@@ -411,8 +411,10 @@ export class PugInviteService {
     _role: string,
     event: typeof schema.events.$inferSelect,
   ): Promise<void> {
-    const branding = await this.settingsService.getBranding();
-    const clientUrl = process.env.CLIENT_URL ?? null;
+    const [branding, clientUrl] = await Promise.all([
+      this.settingsService.getBranding(),
+      this.settingsService.getClientUrl(),
+    ]);
     const communityName = branding.communityName || 'Raid Ledger';
 
     const startDate = event.duration[0];
@@ -519,8 +521,10 @@ export class PugInviteService {
       return;
     }
 
-    const branding = await this.settingsService.getBranding();
-    const clientUrl = process.env.CLIENT_URL ?? null;
+    const [branding, clientUrl] = await Promise.all([
+      this.settingsService.getBranding(),
+      this.settingsService.getClientUrl(),
+    ]);
     const communityName = branding.communityName || 'Raid Ledger';
 
     const startDate = event.duration[0];

--- a/api/src/drizzle/schema/app-settings.ts
+++ b/api/src/drizzle/schema/app-settings.ts
@@ -46,6 +46,7 @@ export const SETTING_KEYS = {
   DISCORD_BOT_SETUP_COMPLETED: 'discord_bot_setup_completed',
   DISCORD_BOT_COMMUNITY_NAME: 'discord_bot_community_name',
   DISCORD_BOT_TIMEZONE: 'discord_bot_timezone',
+  CLIENT_URL: 'client_url',
 } as const;
 
 export type SettingKey = (typeof SETTING_KEYS)[keyof typeof SETTING_KEYS];

--- a/api/src/events/invite.service.ts
+++ b/api/src/events/invite.service.ts
@@ -24,7 +24,6 @@ import type { InviteCodeResolveResponseDto } from '@raid-ledger/contract';
 @Injectable()
 export class InviteService {
   private readonly logger = new Logger(InviteService.name);
-  private readonly clientUrl: string;
 
   constructor(
     @Inject(DrizzleAsyncProvider)
@@ -37,9 +36,7 @@ export class InviteService {
     @Inject(forwardRef(() => DiscordBotClientService))
     private readonly discordClient: DiscordBotClientService | null,
     private readonly settingsService: SettingsService,
-  ) {
-    this.clientUrl = process.env.CLIENT_URL ?? 'http://localhost:5173';
-  }
+  ) {}
 
   /**
    * Resolve an invite code — return event + slot context.
@@ -378,7 +375,9 @@ export class InviteService {
 
     if (!user?.discordId) return;
 
-    const eventUrl = `${this.clientUrl}/events/${eventId}`;
+    const clientUrl =
+      (await this.settingsService.getClientUrl()) ?? 'http://localhost:5173';
+    const eventUrl = `${clientUrl}/events/${eventId}`;
     const message = [
       `You have joined **${eventTitle}**!`,
       `View the event: ${eventUrl}`,

--- a/api/src/events/share.service.ts
+++ b/api/src/events/share.service.ts
@@ -149,10 +149,13 @@ export class ShareService {
   }
 
   private async buildContext(): Promise<EmbedContext> {
-    const branding = await this.settingsService.getBranding();
+    const [branding, clientUrl] = await Promise.all([
+      this.settingsService.getBranding(),
+      this.settingsService.getClientUrl(),
+    ]);
     return {
       communityName: branding.communityName,
-      clientUrl: process.env.CLIENT_URL ?? null,
+      clientUrl,
     };
   }
 }

--- a/api/src/notifications/discord-notification-embed.service.spec.ts
+++ b/api/src/notifications/discord-notification-embed.service.spec.ts
@@ -1,4 +1,5 @@
 import { DiscordNotificationEmbedService } from './discord-notification-embed.service';
+import { SettingsService } from '../settings/settings.service';
 import { EMBED_COLORS } from '../discord-bot/discord-bot.constants';
 
 // Mock discord.js so we can test without real Discord connections
@@ -93,15 +94,21 @@ jest.mock('discord.js', () => {
 
 describe('DiscordNotificationEmbedService', () => {
   let service: DiscordNotificationEmbedService;
+  let mockSettingsService: { getClientUrl: jest.Mock };
 
   beforeEach(() => {
     delete process.env.CLIENT_URL;
-    service = new DiscordNotificationEmbedService();
+    mockSettingsService = {
+      getClientUrl: jest.fn().mockResolvedValue('http://localhost:5173'),
+    };
+    service = new DiscordNotificationEmbedService(
+      mockSettingsService as unknown as SettingsService,
+    );
   });
 
   describe('buildNotificationEmbed', () => {
-    it('should return an embed and row', () => {
-      const { embed, row } = service.buildNotificationEmbed(
+    it('should return an embed and row', async () => {
+      const { embed, row } = await service.buildNotificationEmbed(
         {
           notificationId: 'notif-1',
           type: 'event_reminder',
@@ -115,8 +122,8 @@ describe('DiscordNotificationEmbedService', () => {
       expect(row).toBeDefined();
     });
 
-    it('should use REMINDER color for event_reminder type', () => {
-      const { embed } = service.buildNotificationEmbed(
+    it('should use REMINDER color for event_reminder type', async () => {
+      const { embed } = await service.buildNotificationEmbed(
         {
           notificationId: 'notif-1',
           type: 'event_reminder',
@@ -129,8 +136,8 @@ describe('DiscordNotificationEmbedService', () => {
       expect(embed.toJSON().color).toBe(EMBED_COLORS.REMINDER);
     });
 
-    it('should use ANNOUNCEMENT color for new_event type', () => {
-      const { embed } = service.buildNotificationEmbed(
+    it('should use ANNOUNCEMENT color for new_event type', async () => {
+      const { embed } = await service.buildNotificationEmbed(
         {
           notificationId: 'notif-2',
           type: 'new_event',
@@ -143,8 +150,8 @@ describe('DiscordNotificationEmbedService', () => {
       expect(embed.toJSON().color).toBe(EMBED_COLORS.ANNOUNCEMENT);
     });
 
-    it('should use ROSTER_UPDATE color for slot_vacated type', () => {
-      const { embed } = service.buildNotificationEmbed(
+    it('should use ROSTER_UPDATE color for slot_vacated type', async () => {
+      const { embed } = await service.buildNotificationEmbed(
         {
           notificationId: 'notif-3',
           type: 'slot_vacated',
@@ -157,8 +164,8 @@ describe('DiscordNotificationEmbedService', () => {
       expect(embed.toJSON().color).toBe(EMBED_COLORS.ROSTER_UPDATE);
     });
 
-    it('should use ROSTER_UPDATE color for bench_promoted type', () => {
-      const { embed } = service.buildNotificationEmbed(
+    it('should use ROSTER_UPDATE color for bench_promoted type', async () => {
+      const { embed } = await service.buildNotificationEmbed(
         {
           notificationId: 'notif-4',
           type: 'bench_promoted',
@@ -171,8 +178,8 @@ describe('DiscordNotificationEmbedService', () => {
       expect(embed.toJSON().color).toBe(EMBED_COLORS.ROSTER_UPDATE);
     });
 
-    it('should use REMINDER color for event_rescheduled type', () => {
-      const { embed } = service.buildNotificationEmbed(
+    it('should use REMINDER color for event_rescheduled type', async () => {
+      const { embed } = await service.buildNotificationEmbed(
         {
           notificationId: 'notif-5',
           type: 'event_rescheduled',
@@ -185,9 +192,9 @@ describe('DiscordNotificationEmbedService', () => {
       expect(embed.toJSON().color).toBe(EMBED_COLORS.REMINDER);
     });
 
-    it('should set community name as author and footer', () => {
+    it('should set community name as author and footer', async () => {
       const communityName = 'My Raid Guild';
-      const { embed } = service.buildNotificationEmbed(
+      const { embed } = await service.buildNotificationEmbed(
         {
           notificationId: 'notif-1',
           type: 'event_reminder',
@@ -205,8 +212,8 @@ describe('DiscordNotificationEmbedService', () => {
       expect(json.footer.text).toBe(communityName);
     });
 
-    it('should include emoji in title', () => {
-      const { embed } = service.buildNotificationEmbed(
+    it('should include emoji in title', async () => {
+      const { embed } = await service.buildNotificationEmbed(
         {
           notificationId: 'notif-1',
           type: 'event_reminder',
@@ -221,11 +228,8 @@ describe('DiscordNotificationEmbedService', () => {
       expect(json.title).toContain('⏰');
     });
 
-    it('should include "Adjust Notifications" button in action row', () => {
-      process.env.CLIENT_URL = 'http://localhost:5173';
-      service = new DiscordNotificationEmbedService();
-
-      const { row } = service.buildNotificationEmbed(
+    it('should include "Adjust Notifications" button in action row', async () => {
+      const { row } = await service.buildNotificationEmbed(
         {
           notificationId: 'notif-1',
           type: 'event_reminder',
@@ -242,11 +246,8 @@ describe('DiscordNotificationEmbedService', () => {
       expect(adjustButton).toBeDefined();
     });
 
-    it('should include "View Event" button when eventId is in payload for event_reminder', () => {
-      process.env.CLIENT_URL = 'http://localhost:5173';
-      service = new DiscordNotificationEmbedService();
-
-      const { row } = service.buildNotificationEmbed(
+    it('should include "View Event" button when eventId is in payload for event_reminder', async () => {
+      const { row } = await service.buildNotificationEmbed(
         {
           notificationId: 'notif-1',
           type: 'event_reminder',
@@ -268,11 +269,8 @@ describe('DiscordNotificationEmbedService', () => {
       expect(viewButton?.url).toContain('notif=notif-1');
     });
 
-    it('should include "Sign Up" button for new_event type when eventId present', () => {
-      process.env.CLIENT_URL = 'http://localhost:5173';
-      service = new DiscordNotificationEmbedService();
-
-      const { row } = service.buildNotificationEmbed(
+    it('should include "Sign Up" button for new_event type when eventId present', async () => {
+      const { row } = await service.buildNotificationEmbed(
         {
           notificationId: 'notif-2',
           type: 'new_event',
@@ -293,11 +291,8 @@ describe('DiscordNotificationEmbedService', () => {
       expect(signUpButton?.url).toContain('/events/99');
     });
 
-    it('should include "View Roster" button for slot_vacated type', () => {
-      process.env.CLIENT_URL = 'http://localhost:5173';
-      service = new DiscordNotificationEmbedService();
-
-      const { row } = service.buildNotificationEmbed(
+    it('should include "View Roster" button for slot_vacated type', async () => {
+      const { row } = await service.buildNotificationEmbed(
         {
           notificationId: 'notif-3',
           type: 'slot_vacated',
@@ -315,8 +310,8 @@ describe('DiscordNotificationEmbedService', () => {
       expect(rosterButton).toBeDefined();
     });
 
-    it('should add eventTitle field for event_reminder when payload has eventTitle', () => {
-      const { embed } = service.buildNotificationEmbed(
+    it('should add eventTitle field for event_reminder when payload has eventTitle', async () => {
+      const { embed } = await service.buildNotificationEmbed(
         {
           notificationId: 'notif-1',
           type: 'event_reminder',
@@ -335,8 +330,8 @@ describe('DiscordNotificationEmbedService', () => {
       expect(eventField?.value).toBe('Mythic Raid Night');
     });
 
-    it('should add gameName field for new_event when payload has gameName', () => {
-      const { embed } = service.buildNotificationEmbed(
+    it('should add gameName field for new_event when payload has gameName', async () => {
+      const { embed } = await service.buildNotificationEmbed(
         {
           notificationId: 'notif-2',
           type: 'new_event',
@@ -355,8 +350,8 @@ describe('DiscordNotificationEmbedService', () => {
       expect(gameField?.value).toBe('World of Warcraft');
     });
 
-    it('should add slotName field for slot_vacated when payload has slotName', () => {
-      const { embed } = service.buildNotificationEmbed(
+    it('should add slotName field for slot_vacated when payload has slotName', async () => {
+      const { embed } = await service.buildNotificationEmbed(
         {
           notificationId: 'notif-3',
           type: 'slot_vacated',
@@ -375,8 +370,8 @@ describe('DiscordNotificationEmbedService', () => {
       expect(slotField?.value).toBe('Healer');
     });
 
-    it('should not add fields when payload is not provided', () => {
-      const { embed } = service.buildNotificationEmbed(
+    it('should not add fields when payload is not provided', async () => {
+      const { embed } = await service.buildNotificationEmbed(
         {
           notificationId: 'notif-1',
           type: 'event_reminder',
@@ -390,8 +385,8 @@ describe('DiscordNotificationEmbedService', () => {
       expect(json.fields).toBeUndefined();
     });
 
-    it('should fall back to "Raid Ledger" when communityName is empty', () => {
-      const { embed } = service.buildNotificationEmbed(
+    it('should fall back to "Raid Ledger" when communityName is empty', async () => {
+      const { embed } = await service.buildNotificationEmbed(
         {
           notificationId: 'notif-1',
           type: 'event_reminder',
@@ -411,40 +406,37 @@ describe('DiscordNotificationEmbedService', () => {
   });
 
   describe('buildWelcomeEmbed', () => {
-    it('should return embed and row', () => {
-      const { embed, row } = service.buildWelcomeEmbed('Test Community');
+    it('should return embed and row', async () => {
+      const { embed, row } = await service.buildWelcomeEmbed('Test Community');
       expect(embed).toBeDefined();
       expect(row).toBeDefined();
     });
 
-    it('should use ANNOUNCEMENT color by default', () => {
-      const { embed } = service.buildWelcomeEmbed('Community');
+    it('should use ANNOUNCEMENT color by default', async () => {
+      const { embed } = await service.buildWelcomeEmbed('Community');
       expect(embed.toJSON().color).toBe(EMBED_COLORS.ANNOUNCEMENT);
     });
 
-    it('should use parsed accentColor when provided', () => {
-      const { embed } = service.buildWelcomeEmbed('Community', '#38bdf8');
+    it('should use parsed accentColor when provided', async () => {
+      const { embed } = await service.buildWelcomeEmbed('Community', '#38bdf8');
       // 0x38bdf8 = 3727864
       expect(embed.toJSON().color).toBe(0x38bdf8);
     });
 
-    it('should include community name in title', () => {
-      const { embed } = service.buildWelcomeEmbed('Community');
+    it('should include community name in title', async () => {
+      const { embed } = await service.buildWelcomeEmbed('Community');
       const json = embed.toJSON() as { title: string };
       expect(json.title).toBe('Welcome to Community!');
     });
 
-    it('should include Raid Ledger in description', () => {
-      const { embed } = service.buildWelcomeEmbed('My Guild');
+    it('should include Raid Ledger in description', async () => {
+      const { embed } = await service.buildWelcomeEmbed('My Guild');
       const json = embed.toJSON() as { description: string };
       expect(json.description).toContain('Raid Ledger');
     });
 
-    it('should include "Notification Settings" button in row', () => {
-      process.env.CLIENT_URL = 'http://localhost:5173';
-      service = new DiscordNotificationEmbedService();
-
-      const { row } = service.buildWelcomeEmbed('Community');
+    it('should include "Notification Settings" button in row', async () => {
+      const { row } = await service.buildWelcomeEmbed('Community');
       const rowJson = row.toJSON() as {
         components: Array<{ label: string; url: string }>;
       };
@@ -457,8 +449,8 @@ describe('DiscordNotificationEmbedService', () => {
       );
     });
 
-    it('should include feature fields', () => {
-      const { embed } = service.buildWelcomeEmbed('Community');
+    it('should include feature fields', async () => {
+      const { embed } = await service.buildWelcomeEmbed('Community');
       const json = embed.toJSON() as { fields: Array<{ name: string }> };
       const browseField = json.fields?.find(
         (f) => f.name === 'Browse & sign up for events',
@@ -474,8 +466,8 @@ describe('DiscordNotificationEmbedService', () => {
   });
 
   describe('buildBatchSummaryEmbed', () => {
-    it('should include count in title', () => {
-      const { embed } = service.buildBatchSummaryEmbed(
+    it('should include count in title', async () => {
+      const { embed } = await service.buildBatchSummaryEmbed(
         'event_reminder',
         5,
         'Community',
@@ -485,11 +477,8 @@ describe('DiscordNotificationEmbedService', () => {
       expect(json.title).toContain('5');
     });
 
-    it('should include "Adjust Notifications" and "View All" buttons', () => {
-      process.env.CLIENT_URL = 'http://localhost:5173';
-      service = new DiscordNotificationEmbedService();
-
-      const { row } = service.buildBatchSummaryEmbed(
+    it('should include "Adjust Notifications" and "View All" buttons', async () => {
+      const { row } = await service.buildBatchSummaryEmbed(
         'event_reminder',
         3,
         'Community',

--- a/api/src/notifications/discord-notification.processor.spec.ts
+++ b/api/src/notifications/discord-notification.processor.spec.ts
@@ -16,7 +16,7 @@ describe('DiscordNotificationProcessor', () => {
   };
 
   const mockEmbedService = {
-    buildNotificationEmbed: jest.fn().mockReturnValue({
+    buildNotificationEmbed: jest.fn().mockResolvedValue({
       embed: { toJSON: () => ({}) },
       row: { toJSON: () => ({}) },
     }),

--- a/api/src/notifications/discord-notification.processor.ts
+++ b/api/src/notifications/discord-notification.processor.ts
@@ -46,7 +46,7 @@ export class DiscordNotificationProcessor extends WorkerHost {
       const branding = await this.settingsService.getBranding();
       const communityName = branding.communityName ?? 'Raid Ledger';
 
-      const { embed, row } = this.embedService.buildNotificationEmbed(
+      const { embed, row } = await this.embedService.buildNotificationEmbed(
         {
           notificationId,
           type: type as NotificationType,

--- a/api/src/notifications/discord-notification.service.spec.ts
+++ b/api/src/notifications/discord-notification.service.spec.ts
@@ -33,7 +33,7 @@ describe('DiscordNotificationService', () => {
   };
 
   const mockEmbedService = {
-    buildWelcomeEmbed: jest.fn().mockReturnValue({
+    buildWelcomeEmbed: jest.fn().mockResolvedValue({
       embed: { toJSON: () => ({}) },
       row: { toJSON: () => ({}) },
     }),

--- a/api/src/notifications/discord-notification.service.ts
+++ b/api/src/notifications/discord-notification.service.ts
@@ -169,7 +169,7 @@ export class DiscordNotificationService {
 
     try {
       const branding = await this.settingsService.getBranding();
-      const { embed, row } = this.embedService.buildWelcomeEmbed(
+      const { embed, row } = await this.embedService.buildWelcomeEmbed(
         branding.communityName ?? 'Raid Ledger',
         branding.communityAccentColor,
       );

--- a/api/src/notifications/event-reminder.service.spec.ts
+++ b/api/src/notifications/event-reminder.service.spec.ts
@@ -3,6 +3,7 @@ import { EventReminderService } from './event-reminder.service';
 import { NotificationService } from './notification.service';
 import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
 import { CronJobService } from '../cron-jobs/cron-job.service';
+import { SettingsService } from '../settings/settings.service';
 
 describe('EventReminderService', () => {
   let service: EventReminderService;
@@ -38,6 +39,12 @@ describe('EventReminderService', () => {
             executeWithTracking: jest.fn(
               (_name: string, fn: () => Promise<void>) => fn(),
             ),
+          },
+        },
+        {
+          provide: SettingsService,
+          useValue: {
+            getClientUrl: jest.fn().mockResolvedValue('http://localhost:5173'),
           },
         },
       ],

--- a/api/src/notifications/event-reminder.service.ts
+++ b/api/src/notifications/event-reminder.service.ts
@@ -6,6 +6,7 @@ import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
 import * as schema from '../drizzle/schema';
 import { NotificationService } from './notification.service';
 import { CronJobService } from '../cron-jobs/cron-job.service';
+import { SettingsService } from '../settings/settings.service';
 
 /**
  * Reminder window definitions (ROK-126).
@@ -48,16 +49,14 @@ type ReminderWindowType = (typeof REMINDER_WINDOWS)[number]['type'];
 @Injectable()
 export class EventReminderService {
   private readonly logger = new Logger(EventReminderService.name);
-  private readonly clientUrl: string;
 
   constructor(
     @Inject(DrizzleAsyncProvider)
     private db: PostgresJsDatabase<typeof schema>,
     private readonly notificationService: NotificationService,
     private readonly cronJobService: CronJobService,
-  ) {
-    this.clientUrl = process.env.CLIENT_URL ?? 'http://localhost:5173';
-  }
+    private readonly settingsService: SettingsService,
+  ) {}
 
   /**
    * Main cron: runs every 60 seconds (ROK-126 AC-1).

--- a/api/src/settings/settings.service.ts
+++ b/api/src/settings/settings.service.ts
@@ -487,4 +487,27 @@ export class SettingsService {
     await this.set(SETTING_KEYS.DISCORD_BOT_TIMEZONE, timezone);
     this.logger.log('Discord bot timezone updated');
   }
+
+  /**
+   * Get the client URL with fallback chain (ROK-408):
+   * 1. Explicit app_settings override (client_url)
+   * 2. Derived from Discord callback URL origin
+   * 3. Legacy process.env.CLIENT_URL
+   * 4. null
+   */
+  async getClientUrl(): Promise<string | null> {
+    const explicit = await this.get(SETTING_KEYS.CLIENT_URL);
+    if (explicit) return explicit;
+
+    const callbackUrl = await this.get(SETTING_KEYS.DISCORD_CALLBACK_URL);
+    if (callbackUrl) {
+      try {
+        return new URL(callbackUrl).origin;
+      } catch {
+        /* invalid URL — fall through */
+      }
+    }
+
+    return process.env.CLIENT_URL ?? null;
+  }
 }


### PR DESCRIPTION
## Summary
- Added `getClientUrl()` method to `SettingsService` with fallback chain: explicit `app_settings.client_url` → derived from `discord_callback_url` origin → `process.env.CLIENT_URL` → `null`
- Updated all 7 files that read `process.env.CLIENT_URL` to use `settingsService.getClientUrl()` instead
- Discord embed links, View Event buttons, notification DMs, PUG invite links, and share service links now work in production without requiring a `CLIENT_URL` env var
- Backwards compatible — `process.env.CLIENT_URL` still works as fallback

## Test plan
- [ ] Deploy to production with no `CLIENT_URL` env var set → Discord embeds should show clickable title + View Event button
- [ ] PUG invite DMs should contain correct links
- [ ] Notification embeds should contain correct links
- [ ] Event reminder links should work
- [ ] Set explicit `CLIENT_URL` env var → should take precedence as fallback
- [ ] All 1079 API tests pass, all 1488 web tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)