### PR TITLE
feat: improve search with multi-word matching and shared utility (ROK-383)

### DIFF
--- a/api/src/admin/settings.controller.ts
+++ b/api/src/admin/settings.controller.ts
@@ -29,8 +29,9 @@ import {
   DemoDataStatusDto,
   DemoDataResultDto,
 } from '@raid-ledger/contract';
-import { and, eq, ilike, sql } from 'drizzle-orm';
+import { and, eq, sql } from 'drizzle-orm';
 import * as schema from '../drizzle/schema';
+import { buildWordMatchFilters } from '../common/search.util';
 
 export interface OAuthStatusResponse {
   configured: boolean;
@@ -580,9 +581,7 @@ export class AdminSettingsController {
 
     const conditions = [];
     if (search) {
-      conditions.push(
-        ilike(schema.games.name, `%${search.replace(/[%_\\]/g, '\\$&')}%`),
-      );
+      conditions.push(...buildWordMatchFilters(schema.games.name, search));
     }
     // When showHidden is 'only', show hidden and banned games
     // When showHidden is 'true', show all games (no hidden/banned filter)

--- a/api/src/common/search.util.spec.ts
+++ b/api/src/common/search.util.spec.ts
@@ -1,0 +1,109 @@
+import {
+  stripSearchPunctuation,
+  escapeLikePattern,
+  buildWordMatchFilters,
+} from './search.util';
+
+describe('stripSearchPunctuation', () => {
+  it('removes colons, dashes, em-dashes, apostrophes, periods, and commas', () => {
+    expect(stripSearchPunctuation('Halo: Combat Evolved')).toBe(
+      'Halo Combat Evolved',
+    );
+    expect(stripSearchPunctuation("Tom Clancy's")).toBe('Tom Clancys');
+    expect(stripSearchPunctuation('Counter-Strike')).toBe('CounterStrike');
+    expect(stripSearchPunctuation('Hello — World')).toBe('Hello World');
+    expect(stripSearchPunctuation('v1.0.2, final')).toBe('v102 final');
+  });
+
+  it('collapses multiple spaces into one', () => {
+    expect(stripSearchPunctuation('hello    world')).toBe('hello world');
+    expect(stripSearchPunctuation('  spaced  out  ')).toBe('spaced out');
+  });
+
+  it('trims leading and trailing whitespace', () => {
+    expect(stripSearchPunctuation('  hello  ')).toBe('hello');
+  });
+
+  it('returns empty string for punctuation-only input', () => {
+    expect(stripSearchPunctuation('...:---')).toBe('');
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(stripSearchPunctuation('')).toBe('');
+  });
+
+  it('preserves digits and letters', () => {
+    expect(stripSearchPunctuation('Halo 3')).toBe('Halo 3');
+  });
+});
+
+describe('escapeLikePattern', () => {
+  it('escapes percent sign', () => {
+    expect(escapeLikePattern('100%')).toBe('100\\%');
+  });
+
+  it('escapes underscore', () => {
+    expect(escapeLikePattern('some_thing')).toBe('some\\_thing');
+  });
+
+  it('escapes backslash', () => {
+    expect(escapeLikePattern('path\\to')).toBe('path\\\\to');
+  });
+
+  it('escapes all special characters together', () => {
+    expect(escapeLikePattern('%_\\')).toBe('\\%\\_\\\\');
+  });
+
+  it('leaves normal text unchanged', () => {
+    expect(escapeLikePattern('hello world')).toBe('hello world');
+  });
+
+  it('handles empty string', () => {
+    expect(escapeLikePattern('')).toBe('');
+  });
+});
+
+describe('buildWordMatchFilters', () => {
+  // We cannot test the actual SQL output easily without a full Drizzle
+  // column instance, but we can verify the function's observable behavior:
+  // - returns empty array for empty/blank/punctuation-only queries
+  // - returns one filter per word
+  // We use a mock column to satisfy the type signature.
+
+  const mockColumn = { name: 'name' } as never;
+
+  it('returns empty array for empty string', () => {
+    expect(buildWordMatchFilters(mockColumn, '')).toEqual([]);
+  });
+
+  it('returns empty array for whitespace-only input', () => {
+    expect(buildWordMatchFilters(mockColumn, '   ')).toEqual([]);
+  });
+
+  it('returns empty array for punctuation-only input', () => {
+    expect(buildWordMatchFilters(mockColumn, '...:---')).toEqual([]);
+  });
+
+  it('returns one filter for a single word', () => {
+    const filters = buildWordMatchFilters(mockColumn, 'halo');
+    expect(filters).toHaveLength(1);
+  });
+
+  it('returns multiple filters for multi-word queries', () => {
+    const filters = buildWordMatchFilters(mockColumn, 'halo combat evolved');
+    expect(filters).toHaveLength(3);
+  });
+
+  it('strips punctuation before splitting', () => {
+    const filters = buildWordMatchFilters(mockColumn, 'halo: combat');
+    expect(filters).toHaveLength(2);
+  });
+
+  it('handles mixed punctuation and multiple spaces', () => {
+    const filters = buildWordMatchFilters(
+      mockColumn,
+      "  Tom Clancy's:  Rainbow — Six  ",
+    );
+    expect(filters).toHaveLength(4); // Tom Clancys Rainbow Six
+  });
+});

--- a/api/src/common/search.util.ts
+++ b/api/src/common/search.util.ts
@@ -1,0 +1,41 @@
+import { ilike, type Column, type SQL } from 'drizzle-orm';
+
+/**
+ * Strip punctuation from a search query, leaving only alphanumeric
+ * characters and spaces. Collapses consecutive whitespace into a single
+ * space and trims the result.
+ */
+export function stripSearchPunctuation(input: string): string {
+  return input
+    .replace(/[^a-zA-Z0-9\s]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * Escape special characters (`%`, `_`, `\`) in a string so they are
+ * treated as literals inside an SQL LIKE / ILIKE pattern.
+ */
+export function escapeLikePattern(input: string): string {
+  return input.replace(/[%_\\]/g, '\\$&');
+}
+
+/**
+ * Build an array of Drizzle `ilike` conditions — one per word in the
+ * query — so that every word must appear somewhere in the column value.
+ *
+ * The query is first stripped of punctuation and lowercased, then split
+ * on whitespace. Each word becomes `ilike(column, '%word%')`.
+ *
+ * Consumers should spread the result into an `and()` clause:
+ * ```ts
+ * const filters = buildWordMatchFilters(schema.games.name, query);
+ * db.select().from(schema.games).where(and(...filters, ...otherConditions));
+ * ```
+ */
+export function buildWordMatchFilters(column: Column, query: string): SQL[] {
+  const normalized = stripSearchPunctuation(query).toLowerCase();
+  const words = normalized.split(/\s+/).filter((w) => w.length > 0);
+  if (words.length === 0) return [];
+  return words.map((word) => ilike(column, `%${escapeLikePattern(word)}%`));
+}

--- a/api/src/discord-bot/commands/event-create.command.ts
+++ b/api/src/discord-bot/commands/event-create.command.ts
@@ -9,10 +9,11 @@ import {
   ButtonBuilder,
   ButtonStyle,
 } from 'discord.js';
-import { ilike } from 'drizzle-orm';
+import { and, ilike } from 'drizzle-orm';
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { DrizzleAsyncProvider } from '../../drizzle/drizzle.module';
 import * as schema from '../../drizzle/schema';
+import { buildWordMatchFilters } from '../../common/search.util';
 import { EventsService } from '../../events/events.service';
 import { UsersService } from '../../users/users.service';
 import { PreferencesService } from '../../users/preferences.service';
@@ -307,10 +308,11 @@ export class EventCreateCommand
     interaction: AutocompleteInteraction,
     query: string,
   ): Promise<void> {
+    const filters = buildWordMatchFilters(schema.games.name, query);
     const results = await this.db
       .select({ id: schema.games.id, name: schema.games.name })
       .from(schema.games)
-      .where(ilike(schema.games.name, `%${query}%`))
+      .where(filters.length > 0 ? and(...filters) : undefined)
       .limit(25);
 
     await interaction.respond(

--- a/api/src/igdb/igdb.service.spec.ts
+++ b/api/src/igdb/igdb.service.spec.ts
@@ -345,7 +345,7 @@ describe('IgdbService', () => {
       await service.searchGames('val%heim_test');
 
       // Verify the cache key is normalized
-      expect(mockRedis.get).toHaveBeenCalledWith('igdb:search:val%heim_test');
+      expect(mockRedis.get).toHaveBeenCalledWith('igdb:search:valheimtest');
     });
 
     it('should normalize query for cache keys (lowercase, trim)', async () => {


### PR DESCRIPTION
## Summary
- New shared search utility (`api/src/common/search.util.ts`) with `stripSearchPunctuation()`, `escapeLikePattern()`, and `buildWordMatchFilters()` 
- All search surfaces now use multi-word matching: "halo combat" finds "Halo: Combat Evolved", "world warcraft" finds "World of Warcraft"
- Updated 8 files: igdb service, admin settings controller, users service, and 3 Discord bot autocomplete commands
- Redis cache keys normalize punctuation for better cache hit rates
- 19 unit tests for the shared utility

## Test plan
- [ ] Search "halo combat" in game search — should return "Halo: Combat Evolved"
- [ ] Search "world warcraft" — should return "World of Warcraft"
- [ ] Single-word searches still work (e.g., "valheim")
- [ ] User/player search in admin panel works with multi-word queries
- [ ] Discord bot autocomplete returns correct results

🤖 Generated with [Claude Code](https://claude.com/claude-code)