### PR TITLE
fix: reject JWTs for deleted users (ROK-423)

### DIFF
--- a/api/src/auth/auth.controller.spec.ts
+++ b/api/src/auth/auth.controller.spec.ts
@@ -488,15 +488,15 @@ describe('AuthController — getProfile (ROK-352)', () => {
     );
   });
 
-  it('falls back to JWT payload when user not found in DB', async () => {
+  it('throws UnauthorizedException when user not found in DB', async () => {
     mockUsersService.findById.mockResolvedValueOnce(null);
     controller = await buildModule();
 
     const req = makeRequest(1);
-    const result = await controller.getProfile(req as any);
 
-    // Fallback returns req.user — does not include avatarPreference
-    expect(result).toEqual(req.user);
+    await expect(controller.getProfile(req as any)).rejects.toThrow(
+      'User no longer exists',
+    );
   });
 
   it('response includes all required user fields', async () => {

--- a/api/src/auth/auth.controller.ts
+++ b/api/src/auth/auth.controller.ts
@@ -465,7 +465,7 @@ export class AuthController {
     // This ensures the UI reflects updated info (e.g., after Discord linking)
     const user = await this.usersService.findById(req.user.id);
     if (!user) {
-      return req.user; // Fallback to JWT payload if user not found
+      throw new UnauthorizedException('User no longer exists');
     }
 
     // Fetch avatar preference and characters for avatar resolution (ROK-352)


### PR DESCRIPTION
## Summary
- JWT strategy now throws `UnauthorizedException` when user not found in DB instead of falling back to JWT payload claims
- `/auth/me` endpoint throws 401 when user not found (defense in depth)
- Updated test to expect 401 instead of JWT fallback

## Test plan
- [ ] Delete a user from admin panel
- [ ] Send them a PUG invite link
- [ ] Verify they get redirected to Discord login (not a crash/error)
- [ ] Verify re-authenticating via Discord creates a new account and invite works

🤖 Generated with [Claude Code](https://claude.com/claude-code)