### PR TITLE
fix: suppress Sentry errors from localhost

### DIFF
--- a/web/src/sentry.ts
+++ b/web/src/sentry.ts
@@ -10,6 +10,9 @@ const SENTRY_DSN =
 
 const isProduction = import.meta.env.PROD;
 const telemetryDisabled = import.meta.env.VITE_DISABLE_TELEMETRY === 'true';
+const isLocalhost = ['localhost', '127.0.0.1'].includes(
+    window.location.hostname,
+);
 
 // Track transport-level send failures (e.g. 403 from invalid DSN)
 let _lastTransportFailed = false;
@@ -17,6 +20,7 @@ let _lastTransportFailed = false;
 if (!telemetryDisabled) {
     Sentry.init({
         dsn: SENTRY_DSN,
+        enabled: !isLocalhost,
         environment: isProduction ? 'production' : 'development',
         tracesSampleRate: isProduction ? 0.1 : 1.0,
         replaysSessionSampleRate: 0,


### PR DESCRIPTION
## Summary
- Disable the Sentry SDK on the frontend when the browser hostname is `localhost` or `127.0.0.1`
- Prevents dev-time noise (dynamic import errors, React errors, etc.) from flooding Sentry dashboards
- Production domains are unaffected — Sentry remains fully enabled

## Test plan
- [ ] Run `npm run dev -w web` on localhost — verify no Sentry events are sent (check Network tab for `sentry.io` requests)
- [ ] Deploy via Docker to a real domain — verify Sentry events still fire normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)