### PR TITLE
perf: add cleanup crons for expired sessions and notifications (ROK-412)

### DIFF
--- a/api/src/auth/auth.module.ts
+++ b/api/src/auth/auth.module.ts
@@ -17,6 +17,8 @@ import { SettingsModule } from '../settings/settings.module';
 import { EventsModule } from '../events/events.module';
 import { NotificationModule } from '../notifications/notification.module';
 import { CharactersModule } from '../characters/characters.module';
+import { CronJobModule } from '../cron-jobs/cron-job.module';
+import { SessionCleanupService } from './session-cleanup.service';
 
 /**
  * Auth module with dynamic Discord OAuth support.
@@ -33,6 +35,7 @@ import { CharactersModule } from '../characters/characters.module';
     forwardRef(() => EventsModule),
     forwardRef(() => NotificationModule),
     CharactersModule,
+    CronJobModule,
     JwtModule.registerAsync({
       imports: [ConfigModule],
       useFactory: (configService: ConfigService) => ({
@@ -50,6 +53,7 @@ import { CharactersModule } from '../characters/characters.module';
     IntentTokenService,
     DynamicDiscordStrategy,
     JwtStrategy,
+    SessionCleanupService,
   ],
   exports: [
     AuthService,

--- a/api/src/auth/session-cleanup.service.ts
+++ b/api/src/auth/session-cleanup.service.ts
@@ -1,0 +1,35 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { lt } from 'drizzle-orm';
+import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
+import * as schema from '../drizzle/schema';
+import { CronJobService } from '../cron-jobs/cron-job.service';
+
+@Injectable()
+export class SessionCleanupService {
+  private readonly logger = new Logger(SessionCleanupService.name);
+
+  constructor(
+    @Inject(DrizzleAsyncProvider)
+    private db: PostgresJsDatabase<typeof schema>,
+    private readonly cronJobService: CronJobService,
+  ) {}
+
+  @Cron('0 3 * * *', { name: 'SessionCleanupService_cleanupExpiredSessions' })
+  async cleanupExpiredSessions(): Promise<void> {
+    await this.cronJobService.executeWithTracking(
+      'SessionCleanupService_cleanupExpiredSessions',
+      async () => {
+        const result = await this.db
+          .delete(schema.sessions)
+          .where(lt(schema.sessions.expiresAt, new Date()))
+          .returning({ id: schema.sessions.id });
+
+        if (result.length > 0) {
+          this.logger.log(`Cleaned up ${result.length} expired sessions`);
+        }
+      },
+    );
+  }
+}

--- a/api/src/cron-jobs/cron-job.service.ts
+++ b/api/src/cron-jobs/cron-job.service.ts
@@ -44,6 +44,12 @@ const CORE_JOB_METADATA: Record<string, { description: string }> = {
   VersionCheckService_handleCron: {
     description: 'Checks GitHub for new Raid Ledger releases daily',
   },
+  SessionCleanupService_cleanupExpiredSessions: {
+    description: 'Deletes expired sessions daily at 3 AM',
+  },
+  NotificationService_cleanupExpiredNotifications: {
+    description: 'Deletes expired notifications daily at 4 AM',
+  },
 };
 
 /**

--- a/api/src/notifications/notification.service.ts
+++ b/api/src/notifications/notification.service.ts
@@ -6,6 +6,7 @@ import {
   ForbiddenException,
   Optional,
 } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
 import { eq, and, isNull, desc, lt, not } from 'drizzle-orm';
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
@@ -16,6 +17,7 @@ import {
   type NotificationType,
 } from '../drizzle/schema/notification-preferences';
 import { DiscordNotificationService } from './discord-notification.service';
+import { CronJobService } from '../cron-jobs/cron-job.service';
 
 export type { ChannelPrefs, NotificationType };
 export type Channel = 'inApp' | 'push' | 'discord';
@@ -68,6 +70,7 @@ export class NotificationService {
     @Optional()
     @Inject(DiscordNotificationService)
     private discordNotificationService: DiscordNotificationService | null,
+    private readonly cronJobService: CronJobService,
   ) {}
 
   /**
@@ -312,9 +315,20 @@ export class NotificationService {
     return this.mapPreferencesToDto(updated);
   }
 
+  @Cron('0 4 * * *', {
+    name: 'NotificationService_cleanupExpiredNotifications',
+  })
+  async cleanupExpiredNotifications(): Promise<void> {
+    await this.cronJobService.executeWithTracking(
+      'NotificationService_cleanupExpiredNotifications',
+      async () => {
+        await this.cleanupExpired();
+      },
+    );
+  }
+
   /**
    * Delete expired notifications (for cleanup jobs).
-   * Should be called periodically by a cron job.
    * @returns Number of deleted notifications
    */
   async cleanupExpired(): Promise<number> {


### PR DESCRIPTION
## Summary
- New `SessionCleanupService` — deletes expired sessions daily at 3 AM
- Notification cleanup cron — deletes expired notifications daily at 4 AM
- Both integrate with admin cron job dashboard via `executeWithTracking`

## Test plan
- [x] All 1098 API tests pass
- [x] All 1488 web tests pass
- [x] TypeScript clean, ESLint clean
- [x] Code review: APPROVED

🤖 Generated with [Claude Code](https://claude.com/claude-code)