### PR TITLE
fix: add FK validation in PUG invite claim + character import (ROK-416)

### DIFF
--- a/api/src/characters/characters.service.ts
+++ b/api/src/characters/characters.service.ts
@@ -412,6 +412,19 @@ export class CharactersService {
       dto.gameVariant,
     );
 
+    // Validate user exists before inserting character (ROK-416)
+    const [user] = await this.db
+      .select({ id: schema.users.id })
+      .from(schema.users)
+      .where(eq(schema.users.id, userId))
+      .limit(1);
+
+    if (!user) {
+      throw new NotFoundException(
+        `User ${userId} not found — cannot import character`,
+      );
+    }
+
     // Find the game in the registry by slug based on variant
     const slugCandidates = adapter.resolveGameSlugs(dto.gameVariant);
     const [game] = await this.db

--- a/api/src/events/invite.service.ts
+++ b/api/src/events/invite.service.ts
@@ -287,11 +287,17 @@ export class InviteService {
       .where(eq(schema.users.id, userId))
       .limit(1);
 
+    if (!user) {
+      throw new NotFoundException(
+        `User ${userId} not found — cannot claim invite`,
+      );
+    }
+
     // Use role override from user selection, falling back to slot's preset role (ROK-394)
     const effectiveRole =
       roleOverride ?? (slot.role as 'tank' | 'healer' | 'dps');
 
-    if (user?.discordId) {
+    if (user.discordId) {
       // Existing RL member — create normal signup, delete PUG slot
       try {
         await this.signupsService.signup(slot.eventId, userId, {


### PR DESCRIPTION
## Summary
- Added user existence validation in `InviteService.claimInvite()` before writing `claimed_by_user_id` to `pug_slots`
- Added user existence validation in `CharactersService.importExternal()` before inserting character
- Both throw `NotFoundException` with clear message if user not found, preventing FK constraint violations

## Test plan
- [ ] Verify PUG invite claim flow still works end-to-end
- [ ] Verify character import still works for valid users
- [ ] Confirm no new FK constraint violations in Sentry post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)