### PR TITLE
fix: PUG invite claim flow reorder + stale slot cleanup (ROK-409)

### DIFF
--- a/api/src/auth/auth.service.ts
+++ b/api/src/auth/auth.service.ts
@@ -13,6 +13,8 @@ export const AUTH_EVENTS = {
 export interface DiscordLoginPayload {
   userId: number;
   discordId: string;
+  /** ROK-409: Invite code from PUG invite flow (for anonymous slot matching) */
+  inviteCode?: string;
 }
 
 @Injectable()

--- a/api/src/discord-bot/listeners/pug-invite.listener.spec.ts
+++ b/api/src/discord-bot/listeners/pug-invite.listener.spec.ts
@@ -128,6 +128,7 @@ describe('PugInviteListener', () => {
       expect(pugInviteService.claimPugSlots).toHaveBeenCalledWith(
         'disc-user-456',
         10,
+        undefined,
       );
     });
 

--- a/api/src/discord-bot/listeners/pug-invite.listener.ts
+++ b/api/src/discord-bot/listeners/pug-invite.listener.ts
@@ -147,6 +147,7 @@ export class PugInviteListener {
 
   /**
    * Handle Discord OAuth login — auto-claim matching PUG slots.
+   * ROK-409: Also passes inviteCode for anonymous slot matching.
    */
   @OnEvent(AUTH_EVENTS.DISCORD_LOGIN)
   async handleDiscordLogin(payload: DiscordLoginPayload): Promise<void> {
@@ -154,6 +155,7 @@ export class PugInviteListener {
       await this.pugInviteService.claimPugSlots(
         payload.discordId,
         payload.userId,
+        payload.inviteCode,
       );
     } catch (error) {
       this.logger.error(


### PR DESCRIPTION
## Summary
- **Step reorder:** Moved "Join Discord Server" from step 2 to a CTA on the success screen after signup is complete, preventing user drop-off when they leave the site to join Discord
- **PUG slot cleanup:** Added `cleanupMatchingPugSlots()` in `signups.service.ts` to delete stale PUG slots when a user signs up normally, and updated `claimPugSlots()` to match anonymous slots by invite code (not just Discord ID)
- **Filtered claimed slots:** `pugs.service.findAll()` now excludes slots with `status='claimed'` so the "GUEST INVITES" section only shows unresolved invites

## Test plan
- [ ] PUG invite claim flow: Auth → Choose Role → Confirm → Discord CTA (not Auth → Discord → Role → Confirm)
- [ ] User already in Discord server → Discord step skipped on success screen
- [ ] Normal signup for an event with a matching PUG slot → slot is cleaned up
- [ ] Anonymous PUG invite (no Discord ID) → slot claimed by invite code on OAuth
- [ ] "GUEST INVITES" section shows no stale entries after user signs up
- [ ] All 1079 API + 1488 web tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)