### PR TITLE
perf: frontend query tuning and component memoization (ROK-413)

### DIFF
--- a/web/src/components/calendar/DayEventCard.tsx
+++ b/web/src/components/calendar/DayEventCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import React, { useState, useCallback } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { format, differenceInMinutes } from 'date-fns';
 import { toast } from '../../lib/toast';
@@ -49,7 +49,7 @@ function findNextAvailablePosition(
  * Day view event card with quick-join/leave actions.
  * Extracted from CalendarView's DayEventComponent callback (ROK-191).
  */
-export function DayEventCard({ event, eventOverlapsGameTime }: DayEventCardProps) {
+export const DayEventCard = React.memo(function DayEventCard({ event, eventOverlapsGameTime }: DayEventCardProps) {
     const queryClient = useQueryClient();
     const navigate = useNavigate();
     const { user, isAuthenticated } = useAuth();
@@ -399,4 +399,4 @@ export function DayEventCard({ event, eventOverlapsGameTime }: DayEventCardProps
             </div>
         </>
     );
-}
+});

--- a/web/src/components/events/event-card.tsx
+++ b/web/src/components/events/event-card.tsx
@@ -90,7 +90,7 @@ function getPlaceholderPath(slug: string | undefined): string {
  * Event card component displaying event info with game cover.
  * ROK-222: Uses resolveAvatar() for creator avatar.
  */
-export function EventCard({ event, signupCount = 0, onClick, matchesGameTime }: EventCardProps) {
+export const EventCard = React.memo(function EventCard({ event, signupCount = 0, onClick, matchesGameTime }: EventCardProps) {
     const resolved = useTimezoneStore((s) => s.resolved);
     const gameCoverUrl = event.game?.coverUrl || null;
     const isCancelled = !!event.cancelledAt;
@@ -203,7 +203,7 @@ export function EventCard({ event, signupCount = 0, onClick, matchesGameTime }: 
             </div>
         </div>
     );
-}
+});
 
 /**
  * Skeleton loader for event cards during loading state

--- a/web/src/components/roster/RosterSlot.tsx
+++ b/web/src/components/roster/RosterSlot.tsx
@@ -1,5 +1,5 @@
 import type { RosterAssignmentResponse, RosterRole } from '@raid-ledger/contract';
-import { useRef, useEffect } from 'react';
+import React, { useRef, useEffect } from 'react';
 import { RosterCard } from './RosterCard';
 
 interface RosterSlotProps {
@@ -34,7 +34,7 @@ interface RosterSlotProps {
  * The "pending" (Join?) state is controlled by the parent to survive
  * background React Query refetches that would otherwise remount this component.
  */
-export function RosterSlot({ role, position, item, color, onJoinClick, isCurrentUser = false, onAdminClick, onRemove, onSelfRemove, isPending = false, onPendingChange }: RosterSlotProps) {
+export const RosterSlot = React.memo(function RosterSlot({ role, position, item, color, onJoinClick, isCurrentUser = false, onAdminClick, onRemove, onSelfRemove, isPending = false, onPendingChange }: RosterSlotProps) {
     // Capture the onJoinClick callback so that a React Query refetch
     // that briefly sets onJoinClick=undefined doesn't prevent the
     // confirmation click from firing.
@@ -140,4 +140,4 @@ export function RosterSlot({ role, position, item, color, onJoinClick, isCurrent
             )}
         </div>
     );
-}
+});

--- a/web/src/hooks/use-game-time.ts
+++ b/web/src/hooks/use-game-time.ts
@@ -12,8 +12,7 @@ export function useGameTime(options?: { enabled?: boolean; week?: string; tzOffs
         queryKey: [...GAME_TIME_QUERY_KEY, options?.week ?? 'current', options?.tzOffset],
         queryFn: () => getMyGameTime(options?.week, options?.tzOffset),
         enabled: options?.enabled ?? true,
-        staleTime: 0,
-        refetchOnMount: 'always',
+        staleTime: 30_000,
     });
 }
 


### PR DESCRIPTION
## Summary
- `use-game-time.ts` staleTime 0→30s, removed aggressive `refetchOnMount: 'always'`
- Wrapped `EventCard`, `RosterSlot`, `DayEventCard` in `React.memo()`
- Notification unread count already had 30s staleTime — verified, no change needed

## Test plan
- [x] All 1488 web tests pass
- [x] TypeScript clean, ESLint clean
- [x] Code review: APPROVED

🤖 Generated with [Claude Code](https://claude.com/claude-code)