### PR TITLE
feat(ROK-245): variant-aware dungeon quest database

### DIFF
--- a/api/src/drizzle/migrations/0058_dungeon_quests.sql
+++ b/api/src/drizzle/migrations/0058_dungeon_quests.sql
@@ -1,0 +1,21 @@
+CREATE TABLE "wow_classic_dungeon_quests" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"quest_id" integer NOT NULL,
+	"dungeon_instance_id" integer,
+	"name" varchar(255) NOT NULL,
+	"quest_level" integer,
+	"required_level" integer,
+	"expansion" varchar(20) NOT NULL,
+	"quest_giver_npc" varchar(255),
+	"quest_giver_zone" varchar(255),
+	"prev_quest_id" integer,
+	"next_quest_id" integer,
+	"rewards_json" jsonb,
+	"objectives" text,
+	"class_restriction" jsonb,
+	"race_restriction" jsonb,
+	"starts_inside_dungeon" boolean DEFAULT false NOT NULL,
+	"sharable" boolean DEFAULT true NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "wow_classic_dungeon_quests_quest_id_unique" UNIQUE("quest_id")
+);

--- a/api/src/drizzle/migrations/meta/0058_snapshot.json
+++ b/api/src/drizzle/migrations/meta/0058_snapshot.json
@@ -1,0 +1,3435 @@
+{
+  "id": "fcb42359-aadc-4210-9f33-e7d9329fa473",
+  "prevId": "eacf0288-7161-441c-88fa-426aeea319b0",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_avatar_url": {
+          "name": "custom_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_discord_id_unique": {
+          "name": "users_discord_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "display_name_length": {
+          "name": "display_name_length",
+          "value": "\"users\".\"display_name\" IS NULL OR (LENGTH(\"users\".\"display_name\") >= 2 AND LENGTH(\"users\".\"display_name\") <= 30)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "tsrange",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_config": {
+          "name": "slot_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_attendees": {
+          "name": "max_attendees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_unbench": {
+          "name": "auto_unbench",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "recurrence_group_id": {
+          "name": "recurrence_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_rule": {
+          "name": "recurrence_rule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_instances": {
+          "name": "content_instances",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_15min": {
+          "name": "reminder_15min",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_1hour": {
+          "name": "reminder_1hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reminder_24hour": {
+          "name": "reminder_24hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_events_creator_id": {
+          "name": "idx_events_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_game_id": {
+          "name": "idx_events_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_game_id_games_id_fk": {
+          "name": "events_game_id_games_id_fk",
+          "tableFrom": "events",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_creator_id_users_id_fk": {
+          "name": "events_creator_id_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_types": {
+      "name": "event_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_player_cap": {
+          "name": "default_player_cap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_duration_minutes": {
+          "name": "default_duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_composition": {
+          "name": "requires_composition",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_types_game_id_games_id_fk": {
+          "name": "event_types_game_id_games_id_fk",
+          "tableFrom": "event_types",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_types_game_slug_unique": {
+          "name": "event_types_game_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "game_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "igdb_id": {
+          "name": "igdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregated_rating": {
+          "name": "aggregated_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "popularity": {
+          "name": "popularity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_modes": {
+          "name": "game_modes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "themes": {
+          "name": "themes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "platforms": {
+          "name": "platforms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "screenshots": {
+          "name": "screenshots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "videos": {
+          "name": "videos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "first_release_date": {
+          "name": "first_release_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_count": {
+          "name": "player_count",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitch_game_id": {
+          "name": "twitch_game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crossplay": {
+          "name": "crossplay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color_hex": {
+          "name": "color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_roles": {
+          "name": "has_roles",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_specs": {
+          "name": "has_specs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "max_characters_per_user": {
+          "name": "max_characters_per_user",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "games_igdb_id_unique": {
+          "name": "games_igdb_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "igdb_id"
+          ]
+        },
+        "games_slug_unique": {
+          "name": "games_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_signups": {
+      "name": "event_signups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_avatar_hash": {
+          "name": "discord_avatar_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation_status": {
+          "name": "confirmation_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'signed_up'"
+        },
+        "signed_up_at": {
+          "name": "signed_up_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_event_signups_event_id": {
+          "name": "idx_event_signups_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_signups_discord_user_id": {
+          "name": "idx_event_signups_discord_user_id",
+          "columns": [
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_signups_event_id_events_id_fk": {
+          "name": "event_signups_event_id_events_id_fk",
+          "tableFrom": "event_signups",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_signups_user_id_users_id_fk": {
+          "name": "event_signups_user_id_users_id_fk",
+          "tableFrom": "event_signups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_signups_character_id_characters_id_fk": {
+          "name": "event_signups_character_id_characters_id_fk",
+          "tableFrom": "event_signups",
+          "tableTo": "characters",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_user": {
+          "name": "unique_event_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id"
+          ]
+        },
+        "unique_event_discord_user": {
+          "name": "unique_event_discord_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "discord_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_or_discord": {
+          "name": "user_or_discord",
+          "value": "\"event_signups\".\"user_id\" IS NOT NULL OR \"event_signups\".\"discord_user_id\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.characters": {
+      "name": "characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "realm": {
+          "name": "realm",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class": {
+          "name": "class",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_override": {
+          "name": "role_override",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_main": {
+          "name": "is_main",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "item_level": {
+          "name": "item_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "render_url": {
+          "name": "render_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "race": {
+          "name": "race",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faction": {
+          "name": "faction",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_url": {
+          "name": "profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_variant": {
+          "name": "game_variant",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "equipment": {
+          "name": "equipment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "talents": {
+          "name": "talents",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_one_main_per_game": {
+          "name": "idx_one_main_per_game",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"characters\".\"is_main\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_characters_user_id": {
+          "name": "idx_characters_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "characters_user_id_users_id_fk": {
+          "name": "characters_user_id_users_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "characters_game_id_games_id_fk": {
+          "name": "characters_game_id_games_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_game_character": {
+          "name": "unique_user_game_character",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id",
+            "name",
+            "realm"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.local_credentials": {
+      "name": "local_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "local_credentials_user_id_users_id_fk": {
+          "name": "local_credentials_user_id_users_id_fk",
+          "tableFrom": "local_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "local_credentials_email_unique": {
+          "name": "local_credentials_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.availability": {
+      "name": "availability",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_range": {
+          "name": "time_range",
+          "type": "tsrange",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_availability_user_id": {
+          "name": "idx_availability_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "availability_user_id_users_id_fk": {
+          "name": "availability_user_id_users_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "availability_game_id_games_id_fk": {
+          "name": "availability_game_id_games_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "availability_source_event_id_events_id_fk": {
+          "name": "availability_source_event_id_events_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "events",
+          "columnsFrom": [
+            "source_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roster_assignments": {
+      "name": "roster_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signup_id": {
+          "name": "signup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "is_override": {
+          "name": "is_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_roster_assignments_event_id": {
+          "name": "idx_roster_assignments_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_roster_assignments_signup_id": {
+          "name": "idx_roster_assignments_signup_id",
+          "columns": [
+            {
+              "expression": "signup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roster_assignments_event_id_events_id_fk": {
+          "name": "roster_assignments_event_id_events_id_fk",
+          "tableFrom": "roster_assignments",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "roster_assignments_signup_id_event_signups_id_fk": {
+          "name": "roster_assignments_signup_id_event_signups_id_fk",
+          "tableFrom": "roster_assignments",
+          "tableTo": "event_signups",
+          "columnsFrom": [
+            "signup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_signup": {
+          "name": "unique_event_signup",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "signup_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_settings_key_unique": {
+          "name": "app_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_expires_at": {
+          "name": "idx_notifications_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_preferences": {
+      "name": "user_notification_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_prefs": {
+          "name": "channel_prefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"slot_vacated\":{\"inApp\":true,\"push\":true,\"discord\":true},\"event_reminder\":{\"inApp\":true,\"push\":true,\"discord\":true},\"new_event\":{\"inApp\":true,\"push\":true,\"discord\":true},\"subscribed_game\":{\"inApp\":true,\"push\":true,\"discord\":true},\"achievement_unlocked\":{\"inApp\":true,\"push\":false,\"discord\":false},\"level_up\":{\"inApp\":true,\"push\":false,\"discord\":false},\"missed_event_nudge\":{\"inApp\":true,\"push\":false,\"discord\":false},\"event_rescheduled\":{\"inApp\":true,\"push\":true,\"discord\":true},\"bench_promoted\":{\"inApp\":true,\"push\":true,\"discord\":true},\"event_cancelled\":{\"inApp\":true,\"push\":true,\"discord\":true},\"roster_reassigned\":{\"inApp\":true,\"push\":true,\"discord\":true}}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_preferences_user_id_users_id_fk": {
+          "name": "user_notification_preferences_user_id_users_id_fk",
+          "tableFrom": "user_notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_preference_key": {
+          "name": "unique_user_preference_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_time_templates": {
+      "name": "game_time_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_hour": {
+          "name": "start_hour",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_time_templates_user_id_idx": {
+          "name": "game_time_templates_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_time_templates_user_id_users_id_fk": {
+          "name": "game_time_templates_user_id_users_id_fk",
+          "tableFrom": "game_time_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_game_time_slot": {
+          "name": "unique_user_game_time_slot",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "day_of_week",
+            "start_hour"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_time_absences": {
+      "name": "game_time_absences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_time_absences_user_id_idx": {
+          "name": "game_time_absences_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_time_absences_user_id_users_id_fk": {
+          "name": "game_time_absences_user_id_users_id_fk",
+          "tableFrom": "game_time_absences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_time_overrides": {
+      "name": "game_time_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hour": {
+          "name": "hour",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_time_overrides_user_id_idx": {
+          "name": "game_time_overrides_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_time_overrides_user_id_users_id_fk": {
+          "name": "game_time_overrides_user_id_users_id_fk",
+          "tableFrom": "game_time_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_override_date_hour": {
+          "name": "unique_user_override_date_hour",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "date",
+            "hour"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_interests": {
+      "name": "game_interests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_interests_user_id_users_id_fk": {
+          "name": "game_interests_user_id_users_id_fk",
+          "tableFrom": "game_interests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_interests_game_id_games_id_fk": {
+          "name": "game_interests_game_id_games_id_fk",
+          "tableFrom": "game_interests",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_user_game_interest": {
+          "name": "uq_user_game_interest",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_reminders_sent": {
+      "name": "event_reminders_sent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reminder_type": {
+          "name": "reminder_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_reminders_sent_event_id_events_id_fk": {
+          "name": "event_reminders_sent_event_id_events_id_fk",
+          "tableFrom": "event_reminders_sent",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_reminders_sent_user_id_users_id_fk": {
+          "name": "event_reminders_sent_user_id_users_id_fk",
+          "tableFrom": "event_reminders_sent",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_user_reminder": {
+          "name": "unique_event_user_reminder",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id",
+            "reminder_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_templates": {
+      "name": "event_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_templates_user_id_users_id_fk": {
+          "name": "event_templates_user_id_users_id_fk",
+          "tableFrom": "event_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plugins": {
+      "name": "plugins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config_json": {
+          "name": "config_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plugins_slug_unique": {
+          "name": "plugins_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_user_id_users_id_fk": {
+          "name": "feedback_user_id_users_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pug_slots": {
+      "name": "pug_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_avatar_hash": {
+          "name": "discord_avatar_hash",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class": {
+          "name": "class",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "server_invite_url": {
+          "name": "server_invite_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_event_pug": {
+          "name": "unique_event_pug",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pug_slots\".\"discord_username\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_invite_code": {
+          "name": "unique_invite_code",
+          "columns": [
+            {
+              "expression": "invite_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pug_slots\".\"invite_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pug_slots_event_id_events_id_fk": {
+          "name": "pug_slots_event_id_events_id_fk",
+          "tableFrom": "pug_slots",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pug_slots_claimed_by_user_id_users_id_fk": {
+          "name": "pug_slots_claimed_by_user_id_users_id_fk",
+          "tableFrom": "pug_slots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "claimed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pug_slots_created_by_users_id_fk": {
+          "name": "pug_slots_created_by_users_id_fk",
+          "tableFrom": "pug_slots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cron_jobs": {
+      "name": "cron_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_slug": {
+          "name": "plugin_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused": {
+          "name": "paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cron_jobs_name_unique": {
+          "name": "cron_jobs_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cron_job_executions": {
+      "name": "cron_job_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cron_job_id": {
+          "name": "cron_job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cron_job_executions_job_started_idx": {
+          "name": "cron_job_executions_job_started_idx",
+          "columns": [
+            {
+              "expression": "cron_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cron_job_executions_cron_job_id_cron_jobs_id_fk": {
+          "name": "cron_job_executions_cron_job_id_cron_jobs_id_fk",
+          "tableFrom": "cron_job_executions",
+          "tableTo": "cron_jobs",
+          "columnsFrom": [
+            "cron_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_event_messages": {
+      "name": "discord_event_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embed_state": {
+          "name": "embed_state",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'posted'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_discord_event_messages_event": {
+          "name": "idx_discord_event_messages_event",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_discord_event_messages_message": {
+          "name": "idx_discord_event_messages_message",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_event_messages_event_id_events_id_fk": {
+          "name": "discord_event_messages_event_id_events_id_fk",
+          "tableFrom": "discord_event_messages",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_channel_message": {
+          "name": "unique_event_channel_message",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "channel_id",
+            "message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_bindings": {
+      "name": "channel_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding_purpose": {
+          "name": "binding_purpose",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_bindings_guild_channel_unique": {
+          "name": "channel_bindings_guild_channel_unique",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_bindings_guild": {
+          "name": "idx_channel_bindings_guild",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_bindings_game": {
+          "name": "idx_channel_bindings_game",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_bindings_game_id_games_id_fk": {
+          "name": "channel_bindings_game_id_games_id_fk",
+          "tableFrom": "channel_bindings",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_event_reminders_sent": {
+      "name": "post_event_reminders_sent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pug_slot_id": {
+          "name": "pug_slot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_event_reminders_sent_event_id_events_id_fk": {
+          "name": "post_event_reminders_sent_event_id_events_id_fk",
+          "tableFrom": "post_event_reminders_sent",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_event_reminders_sent_pug_slot_id_pug_slots_id_fk": {
+          "name": "post_event_reminders_sent_pug_slot_id_pug_slots_id_fk",
+          "tableFrom": "post_event_reminders_sent",
+          "tableTo": "pug_slots",
+          "columnsFrom": [
+            "pug_slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_post_event_pug_reminder": {
+          "name": "unique_post_event_pug_reminder",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "pug_slot_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_plans": {
+      "name": "event_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slot_config": {
+          "name": "slot_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_attendees": {
+          "name": "max_attendees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_unbench": {
+          "name": "auto_unbench",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_options": {
+          "name": "poll_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_duration_hours": {
+          "name": "poll_duration_hours",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_mode": {
+          "name": "poll_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "poll_round": {
+          "name": "poll_round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "poll_channel_id": {
+          "name": "poll_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_message_id": {
+          "name": "poll_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "winning_option": {
+          "name": "winning_option",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_event_id": {
+          "name": "created_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_instances": {
+          "name": "content_instances",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_15min": {
+          "name": "reminder_15min",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_1hour": {
+          "name": "reminder_1hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reminder_24hour": {
+          "name": "reminder_24hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "poll_started_at": {
+          "name": "poll_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_ends_at": {
+          "name": "poll_ends_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_event_plans_creator_id": {
+          "name": "idx_event_plans_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_plans_status": {
+          "name": "idx_event_plans_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_plans_creator_id_users_id_fk": {
+          "name": "event_plans_creator_id_users_id_fk",
+          "tableFrom": "event_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_plans_game_id_games_id_fk": {
+          "name": "event_plans_game_id_games_id_fk",
+          "tableFrom": "event_plans",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "event_plans_created_event_id_events_id_fk": {
+          "name": "event_plans_created_event_id_events_id_fk",
+          "tableFrom": "event_plans",
+          "tableTo": "events",
+          "columnsFrom": [
+            "created_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_dungeon_quests": {
+      "name": "wow_classic_dungeon_quests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dungeon_instance_id": {
+          "name": "dungeon_instance_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quest_level": {
+          "name": "quest_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_level": {
+          "name": "required_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expansion": {
+          "name": "expansion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quest_giver_npc": {
+          "name": "quest_giver_npc",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quest_giver_zone": {
+          "name": "quest_giver_zone",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_quest_id": {
+          "name": "prev_quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_quest_id": {
+          "name": "next_quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewards_json": {
+          "name": "rewards_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objectives": {
+          "name": "objectives",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_restriction": {
+          "name": "class_restriction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "race_restriction": {
+          "name": "race_restriction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_inside_dungeon": {
+          "name": "starts_inside_dungeon",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sharable": {
+          "name": "sharable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wow_classic_dungeon_quests_quest_id_unique": {
+          "name": "wow_classic_dungeon_quests_quest_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "quest_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/src/drizzle/migrations/meta/_journal.json
+++ b/api/src/drizzle/migrations/meta/_journal.json
@@ -407,6 +407,13 @@
       "when": 1771900000000,
       "tag": "0057_event_plans",
       "breakpoints": true
+    },
+    {
+      "idx": 58,
+      "version": "7",
+      "when": 1771787655657,
+      "tag": "0058_dungeon_quests",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/drizzle/schema.ts
+++ b/api/src/drizzle/schema.ts
@@ -25,3 +25,4 @@ export * from './schema/discord-event-messages';
 export * from './schema/channel-bindings';
 export * from './schema/post-event-reminders-sent';
 export * from './schema/event-plans';
+export * from './schema/dungeon-quests';

--- a/api/src/drizzle/schema/dungeon-quests.ts
+++ b/api/src/drizzle/schema/dungeon-quests.ts
@@ -1,0 +1,56 @@
+import {
+  pgTable,
+  serial,
+  integer,
+  varchar,
+  text,
+  boolean,
+  jsonb,
+  timestamp,
+} from 'drizzle-orm/pg-core';
+
+/**
+ * WoW Classic dungeon quest data — plugin-owned table for wow-common.
+ * Seeded from TyrsDev/WoW-Classic-Quests dataset on plugin install,
+ * dropped on plugin uninstall.
+ *
+ * ROK-245: Variant-Aware Dungeon Quest Database
+ */
+export const wowClassicDungeonQuests = pgTable('wow_classic_dungeon_quests', {
+  id: serial('id').primaryKey(),
+  /** Quest ID from the TyrsDev dataset (matches Wowhead quest ID) */
+  questId: integer('quest_id').unique().notNull(),
+  /** Blizzard Journal instance ID (matches BlizzardService instance IDs) */
+  dungeonInstanceId: integer('dungeon_instance_id'),
+  /** Quest title */
+  name: varchar('name', { length: 255 }).notNull(),
+  /** Level of the quest itself */
+  questLevel: integer('quest_level'),
+  /** Minimum character level required to pick up the quest */
+  requiredLevel: integer('required_level'),
+  /** Expansion this quest belongs to: 'classic' | 'tbc' | 'wotlk' | 'cata' */
+  expansion: varchar('expansion', { length: 20 }).notNull(),
+  /** NPC name of the quest giver */
+  questGiverNpc: varchar('quest_giver_npc', { length: 255 }),
+  /** Zone where the quest giver is located */
+  questGiverZone: varchar('quest_giver_zone', { length: 255 }),
+  /** Previous quest in the chain (quest_id reference) */
+  prevQuestId: integer('prev_quest_id'),
+  /** Next quest in the chain (quest_id reference) */
+  nextQuestId: integer('next_quest_id'),
+  /** Array of reward item IDs */
+  rewardsJson: jsonb('rewards_json').$type<number[]>(),
+  /** Quest objective text */
+  objectives: text('objectives'),
+  /** Array of class names that can pick up this quest (null = all classes) */
+  classRestriction: jsonb('class_restriction').$type<string[]>(),
+  /** Array of race names that can pick up this quest (null = all races) */
+  raceRestriction: jsonb('race_restriction').$type<string[]>(),
+  /** Whether the quest pickup NPC is inside the dungeon */
+  startsInsideDungeon: boolean('starts_inside_dungeon')
+    .default(false)
+    .notNull(),
+  /** Whether the quest can be shared with party members */
+  sharable: boolean('sharable').default(true).notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull(),
+});

--- a/api/src/plugins/wow-common/data/dungeon-quest-data.json
+++ b/api/src/plugins/wow-common/data/dungeon-quest-data.json
@@ -1,0 +1,8585 @@
+[
+  {
+    "questId": 4295,
+    "dungeonInstanceId": 228,
+    "name": "Rocknot's Ale",
+    "questLevel": 1,
+    "requiredLevel": 1,
+    "expansion": "classic",
+    "questGiverNpc": "Private Rocknot",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5723,
+    "dungeonInstanceId": 226,
+    "name": "Testing an Enemy's Strength",
+    "questLevel": 15,
+    "requiredLevel": 9,
+    "expansion": "classic",
+    "questGiverNpc": "Rahauro",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Search Orgrimmar for Ragefire Chasm, then kill 8 Ragefire Troggs and 8 Ragefire Shaman before returning to Rahauro in Thunder Bluff.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5722,
+    "dungeonInstanceId": 226,
+    "name": "Searching for the Lost Satchel",
+    "questLevel": 16,
+    "requiredLevel": 9,
+    "expansion": "classic",
+    "questGiverNpc": "Rahauro",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "5724",
+    "rewardsJson": null,
+    "objectives": "Search Ragefire Chasm for Maur Grimtotem's corpse and search it for any items of interest.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5724,
+    "dungeonInstanceId": 226,
+    "name": "Returning the Lost Satchel",
+    "questLevel": 16,
+    "requiredLevel": 9,
+    "expansion": "classic",
+    "questGiverNpc": "Maur Grimtotem",
+    "questGiverZone": null,
+    "prevQuestId": "5722",
+    "nextQuestId": null,
+    "rewardsJson": [
+      15452,
+      15453
+    ],
+    "objectives": "Take the Grimtotem Satchel to Rahauro in Thunder Bluff.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5725,
+    "dungeonInstanceId": 226,
+    "name": "The Power to Destroy...",
+    "questLevel": 16,
+    "requiredLevel": 9,
+    "expansion": "classic",
+    "questGiverNpc": "Varimathras",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      15449,
+      15450,
+      15451
+    ],
+    "objectives": "Bring the books Spells of Shadow and Incantations from the Nether to Varimathras in Undercity.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5728,
+    "dungeonInstanceId": 226,
+    "name": "Hidden Enemies",
+    "questLevel": 16,
+    "requiredLevel": 9,
+    "expansion": "classic",
+    "questGiverNpc": "Thrall",
+    "questGiverZone": null,
+    "prevQuestId": "5727",
+    "nextQuestId": "5729",
+    "rewardsJson": null,
+    "objectives": "Kill Bazzalan and Jergosh the Invoker before returning to Thrall in Orgrimmar.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5761,
+    "dungeonInstanceId": 226,
+    "name": "Slaying the Beast",
+    "questLevel": 16,
+    "requiredLevel": 9,
+    "expansion": "classic",
+    "questGiverNpc": "Neeru Fireblade",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Enter Ragefire Chasm and slay Taragaman the Hungerer, then bring his heart back to Neeru Fireblade in Orgrimmar.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 214,
+    "dungeonInstanceId": 63,
+    "name": "Red Silk Bandanas",
+    "questLevel": 17,
+    "requiredLevel": 14,
+    "expansion": "classic",
+    "questGiverNpc": "Scout Riell",
+    "questGiverZone": null,
+    "prevQuestId": "155",
+    "nextQuestId": null,
+    "rewardsJson": [
+      2074,
+      2089,
+      6094
+    ],
+    "objectives": "Scout Riell at the Sentinel Hill Tower wants you to bring her 10 Red Silk Bandanas.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 1486,
+    "dungeonInstanceId": 240,
+    "name": "Deviate Hides",
+    "questLevel": 17,
+    "requiredLevel": 13,
+    "expansion": "classic",
+    "questGiverNpc": "Nalpak",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      6480,
+      918
+    ],
+    "objectives": "Nalpak in the Wailing Caverns wants 20 Deviate Hides.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Gnome",
+      "Tauren",
+      "Undead",
+      "Night Elf",
+      "Dwarf",
+      "Orc",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 1491,
+    "dungeonInstanceId": 240,
+    "name": "Smart Drinks",
+    "questLevel": 18,
+    "requiredLevel": 13,
+    "expansion": "classic",
+    "questGiverNpc": "Mebok Mizzyrix",
+    "questGiverZone": null,
+    "prevQuestId": "865",
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Bring 6 portions of Wailing Essence to Mebok Mizzyrix in Ratchet.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2040,
+    "dungeonInstanceId": 63,
+    "name": "Underground Assault",
+    "questLevel": 20,
+    "requiredLevel": 15,
+    "expansion": "classic",
+    "questGiverNpc": "Shoni the Shilent",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      7606,
+      7607
+    ],
+    "objectives": "Retrieve the Gnoam Sprecklesprocket from the Deadmines and return it to Shoni the Shilent in Stormwind.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 1487,
+    "dungeonInstanceId": 240,
+    "name": "Deviate Eradication",
+    "questLevel": 21,
+    "requiredLevel": 15,
+    "expansion": "classic",
+    "questGiverNpc": "Ebru",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      6476,
+      8071,
+      6481
+    ],
+    "objectives": "Ebru in the Wailing Caverns wants you to kill 7 Deviate Ravagers, 7 Deviate Vipers, 7 Deviate Shamblers and 7 Deviate Dreadfangs.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 1653,
+    "dungeonInstanceId": null,
+    "name": "The Test of Righteousness",
+    "questLevel": 21,
+    "requiredLevel": 20,
+    "expansion": "classic",
+    "questGiverNpc": "Duthorian Rall",
+    "questGiverZone": null,
+    "prevQuestId": "1652",
+    "nextQuestId": "1654",
+    "rewardsJson": null,
+    "objectives": "Speak to Jordan Stilwell in Ironforge",
+    "classRestriction": [
+      "Paladin"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 166,
+    "dungeonInstanceId": 63,
+    "name": "The Defias Brotherhood",
+    "questLevel": 22,
+    "requiredLevel": 14,
+    "expansion": "classic",
+    "questGiverNpc": "Gryan Stoutmantle",
+    "questGiverZone": null,
+    "prevQuestId": "155",
+    "nextQuestId": null,
+    "rewardsJson": [
+      6087,
+      2041,
+      2042
+    ],
+    "objectives": "Kill Edwin VanCleef and bring his head to Gryan Stoutmantle.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 914,
+    "dungeonInstanceId": 240,
+    "name": "Leaders of the Fang",
+    "questLevel": 22,
+    "requiredLevel": 10,
+    "expansion": "classic",
+    "questGiverNpc": "Nara Wildmane",
+    "questGiverZone": null,
+    "prevQuestId": "1490",
+    "nextQuestId": null,
+    "rewardsJson": [
+      6505,
+      6504
+    ],
+    "objectives": "Bring the Gems of Cobrahn, Anacondra, Pythas and Serpentis to Nara Wildmane in Thunder Bluff.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 1442,
+    "dungeonInstanceId": null,
+    "name": "Seeking the Kor Gem",
+    "questLevel": 22,
+    "requiredLevel": 20,
+    "expansion": "classic",
+    "questGiverNpc": "Thundris Windweaver",
+    "questGiverZone": null,
+    "prevQuestId": "1653",
+    "nextQuestId": null,
+    "rewardsJson": [
+      7083
+    ],
+    "objectives": "Bring a Kor Gem to Thundris Windweaver in Darkshore.",
+    "classRestriction": [
+      "Paladin"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 1654,
+    "dungeonInstanceId": null,
+    "name": "The Test of Righteousness",
+    "questLevel": 22,
+    "requiredLevel": 20,
+    "expansion": "classic",
+    "questGiverNpc": "Jordan Stilwell",
+    "questGiverZone": null,
+    "prevQuestId": "1653",
+    "nextQuestId": "1806",
+    "rewardsJson": null,
+    "objectives": "Using Jordan's Weapon Notes, find some Whitestone Oak Lumber, Bailor's Refined Ore Shipment, Jordan's Smithing Hammer, and a Kor Gem, and return them to Jordan Stilwell in Ironforge.",
+    "classRestriction": [
+      "Paladin"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 6562,
+    "dungeonInstanceId": 227,
+    "name": "Trouble in the Deeps",
+    "questLevel": 22,
+    "requiredLevel": 17,
+    "expansion": "classic",
+    "questGiverNpc": "Tsunaman",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "6563",
+    "rewardsJson": null,
+    "objectives": "Speak to Je'neu Sancrea in Ashenvale.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 6563,
+    "dungeonInstanceId": 227,
+    "name": "The Essence of Aku'Mai",
+    "questLevel": 22,
+    "requiredLevel": 17,
+    "expansion": "classic",
+    "questGiverNpc": "Je'neu Sancrea",
+    "questGiverZone": null,
+    "prevQuestId": "6562",
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Bring 20 Sapphires of Aku'Mai to Je'neu Sancrea in Ashenvale.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 6564,
+    "dungeonInstanceId": 227,
+    "name": "Allegiance to the Old Gods",
+    "questLevel": 22,
+    "requiredLevel": 17,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "6565",
+    "rewardsJson": null,
+    "objectives": "Bring the Damp Note to Je'neu Sancrea in Ashenvale.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": false
+  },
+  {
+    "questId": 971,
+    "dungeonInstanceId": 227,
+    "name": "Knowledge in the Deeps",
+    "questLevel": 23,
+    "requiredLevel": 10,
+    "expansion": "classic",
+    "questGiverNpc": "Gerrig Bonegrip",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      6743
+    ],
+    "objectives": "Bring the Lorgalis Manuscript to Gerrig Bonegrip in the Forlorn Cavern in Ironforge.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 1198,
+    "dungeonInstanceId": 227,
+    "name": "In Search of Thaelrid",
+    "questLevel": 24,
+    "requiredLevel": 18,
+    "expansion": "classic",
+    "questGiverNpc": "Dawnwatcher Shaedlass",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "1200",
+    "rewardsJson": null,
+    "objectives": "Seek out Argent Guard Thaelrid in Blackfathom Deeps.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 1275,
+    "dungeonInstanceId": 227,
+    "name": "Researching the Corruption",
+    "questLevel": 24,
+    "requiredLevel": 18,
+    "expansion": "classic",
+    "questGiverNpc": "Gershala Nightwhisper",
+    "questGiverZone": null,
+    "prevQuestId": "3765",
+    "nextQuestId": null,
+    "rewardsJson": [
+      7003,
+      7004
+    ],
+    "objectives": "Gershala Nightwhisper in Auberdine wants 8 Corrupt Brain stems.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 386,
+    "dungeonInstanceId": 238,
+    "name": "What Comes Around...",
+    "questLevel": 25,
+    "requiredLevel": 22,
+    "expansion": "classic",
+    "questGiverNpc": "Guard Berton",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      3400,
+      1317
+    ],
+    "objectives": "Bring the head of Targorr the Dread to Guard Berton in Lakeshire.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 1098,
+    "dungeonInstanceId": 64,
+    "name": "Deathstalkers in Shadowfang",
+    "questLevel": 25,
+    "requiredLevel": 18,
+    "expansion": "classic",
+    "questGiverNpc": "High Executor Hadrec",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      3324
+    ],
+    "objectives": "Find the Deathstalker Adamant and Deathstalker Vincent.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 1199,
+    "dungeonInstanceId": 227,
+    "name": "Twilight Falls",
+    "questLevel": 25,
+    "requiredLevel": 20,
+    "expansion": "classic",
+    "questGiverNpc": "Argent Guard Manados",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      6998,
+      7000
+    ],
+    "objectives": "Bring 10 Twilight Pendants to Argent Guard Manados in Darnassus.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 1740,
+    "dungeonInstanceId": null,
+    "name": "The Orb of Soran'ruk",
+    "questLevel": 25,
+    "requiredLevel": 20,
+    "expansion": "classic",
+    "questGiverNpc": "Doan Karhan",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      6898,
+      15109
+    ],
+    "objectives": "Find 3 Soran'ruk Fragments and 1 Large Soran'ruk Fragment and return them to Doan Karhan in the Barrens.",
+    "classRestriction": [
+      "Warlock"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 377,
+    "dungeonInstanceId": 238,
+    "name": "Crime and Punishment",
+    "questLevel": 26,
+    "requiredLevel": 22,
+    "expansion": "classic",
+    "questGiverNpc": "Councilman Millstipe",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      2033,
+      2906
+    ],
+    "objectives": "Councilman Millstipe of Darkshire wants you to bring him the hand of Dextren Ward.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 387,
+    "dungeonInstanceId": 238,
+    "name": "Quell The Uprising",
+    "questLevel": 26,
+    "requiredLevel": 22,
+    "expansion": "classic",
+    "questGiverNpc": "Warden Thelwater",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Warden Thelwater of Stormwind wants you to kill 10 Defias Prisoners, 8 Defias Convicts, and 8 Defias Insurgents in The Stockade.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 388,
+    "dungeonInstanceId": 238,
+    "name": "The Color of Blood",
+    "questLevel": 26,
+    "requiredLevel": 22,
+    "expansion": "classic",
+    "questGiverNpc": "Nikova Raskol",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Nikova Raskol of Stormwind wants you to collect 10 Red Wool Bandanas.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 1013,
+    "dungeonInstanceId": 64,
+    "name": "The Book of Ur",
+    "questLevel": 26,
+    "requiredLevel": 16,
+    "expansion": "classic",
+    "questGiverNpc": "Keeper Bel'dugur",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      6335,
+      4534
+    ],
+    "objectives": "Bring the Book of Ur to Keeper Bel'dugur at the Apothecarium in the Undercity.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 1221,
+    "dungeonInstanceId": 234,
+    "name": "Blueleaf Tubers",
+    "questLevel": 26,
+    "requiredLevel": 20,
+    "expansion": "classic",
+    "questGiverNpc": "Mebok Mizzyrix",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      6755
+    ],
+    "objectives": "Grab a Crate with Holes.$BGrab a Snufflenose Command Stick.$BGrab and read the Snufflenose Owner's Manual.$B$BIn Razorfen Kraul, use the Crate with Holes to summon a Snufflenose Gopher, and use the Command Stick on the gopher to make it search for Tubers.$B$BBring 6 Blueleaf Tubers, the Snufflenose Command Stick and the Crate with Holes to Mebok Mizzyrix in Ratchet.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2922,
+    "dungeonInstanceId": 231,
+    "name": "Save Techbot's Brain!",
+    "questLevel": 26,
+    "requiredLevel": 20,
+    "expansion": "classic",
+    "questGiverNpc": "Tinkmaster Overspark",
+    "questGiverZone": null,
+    "prevQuestId": "2923",
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Bring Techbot's Memory Core to Tinkmaster Overspark in Ironforge.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2923,
+    "dungeonInstanceId": 231,
+    "name": "Tinkmaster Overspark",
+    "questLevel": 26,
+    "requiredLevel": 20,
+    "expansion": "classic",
+    "questGiverNpc": "Brother Sarno",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "2922",
+    "rewardsJson": null,
+    "objectives": "Speak with Tinkmaster Overspark in Ironforge.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 6565,
+    "dungeonInstanceId": 227,
+    "name": "Allegiance to the Old Gods",
+    "questLevel": 26,
+    "requiredLevel": 17,
+    "expansion": "classic",
+    "questGiverNpc": "Je'neu Sancrea",
+    "questGiverZone": null,
+    "prevQuestId": "6564",
+    "nextQuestId": null,
+    "rewardsJson": [
+      17694,
+      17695
+    ],
+    "objectives": "Kill Lorgus Jett in Blackfathom Deeps and then return to Je'neu Sancrea in Ashenvale.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 378,
+    "dungeonInstanceId": 238,
+    "name": "The Fury Runs Deep",
+    "questLevel": 27,
+    "requiredLevel": 22,
+    "expansion": "classic",
+    "questGiverNpc": "Motley Garmason",
+    "questGiverZone": null,
+    "prevQuestId": "303",
+    "nextQuestId": null,
+    "rewardsJson": [
+      3562,
+      1264
+    ],
+    "objectives": "Motley Garmason wants Kam Deepfury's head brought to him at Dun Modr.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 1014,
+    "dungeonInstanceId": 64,
+    "name": "Arugal Must Die",
+    "questLevel": 27,
+    "requiredLevel": 18,
+    "expansion": "classic",
+    "questGiverNpc": "Dalar Dawnweaver",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      6414
+    ],
+    "objectives": "Kill Arugal and bring his head to Dalar Dawnweaver at the Sepulcher.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 1200,
+    "dungeonInstanceId": 227,
+    "name": "Blackfathom Villainy",
+    "questLevel": 27,
+    "requiredLevel": 18,
+    "expansion": "classic",
+    "questGiverNpc": "Argent Guard Thaelrid",
+    "questGiverZone": null,
+    "prevQuestId": "1198",
+    "nextQuestId": null,
+    "rewardsJson": [
+      7001,
+      7002
+    ],
+    "objectives": "Bring the head of Twilight Lord Kelris to Dawnwatcher Selgorm in Darnassus.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2926,
+    "dungeonInstanceId": 231,
+    "name": "Gnogaine",
+    "questLevel": 27,
+    "requiredLevel": 20,
+    "expansion": "classic",
+    "questGiverNpc": "Ozzie Togglevolt",
+    "questGiverZone": null,
+    "prevQuestId": "2927",
+    "nextQuestId": "2962",
+    "rewardsJson": null,
+    "objectives": "Use the Empty Leaden Collection Phial on Irradiated Invaders or Irradiated Pillagers to collect radioactive fallout. Once it is full, take it back to Ozzie Togglevolt in Kharanos.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2927,
+    "dungeonInstanceId": 231,
+    "name": "The Day After",
+    "questLevel": 27,
+    "requiredLevel": 20,
+    "expansion": "classic",
+    "questGiverNpc": "Gnoarn",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "2926",
+    "rewardsJson": null,
+    "objectives": "Speak with Ozzie Togglevolt in Kharanos.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 6561,
+    "dungeonInstanceId": 227,
+    "name": "Blackfathom Villainy",
+    "questLevel": 27,
+    "requiredLevel": 18,
+    "expansion": "classic",
+    "questGiverNpc": "Argent Guard Thaelrid",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      7001,
+      7002
+    ],
+    "objectives": "Bring the head of Twilight Lord Kelris to Bashana Runetotem in Thunder Bluff.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 6921,
+    "dungeonInstanceId": 227,
+    "name": "Amongst the Ruins",
+    "questLevel": 27,
+    "requiredLevel": 21,
+    "expansion": "classic",
+    "questGiverNpc": "Je'neu Sancrea",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Bring the Fathom Core to Je'neu Sancrea at Zoram'gar Outpost, Ashenvale.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2931,
+    "dungeonInstanceId": 231,
+    "name": "Castpipe's Task",
+    "questLevel": 28,
+    "requiredLevel": 25,
+    "expansion": "classic",
+    "questGiverNpc": "Gaxim Rustfizzle",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "2930",
+    "rewardsJson": null,
+    "objectives": "Speak with Master Mechanic Castpipe in Ironforge.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 391,
+    "dungeonInstanceId": 238,
+    "name": "The Stockade Riots",
+    "questLevel": 29,
+    "requiredLevel": 16,
+    "expansion": "classic",
+    "questGiverNpc": "Warden Thelwater",
+    "questGiverZone": null,
+    "prevQuestId": "389",
+    "nextQuestId": "392",
+    "rewardsJson": null,
+    "objectives": "Kill Bazil Thredd and bring his head back to Warden Thelwater at the Stockade.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 1142,
+    "dungeonInstanceId": 234,
+    "name": "Mortality Wanes",
+    "questLevel": 30,
+    "requiredLevel": 25,
+    "expansion": "classic",
+    "questGiverNpc": "Heralath Fallowbrook",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      6751,
+      6752
+    ],
+    "objectives": "Find and return Treshala's Pendant to Treshala Fallowbrook in Darnassus.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 1144,
+    "dungeonInstanceId": 234,
+    "name": "Willix the Importer",
+    "questLevel": 30,
+    "requiredLevel": 22,
+    "expansion": "classic",
+    "questGiverNpc": "Willix the Importer",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      6748,
+      6750,
+      6749
+    ],
+    "objectives": "Escort Willix the Importer out of Razorfen Kraul.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2904,
+    "dungeonInstanceId": 231,
+    "name": "A Fine Mess",
+    "questLevel": 30,
+    "requiredLevel": 20,
+    "expansion": "classic",
+    "questGiverNpc": "Kernobee",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      9535,
+      9536
+    ],
+    "objectives": "Escort Kernobee to the Clockwerk Run exit and then report to Scooty in Booty Bay.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2924,
+    "dungeonInstanceId": 231,
+    "name": "Essential Artificials",
+    "questLevel": 30,
+    "requiredLevel": 24,
+    "expansion": "classic",
+    "questGiverNpc": "Klockmort Spannerspan",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Bring 12 Essential Artificials to Klockmort Spannerspan in Ironforge.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2925,
+    "dungeonInstanceId": 231,
+    "name": "Klockmort's Essentials",
+    "questLevel": 30,
+    "requiredLevel": 24,
+    "expansion": "classic",
+    "questGiverNpc": "Mathiel",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "2924",
+    "rewardsJson": null,
+    "objectives": "Speak with Klockmort Spannerspan in Ironforge.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2928,
+    "dungeonInstanceId": 231,
+    "name": "Gyrodrillmatic Excavationators",
+    "questLevel": 30,
+    "requiredLevel": 20,
+    "expansion": "classic",
+    "questGiverNpc": "Shoni the Shilent",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      9608,
+      9609
+    ],
+    "objectives": "Bring twenty-four Robo-mechanical Guts to Shoni in Stormwind.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2930,
+    "dungeonInstanceId": 231,
+    "name": "Data Rescue",
+    "questLevel": 30,
+    "requiredLevel": 25,
+    "expansion": "classic",
+    "questGiverNpc": "Master Mechanic Castpipe",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      9605,
+      9604
+    ],
+    "objectives": "Bring a Prismatic Punch Card to Master Mechanic Castpipe in Ironforge.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2951,
+    "dungeonInstanceId": 231,
+    "name": "The Sparklematic 5200!",
+    "questLevel": 30,
+    "requiredLevel": 25,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Insert a Grime-Encrusted Item into the Sparklematic 5200, and be sure to have three silver coins to start the machine.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2952,
+    "dungeonInstanceId": 231,
+    "name": "The Sparklematic 5200!",
+    "questLevel": 30,
+    "requiredLevel": 25,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": "2951",
+    "nextQuestId": null,
+    "rewardsJson": [
+      9363
+    ],
+    "objectives": "",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2953,
+    "dungeonInstanceId": 231,
+    "name": "More Sparklematic Action",
+    "questLevel": 30,
+    "requiredLevel": 25,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": "2952",
+    "nextQuestId": null,
+    "rewardsJson": [
+      9363
+    ],
+    "objectives": "",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2962,
+    "dungeonInstanceId": 231,
+    "name": "The Only Cure is More Green Glow",
+    "questLevel": 30,
+    "requiredLevel": 20,
+    "expansion": "classic",
+    "questGiverNpc": "Ozzie Togglevolt",
+    "questGiverZone": null,
+    "prevQuestId": "2926",
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Travel to Gnomeregan and bring back High Potency Radioactive Fallout. Be warned, the fallout is unstable and will collapse rather quickly.$B$BOzzie will also require your Heavy Leaden Collection Phial when the task is complete.\n",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4601,
+    "dungeonInstanceId": 231,
+    "name": "The Sparklematic 5200!",
+    "questLevel": 30,
+    "requiredLevel": 25,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Insert a Grime-Encrusted Item into the Sparklematic 5200, and be sure to have three silver coins to start the machine.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4602,
+    "dungeonInstanceId": 231,
+    "name": "The Sparklematic 5200!",
+    "questLevel": 30,
+    "requiredLevel": 25,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Insert a Grime-Encrusted Item into the Sparklematic 5200, and be sure to have three silver coins to start the machine.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4603,
+    "dungeonInstanceId": 231,
+    "name": "More Sparklematic Action",
+    "questLevel": 30,
+    "requiredLevel": 25,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": "4605",
+    "nextQuestId": null,
+    "rewardsJson": [
+      9363
+    ],
+    "objectives": "",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4604,
+    "dungeonInstanceId": 231,
+    "name": "More Sparklematic Action",
+    "questLevel": 30,
+    "requiredLevel": 25,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": "4606",
+    "nextQuestId": null,
+    "rewardsJson": [
+      9363
+    ],
+    "objectives": "",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4605,
+    "dungeonInstanceId": 231,
+    "name": "The Sparklematic 5200!",
+    "questLevel": 30,
+    "requiredLevel": 25,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": "4601",
+    "nextQuestId": null,
+    "rewardsJson": [
+      9363
+    ],
+    "objectives": "",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4606,
+    "dungeonInstanceId": 231,
+    "name": "The Sparklematic 5200!",
+    "questLevel": 30,
+    "requiredLevel": 25,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": "4602",
+    "nextQuestId": null,
+    "rewardsJson": [
+      9363
+    ],
+    "objectives": "",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 6922,
+    "dungeonInstanceId": null,
+    "name": "Baron Aquanis",
+    "questLevel": 30,
+    "requiredLevel": 21,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      16886,
+      16887
+    ],
+    "objectives": "Bring the Strange Water Globe to Je'neu Sancrea at Zoram'gar Outpost, Ashenvale.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 1109,
+    "dungeonInstanceId": 234,
+    "name": "Going, Going, Guano!",
+    "questLevel": 33,
+    "requiredLevel": 30,
+    "expansion": "classic",
+    "questGiverNpc": "Master Apothecary Faranell",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "1113",
+    "rewardsJson": null,
+    "objectives": "Bring 1 pile of Kraul Guano to Master Apothecary Faranell in the Undercity.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 1101,
+    "dungeonInstanceId": 234,
+    "name": "The Crone of the Kraul",
+    "questLevel": 34,
+    "requiredLevel": 29,
+    "expansion": "classic",
+    "questGiverNpc": "Falfindel Waywarder",
+    "questGiverZone": null,
+    "prevQuestId": "1100",
+    "nextQuestId": null,
+    "rewardsJson": [
+      4197,
+      6742,
+      6725
+    ],
+    "objectives": "Bring Razorflank's Medallion to Falfindel Waywarder in Thalanaar.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 1102,
+    "dungeonInstanceId": 234,
+    "name": "A Vengeful Fate",
+    "questLevel": 34,
+    "requiredLevel": 29,
+    "expansion": "classic",
+    "questGiverNpc": "Auld Stonespire",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      4197,
+      6742,
+      6725
+    ],
+    "objectives": "Bring Razorflank's Heart to Auld Stonespire in Thunder Bluff.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2945,
+    "dungeonInstanceId": 231,
+    "name": "Grime-Encrusted Ring",
+    "questLevel": 34,
+    "requiredLevel": 28,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Figure out a way to remove the grime from the Grime-Encrusted Ring.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2947,
+    "dungeonInstanceId": 231,
+    "name": "Return of the Ring",
+    "questLevel": 34,
+    "requiredLevel": 28,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": "2945",
+    "nextQuestId": "2948",
+    "rewardsJson": null,
+    "objectives": "You may either keep the ring, or you may find the person responsible for the imprint and engravings on the inside of the band.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2949,
+    "dungeonInstanceId": 231,
+    "name": "Return of the Ring",
+    "questLevel": 34,
+    "requiredLevel": 28,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": "2945",
+    "nextQuestId": "2950",
+    "rewardsJson": null,
+    "objectives": "You may either keep the ring, or you may find the person responsible for the imprint and engravings on the inside of the band.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 721,
+    "dungeonInstanceId": 239,
+    "name": "A Sign of Hope",
+    "questLevel": 35,
+    "requiredLevel": 35,
+    "expansion": "classic",
+    "questGiverNpc": "Prospector Ryedol",
+    "questGiverZone": null,
+    "prevQuestId": "720",
+    "nextQuestId": "722",
+    "rewardsJson": null,
+    "objectives": "Find Hammertoe Grez in Uldaman.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2841,
+    "dungeonInstanceId": 231,
+    "name": "Rig Wars",
+    "questLevel": 35,
+    "requiredLevel": 25,
+    "expansion": "classic",
+    "questGiverNpc": "Nogg",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      9623,
+      9624,
+      9625
+    ],
+    "objectives": "Retrieve the Rig Blueprints and Thermaplugg's Safe Combination from Gnomeregan and bring them to Nogg in Orgrimmar.\n",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2842,
+    "dungeonInstanceId": 231,
+    "name": "Chief Engineer Scooty",
+    "questLevel": 35,
+    "requiredLevel": 20,
+    "expansion": "classic",
+    "questGiverNpc": "Sovik",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "2843",
+    "rewardsJson": null,
+    "objectives": "Speak with Scooty in Booty Bay.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2843,
+    "dungeonInstanceId": 231,
+    "name": "Gnomer-gooooone!",
+    "questLevel": 35,
+    "requiredLevel": 20,
+    "expansion": "classic",
+    "questGiverNpc": "Scooty",
+    "questGiverZone": null,
+    "prevQuestId": "2842",
+    "nextQuestId": null,
+    "rewardsJson": [
+      9173
+    ],
+    "objectives": "Wait for Scooty to calibrate the Goblin Transponder.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2929,
+    "dungeonInstanceId": 231,
+    "name": "The Grand Betrayal",
+    "questLevel": 35,
+    "requiredLevel": 25,
+    "expansion": "classic",
+    "questGiverNpc": "High Tinker Mekkatorque",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      9623,
+      9624,
+      9625
+    ],
+    "objectives": "Venture to Gnomeregan and kill Mekgineer Thermaplugg. Return to High Tinker Mekkatorque when the task is complete.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 6626,
+    "dungeonInstanceId": 233,
+    "name": "A Host of Evil",
+    "questLevel": 35,
+    "requiredLevel": 28,
+    "expansion": "classic",
+    "questGiverNpc": "Myriam Moonsinger",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Kill 8 Razorfen Battleguard, 8 Razorfen Thornweavers, and 8 Death's Head Cultists and return to Myriam Moonsinger near the entrance to Razorfen Downs.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 1160,
+    "dungeonInstanceId": 316,
+    "name": "Test of Lore",
+    "questLevel": 36,
+    "requiredLevel": 25,
+    "expansion": "classic",
+    "questGiverNpc": "Parqual Fintallas",
+    "questGiverZone": null,
+    "prevQuestId": "1159",
+    "nextQuestId": "6628",
+    "rewardsJson": null,
+    "objectives": "Find The Beginnings of the Undead Threat, and return it to Parqual Fintallas in Undercity.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 6521,
+    "dungeonInstanceId": 233,
+    "name": "An Unholy Alliance",
+    "questLevel": 36,
+    "requiredLevel": 28,
+    "expansion": "classic",
+    "questGiverNpc": "Varimathras",
+    "questGiverZone": null,
+    "prevQuestId": "6522",
+    "nextQuestId": null,
+    "rewardsJson": [
+      17039,
+      17042,
+      17043
+    ],
+    "objectives": "Bring Ambassador Malcin's Head to Varimathras in the Undercity.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 6522,
+    "dungeonInstanceId": 233,
+    "name": "An Unholy Alliance",
+    "questLevel": 36,
+    "requiredLevel": 28,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "6521",
+    "rewardsJson": null,
+    "objectives": "Take the Small Scroll to Varimathras in the Undercity.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 3523,
+    "dungeonInstanceId": 233,
+    "name": "Scourge of the Downs",
+    "questLevel": 37,
+    "requiredLevel": 32,
+    "expansion": "classic",
+    "questGiverNpc": "Belnistrasz",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "3525",
+    "rewardsJson": null,
+    "objectives": "If you agree to aid Belnistrasz, speak with him again and hand the Oathstone he gave you back to him.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 3525,
+    "dungeonInstanceId": 233,
+    "name": "Extinguishing the Idol",
+    "questLevel": 37,
+    "requiredLevel": 32,
+    "expansion": "classic",
+    "questGiverNpc": "Belnistrasz",
+    "questGiverZone": null,
+    "prevQuestId": "3523",
+    "nextQuestId": null,
+    "rewardsJson": [
+      10710
+    ],
+    "objectives": "Escort Belnistrasz to the Quilboar's idol in Razorfen Downs.$B$BProtect Belnistrasz while he performs the ritual to shut down the idol.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 1049,
+    "dungeonInstanceId": 316,
+    "name": "Compendium of the Fallen",
+    "questLevel": 38,
+    "requiredLevel": 28,
+    "expansion": "classic",
+    "questGiverNpc": "Sage Truthseeker",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      7747,
+      17508,
+      7749
+    ],
+    "objectives": "Retrieve the Compendium of the Fallen from the Monastery in Tirisfal Glades and return to Sage Truthseeker in Thunder Bluff.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 1050,
+    "dungeonInstanceId": 316,
+    "name": "Mythology of the Titans",
+    "questLevel": 38,
+    "requiredLevel": 28,
+    "expansion": "classic",
+    "questGiverNpc": "Librarian Mae Paledust",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      7746
+    ],
+    "objectives": "Retrieve Mythology of the Titans from the Monastery and bring it to Librarian Mae Paledust in Ironforge.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 722,
+    "dungeonInstanceId": 239,
+    "name": "Amulet of Secrets",
+    "questLevel": 40,
+    "requiredLevel": 35,
+    "expansion": "classic",
+    "questGiverNpc": "Hammertoe Grez",
+    "questGiverZone": null,
+    "prevQuestId": "721",
+    "nextQuestId": "723",
+    "rewardsJson": null,
+    "objectives": "Find Hammertoe's Amulet and return it to him in Uldaman.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 1053,
+    "dungeonInstanceId": 316,
+    "name": "In the Name of the Light",
+    "questLevel": 40,
+    "requiredLevel": 34,
+    "expansion": "classic",
+    "questGiverNpc": "Raleigh the Devout",
+    "questGiverZone": null,
+    "prevQuestId": "1052",
+    "nextQuestId": null,
+    "rewardsJson": [
+      6829,
+      6830,
+      6831,
+      11262
+    ],
+    "objectives": "Kill High Inquisitor Whitemane, Scarlet Commander Mograine,  Herod, the Scarlet Champion and Houndmaster Loksey and then report back to Raleigh the Devout in Southshore.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 1951,
+    "dungeonInstanceId": null,
+    "name": "Rituals of Power",
+    "questLevel": 40,
+    "requiredLevel": 30,
+    "expansion": "classic",
+    "questGiverNpc": "Magus Tirth",
+    "questGiverZone": null,
+    "prevQuestId": "1950",
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Bring the book Rituals of Power to Tabetha in Dustwallow Marsh.",
+    "classRestriction": [
+      "Mage"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 1956,
+    "dungeonInstanceId": null,
+    "name": "Power in Uldaman",
+    "questLevel": 40,
+    "requiredLevel": 35,
+    "expansion": "classic",
+    "questGiverNpc": "Tabetha",
+    "questGiverZone": null,
+    "prevQuestId": "1955",
+    "nextQuestId": "1957",
+    "rewardsJson": null,
+    "objectives": "Retrieve an Obsidian Power Source and bring it to Tabetha in Dustwallow Marsh.",
+    "classRestriction": [
+      "Mage"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 2240,
+    "dungeonInstanceId": 239,
+    "name": "The Hidden Chamber",
+    "questLevel": 40,
+    "requiredLevel": 35,
+    "expansion": "classic",
+    "questGiverNpc": "Baelog",
+    "questGiverZone": null,
+    "prevQuestId": "2398",
+    "nextQuestId": null,
+    "rewardsJson": [
+      9626,
+      9627
+    ],
+    "objectives": "Read Baelog's Journal, explore the hidden chamber, then report to Prospector Stormpike.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2398,
+    "dungeonInstanceId": 239,
+    "name": "The Lost Dwarves",
+    "questLevel": 40,
+    "requiredLevel": 35,
+    "expansion": "classic",
+    "questGiverNpc": "Prospector Stormpike",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "2240",
+    "rewardsJson": null,
+    "objectives": "Find Baelog in Uldaman.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2198,
+    "dungeonInstanceId": 239,
+    "name": "The Shattered Necklace",
+    "questLevel": 41,
+    "requiredLevel": 37,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "2199",
+    "rewardsJson": null,
+    "objectives": "Search for the original creator of the shattered necklace to learn of its potential value.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2199,
+    "dungeonInstanceId": 239,
+    "name": "Lore for a Price",
+    "questLevel": 41,
+    "requiredLevel": 37,
+    "expansion": "classic",
+    "questGiverNpc": "Talvash del Kissel",
+    "questGiverZone": null,
+    "prevQuestId": "2198",
+    "nextQuestId": "2200",
+    "rewardsJson": null,
+    "objectives": "Bring five silver bars to Talvash del Kissel in Ironforge.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2283,
+    "dungeonInstanceId": 239,
+    "name": "Necklace Recovery",
+    "questLevel": 41,
+    "requiredLevel": 37,
+    "expansion": "classic",
+    "questGiverNpc": "Dran Droffers",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "2284",
+    "rewardsJson": null,
+    "objectives": "Look for a valuable necklace within the Uldaman dig site and bring it back to Dran Droffers in Orgrimmar.  The necklace may be damaged.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2284,
+    "dungeonInstanceId": 239,
+    "name": "Necklace Recovery, Take 2",
+    "questLevel": 41,
+    "requiredLevel": 37,
+    "expansion": "classic",
+    "questGiverNpc": "Dran Droffers",
+    "questGiverZone": null,
+    "prevQuestId": "2283",
+    "nextQuestId": "2318",
+    "rewardsJson": null,
+    "objectives": "Find a clue as to the gems' whereabouts in the depths of Uldaman.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 1048,
+    "dungeonInstanceId": 316,
+    "name": "Into The Scarlet Monastery",
+    "questLevel": 42,
+    "requiredLevel": 33,
+    "expansion": "classic",
+    "questGiverNpc": "Varimathras",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      6802,
+      6803,
+      10711
+    ],
+    "objectives": "Kill High Inquisitor Whitemane, Scarlet Commander Mograine, Herod, the Scarlet Champion and Houndmaster Loksey and then report back to Varimathras in the Undercity.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2200,
+    "dungeonInstanceId": 239,
+    "name": "Back to Uldaman",
+    "questLevel": 42,
+    "requiredLevel": 37,
+    "expansion": "classic",
+    "questGiverNpc": "Talvash del Kissel",
+    "questGiverZone": null,
+    "prevQuestId": "2199",
+    "nextQuestId": "2201",
+    "rewardsJson": null,
+    "objectives": "Search for clues as to the current disposition of Talvash's necklace within Uldaman.  The slain paladin he mentioned was the person who had it last.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2318,
+    "dungeonInstanceId": 239,
+    "name": "Translating the Journal",
+    "questLevel": 42,
+    "requiredLevel": 37,
+    "expansion": "classic",
+    "questGiverNpc": "Remains of a Paladin",
+    "questGiverZone": null,
+    "prevQuestId": "2284",
+    "nextQuestId": "2338",
+    "rewardsJson": null,
+    "objectives": "Find someone who can translate the paladin's journal.  The closest location that might have someone is Kargath, in the Badlands.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2338,
+    "dungeonInstanceId": 239,
+    "name": "Translating the Journal",
+    "questLevel": 42,
+    "requiredLevel": 37,
+    "expansion": "classic",
+    "questGiverNpc": "Jarkal Mossmeld",
+    "questGiverZone": null,
+    "prevQuestId": "2318",
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Let Jarkal borrow the necklace.  In exchange, he will translate the journal for you.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 3341,
+    "dungeonInstanceId": 233,
+    "name": "Bring the End",
+    "questLevel": 42,
+    "requiredLevel": 37,
+    "expansion": "classic",
+    "questGiverNpc": "Andrew Brownell",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      10823,
+      10824
+    ],
+    "objectives": "Andrew Brownell wants you to kill Amnennar the Coldbringer and return his skull.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 3636,
+    "dungeonInstanceId": 233,
+    "name": "Bring the Light",
+    "questLevel": 42,
+    "requiredLevel": 39,
+    "expansion": "classic",
+    "questGiverNpc": "Archbishop Benedictus",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      10823,
+      10824
+    ],
+    "objectives": "Archbishop Bendictus wants you to slay Amnennar the Coldbringer in Razorfen Downs.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7068,
+    "dungeonInstanceId": 232,
+    "name": "Shadowshard Fragments",
+    "questLevel": 42,
+    "requiredLevel": 39,
+    "expansion": "classic",
+    "questGiverNpc": "Uthel'nay",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      17772,
+      17773
+    ],
+    "objectives": "Collect 10 Shadowshard Fragments from Maraudon and return them to Uthel'nay in Orgrimmar.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7070,
+    "dungeonInstanceId": 232,
+    "name": "Shadowshard Fragments",
+    "questLevel": 42,
+    "requiredLevel": 39,
+    "expansion": "classic",
+    "questGiverNpc": "Archmage Tervosh",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      17772,
+      17773
+    ],
+    "objectives": "Collect 10 Shadowshard Fragments from Maraudon and return them to Archmage Tervosh in Theramore on the coast of Dustwallow Marsh.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2201,
+    "dungeonInstanceId": 239,
+    "name": "Find the Gems",
+    "questLevel": 43,
+    "requiredLevel": 37,
+    "expansion": "classic",
+    "questGiverNpc": "Remains of a Paladin",
+    "questGiverZone": null,
+    "prevQuestId": "2200",
+    "nextQuestId": "2204",
+    "rewardsJson": null,
+    "objectives": "Find the ruby, sapphire, and topaz that are scattered throughout Uldaman.  Once acquired, contact Talvash del Kissel remotely by using the Phial of Scrying he previously gave you.$B$BFrom the journal, you know...$B* The ruby has been stashed in a barricaded Shadowforge area.$B* The topaz has been hidden in an urn in one of the Trogg areas, near some Alliance dwarves.$B$B* The sapphire has been claimed by Grimlok, the trogg leader.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2204,
+    "dungeonInstanceId": 239,
+    "name": "Restoring the Necklace",
+    "questLevel": 44,
+    "requiredLevel": 37,
+    "expansion": "classic",
+    "questGiverNpc": "Talvash del Kissel",
+    "questGiverZone": null,
+    "prevQuestId": "2201",
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Obtain a power source from the most powerful construct you can find in Uldaman, and deliver it to Talvash del Kissel in Ironforge.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2339,
+    "dungeonInstanceId": 239,
+    "name": "Find the Gems and Power Source",
+    "questLevel": 44,
+    "requiredLevel": 37,
+    "expansion": "classic",
+    "questGiverNpc": "Jarkal Mossmeld",
+    "questGiverZone": null,
+    "prevQuestId": "2338",
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Recover all three gems and a power source for the necklace from Uldaman, and then bring them to Jarkal Mossmeld in Kargath.  Jarkal believes a power source might be found on the strongest construct present in Uldaman.$B$BFrom the journal, you know...$B* The ruby has been stashed in a barricaded Shadowforge area.$B* The topaz has been hidden in an urn in one of the Trogg areas, near some Alliance dwarves.$B* The sapphire has been claimed by Grimlok, the trogg leader.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2340,
+    "dungeonInstanceId": 239,
+    "name": "Deliver the Gems",
+    "questLevel": 44,
+    "requiredLevel": 37,
+    "expansion": "classic",
+    "questGiverNpc": "Jarkal Mossmeld",
+    "questGiverZone": null,
+    "prevQuestId": "2339",
+    "nextQuestId": "2341",
+    "rewardsJson": null,
+    "objectives": "Deliver the Necklace and Gem Salvage to Dran Droffers in Orgrimmar.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2341,
+    "dungeonInstanceId": 239,
+    "name": "Necklace Recovery, Take 3",
+    "questLevel": 44,
+    "requiredLevel": 37,
+    "expansion": "classic",
+    "questGiverNpc": "Dran Droffers",
+    "questGiverZone": null,
+    "prevQuestId": "2340",
+    "nextQuestId": null,
+    "rewardsJson": [
+      7888
+    ],
+    "objectives": "Visit Jarkal Mossmeld in Kargath to see if he was successful.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2361,
+    "dungeonInstanceId": 239,
+    "name": "Restoring the Necklace",
+    "questLevel": 44,
+    "requiredLevel": 37,
+    "expansion": "classic",
+    "questGiverNpc": "Talvash del Kissel",
+    "questGiverZone": null,
+    "prevQuestId": "2204",
+    "nextQuestId": null,
+    "rewardsJson": [
+      7673
+    ],
+    "objectives": "",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 1139,
+    "dungeonInstanceId": 239,
+    "name": "The Lost Tablets of Will",
+    "questLevel": 45,
+    "requiredLevel": 35,
+    "expansion": "classic",
+    "questGiverNpc": "Advisor Belgrum",
+    "questGiverZone": null,
+    "prevQuestId": "762",
+    "nextQuestId": null,
+    "rewardsJson": [
+      6723
+    ],
+    "objectives": "Find the Tablet of Will, and return them to Advisor Belgrum in Ironforge.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2864,
+    "dungeonInstanceId": 241,
+    "name": "Tran'rek",
+    "questLevel": 45,
+    "requiredLevel": 40,
+    "expansion": "classic",
+    "questGiverNpc": "Krazek",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "2865",
+    "rewardsJson": null,
+    "objectives": "Speak with Tran'rek in Gadgetzan.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2865,
+    "dungeonInstanceId": 241,
+    "name": "Scarab Shells",
+    "questLevel": 45,
+    "requiredLevel": 40,
+    "expansion": "classic",
+    "questGiverNpc": "Tran'rek",
+    "questGiverZone": null,
+    "prevQuestId": "2864",
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Bring 5 Uncracked Scarab Shells to Tran'rek in Gadgetzan.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2936,
+    "dungeonInstanceId": 241,
+    "name": "The Spider God",
+    "questLevel": 45,
+    "requiredLevel": 40,
+    "expansion": "classic",
+    "questGiverNpc": "Master Gadrin",
+    "questGiverZone": null,
+    "prevQuestId": "2935",
+    "nextQuestId": "2937",
+    "rewardsJson": null,
+    "objectives": "Read from the Tablet of Theka to learn the name of the Witherbark spider god, then return to Master Gadrin.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 3042,
+    "dungeonInstanceId": 241,
+    "name": "Troll Temper",
+    "questLevel": 45,
+    "requiredLevel": 40,
+    "expansion": "classic",
+    "questGiverNpc": "Trenton Lighthammer",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Bring 20 Vials of Troll Temper to Trenton Lighthammer in Gadgetzan.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2769,
+    "dungeonInstanceId": null,
+    "name": "The Brassbolts Brothers",
+    "questLevel": 46,
+    "requiredLevel": 40,
+    "expansion": "classic",
+    "questGiverNpc": "Klockmort Spannerspan",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "2770",
+    "rewardsJson": null,
+    "objectives": "Speak with Wizzle Brassbolts in the Shimmering Flats.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 2846,
+    "dungeonInstanceId": 241,
+    "name": "Tiara of the Deep",
+    "questLevel": 46,
+    "requiredLevel": 40,
+    "expansion": "classic",
+    "questGiverNpc": "Tabetha",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      9527,
+      9531
+    ],
+    "objectives": "Bring the Tiara of the Deep to Tabetha in Dustwallow Marsh.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2861,
+    "dungeonInstanceId": 241,
+    "name": "Tabetha's Task",
+    "questLevel": 46,
+    "requiredLevel": 40,
+    "expansion": "classic",
+    "questGiverNpc": "Ursyn Ghull",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "2846",
+    "rewardsJson": null,
+    "objectives": "Speak with Tabetha in Dustwallow Marsh.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2278,
+    "dungeonInstanceId": 239,
+    "name": "The Platinum Discs",
+    "questLevel": 47,
+    "requiredLevel": 40,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Speak with stone watcher and learn what ancient lore it keeps.  Once you have learned what lore it has to offer, activate the Discs of Norgannon.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2279,
+    "dungeonInstanceId": 239,
+    "name": "The Platinum Discs",
+    "questLevel": 47,
+    "requiredLevel": 40,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": "2278",
+    "nextQuestId": "2439",
+    "rewardsJson": null,
+    "objectives": "Take the miniature version of the Discs of Norgannon to the Explorers' League in Ironforge.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2280,
+    "dungeonInstanceId": 239,
+    "name": "The Platinum Discs",
+    "questLevel": 47,
+    "requiredLevel": 40,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": "2278",
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Take the miniature version of the Discs of Norgannon to the one of the sages in Thunder Bluff.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2768,
+    "dungeonInstanceId": 241,
+    "name": "Divino-matic Rod",
+    "questLevel": 47,
+    "requiredLevel": 40,
+    "expansion": "classic",
+    "questGiverNpc": "Chief Engineer Bilgewhizzle",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      9533,
+      9534
+    ],
+    "objectives": "Bring the Divino-matic Rod to Chief Engineer Bilgewhizzle in Gadgetzan.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2991,
+    "dungeonInstanceId": 241,
+    "name": "Nekrum's Medallion",
+    "questLevel": 47,
+    "requiredLevel": 40,
+    "expansion": "classic",
+    "questGiverNpc": "Thadius Grimshade",
+    "questGiverZone": null,
+    "prevQuestId": "2990",
+    "nextQuestId": "2992",
+    "rewardsJson": null,
+    "objectives": "Bring Nekrum's Medallion to Thadius Grimshade in the Blasted Lands.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 3527,
+    "dungeonInstanceId": 241,
+    "name": "The Prophecy of Mosh'aru",
+    "questLevel": 47,
+    "requiredLevel": 40,
+    "expansion": "classic",
+    "questGiverNpc": "Yeh'kinya",
+    "questGiverZone": null,
+    "prevQuestId": "3520",
+    "nextQuestId": "4787",
+    "rewardsJson": null,
+    "objectives": "Bring the First and Second Mosh'aru Tablets to Yeh'kinya in Tanaris.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7028,
+    "dungeonInstanceId": 232,
+    "name": "Twisted Evils",
+    "questLevel": 47,
+    "requiredLevel": 41,
+    "expansion": "classic",
+    "questGiverNpc": "Willow",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      17775,
+      17776,
+      17777,
+      17779
+    ],
+    "objectives": "Collect 15 Theradric Crystal Carvings for Willow in Desolace.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7029,
+    "dungeonInstanceId": 232,
+    "name": "Vyletongue Corruption",
+    "questLevel": 47,
+    "requiredLevel": 41,
+    "expansion": "classic",
+    "questGiverNpc": "Vark Battlescar",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      17768,
+      17778,
+      17770
+    ],
+    "objectives": "Fill the Coated Cerulean Vial at the orange crystal pool in Maraudon.$B$BUse the Filled Cerulean Vial on the Vylestem Vines to force the corrupted Noxxious Scion to emerge.$B$BHeal 8 plants by killing these Noxxious Scion, then return to Vark Battlescar in Shadowprey Village.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7041,
+    "dungeonInstanceId": 232,
+    "name": "Vyletongue Corruption",
+    "questLevel": 47,
+    "requiredLevel": 41,
+    "expansion": "classic",
+    "questGiverNpc": "Talendria",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      17768,
+      17778,
+      17770
+    ],
+    "objectives": "Fill the Coated Cerulean Vial at the orange crystal pool in Maraudon.$B$BUse the Filled Cerulean Vial on the Vylestem Vines to force the corrupted Noxxious Scion to emerge.$B$BHeal 8 plants by killing these Noxxious Scion, then return to Talendria in Nijel's Point.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7067,
+    "dungeonInstanceId": 232,
+    "name": "The Pariah's Instructions",
+    "questLevel": 48,
+    "requiredLevel": 39,
+    "expansion": "classic",
+    "questGiverNpc": "Centaur Pariah",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      17774
+    ],
+    "objectives": "Read the Pariah's Instructions. Afterwards, obtain the Amulet of Union from Maraudon and return it to the Centaur Pariah in southern Desolace.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7044,
+    "dungeonInstanceId": 232,
+    "name": "Legends of Maraudon",
+    "questLevel": 49,
+    "requiredLevel": 41,
+    "expansion": "classic",
+    "questGiverNpc": "Cavindra",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Recover the two parts of the Scepter of Celebras: the Celebrian Rod and the Celebrian Diamond.$B$BFind a way to speak with Celebras.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7046,
+    "dungeonInstanceId": 232,
+    "name": "The Scepter of Celebras",
+    "questLevel": 49,
+    "requiredLevel": 41,
+    "expansion": "classic",
+    "questGiverNpc": "Celebras the Redeemed",
+    "questGiverZone": null,
+    "prevQuestId": "7044",
+    "nextQuestId": null,
+    "rewardsJson": [
+      17191
+    ],
+    "objectives": "Assist Celebras the Redeemed while he creates the Scepter of Celebras.$B$BSpeak with him when the ritual is complete.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 1445,
+    "dungeonInstanceId": 237,
+    "name": "The Temple of Atal'Hakkar",
+    "questLevel": 50,
+    "requiredLevel": 38,
+    "expansion": "classic",
+    "questGiverNpc": "Fel'zerul",
+    "questGiverZone": null,
+    "prevQuestId": "1444",
+    "nextQuestId": null,
+    "rewardsJson": [
+      1490
+    ],
+    "objectives": "Collect 20 Fetishes of Hakkar and bring them to Fel'Zerul in Stonard.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 1475,
+    "dungeonInstanceId": 237,
+    "name": "Into The Temple of Atal'Hakkar",
+    "questLevel": 50,
+    "requiredLevel": 38,
+    "expansion": "classic",
+    "questGiverNpc": "Brohann Caskbelly",
+    "questGiverZone": null,
+    "prevQuestId": "1469",
+    "nextQuestId": null,
+    "rewardsJson": [
+      1490
+    ],
+    "objectives": "Gather 10 Atal'ai Tablets for Brohann Caskbelly in Stormwind.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 2770,
+    "dungeonInstanceId": 241,
+    "name": "Gahz'rilla",
+    "questLevel": 50,
+    "requiredLevel": 40,
+    "expansion": "classic",
+    "questGiverNpc": "Wizzle Brassbolts",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      11122
+    ],
+    "objectives": "Bring Gahz'rilla's Electrified Scale to Wizzle Brassbolts in the Shimmering Flats.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 3380,
+    "dungeonInstanceId": 237,
+    "name": "The Sunken Temple",
+    "questLevel": 51,
+    "requiredLevel": 46,
+    "expansion": "classic",
+    "questGiverNpc": "Witch Doctor Uzer'i",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "3444",
+    "rewardsJson": null,
+    "objectives": "Find Marvon Rivetseeker in Tanaris.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 3446,
+    "dungeonInstanceId": 237,
+    "name": "Into the Depths",
+    "questLevel": 51,
+    "requiredLevel": 46,
+    "expansion": "classic",
+    "questGiverNpc": "Marvon Rivetseeker",
+    "questGiverZone": null,
+    "prevQuestId": "3444",
+    "nextQuestId": "3447",
+    "rewardsJson": null,
+    "objectives": "Find the Altar of Hakkar in the Sunken Temple in Swamp of Sorrows.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 3447,
+    "dungeonInstanceId": 237,
+    "name": "Secret of the Circle",
+    "questLevel": 51,
+    "requiredLevel": 46,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": "3446",
+    "nextQuestId": null,
+    "rewardsJson": [
+      10773
+    ],
+    "objectives": "Travel into the Sunken Temple and discover the secret hidden in the circle of statues.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7064,
+    "dungeonInstanceId": 232,
+    "name": "Corruption of Earth and Seed",
+    "questLevel": 51,
+    "requiredLevel": 45,
+    "expansion": "classic",
+    "questGiverNpc": "Selendra",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      17705,
+      17743,
+      17753
+    ],
+    "objectives": "Slay Princess Theradras and return to Selendra near Shadowprey Village in Desolace.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7065,
+    "dungeonInstanceId": 232,
+    "name": "Corruption of Earth and Seed",
+    "questLevel": 51,
+    "requiredLevel": 45,
+    "expansion": "classic",
+    "questGiverNpc": "Keeper Marandis",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      17705,
+      17743,
+      17753
+    ],
+    "objectives": "Slay Princess Theradras and return to Keeper Marandis at Nijel's Point in Desolace.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7066,
+    "dungeonInstanceId": 232,
+    "name": "Seed of Life",
+    "questLevel": 51,
+    "requiredLevel": 39,
+    "expansion": "classic",
+    "questGiverNpc": "Zaetar's Spirit",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Seek out Remulos in Moonglade and give him the Seed of Life.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 3801,
+    "dungeonInstanceId": 228,
+    "name": "Dark Iron Legacy",
+    "questLevel": 52,
+    "requiredLevel": 48,
+    "expansion": "classic",
+    "questGiverNpc": "Franclorn Forgewright",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "3802",
+    "rewardsJson": null,
+    "objectives": "Speak with Franclorn Forgewright if you are interested in obtaining a key to the city major.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 3802,
+    "dungeonInstanceId": 228,
+    "name": "Dark Iron Legacy",
+    "questLevel": 52,
+    "requiredLevel": 48,
+    "expansion": "classic",
+    "questGiverNpc": "Franclorn Forgewright",
+    "questGiverZone": null,
+    "prevQuestId": "3801",
+    "nextQuestId": null,
+    "rewardsJson": [
+      11000
+    ],
+    "objectives": "Slay Fineous Darkvire and recover the great hammer, Ironfel. Take Ironfel to the Shrine of Thaurissan and place it on the statue of Franclorn Forgewright.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 3906,
+    "dungeonInstanceId": null,
+    "name": "Disharmony of Flame",
+    "questLevel": 52,
+    "requiredLevel": 48,
+    "expansion": "classic",
+    "questGiverNpc": "Thunderheart",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "3907",
+    "rewardsJson": null,
+    "objectives": "Travel to the quarry in Blackrock Mountain and slay Overmaster Pyron. Return to Thunderheart when you have completed this assignment.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 3981,
+    "dungeonInstanceId": 228,
+    "name": "Commander Gor'shak",
+    "questLevel": 52,
+    "requiredLevel": 48,
+    "expansion": "classic",
+    "questGiverNpc": "Galamav the Marksman",
+    "questGiverZone": null,
+    "prevQuestId": "3907",
+    "nextQuestId": "3982",
+    "rewardsJson": null,
+    "objectives": "Find Commander Gor'shak in Blackrock Depths.$B$BYou recall that the crudely drawn picture of the orc included bars drawn over the portrait. Perhaps you should search for a prison of some sort.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4081,
+    "dungeonInstanceId": 228,
+    "name": "KILL ON SIGHT: Dark Iron Dwarves",
+    "questLevel": 52,
+    "requiredLevel": 48,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Venture to Blackrock Depths and destroy the vile aggressors!$B$BWarlord Goretooth wants you to kill 15 Anvilrage Guardsmen, 10 Anvilrage Wardens and 5 Anvilrage Footmen. Return to him once your task is complete.$B$B",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4143,
+    "dungeonInstanceId": null,
+    "name": "Haze of Evil",
+    "questLevel": 52,
+    "requiredLevel": 47,
+    "expansion": "classic",
+    "questGiverNpc": "Gregan Brewspewer",
+    "questGiverZone": null,
+    "prevQuestId": "4142",
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Collect 5 samples of Atal'ai Haze, then return to Muigin in Un'Goro Crater.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 4262,
+    "dungeonInstanceId": null,
+    "name": "Overmaster Pyron",
+    "questLevel": 52,
+    "requiredLevel": 48,
+    "expansion": "classic",
+    "questGiverNpc": "Jalinda Sprig",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "4263",
+    "rewardsJson": null,
+    "objectives": "Slay Overmaster Pyron and return to Jalinda Sprig.$B$BYou recall Jalinda talking about Pyron guarding the quarry. Perhaps you should search there?",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8232,
+    "dungeonInstanceId": null,
+    "name": "The Green Drake",
+    "questLevel": 52,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": "Ogtinc",
+    "questGiverZone": null,
+    "prevQuestId": "8231",
+    "nextQuestId": null,
+    "rewardsJson": [
+      20083,
+      19991,
+      19992
+    ],
+    "objectives": "Bring the Tooth of Morphaz to Ogtinc in Azshara.  Ogtinc resides atop the cliffs northeast the Ruins of Eldarath.",
+    "classRestriction": [
+      "Hunter"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8236,
+    "dungeonInstanceId": null,
+    "name": "The Azure Key",
+    "questLevel": 52,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": "Archmage Xylem",
+    "questGiverZone": null,
+    "prevQuestId": "8235",
+    "nextQuestId": null,
+    "rewardsJson": [
+      19984,
+      20255,
+      19982
+    ],
+    "objectives": "Return the Azure Key to Lord Jorach Ravenholdt.",
+    "classRestriction": [
+      "Rogue"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8253,
+    "dungeonInstanceId": null,
+    "name": "Destroy Morphaz",
+    "questLevel": 52,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": "Archmage Xylem",
+    "questGiverZone": null,
+    "prevQuestId": "8252",
+    "nextQuestId": null,
+    "rewardsJson": [
+      20035,
+      20037,
+      20036
+    ],
+    "objectives": "Retrieve the Arcane Shard from Morphaz and return to Archmage Xylem.",
+    "classRestriction": [
+      "Mage"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8257,
+    "dungeonInstanceId": null,
+    "name": "Blood of Morphaz",
+    "questLevel": 52,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": "Ogtinc",
+    "questGiverZone": null,
+    "prevQuestId": "8256",
+    "nextQuestId": null,
+    "rewardsJson": [
+      19990,
+      20082,
+      20006
+    ],
+    "objectives": "Kill Morphaz in the sunken temple of Atal'Hakkar, and return his blood to Greta Mosshoof in Felwood.  The entrance to the sunken temple can be found in the Swamp of Sorrows.",
+    "classRestriction": [
+      "Priest"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8413,
+    "dungeonInstanceId": null,
+    "name": "Da Voodoo",
+    "questLevel": 52,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": "Bath'rah the Windwatcher",
+    "questGiverZone": null,
+    "prevQuestId": "8412",
+    "nextQuestId": null,
+    "rewardsJson": [
+      20369,
+      20503,
+      20556
+    ],
+    "objectives": "Bring the voodoo feathers to Bath'rah the Windwatcher.",
+    "classRestriction": [
+      "Shaman"
+    ],
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8418,
+    "dungeonInstanceId": null,
+    "name": "Forging the Mightstone",
+    "questLevel": 52,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": "Commander Ashlam Valorfist",
+    "questGiverZone": null,
+    "prevQuestId": "8416",
+    "nextQuestId": null,
+    "rewardsJson": [
+      20504,
+      20620,
+      20512,
+      20505
+    ],
+    "objectives": "Bring the voodoo feathers to Ashlam Valorfist.",
+    "classRestriction": [
+      "Paladin"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8422,
+    "dungeonInstanceId": null,
+    "name": "Trolls of a Feather",
+    "questLevel": 52,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": "Impsy",
+    "questGiverZone": null,
+    "prevQuestId": "8421",
+    "nextQuestId": null,
+    "rewardsJson": [
+      20536,
+      20534,
+      20530
+    ],
+    "objectives": "Bring a total of 6 Voodoo Feathers from the trolls in sunken temple.",
+    "classRestriction": [
+      "Warlock"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8425,
+    "dungeonInstanceId": null,
+    "name": "Voodoo Feathers",
+    "questLevel": 52,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": "Fallen Hero of the Horde",
+    "questGiverZone": null,
+    "prevQuestId": "8424",
+    "nextQuestId": null,
+    "rewardsJson": [
+      20521,
+      20130,
+      20517
+    ],
+    "objectives": "Bring the Voodoo Feathers from the trolls in the Sunken Temple to the Fallen Hero of the Horde.",
+    "classRestriction": [
+      "Warrior"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 9053,
+    "dungeonInstanceId": null,
+    "name": "A Better Ingredient",
+    "questLevel": 52,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": "Torwa Pathfinder",
+    "questGiverZone": null,
+    "prevQuestId": "9051",
+    "nextQuestId": null,
+    "rewardsJson": [
+      22274,
+      22272,
+      22458
+    ],
+    "objectives": "Retrieve a Putrid Vine from the guardian at the bottom of the Sunken Temple and return to Torwa Pathfinder.",
+    "classRestriction": [
+      "Druid"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 1446,
+    "dungeonInstanceId": 237,
+    "name": "Jammal'an the Prophet",
+    "questLevel": 53,
+    "requiredLevel": 38,
+    "expansion": "classic",
+    "questGiverNpc": "Atal'ai Exile",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      11123,
+      11124
+    ],
+    "objectives": "The Atal'ai Exile in The Hinterlands wants the Head of Jammal'an.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 3528,
+    "dungeonInstanceId": 237,
+    "name": "The God Hakkar",
+    "questLevel": 53,
+    "requiredLevel": 40,
+    "expansion": "classic",
+    "questGiverNpc": "Yeh'kinya",
+    "questGiverZone": null,
+    "prevQuestId": "4787",
+    "nextQuestId": null,
+    "rewardsJson": [
+      10749,
+      10750,
+      10751
+    ],
+    "objectives": "Bring the Filled Egg of Hakkar to Yeh'kinya in Tanaris.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4136,
+    "dungeonInstanceId": 228,
+    "name": "Ribbly Screwspigot",
+    "questLevel": 53,
+    "requiredLevel": 48,
+    "expansion": "classic",
+    "questGiverNpc": "Yuka Screwspigot",
+    "questGiverZone": null,
+    "prevQuestId": "4324",
+    "nextQuestId": null,
+    "rewardsJson": [
+      11865,
+      11963,
+      12049
+    ],
+    "objectives": "Bring Ribbly's Head to Yuka Screwspigot in the Burning Steppes.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4148,
+    "dungeonInstanceId": null,
+    "name": "Bloodpetal Zapper",
+    "questLevel": 53,
+    "requiredLevel": 47,
+    "expansion": "classic",
+    "questGiverNpc": "Larion",
+    "questGiverZone": null,
+    "prevQuestId": "4146",
+    "nextQuestId": null,
+    "rewardsJson": [
+      11320
+    ],
+    "objectives": "",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 4324,
+    "dungeonInstanceId": 228,
+    "name": "Yuka Screwspigot",
+    "questLevel": 53,
+    "requiredLevel": 48,
+    "expansion": "classic",
+    "questGiverNpc": "Yorba Screwspigot",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "4136",
+    "rewardsJson": null,
+    "objectives": "Speak with Yuka Screwspigot in the Burning Steppes.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 3982,
+    "dungeonInstanceId": 228,
+    "name": "What Is Going On?",
+    "questLevel": 54,
+    "requiredLevel": 48,
+    "expansion": "classic",
+    "questGiverNpc": "Commander Gor'shak",
+    "questGiverZone": null,
+    "prevQuestId": "3981",
+    "nextQuestId": "4001",
+    "rewardsJson": null,
+    "objectives": "Defend Gor'shak.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4001,
+    "dungeonInstanceId": 228,
+    "name": "What Is Going On?",
+    "questLevel": 54,
+    "requiredLevel": 48,
+    "expansion": "classic",
+    "questGiverNpc": "Commander Gor'shak",
+    "questGiverZone": null,
+    "prevQuestId": "3982",
+    "nextQuestId": "4002",
+    "rewardsJson": null,
+    "objectives": "Speak with Kharan Mighthammer and gather information about Princess Moira Bronzebeard's kidnapping. Take that information to Thrall in Orgrimmar.$B$BYou recall Gor'shak mentioning that Kharan is being held in a cell nearby.\n",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4002,
+    "dungeonInstanceId": 228,
+    "name": "The Eastern Kingdom",
+    "questLevel": 54,
+    "requiredLevel": 48,
+    "expansion": "classic",
+    "questGiverNpc": "Thrall",
+    "questGiverZone": null,
+    "prevQuestId": "4001",
+    "nextQuestId": "4003",
+    "rewardsJson": null,
+    "objectives": "Speak with Thrall if you are prepared to take on the mission he has planned.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4082,
+    "dungeonInstanceId": 228,
+    "name": "KILL ON SIGHT: High Ranking Dark Iron Officials",
+    "questLevel": 54,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": "4081",
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Venture to Blackrock Depths and destroy the vile aggressors!$B$BWarlord Goretooth wants you to kill 10 Anvilrage Medics, 10 Anvilrage Soldiers and 10 Anvilrage Officers. Return to him once your task is complete.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4201,
+    "dungeonInstanceId": 228,
+    "name": "The Love Potion",
+    "questLevel": 54,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": "Mistress Nagmara",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      11962,
+      11866
+    ],
+    "objectives": "Bring 4 Gromsblood, 10 Giant Silver Veins and Nagmara's Filled Vial to Mistress Nagmara in Blackrock Depths.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4241,
+    "dungeonInstanceId": 228,
+    "name": "Marshal Windsor",
+    "questLevel": 54,
+    "requiredLevel": 48,
+    "expansion": "classic",
+    "questGiverNpc": "Marshal Maxwell",
+    "questGiverZone": null,
+    "prevQuestId": "4224",
+    "nextQuestId": "4242",
+    "rewardsJson": null,
+    "objectives": "Travel to Blackrock Mountain in the northwest and enter Blackrock Depths. Find out what became of Marshal Windsor.$B$BYou recall Ragged John talking about Windsor being dragged off to a prison.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4242,
+    "dungeonInstanceId": 228,
+    "name": "Abandoned Hope",
+    "questLevel": 54,
+    "requiredLevel": 48,
+    "expansion": "classic",
+    "questGiverNpc": "Marshal Windsor",
+    "questGiverZone": null,
+    "prevQuestId": "4241",
+    "nextQuestId": null,
+    "rewardsJson": [
+      12018,
+      12021,
+      12041
+    ],
+    "objectives": "Give Marshal Maxwell the bad news.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7201,
+    "dungeonInstanceId": 228,
+    "name": "The Last Element",
+    "questLevel": 54,
+    "requiredLevel": 48,
+    "expansion": "classic",
+    "questGiverNpc": "Shadowmage Vivian Lagrave",
+    "questGiverZone": null,
+    "prevQuestId": "3906",
+    "nextQuestId": null,
+    "rewardsJson": [
+      12038
+    ],
+    "objectives": "Travel to Blackrock Depths and recover 10 Essence of the Elements. Your first inclination is to search the golems and golem makers. You remember Vivian Lagrave also muttering something about elementals.\n",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 3373,
+    "dungeonInstanceId": 237,
+    "name": "The Essence of Eranikus",
+    "questLevel": 55,
+    "requiredLevel": 48,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      10455
+    ],
+    "objectives": "Place the Essence of Eranikus in the Essence Font located in this lair in the Sunken Temple.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4083,
+    "dungeonInstanceId": 228,
+    "name": "The Spectral Chalice",
+    "questLevel": 55,
+    "requiredLevel": 40,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4123,
+    "dungeonInstanceId": 228,
+    "name": "The Heart of the Mountain",
+    "questLevel": 55,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": "Maxwort Uberglint",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Bring the Heart of the Mountain to Maxwort Uberglint in the Burning Steppes.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4126,
+    "dungeonInstanceId": 228,
+    "name": "Hurley Blackbreath",
+    "questLevel": 55,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": "Ragnar Thunderbrew",
+    "questGiverZone": null,
+    "prevQuestId": "4128",
+    "nextQuestId": null,
+    "rewardsJson": [
+      11964,
+      12003,
+      12000
+    ],
+    "objectives": "Bring the Lost Thunderbrew Recipe to Ragnar Thunderbrew in Kharanos.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4128,
+    "dungeonInstanceId": 228,
+    "name": "Ragnar Thunderbrew",
+    "questLevel": 55,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": "Enohar Thunderbrew",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "4126",
+    "rewardsJson": null,
+    "objectives": "Speak with Ragnar Thunderbrew.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4133,
+    "dungeonInstanceId": 228,
+    "name": "Vivian Lagrave",
+    "questLevel": 55,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": "Apothecary Zinge",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "4134",
+    "rewardsJson": null,
+    "objectives": "Speak with Shadowmaster Vivian Lagrave in Kargath.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4134,
+    "dungeonInstanceId": 228,
+    "name": "Lost Thunderbrew Recipe",
+    "questLevel": 55,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": "Shadowmage Vivian Lagrave",
+    "questGiverZone": null,
+    "prevQuestId": "4133",
+    "nextQuestId": null,
+    "rewardsJson": [
+      11964,
+      3928,
+      12000,
+      6149
+    ],
+    "objectives": "Bring the Lost Thunderbrew Recipe to Vivian Lagrave in Kargath.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 3907,
+    "dungeonInstanceId": 228,
+    "name": "Disharmony of Fire",
+    "questLevel": 56,
+    "requiredLevel": 48,
+    "expansion": "classic",
+    "questGiverNpc": "Thunderheart",
+    "questGiverZone": null,
+    "prevQuestId": "3906",
+    "nextQuestId": null,
+    "rewardsJson": [
+      12113,
+      12114,
+      12112,
+      12115
+    ],
+    "objectives": "Enter Blackrock Depths and track down Lord Incendius. Slay him and return any source of information you may find to Thunderheart.\n",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4263,
+    "dungeonInstanceId": 228,
+    "name": "Incendius!",
+    "questLevel": 56,
+    "requiredLevel": 48,
+    "expansion": "classic",
+    "questGiverNpc": "Jalinda Sprig",
+    "questGiverZone": null,
+    "prevQuestId": "4262",
+    "nextQuestId": null,
+    "rewardsJson": [
+      12113,
+      12114,
+      12112,
+      12115
+    ],
+    "objectives": "Find Lord Incendius in Blackrock Depths and destroy him!",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4286,
+    "dungeonInstanceId": 228,
+    "name": "The Good Stuff",
+    "questLevel": 56,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": "Oralius",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      11883
+    ],
+    "objectives": "Travel to Blackrock Depths and recover 20 Dark Iron Fanny Packs. Return to Oralius when you have completed this task. You assume that the Dark Iron dwarves inside Blackrock Depths carry these 'fanny pack' contraptions.\n",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7488,
+    "dungeonInstanceId": 230,
+    "name": "Lethtendris's Web",
+    "questLevel": 57,
+    "requiredLevel": 54,
+    "expansion": "classic",
+    "questGiverNpc": "Latronicus Moonspear",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      18491
+    ],
+    "objectives": "Bring Lethtendris' Web to Latronicus Moonspear at the Feathermoon Stronghold in Feralas.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7489,
+    "dungeonInstanceId": 230,
+    "name": "Lethtendris's Web",
+    "questLevel": 57,
+    "requiredLevel": 54,
+    "expansion": "classic",
+    "questGiverNpc": "Talo Thornhoof",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      18491
+    ],
+    "objectives": "Bring Lethtendris's Web to Talo Thornhoof at Camp Mojache in Feralas.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7492,
+    "dungeonInstanceId": 230,
+    "name": "Camp Mojache",
+    "questLevel": 57,
+    "requiredLevel": 54,
+    "expansion": "classic",
+    "questGiverNpc": "Harbinger Balthazad",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "7489",
+    "rewardsJson": null,
+    "objectives": "Speak with Talo Thornhoof at Camp Mojache in Feralas.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7494,
+    "dungeonInstanceId": 230,
+    "name": "Feathermoon Stronghold",
+    "questLevel": 57,
+    "requiredLevel": 54,
+    "expansion": "classic",
+    "questGiverNpc": "Courier Hammerfall",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "7488",
+    "rewardsJson": null,
+    "objectives": "Speak with Latronicus Moonspear at the Feathermoon Stronghold in Feralas.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4024,
+    "dungeonInstanceId": 228,
+    "name": "A Taste of Flame",
+    "questLevel": 58,
+    "requiredLevel": 52,
+    "expansion": "classic",
+    "questGiverNpc": "Cyrus Therepentous",
+    "questGiverZone": null,
+    "prevQuestId": "4023",
+    "nextQuestId": null,
+    "rewardsJson": [
+      12066,
+      12082,
+      12083
+    ],
+    "objectives": "Travel to Blackrock Depths and slay Bael'Gar.$B$BYou only know that the giant resides inside Blackrock Depths. Remember to use the Altered Black Dragonflight Molt on Bael'Gar's remains to capture the Fiery Essence.$B$BReturn the Encased Fiery Essence to Cyrus Therepentous.$B$B",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4063,
+    "dungeonInstanceId": 228,
+    "name": "The Rise of the Machines",
+    "questLevel": 58,
+    "requiredLevel": 52,
+    "expansion": "classic",
+    "questGiverNpc": "Lotwil Veriatus",
+    "questGiverZone": null,
+    "prevQuestId": "4062",
+    "nextQuestId": null,
+    "rewardsJson": [
+      12109,
+      12110,
+      12108,
+      12111
+    ],
+    "objectives": "Find and slay Golem Lord Argelmach. Return his head to Lotwil. You will also need to collect 10 Intact Elemental Cores from the Ragereaver Golems and Warbringer Constructs protecting Argelmach. You know this because you are psychic. ",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4121,
+    "dungeonInstanceId": 228,
+    "name": "Precarious Predicament",
+    "questLevel": 58,
+    "requiredLevel": 52,
+    "expansion": "classic",
+    "questGiverNpc": "Grark Lorkrub",
+    "questGiverZone": null,
+    "prevQuestId": "4122",
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Escort your prisoner, Grark Lorkrub, through Burning Steppes and through Blackrock Mountain to the Searing Gorge.$B$BYou recall Lexlort mentioning that he would have his men waiting on the other side to take Grark into custody.$B$BYou will also be required to hand over your Thorium Shackles to Lexlort.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4122,
+    "dungeonInstanceId": 228,
+    "name": "Grark Lorkrub",
+    "questLevel": 58,
+    "requiredLevel": 52,
+    "expansion": "classic",
+    "questGiverNpc": "Lexlort",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Travel to the Burning Steppes and find Grark Lorkrub. You recall Lexlort mentioning that he was last seen in a massive Blackrock fortress.$B$BWhen you find Grark Lorkrub, use the Thorium Shackles to bind him and then lead him back through Blackrock Mountain to the Searing Gorge. Lexlort will have his men waiting on the other side to take Grark into custody.\n",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4132,
+    "dungeonInstanceId": 228,
+    "name": "Operation: Death to Angerforge",
+    "questLevel": 58,
+    "requiredLevel": 52,
+    "expansion": "classic",
+    "questGiverNpc": "Warlord Goretooth",
+    "questGiverZone": null,
+    "prevQuestId": "4121",
+    "nextQuestId": null,
+    "rewardsJson": [
+      12059
+    ],
+    "objectives": "Travel to Blackrock Depths and slay General Angerforge! Return to Warlord Goretooth when the task is complete.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4264,
+    "dungeonInstanceId": 228,
+    "name": "A Crumpled Up Note",
+    "questLevel": 58,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": "4242",
+    "nextQuestId": "4282",
+    "rewardsJson": null,
+    "objectives": "You may have just stumbled on to something that Marshal Windsor would be interested in seeing. There may be hope, after all.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4282,
+    "dungeonInstanceId": 228,
+    "name": "A Shred of Hope",
+    "questLevel": 58,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": "Marshal Windsor",
+    "questGiverZone": null,
+    "prevQuestId": "4264",
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Return Marshal Windsor's Lost Information.$B$BMarshal Windsor believes that the information is being held by Golem Lord Argelmach and General Angerforge.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4322,
+    "dungeonInstanceId": 228,
+    "name": "Jail Break!",
+    "questLevel": 58,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": "Marshal Windsor",
+    "questGiverZone": null,
+    "prevQuestId": "4282",
+    "nextQuestId": "6402",
+    "rewardsJson": [
+      12061,
+      12065,
+      12062
+    ],
+    "objectives": "Help Marshal Windsor get his gear back and free his friends. Return to Marshal Maxwell if you succeed.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4788,
+    "dungeonInstanceId": 229,
+    "name": "The Final Tablets",
+    "questLevel": 58,
+    "requiredLevel": 40,
+    "expansion": "classic",
+    "questGiverNpc": "Prospector Ironboot",
+    "questGiverZone": null,
+    "prevQuestId": "5065",
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Bring the Fifth and Sixth Mosh'aru Tablets to Prospector Ironboot in Tanaris.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 5529,
+    "dungeonInstanceId": 235,
+    "name": "Plagued Hatchlings",
+    "questLevel": 58,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Betina Bigglezink",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Kill 20 Plagued Hatchlings, then return to Betina Bigglezink at the Light's Hope Chapel.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5582,
+    "dungeonInstanceId": 235,
+    "name": "Healthy Dragon Scale",
+    "questLevel": 58,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": "5529",
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Bring the Healthy Dragon Scale to Betina Bigglezink at the Light's Hope Chapel in Eastern Plaguelands.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7441,
+    "dungeonInstanceId": 230,
+    "name": "Pusillin and the Elder Azj'Tordin",
+    "questLevel": 58,
+    "requiredLevel": 54,
+    "expansion": "classic",
+    "questGiverNpc": "Azj'Tordin",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      18411,
+      18410
+    ],
+    "objectives": "Travel to Dire Maul and locate the Imp, Pusillin. Convince Pusillin to give you Azj'Tordin's Book of Incantations through any means necessary.$B$BReturn to Azj'Tordin at the Lariss Pavilion in Feralas should you recover the Book of Incantations.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4003,
+    "dungeonInstanceId": 228,
+    "name": "The Royal Rescue",
+    "questLevel": 59,
+    "requiredLevel": 48,
+    "expansion": "classic",
+    "questGiverNpc": "Thrall",
+    "questGiverZone": null,
+    "prevQuestId": "4002",
+    "nextQuestId": "4004",
+    "rewardsJson": null,
+    "objectives": "Slay Emperor Dagran Thaurissan and free Princess Moira Bronzebeard from his evil spell. \n",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4341,
+    "dungeonInstanceId": 228,
+    "name": "Kharan Mighthammer",
+    "questLevel": 59,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": "King Magni Bronzebeard",
+    "questGiverZone": null,
+    "prevQuestId": "3701",
+    "nextQuestId": "4342",
+    "rewardsJson": null,
+    "objectives": "Travel to Blackrock Depths and find Kharan Mighthammer.$B$BThe King mentioned that Kharan was being held prisoner there - perhaps you should try looking for a prison.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4342,
+    "dungeonInstanceId": 228,
+    "name": "Kharan's Tale",
+    "questLevel": 59,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": "Kharan Mighthammer",
+    "questGiverZone": null,
+    "prevQuestId": "4341",
+    "nextQuestId": "4361",
+    "rewardsJson": null,
+    "objectives": "Listen as Kharan Mighthammer tells his story.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4361,
+    "dungeonInstanceId": 228,
+    "name": "The Bearer of Bad News",
+    "questLevel": 59,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": "Kharan Mighthammer",
+    "questGiverZone": null,
+    "prevQuestId": "4342",
+    "nextQuestId": "4362",
+    "rewardsJson": null,
+    "objectives": "Return to Ironforge and deliver the bad news to King Magni Bronzebeard.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4362,
+    "dungeonInstanceId": 228,
+    "name": "The Fate of the Kingdom",
+    "questLevel": 59,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": "King Magni Bronzebeard",
+    "questGiverZone": null,
+    "prevQuestId": "4361",
+    "nextQuestId": "4363",
+    "rewardsJson": null,
+    "objectives": "Return to Blackrock Depths and rescue Princess Moira Bronzebeard from the evil clutches of Emperor Dagran Thaurissan.\n",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4363,
+    "dungeonInstanceId": 228,
+    "name": "The Princess's Surprise",
+    "questLevel": 59,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": "Princess Moira Bronzebeard",
+    "questGiverZone": null,
+    "prevQuestId": "4362",
+    "nextQuestId": null,
+    "rewardsJson": [
+      12548,
+      12543
+    ],
+    "objectives": "Return to Ironforge and speak with King Magni Bronzebeard.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4701,
+    "dungeonInstanceId": 229,
+    "name": "Put Her Down",
+    "questLevel": 59,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Helendis Riverhorn",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      15824,
+      15825,
+      15827
+    ],
+    "objectives": "Travel to Blackrock Spire and destroy the source of the worg menace. As you left Helendis, he shouted a name: Halycon. It is what the orcs refer to in regards to the worg.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 4724,
+    "dungeonInstanceId": 229,
+    "name": "The Pack Mistress",
+    "questLevel": 59,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Galamav the Marksman",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      15824,
+      15825,
+      15827
+    ],
+    "objectives": "Slay Halycon, pack mistress of the Bloodaxe worg.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 4729,
+    "dungeonInstanceId": 229,
+    "name": "Kibler's Exotic Pets",
+    "questLevel": 59,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Kibler",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      12264
+    ],
+    "objectives": "Travel to Blackrock Spire and find Bloodaxe Worg Pups. Use the cage to carry the ferocious little beasts. Bring back a Caged Worg Pup to Kibler.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 4862,
+    "dungeonInstanceId": 229,
+    "name": "En-Ay-Es-Tee-Why",
+    "questLevel": 59,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Kibler",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      12529
+    ],
+    "objectives": "Travel to Blackrock Spire and collect 15 Spire Spider Eggs for Kibler.$B$BBy the sound of it, these eggs could be found near spiders.\n",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 4981,
+    "dungeonInstanceId": 229,
+    "name": "Operative Bijou",
+    "questLevel": 59,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Lexlort",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "4982",
+    "rewardsJson": null,
+    "objectives": "Travel to Blackrock Spire and find out what happened to Bijou.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 4982,
+    "dungeonInstanceId": 229,
+    "name": "Bijou's Belongings",
+    "questLevel": 59,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Bijou",
+    "questGiverZone": null,
+    "prevQuestId": "4981",
+    "nextQuestId": "4983",
+    "rewardsJson": null,
+    "objectives": "Find Bijou's Belongings and return them to her. You recall her mentioning that she stashed them on the bottom floor of the city.\n",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 4983,
+    "dungeonInstanceId": 229,
+    "name": "Bijou's Reconnaissance Report",
+    "questLevel": 59,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Bijou",
+    "questGiverZone": null,
+    "prevQuestId": "4982",
+    "nextQuestId": null,
+    "rewardsJson": [
+      15858,
+      15859
+    ],
+    "objectives": "Take Bijou's Reconnaissance Report back to Grandmaster Lexlort in Kargath.\n",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 5001,
+    "dungeonInstanceId": 229,
+    "name": "Bijou's Belongings",
+    "questLevel": 59,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Bijou",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "5002",
+    "rewardsJson": null,
+    "objectives": "Find Bijou's Belongings and return them to her. Good luck!\n",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 5002,
+    "dungeonInstanceId": 229,
+    "name": "Message to Maxwell",
+    "questLevel": 59,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Bijou",
+    "questGiverZone": null,
+    "prevQuestId": "5001",
+    "nextQuestId": "5081",
+    "rewardsJson": null,
+    "objectives": "Travel to the Burning Steppes and give Bijou's Information to Marshal Maxwell.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 1193,
+    "dungeonInstanceId": 230,
+    "name": "A Broken Trap",
+    "questLevel": 60,
+    "requiredLevel": 56,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 1318,
+    "dungeonInstanceId": 230,
+    "name": "Unfinished Gordok Business",
+    "questLevel": 60,
+    "requiredLevel": 60,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      18366,
+      18367,
+      18368,
+      18369
+    ],
+    "objectives": "Find the Gauntlet of Gordok Might and return it to Captain Kromcrush in Dire Maul.$B$BAccording to Kromcrush, the \"old timey story\" says that Tortheldrin - a \"creepy\" elf who called himself a prince - stole it from one of the Gordok kings.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4004,
+    "dungeonInstanceId": 228,
+    "name": "The Princess Saved?",
+    "questLevel": 60,
+    "requiredLevel": 48,
+    "expansion": "classic",
+    "questGiverNpc": "Princess Moira Bronzebeard",
+    "questGiverZone": null,
+    "prevQuestId": "4003",
+    "nextQuestId": null,
+    "rewardsJson": [
+      12544,
+      12545
+    ],
+    "objectives": "Return to Thrall!\n",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4742,
+    "dungeonInstanceId": 229,
+    "name": "Seal of Ascension",
+    "questLevel": 60,
+    "requiredLevel": 57,
+    "expansion": "classic",
+    "questGiverNpc": "Vaelan",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "4743",
+    "rewardsJson": null,
+    "objectives": "Find the three gemstones of command: The Gemstone of Smolderthorn, Gemstone of Spirestone, and Gemstone of Bloodaxe. Return them, along with the Unadorned Seal of Ascension, to Vaelan.$B$BThe Generals, as told to you by Vaelan, are: War Master Voone of the Smolderthorn; Highlord Omokk of the Spirestone; and Overlord Wyrmthalak  of the Bloodaxe.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 4743,
+    "dungeonInstanceId": 229,
+    "name": "Seal of Ascension",
+    "questLevel": 60,
+    "requiredLevel": 57,
+    "expansion": "classic",
+    "questGiverNpc": "Vaelan",
+    "questGiverZone": null,
+    "prevQuestId": "4742",
+    "nextQuestId": null,
+    "rewardsJson": [
+      12344
+    ],
+    "objectives": "Travel to the Wyrmbog in Dustwallow Marsh. Find the ancient drake, Emberstrife and beat him without mercy until his will is broken.$B$BIt is at that moment which you must place the Unforged Seal of Ascension before the great beast. You must then be quick to use the Orb of Draconic Energy on his weakened form and claim dominion over his mental faculties. Control the beast and force the Flames of the Black Dragonflight upon the Unforged Seal of Ascension!",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 4771,
+    "dungeonInstanceId": 235,
+    "name": "Dawn's Gambit",
+    "questLevel": 60,
+    "requiredLevel": 57,
+    "expansion": "classic",
+    "questGiverNpc": "Betina Bigglezink",
+    "questGiverZone": null,
+    "prevQuestId": "5531",
+    "nextQuestId": null,
+    "rewardsJson": [
+      15853,
+      15854
+    ],
+    "objectives": "Place Dawn's Gambit in the Viewing Room of the Scholomance.  Defeat Vectus, then return to Betina Bigglezink.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 4866,
+    "dungeonInstanceId": 229,
+    "name": "Mother's Milk",
+    "questLevel": 60,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Ragged John",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      15873
+    ],
+    "objectives": "In the heart of Blackrock Spire you will find Mother Smolderweb. Engage her and get her to poison you. Chances are good that you will have to kill her as well. Return to Ragged John when you are poisoned so that he can 'milk' you.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 4867,
+    "dungeonInstanceId": 229,
+    "name": "Urok Doomhowl",
+    "questLevel": 60,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Warosh",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      15867
+    ],
+    "objectives": "Read Warosh's Scroll.  Bring Warosh's Mojo to Warosh.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 4903,
+    "dungeonInstanceId": 229,
+    "name": "Warlord's Command",
+    "questLevel": 60,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Warlord Goretooth",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "4941",
+    "rewardsJson": [
+      13958,
+      13959,
+      13961,
+      13962,
+      13963
+    ],
+    "objectives": "Slay Highlord Omokk, War Master Voone, and Overlord Wyrmthalak. Recover Important Blackrock Documents. Return to Warlord Goretooth in Kargath when the mission has been accomplished.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 5047,
+    "dungeonInstanceId": 229,
+    "name": "Finkle Einhorn, At Your Service!",
+    "questLevel": 60,
+    "requiredLevel": 57,
+    "expansion": "classic",
+    "questGiverNpc": "Finkle Einhorn",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Talk to Malyfous Darkhammer in Everlook.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 5081,
+    "dungeonInstanceId": 229,
+    "name": "Maxwell's Mission",
+    "questLevel": 60,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Marshal Maxwell",
+    "questGiverZone": null,
+    "prevQuestId": "5002",
+    "nextQuestId": null,
+    "rewardsJson": [
+      13958,
+      13959,
+      13961,
+      13962,
+      13963
+    ],
+    "objectives": "Travel to Blackrock Spire and destroy War Master Voone, Highlord Omokk, and Overlord Wyrmthalak. Return to Marshal Maxwell when the job is done.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 5089,
+    "dungeonInstanceId": 229,
+    "name": "General Drakkisath's Command",
+    "questLevel": 60,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "5102",
+    "rewardsJson": null,
+    "objectives": "Take General Drakkisath's Command to Marshal Maxwell in Burning Steppes.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 5103,
+    "dungeonInstanceId": null,
+    "name": "Hot Fiery Death",
+    "questLevel": 60,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "5124",
+    "rewardsJson": null,
+    "objectives": "Someone in this world must know what to do with these gauntlets. Good luck!",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 5122,
+    "dungeonInstanceId": 236,
+    "name": "The Medallion of Faith",
+    "questLevel": 60,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Aurius",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5125,
+    "dungeonInstanceId": 236,
+    "name": "Aurius' Reckoning",
+    "questLevel": 60,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Aurius",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      17044,
+      17045
+    ],
+    "objectives": "",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5127,
+    "dungeonInstanceId": 229,
+    "name": "The Demon Forge",
+    "questLevel": 60,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Lorax",
+    "questGiverZone": null,
+    "prevQuestId": "5126",
+    "nextQuestId": null,
+    "rewardsJson": [
+      12696,
+      9224,
+      12849
+    ],
+    "objectives": "Travel to Blackrock Spire and find Goraluk Anvilcrack. Slay him and then use the Blood Stained Pike upon his corpse. After his soul has been siphoned, the pike will be Soul Stained.$B$BYou must also find the Unforged Rune Covered Breastplate.$B$BReturn both the Soul Stained Pike and the Unforged Rune Covered Breastplate to Lorax in Winterspring.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 5160,
+    "dungeonInstanceId": 229,
+    "name": "The Matron Protectorate",
+    "questLevel": 60,
+    "requiredLevel": 57,
+    "expansion": "classic",
+    "questGiverNpc": "Awbee",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "5161",
+    "rewardsJson": null,
+    "objectives": "Travel to Winterspring and find Haleh. Give her Awbee's scale.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 5212,
+    "dungeonInstanceId": 236,
+    "name": "The Flesh Does Not Lie",
+    "questLevel": 60,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Betina Bigglezink",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "5213",
+    "rewardsJson": null,
+    "objectives": "Recover 10 Plagued Flesh Samples from Stratholme and return them to Betina Bigglezink. You suspect that any creature in Stratholme would have said flesh sample.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5213,
+    "dungeonInstanceId": 236,
+    "name": "The Active Agent",
+    "questLevel": 60,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Betina Bigglezink",
+    "questGiverZone": null,
+    "prevQuestId": "5212",
+    "nextQuestId": null,
+    "rewardsJson": [
+      13209,
+      19812
+    ],
+    "objectives": "Travel to Stratholme and search the ziggurats. Find and return new Scourge Data to Betina Bigglezink.\n",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5214,
+    "dungeonInstanceId": 236,
+    "name": "The Great Fras Siabi",
+    "questLevel": 60,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Smokey LaRue",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      13171
+    ],
+    "objectives": "Find Fras Siabi's smoke shop in Stratholme and recover a box of Siabi's Premium Tobacco. Return to Smokey LaRue when the job is done.\n",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5243,
+    "dungeonInstanceId": 236,
+    "name": "Houses of the Holy",
+    "questLevel": 60,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Leonid Barthalomew the Revered",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      13216,
+      3928,
+      13217,
+      6149
+    ],
+    "objectives": "Travel to Stratholme, in the north. Search the supply crates that litter the city and recover 5 Stratholme Holy Water. Return to Leonid Barthalomew the Revered when you have collected enough of the blessed fluid.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5251,
+    "dungeonInstanceId": 236,
+    "name": "The Archivist",
+    "questLevel": 60,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Duke Nicholas Zverenhoff",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Travel to Stratholme and find Archivist Galford of the Scarlet Crusade. Destroy him and burn down the Scarlet Archive.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5262,
+    "dungeonInstanceId": 236,
+    "name": "The Truth Comes Crashing Down",
+    "questLevel": 60,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": "5251",
+    "nextQuestId": "5263",
+    "rewardsJson": null,
+    "objectives": "Take the Head of Balnazzar to Duke Nicholas Zverenhoff in the Eastern Plaguelands.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5263,
+    "dungeonInstanceId": 236,
+    "name": "Above and Beyond",
+    "questLevel": 60,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Duke Nicholas Zverenhoff",
+    "questGiverZone": null,
+    "prevQuestId": "5262",
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Venture to Stratholme and destroy Baron Rivendare. Take his head and return to Duke Nicholas Zverenhoff.\n",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5281,
+    "dungeonInstanceId": null,
+    "name": "The Restless Souls",
+    "questLevel": 60,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Caretaker Alen",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "5282",
+    "rewardsJson": null,
+    "objectives": "Find Egan. You only know that he was last seen around Stratholme.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 5282,
+    "dungeonInstanceId": 236,
+    "name": "The Restless Souls",
+    "questLevel": 60,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Egan",
+    "questGiverZone": null,
+    "prevQuestId": "5281",
+    "nextQuestId": null,
+    "rewardsJson": [
+      13315
+    ],
+    "objectives": "Use Egan's Blaster on the ghostly and spectral citizens of Stratholme. When the restless souls break free from their ghostly shells, use the blaster again - freedom will be theirs!$B$BFree 15 Restless Souls and return to Egan.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5305,
+    "dungeonInstanceId": null,
+    "name": "Sweet Serenity",
+    "questLevel": 60,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": "Lilith the Lithe",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      12824
+    ],
+    "objectives": "Travel to Stratholme and kill the Crimson Hammersmith. Recover the Crimson Hammersmith's Apron and return to Lilith.\n",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 5306,
+    "dungeonInstanceId": null,
+    "name": "Snakestone of the Shadow Huntress",
+    "questLevel": 60,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": "Kilram",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      12821
+    ],
+    "objectives": "Travel to Blackrock Spire and slay Shadow Hunter Vosh'gajin. Recover Vosh'gajin's Snakestone and return to Kilram.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 5307,
+    "dungeonInstanceId": null,
+    "name": "Corruption",
+    "questLevel": 60,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": "Seril Scourgebane",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      12825
+    ],
+    "objectives": "Find the Black Guard Swordsmith in Stratholme and destroy him. Recover the Insignia of the Black Guard and return to Seril Scourgebane.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 5341,
+    "dungeonInstanceId": 235,
+    "name": "Barov Family Fortune",
+    "questLevel": 60,
+    "requiredLevel": 52,
+    "expansion": "classic",
+    "questGiverNpc": "Alexi Barov",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "5342",
+    "rewardsJson": null,
+    "objectives": "Venture to the Scholomance and recover the Barov family fortune. Four deeds make up this fortune: The Deed to Caer Darrow; The Deed to Brill; The Deed to Tarren Mill; and The Deed to Southshore. Return to Alexi Barov when you have completed this task.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5343,
+    "dungeonInstanceId": 235,
+    "name": "Barov Family Fortune",
+    "questLevel": 60,
+    "requiredLevel": 52,
+    "expansion": "classic",
+    "questGiverNpc": "Weldon Barov",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "5344",
+    "rewardsJson": null,
+    "objectives": "Venture to the Scholomance and recover the Barov family fortune. Four deeds make up this fortune: The Deed to Caer Darrow; The Deed to Brill; The Deed to Tarren Mill; and The Deed to Southshore. Return to Weldon Barov when you have completed this task.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5382,
+    "dungeonInstanceId": 235,
+    "name": "Doctor Theolen Krastinov, the Butcher",
+    "questLevel": 60,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Eva Sarkhoff",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "5515",
+    "rewardsJson": null,
+    "objectives": "Find Doctor Theolen Krastinov inside the Scholomance. Destroy him, then burn the Remains of Eva Sarkhoff and the Remains of Lucien Sarkhoff. Return to Eva Sarkhoff when the task is complete.\n",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5384,
+    "dungeonInstanceId": 235,
+    "name": "Kirtonos the Herald",
+    "questLevel": 60,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Eva Sarkhoff",
+    "questGiverZone": null,
+    "prevQuestId": "5515",
+    "nextQuestId": null,
+    "rewardsJson": [
+      15805,
+      13544,
+      15806
+    ],
+    "objectives": "Return to the Scholomance with the Blood of Innocents. Find the porch and place the Blood of Innocents in the brazier. Kirtonos will come to feast upon your soul.$B$BFight valiantly, do not give an inch! Destroy Kirtonos and return to Eva Sarkhoff.\n",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5463,
+    "dungeonInstanceId": 236,
+    "name": "Menethil's Gift",
+    "questLevel": 60,
+    "requiredLevel": 57,
+    "expansion": "classic",
+    "questGiverNpc": "Leonid Barthalomew the Revered",
+    "questGiverZone": null,
+    "prevQuestId": "5462",
+    "nextQuestId": "5464",
+    "rewardsJson": null,
+    "objectives": "Travel to Stratholme and find Menethil's Gift. Place the Keepsake of Remembrance upon the unholy ground. ",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5466,
+    "dungeonInstanceId": 235,
+    "name": "The Lich, Ras Frostwhisper",
+    "questLevel": 60,
+    "requiredLevel": 57,
+    "expansion": "classic",
+    "questGiverNpc": "Magistrate Marduke",
+    "questGiverZone": null,
+    "prevQuestId": "5465",
+    "nextQuestId": null,
+    "rewardsJson": [
+      13982,
+      14002,
+      13986,
+      13984
+    ],
+    "objectives": "Find Ras Frostwhisper in the Scholomance. When you have found him, use the Soulbound Keepsake on his undead visage. Should you succeed in reverting him to a mortal, strike him down and recover the Human Head of Ras Frostwhisper. Take the head back to Magistrate Marduke.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5515,
+    "dungeonInstanceId": 235,
+    "name": "Krastinov's Bag of Horrors",
+    "questLevel": 60,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Eva Sarkhoff",
+    "questGiverZone": null,
+    "prevQuestId": "5382",
+    "nextQuestId": "5384",
+    "rewardsJson": null,
+    "objectives": "Locate Jandice Barov in the Scholomance and destroy her. From her corpse recover Krastinov's Bag of Horrors. Return the bag to Eva Sarkhoff.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5518,
+    "dungeonInstanceId": 230,
+    "name": "The Gordok Ogre Suit",
+    "questLevel": 60,
+    "requiredLevel": 56,
+    "expansion": "classic",
+    "questGiverNpc": "Knot Thimblejack",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      18258
+    ],
+    "objectives": "Bring 4 Bolts of Runecloth, 8 Rugged Leather, 2 Rune Threads, and Ogre Tannin to Knot Thimblejack.  He is currently chained inside the Gordok wing of Dire Maul.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5519,
+    "dungeonInstanceId": 230,
+    "name": "The Gordok Ogre Suit",
+    "questLevel": 60,
+    "requiredLevel": 56,
+    "expansion": "classic",
+    "questGiverNpc": "Knot Thimblejack",
+    "questGiverZone": null,
+    "prevQuestId": "5518",
+    "nextQuestId": null,
+    "rewardsJson": [
+      18258
+    ],
+    "objectives": "",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5522,
+    "dungeonInstanceId": null,
+    "name": "Leonid Barthalomew",
+    "questLevel": 60,
+    "requiredLevel": 57,
+    "expansion": "classic",
+    "questGiverNpc": "Tinkee Steamboil",
+    "questGiverZone": null,
+    "prevQuestId": "4735",
+    "nextQuestId": "5531",
+    "rewardsJson": null,
+    "objectives": "Bring the Frozen Eggs to Leonid Barthalomew in the Eastern Plaguelands.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 5525,
+    "dungeonInstanceId": 230,
+    "name": "Free Knot!",
+    "questLevel": 60,
+    "requiredLevel": 56,
+    "expansion": "classic",
+    "questGiverNpc": "Knot Thimblejack",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5526,
+    "dungeonInstanceId": null,
+    "name": "Shards of the Felvine",
+    "questLevel": 60,
+    "requiredLevel": 56,
+    "expansion": "classic",
+    "questGiverNpc": "Rabine Saturna",
+    "questGiverZone": null,
+    "prevQuestId": "5527",
+    "nextQuestId": null,
+    "rewardsJson": [
+      18535,
+      18536
+    ],
+    "objectives": "Find the Felvine in Dire Maul and acquire a shard from it.  Chances are you'll only be able to procure one with the demise of Alzzin the Wildshaper.  Use the Reliquary of Purity to securely seal the shard inside, and return it to Rabine Saturna in Nighthaven, Moonglade.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 5528,
+    "dungeonInstanceId": 230,
+    "name": "The Gordok Taste Test",
+    "questLevel": 60,
+    "requiredLevel": 56,
+    "expansion": "classic",
+    "questGiverNpc": "Stomper Kreeg",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      18269,
+      18284
+    ],
+    "objectives": "",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5531,
+    "dungeonInstanceId": 235,
+    "name": "Betina Bigglezink",
+    "questLevel": 60,
+    "requiredLevel": 57,
+    "expansion": "classic",
+    "questGiverNpc": "Leonid Barthalomew the Revered",
+    "questGiverZone": null,
+    "prevQuestId": "5522",
+    "nextQuestId": "4771",
+    "rewardsJson": null,
+    "objectives": "Bring the Frozen Eggs to Betina Bigglezink.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 5848,
+    "dungeonInstanceId": 236,
+    "name": "Of Love and Family",
+    "questLevel": 60,
+    "requiredLevel": 52,
+    "expansion": "classic",
+    "questGiverNpc": "Artist Renfray",
+    "questGiverZone": null,
+    "prevQuestId": "5846",
+    "nextQuestId": "5861",
+    "rewardsJson": null,
+    "objectives": "Travel to Stratholme, in the northern part of the Plaguelands. It is in the Scarlet Bastion that you will find the painting 'Of Love and Family,' hidden behind another painting depicting the twin moons of our world.$B$BReturn the painting to Tirion Fordring.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 6163,
+    "dungeonInstanceId": 236,
+    "name": "Ramstein",
+    "questLevel": 60,
+    "requiredLevel": 56,
+    "expansion": "classic",
+    "questGiverNpc": "Nathanos Blightcaller",
+    "questGiverZone": null,
+    "prevQuestId": "6135",
+    "nextQuestId": null,
+    "rewardsJson": [
+      18022,
+      17001
+    ],
+    "objectives": "Travel to Stratholme and slay Ramstein the Gorger. Take his head as a souvenir for Nathanos.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 6642,
+    "dungeonInstanceId": 741,
+    "name": "Favor Amongst the Brotherhood, Dark Iron Ore",
+    "questLevel": 60,
+    "requiredLevel": 60,
+    "expansion": "classic",
+    "questGiverNpc": "Lokhtos Darkbargainer",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 6643,
+    "dungeonInstanceId": 741,
+    "name": "Favor Amongst the Brotherhood, Fiery Core",
+    "questLevel": 60,
+    "requiredLevel": 60,
+    "expansion": "classic",
+    "questGiverNpc": "Lokhtos Darkbargainer",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 6644,
+    "dungeonInstanceId": 741,
+    "name": "Favor Amongst the Brotherhood, Lava Core",
+    "questLevel": 60,
+    "requiredLevel": 60,
+    "expansion": "classic",
+    "questGiverNpc": "Lokhtos Darkbargainer",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 6645,
+    "dungeonInstanceId": 741,
+    "name": "Favor Amongst the Brotherhood, Core Leather",
+    "questLevel": 60,
+    "requiredLevel": 60,
+    "expansion": "classic",
+    "questGiverNpc": "Lokhtos Darkbargainer",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 6646,
+    "dungeonInstanceId": 741,
+    "name": "Favor Amongst the Brotherhood, Blood of the Mountain",
+    "questLevel": 60,
+    "requiredLevel": 60,
+    "expansion": "classic",
+    "questGiverNpc": "Lokhtos Darkbargainer",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 7429,
+    "dungeonInstanceId": 230,
+    "name": "Free Knot!",
+    "questLevel": 60,
+    "requiredLevel": 56,
+    "expansion": "classic",
+    "questGiverNpc": "Knot Thimblejack",
+    "questGiverZone": null,
+    "prevQuestId": "5525",
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7461,
+    "dungeonInstanceId": 230,
+    "name": "The Madness Within",
+    "questLevel": 60,
+    "requiredLevel": 56,
+    "expansion": "classic",
+    "questGiverNpc": "Shen'dralar Ancient",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "You must destroy the guardians surrounding the 5 Pylons that power the Prison of Immol'thar. Once the Pylons have powered down, the force field surrounding Immol'thar will have dissipated.$B$BEnter the Prison of Immol'thar and eradicate the foul demon that stands at its heart. Finally, confront Prince Tortheldrin in Athenaeum.$B$BReturn to the Shen'dralar Ancient in the courtyard should you complete this quest.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7462,
+    "dungeonInstanceId": 230,
+    "name": "The Treasure of the Shen'dralar",
+    "questLevel": 60,
+    "requiredLevel": 57,
+    "expansion": "classic",
+    "questGiverNpc": "Shen'dralar Ancient",
+    "questGiverZone": null,
+    "prevQuestId": "7461",
+    "nextQuestId": null,
+    "rewardsJson": [
+      18420,
+      18421,
+      18424
+    ],
+    "objectives": "Return to the Athenaeum and find the Treasure of the Shen'dralar. Claim your reward!",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7463,
+    "dungeonInstanceId": 230,
+    "name": "Arcane Refreshment",
+    "questLevel": 60,
+    "requiredLevel": 60,
+    "expansion": "classic",
+    "questGiverNpc": "Lorekeeper Lydros",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Travel to the Warpwood Quarter of Dire Maul and slay the water elemental, Hydrospawn. Return to Lorekeeper Lydros in the Athenaeum with the Hydrospawn Essence.",
+    "classRestriction": [
+      "Mage"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7478,
+    "dungeonInstanceId": 230,
+    "name": "Libram of Rapidity",
+    "questLevel": 60,
+    "requiredLevel": 57,
+    "expansion": "classic",
+    "questGiverNpc": "Lorekeeper Lydros",
+    "questGiverZone": null,
+    "prevQuestId": "7481",
+    "nextQuestId": null,
+    "rewardsJson": [
+      18329
+    ],
+    "objectives": "Bring a Libram of Rapidity, 1 Pristine Black Diamond, 2 Large Brilliant Shards, and 2 Blood of Heroes to Lorekeeper Lydros in Dire Maul to receive an Arcanum of Rapidity.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7479,
+    "dungeonInstanceId": 230,
+    "name": "Libram of Focus",
+    "questLevel": 60,
+    "requiredLevel": 57,
+    "expansion": "classic",
+    "questGiverNpc": "Lorekeeper Lydros",
+    "questGiverZone": null,
+    "prevQuestId": "7481",
+    "nextQuestId": null,
+    "rewardsJson": [
+      18330
+    ],
+    "objectives": "Bring a Libram of Focus, 1 Pristine Black Diamond, 4 Large Brilliant Shards, and 2 Skin of Shadow to Lorekeeper Lydros in Dire Maul to receive an Arcanum of Focus.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7480,
+    "dungeonInstanceId": 230,
+    "name": "Libram of Protection",
+    "questLevel": 60,
+    "requiredLevel": 57,
+    "expansion": "classic",
+    "questGiverNpc": "Lorekeeper Lydros",
+    "questGiverZone": null,
+    "prevQuestId": "7481",
+    "nextQuestId": null,
+    "rewardsJson": [
+      18331
+    ],
+    "objectives": "Bring a Libram of Protection, 1 Pristine Black Diamond, 2 Large Brilliant Shards, and 1 Frayed Abomination Stitching to Lorekeeper Lydros in Dire Maul to receive an Arcanum of Protection.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7481,
+    "dungeonInstanceId": 230,
+    "name": "Elven Legends",
+    "questLevel": 60,
+    "requiredLevel": 54,
+    "expansion": "classic",
+    "questGiverNpc": "Sage Korolusk",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Search Dire Maul for Kariel Winthalus. Report back to Sage Korolusk at Camp Mojache with whatever information that you may find.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7482,
+    "dungeonInstanceId": 230,
+    "name": "Elven Legends",
+    "questLevel": 60,
+    "requiredLevel": 54,
+    "expansion": "classic",
+    "questGiverNpc": "Scholar Runethorn",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Search Dire Maul for Kariel Winthalus. Report back to Scholar Runethorn at Feathermoon with whatever information that you may find.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7483,
+    "dungeonInstanceId": 230,
+    "name": "Libram of Rapidity",
+    "questLevel": 60,
+    "requiredLevel": 57,
+    "expansion": "classic",
+    "questGiverNpc": "Lorekeeper Lydros",
+    "questGiverZone": null,
+    "prevQuestId": "7482",
+    "nextQuestId": null,
+    "rewardsJson": [
+      18329
+    ],
+    "objectives": "Bring a Libram of Rapidity, 1 Pristine Black Diamond, 2 Large Brilliant Shards, and 2 Blood of Heroes to Lorekeeper Lydros in Dire Maul to receive an Arcanum of Rapidity.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7484,
+    "dungeonInstanceId": 230,
+    "name": "Libram of Focus",
+    "questLevel": 60,
+    "requiredLevel": 57,
+    "expansion": "classic",
+    "questGiverNpc": "Lorekeeper Lydros",
+    "questGiverZone": null,
+    "prevQuestId": "7482",
+    "nextQuestId": null,
+    "rewardsJson": [
+      18330
+    ],
+    "objectives": "Bring a Libram of Focus, 1 Pristine Black Diamond, 4 Large Brilliant Shards, and 2 Skin of Shadow to Lorekeeper Lydros in Dire Maul to receive an Arcanum of Focus.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7485,
+    "dungeonInstanceId": 230,
+    "name": "Libram of Protection",
+    "questLevel": 60,
+    "requiredLevel": 57,
+    "expansion": "classic",
+    "questGiverNpc": "Lorekeeper Lydros",
+    "questGiverZone": null,
+    "prevQuestId": "7482",
+    "nextQuestId": null,
+    "rewardsJson": [
+      18331
+    ],
+    "objectives": "Bring a Libram of Protection, 1 Pristine Black Diamond, 2 Large Brilliant Shards, and 1 Frayed Abomination Stitching to Lorekeeper Lydros in Dire Maul to receive an Arcanum of Protection.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7487,
+    "dungeonInstanceId": 741,
+    "name": "Attunement to the Core",
+    "questLevel": 60,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Lothos Riftwaker",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Venture to the Molten Core entry portal in Blackrock Depths and recover a Core Fragment. Return to Lothos Riftwaker in Blackrock Mountain when you have recovered the Core Fragment.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 7498,
+    "dungeonInstanceId": 230,
+    "name": "Garona: A Study on Stealth and Treachery",
+    "questLevel": 60,
+    "requiredLevel": 54,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      18465
+    ],
+    "objectives": "Return the book to its rightful owners.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7499,
+    "dungeonInstanceId": 230,
+    "name": "Codex of Defense",
+    "questLevel": 60,
+    "requiredLevel": 54,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      18466
+    ],
+    "objectives": "Return the book to its rightful owners.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7500,
+    "dungeonInstanceId": 230,
+    "name": "The Arcanist's Cookbook",
+    "questLevel": 60,
+    "requiredLevel": 54,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      18468
+    ],
+    "objectives": "Return the book to its rightful owners.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7501,
+    "dungeonInstanceId": 230,
+    "name": "The Light and How To Swing It",
+    "questLevel": 60,
+    "requiredLevel": 54,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      18472
+    ],
+    "objectives": "Return the book to its rightful owners.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7502,
+    "dungeonInstanceId": 230,
+    "name": "Harnessing Shadows",
+    "questLevel": 60,
+    "requiredLevel": 54,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      18467
+    ],
+    "objectives": "Return the book to its rightful owners.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7503,
+    "dungeonInstanceId": 230,
+    "name": "The Greatest Race of Hunters",
+    "questLevel": 60,
+    "requiredLevel": 54,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      18473
+    ],
+    "objectives": "Return the book to its rightful owners.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7504,
+    "dungeonInstanceId": 230,
+    "name": "Holy Bologna: What the Light Won't Tell You",
+    "questLevel": 60,
+    "requiredLevel": 54,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      18469
+    ],
+    "objectives": "Return the book to its rightful owners.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7505,
+    "dungeonInstanceId": 230,
+    "name": "Frost Shock and You",
+    "questLevel": 60,
+    "requiredLevel": 54,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      18471
+    ],
+    "objectives": "Return the book to its rightful owners.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7506,
+    "dungeonInstanceId": 230,
+    "name": "The Emerald Dream...",
+    "questLevel": 60,
+    "requiredLevel": 54,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      18470
+    ],
+    "objectives": "Return the book to its rightful owners.",
+    "classRestriction": [
+      "Druid"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7507,
+    "dungeonInstanceId": 230,
+    "name": "Foror's Compendium",
+    "questLevel": 60,
+    "requiredLevel": 60,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "7508",
+    "rewardsJson": null,
+    "objectives": "Return Foror's Compendium of Dragon Slaying to the Athenaeum.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7508,
+    "dungeonInstanceId": 230,
+    "name": "The Forging of Quel'Serrar",
+    "questLevel": 60,
+    "requiredLevel": 60,
+    "expansion": "classic",
+    "questGiverNpc": "Lorekeeper Lydros",
+    "questGiverZone": null,
+    "prevQuestId": "7507",
+    "nextQuestId": "7509",
+    "rewardsJson": null,
+    "objectives": "Give the Dull and Flat Elven Blade to Lorekeeper Lydros.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7581,
+    "dungeonInstanceId": null,
+    "name": "The Prison's Bindings",
+    "questLevel": 60,
+    "requiredLevel": 60,
+    "expansion": "classic",
+    "questGiverNpc": "Daio the Decrepit",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "7583",
+    "rewardsJson": null,
+    "objectives": "Travel to Dire Maul in Feralas and recover 15 Satyr Blood from the Wildspawn Satyr that inhabit the Warpwood Quarter. Return to Daio in the Tainted Scar when this is done.\n",
+    "classRestriction": [
+      "Warlock"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 7604,
+    "dungeonInstanceId": 228,
+    "name": "A Binding Contract",
+    "questLevel": 60,
+    "requiredLevel": 60,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      18592
+    ],
+    "objectives": "Turn the Thorium Brotherhood Contract in to Lokhtos Darkbargainer if you would like to receive the plans for Sulfuron.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7629,
+    "dungeonInstanceId": null,
+    "name": "Imp Delivery",
+    "questLevel": 60,
+    "requiredLevel": 60,
+    "expansion": "classic",
+    "questGiverNpc": "Gorzeeki Wildeyes",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "7631",
+    "rewardsJson": null,
+    "objectives": "Bring the Imp in a Jar to the alchemy lab in the Scholomance.  After the parchment is created, return the jar to Gorzeeki Wildeyes.",
+    "classRestriction": [
+      "Warlock"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 7631,
+    "dungeonInstanceId": null,
+    "name": "Dreadsteed of Xoroth",
+    "questLevel": 60,
+    "requiredLevel": 60,
+    "expansion": "classic",
+    "questGiverNpc": "Mor'zul Bloodbringer",
+    "questGiverZone": null,
+    "prevQuestId": "7629",
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Read Mor'zul's Instructions.  Summon a Xorothian Dreadsteed, defeat it, then bind its spirit to you.",
+    "classRestriction": [
+      "Warlock"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 7642,
+    "dungeonInstanceId": null,
+    "name": "Collection of Goods",
+    "questLevel": 60,
+    "requiredLevel": 60,
+    "expansion": "classic",
+    "questGiverNpc": "Grimand Elmore",
+    "questGiverZone": null,
+    "prevQuestId": "7641",
+    "nextQuestId": "7643",
+    "rewardsJson": null,
+    "objectives": "Bring 40 Runecloth, 6 Arcanite Bars, 10 Arthas' Tears, 5 Stratholme Holy Water vials, and 150 gold to Grimand Elmore in the Dwarven District of Stormwind.",
+    "classRestriction": [
+      "Paladin"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 7643,
+    "dungeonInstanceId": null,
+    "name": "Ancient Equine Spirit",
+    "questLevel": 60,
+    "requiredLevel": 60,
+    "expansion": "classic",
+    "questGiverNpc": "Lord Grayson Shadowbreaker",
+    "questGiverZone": null,
+    "prevQuestId": "7642",
+    "nextQuestId": "7644",
+    "rewardsJson": null,
+    "objectives": "Acquire special horse feed used for feeding a spirit horse.  Merideth Carlson in Southshore apparently is the source for such food.$B$BTravel to the Dire Maul dungeon in Feralas and slay Tendris Warpwood.  Doing so will free the Ancient Equine Spirit.  Feed it the special horse feed, thereby soothing the spirit.  Finally, give it the Arcanite Barding so it may bless it.",
+    "classRestriction": [
+      "Paladin"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 7647,
+    "dungeonInstanceId": null,
+    "name": "Judgment and Redemption",
+    "questLevel": 60,
+    "requiredLevel": 60,
+    "expansion": "classic",
+    "questGiverNpc": "Lord Grayson Shadowbreaker",
+    "questGiverZone": null,
+    "prevQuestId": "7646",
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Use the Divination Scryer in the heart of the Great Ossuary's basement in the Scholomance.  Doing so will bring forth the spirits you must judge.  Defeating these spirits will summon forth Death Knight Darkreaver.  Defeat him and reclaim the lost soul of the fallen charger.$B$BGive the Charger's Redeemed Soul and the Blessed Enchanted Barding to Darkreaver's Fallen Charger.",
+    "classRestriction": [
+      "Paladin"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 7649,
+    "dungeonInstanceId": null,
+    "name": "Enchanted Thorium Platemail: Volume I",
+    "questLevel": 60,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      12727
+    ],
+    "objectives": "Return the book to its rightful owners.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 7650,
+    "dungeonInstanceId": null,
+    "name": "Enchanted Thorium Platemail: Volume II",
+    "questLevel": 60,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      12726
+    ],
+    "objectives": "Return the book to its rightful owners.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 7651,
+    "dungeonInstanceId": null,
+    "name": "Enchanted Thorium Platemail: Volume III",
+    "questLevel": 60,
+    "requiredLevel": 50,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      12725
+    ],
+    "objectives": "Return the book to its rightful owners.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 7666,
+    "dungeonInstanceId": null,
+    "name": "Again Into the Great Ossuary",
+    "questLevel": 60,
+    "requiredLevel": 60,
+    "expansion": "classic",
+    "questGiverNpc": "Lord Grayson Shadowbreaker",
+    "questGiverZone": null,
+    "prevQuestId": "7647",
+    "nextQuestId": null,
+    "rewardsJson": [
+      18746
+    ],
+    "objectives": "",
+    "classRestriction": [
+      "Paladin"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 7668,
+    "dungeonInstanceId": null,
+    "name": "The Darkreaver Menace",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Sagorne Creststrider",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      18807
+    ],
+    "objectives": "Use the Divination Scryer in the heart of the Great Ossuary's basement in the Scholomance.  Doing so will bring forth spirits you must fight.  Defeating these spirits will summon forth Death Knight Darkreaver; defeat him.$B$BBring Darkreaver's Head to Sagorne Creststrider in the Valley of Wisdom, Orgrimmar.",
+    "classRestriction": [
+      "Shaman"
+    ],
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 7703,
+    "dungeonInstanceId": 230,
+    "name": "Unfinished Gordok Business",
+    "questLevel": 60,
+    "requiredLevel": 60,
+    "expansion": "classic",
+    "questGiverNpc": "Captain Kromcrush",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": [
+      18366,
+      18367,
+      18368,
+      18369
+    ],
+    "objectives": "Find the Gauntlet of Gordok Might and return it to Captain Kromcrush in Dire Maul.$B$BAccording to Kromcrush, the \"old timey story\" says that Tortheldrin - a \"creepy\" elf who called himself a prince - stole it from one of the Gordok kings.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 7737,
+    "dungeonInstanceId": null,
+    "name": "Gaining Acceptance",
+    "questLevel": 60,
+    "requiredLevel": 45,
+    "expansion": "classic",
+    "questGiverNpc": "Master Smith Burninate",
+    "questGiverZone": null,
+    "prevQuestId": "7722",
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 7761,
+    "dungeonInstanceId": 229,
+    "name": "Blackhand's Command",
+    "questLevel": 60,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": null,
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "That is one stupid orc. It would appear as if you need to find this brand and gain the Mark of Drakkisath in order to access the Orb of Command.$B$BThe letter indicates that General Drakkisath guards the brand. Perhaps you should investigate.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": false
+  },
+  {
+    "questId": 7848,
+    "dungeonInstanceId": 741,
+    "name": "Attunement to the Core",
+    "questLevel": 60,
+    "requiredLevel": 55,
+    "expansion": "classic",
+    "questGiverNpc": "Lothos Riftwaker",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Venture to the Molten Core entry portal in Blackrock Depths and recover a Core Fragment. Return to Lothos Riftwaker in Blackrock Mountain when you have recovered the Core Fragment.",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": false
+  },
+  {
+    "questId": 7877,
+    "dungeonInstanceId": 230,
+    "name": "The Treasure of the Shen'dralar",
+    "questLevel": 60,
+    "requiredLevel": 57,
+    "expansion": "classic",
+    "questGiverNpc": "Shen'dralar Ancient",
+    "questGiverZone": null,
+    "prevQuestId": "7461",
+    "nextQuestId": null,
+    "rewardsJson": [
+      18420,
+      18421,
+      18424
+    ],
+    "objectives": "Return to the Athenaeum and find the Treasure of the Shen'dralar. Claim your reward!",
+    "classRestriction": null,
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 8258,
+    "dungeonInstanceId": null,
+    "name": "The Darkreaver Menace",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Sagorne Creststrider",
+    "questGiverZone": null,
+    "prevQuestId": "7667",
+    "nextQuestId": null,
+    "rewardsJson": [
+      20134
+    ],
+    "objectives": "Use the Divination Scryer in the heart of the Great Ossuary's basement in the Scholomance.  Doing so will bring forth spirits you must fight.  Defeating these spirits will summon forth Death Knight Darkreaver; defeat him.$B$BBring Darkreaver's Head to Sagorne Creststrider in the Valley of Wisdom, Orgrimmar.",
+    "classRestriction": [
+      "Shaman"
+    ],
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8905,
+    "dungeonInstanceId": null,
+    "name": "An Earnest Proposition",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Deliana",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "8922",
+    "rewardsJson": [
+      22108
+    ],
+    "objectives": "Acquire 15 Winterspring Blood Samples and 20 gold and bring them along with a set of Wildheart Bracers to Deliana in Ironforge.",
+    "classRestriction": [
+      "Druid"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8906,
+    "dungeonInstanceId": null,
+    "name": "An Earnest Proposition",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Deliana",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "8922",
+    "rewardsJson": [
+      22011
+    ],
+    "objectives": "Acquire 15 Winterspring Blood Samples and 20 gold and bring them along with a set of Beaststalker's Bindings to Deliana in Ironforge.",
+    "classRestriction": [
+      "Hunter"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8907,
+    "dungeonInstanceId": null,
+    "name": "An Earnest Proposition",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Deliana",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "8922",
+    "rewardsJson": [
+      22063
+    ],
+    "objectives": "Acquire 15 Winterspring Blood Samples and 20 gold and bring them along with a set of Magister's Bindings to Deliana in Ironforge.",
+    "classRestriction": [
+      "Mage"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8908,
+    "dungeonInstanceId": null,
+    "name": "An Earnest Proposition",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Deliana",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "8922",
+    "rewardsJson": [
+      22088
+    ],
+    "objectives": "Acquire 15 Winterspring Blood Samples and 20 gold and bring them along with a set of Lightforge Bracers to Deliana in Ironforge.",
+    "classRestriction": [
+      "Paladin"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8909,
+    "dungeonInstanceId": null,
+    "name": "An Earnest Proposition",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Deliana",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "8922",
+    "rewardsJson": [
+      22079
+    ],
+    "objectives": "Acquire 15 Winterspring Blood Samples and 20 gold and bring them along with 1 set of Devout Bracers to Deliana in Ironforge.",
+    "classRestriction": [
+      "Priest"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8910,
+    "dungeonInstanceId": null,
+    "name": "An Earnest Proposition",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Deliana",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "8922",
+    "rewardsJson": [
+      22004
+    ],
+    "objectives": "Acquire 15 Winterspring Blood Samples and 20 gold and bring them along with a set of Shadowcraft Bracers to Deliana in Ironforge.\n",
+    "classRestriction": [
+      "Rogue"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8911,
+    "dungeonInstanceId": null,
+    "name": "An Earnest Proposition",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Deliana",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "8922",
+    "rewardsJson": [
+      22071
+    ],
+    "objectives": "Acquire 15 Winterspring Blood Samples and 20 gold and bring them along with a set of Dreadmist Bracers to Deliana in Ironforge.\n",
+    "classRestriction": [
+      "Warlock"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8912,
+    "dungeonInstanceId": null,
+    "name": "An Earnest Proposition",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Deliana",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "8922",
+    "rewardsJson": [
+      21996
+    ],
+    "objectives": "Acquire 15 Winterspring Blood Samples and 20 gold and bring them along with a set of Bracers of Valor to Deliana in Ironforge.",
+    "classRestriction": [
+      "Warrior"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8913,
+    "dungeonInstanceId": null,
+    "name": "An Earnest Proposition",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Mokvar",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "8923",
+    "rewardsJson": [
+      22108
+    ],
+    "objectives": "Acquire 15 Silithus Venom Samples and 20 gold and bring them along with a set of Wildheart Bracers to Mokvar in Orgrimmar.",
+    "classRestriction": [
+      "Druid"
+    ],
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8914,
+    "dungeonInstanceId": null,
+    "name": "An Earnest Proposition",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Mokvar",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "8923",
+    "rewardsJson": [
+      22011
+    ],
+    "objectives": "Acquire 15 Silithus Venom Samples and 20 gold and bring them along with a set of Beaststalker's Bindings to Mokvar in Orgrimmar.",
+    "classRestriction": [
+      "Hunter"
+    ],
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8915,
+    "dungeonInstanceId": null,
+    "name": "An Earnest Proposition",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Mokvar",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "8923",
+    "rewardsJson": [
+      22063
+    ],
+    "objectives": "Acquire 15 Silithus Venom Samples and 20 gold and bring them along with a set of Magister's Bindings to Mokvar in Orgrimmar.\n",
+    "classRestriction": [
+      "Mage"
+    ],
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8916,
+    "dungeonInstanceId": null,
+    "name": "An Earnest Proposition",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Mokvar",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "8923",
+    "rewardsJson": [
+      22079
+    ],
+    "objectives": "Acquire 15 Silithus Venom Samples and 20 gold and bring them along with a set of Devout Bracers to Mokvar in Orgrimmar.\n",
+    "classRestriction": [
+      "Priest"
+    ],
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8917,
+    "dungeonInstanceId": null,
+    "name": "An Earnest Proposition",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Mokvar",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "8923",
+    "rewardsJson": [
+      22004
+    ],
+    "objectives": "Acquire 15 Silithus Venom Samples and 20 gold and bring them along with a set of Shadowcraft Bracers to Mokvar in Orgrimmar.\n",
+    "classRestriction": [
+      "Rogue"
+    ],
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8918,
+    "dungeonInstanceId": null,
+    "name": "An Earnest Proposition",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Mokvar",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "8923",
+    "rewardsJson": [
+      22095
+    ],
+    "objectives": "Acquire 15 Silithus Venom Samples and 20 gold and bring them along with a set of Bindings of Elements to Mokvar in Orgrimmar.\n",
+    "classRestriction": [
+      "Shaman"
+    ],
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8919,
+    "dungeonInstanceId": null,
+    "name": "An Earnest Proposition",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Mokvar",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "8923",
+    "rewardsJson": [
+      22071
+    ],
+    "objectives": "Acquire 15 Silithus Venom Samples and 20 gold and bring them along with a set of Dreadmist Bracers to Mokvar in Orgrimmar.",
+    "classRestriction": [
+      "Warlock"
+    ],
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8920,
+    "dungeonInstanceId": null,
+    "name": "An Earnest Proposition",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Mokvar",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "8923",
+    "rewardsJson": [
+      21996
+    ],
+    "objectives": "Acquire 15 Silithus Venom Samples and 20 gold and bring them along with a set of Bracers of Valor to Mokvar in Orgrimmar.\n",
+    "classRestriction": [
+      "Warrior"
+    ],
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8926,
+    "dungeonInstanceId": null,
+    "name": "Just Compensation",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Deliana",
+    "questGiverZone": null,
+    "prevQuestId": "8977",
+    "nextQuestId": "8929",
+    "rewardsJson": [
+      22106,
+      22110
+    ],
+    "objectives": "Bring a Wildheart Belt and a set of Wildheart Gloves Deliana in Ironforge.",
+    "classRestriction": [
+      "Druid"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8927,
+    "dungeonInstanceId": null,
+    "name": "Just Compensation",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Mokvar",
+    "questGiverZone": null,
+    "prevQuestId": "8978",
+    "nextQuestId": "8930",
+    "rewardsJson": [
+      22106,
+      22110
+    ],
+    "objectives": "Bring a Wildheart Belt and a set of Wildheart Gloves to Mokvar in Orgrimmar.",
+    "classRestriction": [
+      "Druid"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8931,
+    "dungeonInstanceId": null,
+    "name": "Just Compensation",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Deliana",
+    "questGiverZone": null,
+    "prevQuestId": "8977",
+    "nextQuestId": "8929",
+    "rewardsJson": [
+      22010,
+      22015
+    ],
+    "objectives": "Bring a Beaststalker's Belt and a set of Beaststalker's Gloves to Deliana in Ironforge.",
+    "classRestriction": [
+      "Hunter"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8932,
+    "dungeonInstanceId": null,
+    "name": "Just Compensation",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Deliana",
+    "questGiverZone": null,
+    "prevQuestId": "8977",
+    "nextQuestId": "8929",
+    "rewardsJson": [
+      22062,
+      22066
+    ],
+    "objectives": "Bring a Magister's Belt and a set of Magister's Gloves to Deliana in Ironforge.\n",
+    "classRestriction": [
+      "Mage"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8933,
+    "dungeonInstanceId": null,
+    "name": "Just Compensation",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Deliana",
+    "questGiverZone": null,
+    "prevQuestId": "8977",
+    "nextQuestId": "8929",
+    "rewardsJson": [
+      22086,
+      22090
+    ],
+    "objectives": "Bring a Lightforge Belt and a set of Lightforge Gauntlets to Deliana in Ironforge.\n",
+    "classRestriction": [
+      "Paladin"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8934,
+    "dungeonInstanceId": null,
+    "name": "Just Compensation",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Deliana",
+    "questGiverZone": null,
+    "prevQuestId": "8977",
+    "nextQuestId": "8929",
+    "rewardsJson": [
+      22078,
+      22081
+    ],
+    "objectives": "Bring a Devout Belt and a set of Devout Gloves to Deliana in Ironforge.",
+    "classRestriction": [
+      "Priest"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8935,
+    "dungeonInstanceId": null,
+    "name": "Just Compensation",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Deliana",
+    "questGiverZone": null,
+    "prevQuestId": "8977",
+    "nextQuestId": "8929",
+    "rewardsJson": [
+      22002,
+      22006
+    ],
+    "objectives": "Bring a Shadowcraft Belt and a set of Shadowcraft Gloves to Deliana in Ironforge.",
+    "classRestriction": [
+      "Rogue"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8936,
+    "dungeonInstanceId": null,
+    "name": "Just Compensation",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Deliana",
+    "questGiverZone": null,
+    "prevQuestId": "8977",
+    "nextQuestId": "8929",
+    "rewardsJson": [
+      22070,
+      22077
+    ],
+    "objectives": "Bring a Dreadmist Belt and a set of Dreadmist Wraps to Deliana in Ironforge.",
+    "classRestriction": [
+      "Warlock"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8937,
+    "dungeonInstanceId": null,
+    "name": "Just Compensation",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Deliana",
+    "questGiverZone": null,
+    "prevQuestId": "8977",
+    "nextQuestId": "8929",
+    "rewardsJson": [
+      21994,
+      21998
+    ],
+    "objectives": "Bring a Belt of Valor and a set of Gauntlets of Valor to Deliana in Ironforge.",
+    "classRestriction": [
+      "Warrior"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8938,
+    "dungeonInstanceId": null,
+    "name": "Just Compensation",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Mokvar",
+    "questGiverZone": null,
+    "prevQuestId": "8978",
+    "nextQuestId": "8930",
+    "rewardsJson": [
+      22010,
+      22015
+    ],
+    "objectives": "Bring a Beaststalker's Belt and a set of Beaststalker's Gloves to Mokvar in Orgrimmar.",
+    "classRestriction": [
+      "Hunter"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8939,
+    "dungeonInstanceId": null,
+    "name": "Just Compensation",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Mokvar",
+    "questGiverZone": null,
+    "prevQuestId": "8978",
+    "nextQuestId": "8930",
+    "rewardsJson": [
+      22062,
+      22066
+    ],
+    "objectives": "Bring a Magister's Belt and a set of Magister's Gloves to Mokvar in Orgrimmar.",
+    "classRestriction": [
+      "Mage"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8940,
+    "dungeonInstanceId": null,
+    "name": "Just Compensation",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Mokvar",
+    "questGiverZone": null,
+    "prevQuestId": "8978",
+    "nextQuestId": "8930",
+    "rewardsJson": [
+      22078,
+      22081
+    ],
+    "objectives": "Bring a Devout Belt and a set of Devout Gloves to Mokvar in Orgrimmar.",
+    "classRestriction": [
+      "Priest"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8941,
+    "dungeonInstanceId": null,
+    "name": "Just Compensation",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Mokvar",
+    "questGiverZone": null,
+    "prevQuestId": "8978",
+    "nextQuestId": "8930",
+    "rewardsJson": [
+      22006,
+      22002
+    ],
+    "objectives": "Bring a Shadowcraft Belt and a set of Shadowcraft Gloves to Mokvar in Orgrimmar.",
+    "classRestriction": [
+      "Rogue"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8942,
+    "dungeonInstanceId": null,
+    "name": "Just Compensation",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Mokvar",
+    "questGiverZone": null,
+    "prevQuestId": "8978",
+    "nextQuestId": "8930",
+    "rewardsJson": [
+      22098,
+      22099
+    ],
+    "objectives": "Bring a Cord of Elements and a set of Gauntlets of Elements to Mokvar in Orgrimmar.\n",
+    "classRestriction": [
+      "Shaman"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8943,
+    "dungeonInstanceId": null,
+    "name": "Just Compensation",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Mokvar",
+    "questGiverZone": null,
+    "prevQuestId": "8978",
+    "nextQuestId": "8930",
+    "rewardsJson": [
+      22070,
+      22077
+    ],
+    "objectives": "Bring a Dreadmist Belt and a set of Dreadmist Wraps to Mokvar in Orgrimmar.\n",
+    "classRestriction": [
+      "Warlock"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8944,
+    "dungeonInstanceId": null,
+    "name": "Just Compensation",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Mokvar",
+    "questGiverZone": null,
+    "prevQuestId": "8978",
+    "nextQuestId": "8930",
+    "rewardsJson": [
+      21994,
+      21998
+    ],
+    "objectives": "Bring a Belt of Valor and a set of Gauntlets of Valor to Mokvar in Orgrimmar.\n",
+    "classRestriction": [
+      "Warrior"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8945,
+    "dungeonInstanceId": 236,
+    "name": "Dead Man's Plea",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Anthion Harmon",
+    "questGiverZone": null,
+    "prevQuestId": null,
+    "nextQuestId": "8946",
+    "rewardsJson": [
+      22137
+    ],
+    "objectives": "Go into Stratholme and rescue Ysida Harmon from Baron Rivendare.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 8948,
+    "dungeonInstanceId": 230,
+    "name": "Anthion's Old Friend",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Anthion Harmon",
+    "questGiverZone": null,
+    "prevQuestId": "8947",
+    "nextQuestId": "8949",
+    "rewardsJson": null,
+    "objectives": "Take the incomplete Banner of Provocation to Falrin Treeshaper at the library in Dire Maul.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 8949,
+    "dungeonInstanceId": 230,
+    "name": "Falrin's Vendetta",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Falrin Treeshaper",
+    "questGiverZone": null,
+    "prevQuestId": "8948",
+    "nextQuestId": "8950",
+    "rewardsJson": [
+      22150,
+      22149
+    ],
+    "objectives": "Collect 25 Ogre Warbeads from Ogres inside Dire Maul or Blackrock Spire and return to Falrin Treeshaper inside the Athenaeum in Dire Maul.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 8950,
+    "dungeonInstanceId": 230,
+    "name": "The Instigator's Enchantment",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Falrin Treeshaper",
+    "questGiverZone": null,
+    "prevQuestId": "8949",
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Bring the following to Falrin Treeshaper inside Dire Maul: 1 Jeering Spectre's Essence, 4 Dark Runes and 8 Large Brilliant Shards.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 8951,
+    "dungeonInstanceId": null,
+    "name": "Anthion's Parting Words",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Anthion Harmon",
+    "questGiverZone": null,
+    "prevQuestId": "9015",
+    "nextQuestId": "8960",
+    "rewardsJson": [
+      22107,
+      22111,
+      22112
+    ],
+    "objectives": "Return to Deliana in Ironforge with a set of Wildheart Boots, a Wildheart Kilt and Wildheart Spaulders.",
+    "classRestriction": [
+      "Druid"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8952,
+    "dungeonInstanceId": null,
+    "name": "Anthion's Parting Words",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Anthion Harmon",
+    "questGiverZone": null,
+    "prevQuestId": "9015",
+    "nextQuestId": "8960",
+    "rewardsJson": [
+      22061,
+      22017,
+      22016
+    ],
+    "objectives": "Return to Deliana in Ironforge with a set of Beaststalker's Boots, Beaststalker's Pants and Beaststalker's Mantle.",
+    "classRestriction": [
+      "Hunter"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8953,
+    "dungeonInstanceId": null,
+    "name": "Anthion's Parting Words",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Anthion Harmon",
+    "questGiverZone": null,
+    "prevQuestId": "9015",
+    "nextQuestId": "8960",
+    "rewardsJson": [
+      22064,
+      22067,
+      22068
+    ],
+    "objectives": "Return to Deliana in Ironforge with a set of Magister's Boots, Magister's Leggings and Magister's Mantle.",
+    "classRestriction": [
+      "Mage"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8954,
+    "dungeonInstanceId": null,
+    "name": "Anthion's Parting Words",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Anthion Harmon",
+    "questGiverZone": null,
+    "prevQuestId": "9015",
+    "nextQuestId": "8960",
+    "rewardsJson": [
+      22087,
+      22092,
+      22093
+    ],
+    "objectives": "Return to Deliana in Ironforge with a set of Lightforge Boots, Lightforge Legplates and Lightforge Spaulders.",
+    "classRestriction": [
+      "Paladin"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8955,
+    "dungeonInstanceId": null,
+    "name": "Anthion's Parting Words",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Anthion Harmon",
+    "questGiverZone": null,
+    "prevQuestId": "9015",
+    "nextQuestId": "8960",
+    "rewardsJson": [
+      22084,
+      22085,
+      22082
+    ],
+    "objectives": "Return to Deliana in Ironforge with a set of Devout Sandals, Devout Skirt and Devout Mantle.",
+    "classRestriction": [
+      "Priest"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8956,
+    "dungeonInstanceId": null,
+    "name": "Anthion's Parting Words",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Anthion Harmon",
+    "questGiverZone": null,
+    "prevQuestId": "9015",
+    "nextQuestId": "8960",
+    "rewardsJson": [
+      22003,
+      22007,
+      22008
+    ],
+    "objectives": "Return to Deliana in Ironforge with a set of Shadowcraft Boots, Shadowcraft Pants and Shadowcraft Spaulders.",
+    "classRestriction": [
+      "Rogue"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8957,
+    "dungeonInstanceId": null,
+    "name": "Anthion's Parting Words",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Anthion Harmon",
+    "questGiverZone": null,
+    "prevQuestId": "9015",
+    "nextQuestId": "9032",
+    "rewardsJson": [
+      22096,
+      22100,
+      22101
+    ],
+    "objectives": "Return to Mokvar in Orgimmar with a set of Boots of Elements, Kilt of Elements and Pauldrons of Elements.",
+    "classRestriction": [
+      "Shaman"
+    ],
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8958,
+    "dungeonInstanceId": null,
+    "name": "Anthion's Parting Words",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Anthion Harmon",
+    "questGiverZone": null,
+    "prevQuestId": "9015",
+    "nextQuestId": "8960",
+    "rewardsJson": [
+      22076,
+      22072,
+      22073
+    ],
+    "objectives": "Return to Deliana in Ironforge with a set of Dreadmist Sandals, Dreadmist Leggings and Dreadmist Mantle.",
+    "classRestriction": [
+      "Warlock"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8959,
+    "dungeonInstanceId": null,
+    "name": "Anthion's Parting Words",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Anthion Harmon",
+    "questGiverZone": null,
+    "prevQuestId": "9015",
+    "nextQuestId": "8960",
+    "rewardsJson": [
+      21995,
+      22000,
+      22001
+    ],
+    "objectives": "Return to Deliana in Ironforge with a set of Boots of Valor, Legplates of Valor and Spaulders of Valor.",
+    "classRestriction": [
+      "Warrior"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8966,
+    "dungeonInstanceId": 229,
+    "name": "The Left Piece of Lord Valthalak's Amulet",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Bodley",
+    "questGiverZone": null,
+    "prevQuestId": "8962",
+    "nextQuestId": "8970",
+    "rewardsJson": null,
+    "objectives": "Use the Brazier of Beckoning to summon forth the spirit of Mor Grayhoof and slay him. Return to Bodley inside Blackrock Mountain with the Left Piece of Lord Valthalak's Amulet and the Brazier of Beckoning.",
+    "classRestriction": [
+      "Mage",
+      "Warrior"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8967,
+    "dungeonInstanceId": 230,
+    "name": "The Left Piece of Lord Valthalak's Amulet",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Bodley",
+    "questGiverZone": null,
+    "prevQuestId": "8963",
+    "nextQuestId": "8970",
+    "rewardsJson": null,
+    "objectives": "Use the Brazier of Beckoning to summon forth the spirit of Isalien and slay her. Return to Bodley inside Blackrock Mountain with the Left Piece of Lord Valthalak's Amulet and the Brazier of Beckoning.",
+    "classRestriction": [
+      "Druid",
+      "Warlock"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 8968,
+    "dungeonInstanceId": 236,
+    "name": "The Left Piece of Lord Valthalak's Amulet",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Bodley",
+    "questGiverZone": null,
+    "prevQuestId": "8964",
+    "nextQuestId": "8970",
+    "rewardsJson": null,
+    "objectives": "Use the Brazier of Beckoning to summon forth Jarien and Sothos and slay them. Return to Bodley inside Blackrock Mountain with the Left Piece of Lord Valthalak's Amulet and the Brazier of Beckoning.",
+    "classRestriction": [
+      "Rogue",
+      "Hunter"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 8969,
+    "dungeonInstanceId": 235,
+    "name": "The Left Piece of Lord Valthalak's Amulet",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Bodley",
+    "questGiverZone": null,
+    "prevQuestId": "8965",
+    "nextQuestId": "8970",
+    "rewardsJson": null,
+    "objectives": "Use the Brazier of Beckoning to summon forth the spirit of Kormok and slay him. Return to Bodley inside Blackrock Mountain with the Left Piece of Lord Valthalak's Amulet and the Brazier of Beckoning.",
+    "classRestriction": [
+      "Shaman",
+      "Priest",
+      "Paladin"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 8989,
+    "dungeonInstanceId": 229,
+    "name": "The Right Piece of Lord Valthalak's Amulet",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Bodley",
+    "questGiverZone": null,
+    "prevQuestId": "8986",
+    "nextQuestId": "8994",
+    "rewardsJson": null,
+    "objectives": "Use the Brazier of Beckoning to summon forth the spirit of Mor Grayhoof and slay him. Return to Bodley inside Blackrock Mountain with the recombined Lord Valthalak's Amulet and the Brazier of Beckoning.",
+    "classRestriction": [
+      "Druid",
+      "Shaman",
+      "Paladin"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 8990,
+    "dungeonInstanceId": 230,
+    "name": "The Right Piece of Lord Valthalak's Amulet",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Bodley",
+    "questGiverZone": null,
+    "prevQuestId": "8985",
+    "nextQuestId": "8994",
+    "rewardsJson": null,
+    "objectives": "Use the Brazier of Beckoning to summon forth the spirit of Isalien and slay her. Return to Bodley inside Blackrock Mountain with the recombined Lord Valthalak's Amulet and the Brazier of Beckoning.",
+    "classRestriction": [
+      "Rogue",
+      "Warrior"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 8991,
+    "dungeonInstanceId": 236,
+    "name": "The Right Piece of Lord Valthalak's Amulet",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Bodley",
+    "questGiverZone": null,
+    "prevQuestId": "8987",
+    "nextQuestId": "8994",
+    "rewardsJson": null,
+    "objectives": "Use the Brazier of Beckoning to summon forth Jarien and Sothos and slay them. Return to Bodley inside Blackrock Mountain with the recombined Lord Valthalak's Amulet and the Brazier of Beckoning.",
+    "classRestriction": [
+      "Mage",
+      "Priest"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 8992,
+    "dungeonInstanceId": 235,
+    "name": "The Right Piece of Lord Valthalak's Amulet",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Bodley",
+    "questGiverZone": null,
+    "prevQuestId": "8988",
+    "nextQuestId": "8994",
+    "rewardsJson": null,
+    "objectives": "Use the Brazier of Beckoning to summon forth the spirit of Kormok and slay him. Return to Bodley inside Blackrock Mountain with the recombined Lord Valthalak's Amulet and the Brazier of Beckoning.",
+    "classRestriction": [
+      "Warlock",
+      "Hunter"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 8999,
+    "dungeonInstanceId": null,
+    "name": "Saving the Best for Last",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Deliana",
+    "questGiverZone": null,
+    "prevQuestId": "8997",
+    "nextQuestId": null,
+    "rewardsJson": [
+      22109,
+      22113
+    ],
+    "objectives": "Give Deliana your Wildheart Cowl and Wildheart Vest.",
+    "classRestriction": [
+      "Druid"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 9000,
+    "dungeonInstanceId": null,
+    "name": "Saving the Best for Last",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Deliana",
+    "questGiverZone": null,
+    "prevQuestId": "8997",
+    "nextQuestId": null,
+    "rewardsJson": [
+      22013,
+      22060
+    ],
+    "objectives": "Give Deliana your Beaststalker's Cap and Beaststalker's Tunic.",
+    "classRestriction": [
+      "Hunter"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 9001,
+    "dungeonInstanceId": null,
+    "name": "Saving the Best for Last",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Deliana",
+    "questGiverZone": null,
+    "prevQuestId": "8997",
+    "nextQuestId": null,
+    "rewardsJson": [
+      22065,
+      22069
+    ],
+    "objectives": "Give Deliana your Magister's Crown and Magister's Robes.",
+    "classRestriction": [
+      "Mage"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 9002,
+    "dungeonInstanceId": null,
+    "name": "Saving the Best for Last",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Deliana",
+    "questGiverZone": null,
+    "prevQuestId": "8997",
+    "nextQuestId": null,
+    "rewardsJson": [
+      22091,
+      22089
+    ],
+    "objectives": "Give Deliana your Lightforge Helm and Lightforge Breastplate.",
+    "classRestriction": [
+      "Paladin"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 9003,
+    "dungeonInstanceId": null,
+    "name": "Saving the Best for Last",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Deliana",
+    "questGiverZone": null,
+    "prevQuestId": "8997",
+    "nextQuestId": null,
+    "rewardsJson": [
+      22080,
+      22083
+    ],
+    "objectives": "Give Deliana your Devout Crown and Devout Robe.",
+    "classRestriction": [
+      "Priest"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 9004,
+    "dungeonInstanceId": null,
+    "name": "Saving the Best for Last",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Deliana",
+    "questGiverZone": null,
+    "prevQuestId": "8997",
+    "nextQuestId": null,
+    "rewardsJson": [
+      22005,
+      22009
+    ],
+    "objectives": "Give Deliana your Shadowcraft Cap and Shadowcraft Tunic.",
+    "classRestriction": [
+      "Rogue"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 9005,
+    "dungeonInstanceId": null,
+    "name": "Saving the Best for Last",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Deliana",
+    "questGiverZone": null,
+    "prevQuestId": "8997",
+    "nextQuestId": null,
+    "rewardsJson": [
+      22074,
+      22075
+    ],
+    "objectives": "Give Deliana your Dreadmist Mask and Dreadmist Robe.",
+    "classRestriction": [
+      "Warlock"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 9006,
+    "dungeonInstanceId": null,
+    "name": "Saving the Best for Last",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Deliana",
+    "questGiverZone": null,
+    "prevQuestId": "8997",
+    "nextQuestId": null,
+    "rewardsJson": [
+      21999,
+      21997
+    ],
+    "objectives": "Give Deliana your Helm of Valor and Breastplate of Valor.",
+    "classRestriction": [
+      "Warrior"
+    ],
+    "raceRestriction": [
+      "Gnome",
+      "Night Elf",
+      "Dwarf",
+      "Human"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 9007,
+    "dungeonInstanceId": null,
+    "name": "Saving the Best for Last",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Mokvar",
+    "questGiverZone": null,
+    "prevQuestId": "8998",
+    "nextQuestId": null,
+    "rewardsJson": [
+      22109,
+      22113
+    ],
+    "objectives": "Give Mokvar your Wildheart Cowl and Wildheart Vest.",
+    "classRestriction": [
+      "Druid"
+    ],
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 9008,
+    "dungeonInstanceId": null,
+    "name": "Saving the Best for Last",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Mokvar",
+    "questGiverZone": null,
+    "prevQuestId": "8998",
+    "nextQuestId": null,
+    "rewardsJson": [
+      22013,
+      22060
+    ],
+    "objectives": "Give Mokvar your Beaststalker's Cap and Beaststalker's Tunic.",
+    "classRestriction": [
+      "Hunter"
+    ],
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 9009,
+    "dungeonInstanceId": null,
+    "name": "Saving the Best for Last",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Mokvar",
+    "questGiverZone": null,
+    "prevQuestId": "8998",
+    "nextQuestId": null,
+    "rewardsJson": [
+      22080,
+      22083
+    ],
+    "objectives": "Give Mokvar your Devout Crown and Devout Robe.",
+    "classRestriction": [
+      "Priest"
+    ],
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 9010,
+    "dungeonInstanceId": null,
+    "name": "Saving the Best for Last",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Mokvar",
+    "questGiverZone": null,
+    "prevQuestId": "8998",
+    "nextQuestId": null,
+    "rewardsJson": [
+      22005,
+      22009
+    ],
+    "objectives": "Give Mokvar your Shadowcraft Cap and Shadowcraft Tunic.",
+    "classRestriction": [
+      "Rogue"
+    ],
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 9011,
+    "dungeonInstanceId": null,
+    "name": "Saving the Best for Last",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Mokvar",
+    "questGiverZone": null,
+    "prevQuestId": "8998",
+    "nextQuestId": null,
+    "rewardsJson": [
+      22097,
+      22102
+    ],
+    "objectives": "Give Mokvar your Coif of Elements and Vest of Elements.",
+    "classRestriction": [
+      "Shaman"
+    ],
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 9012,
+    "dungeonInstanceId": null,
+    "name": "Saving the Best for Last",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Mokvar",
+    "questGiverZone": null,
+    "prevQuestId": "8998",
+    "nextQuestId": null,
+    "rewardsJson": [
+      22074,
+      22075
+    ],
+    "objectives": "Give Mokvar your Dreadmist Mask and Dreadmist Robe.",
+    "classRestriction": [
+      "Warlock"
+    ],
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 9013,
+    "dungeonInstanceId": null,
+    "name": "Saving the Best for Last",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Mokvar",
+    "questGiverZone": null,
+    "prevQuestId": "8998",
+    "nextQuestId": null,
+    "rewardsJson": [
+      21999,
+      21997
+    ],
+    "objectives": "Give Mokvar your Helm of Valor and Breastplate of Valor.",
+    "classRestriction": [
+      "Warrior"
+    ],
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 9014,
+    "dungeonInstanceId": null,
+    "name": "Saving the Best for Last",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Mokvar",
+    "questGiverZone": null,
+    "prevQuestId": "8998",
+    "nextQuestId": null,
+    "rewardsJson": [
+      22065,
+      22069
+    ],
+    "objectives": "Give Mokvar your Magister's Crown and Magister's Robes.",
+    "classRestriction": [
+      "Mage"
+    ],
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 9015,
+    "dungeonInstanceId": 228,
+    "name": "The Challenge",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Falrin Treeshaper",
+    "questGiverZone": null,
+    "prevQuestId": "8950",
+    "nextQuestId": null,
+    "rewardsJson": null,
+    "objectives": "Travel to the Ring of the Law in Blackrock Depths and place the Banner of Provocation in its center as you are sentenced by High Justice Grimstone.  Slay Theldren and his gladiators and return to Anthion Harmon in the Eastern Plaguelands with the first piece of Lord Valthalak's amulet.",
+    "classRestriction": null,
+    "raceRestriction": null,
+    "startsInsideDungeon": true,
+    "sharable": true
+  },
+  {
+    "questId": 9016,
+    "dungeonInstanceId": null,
+    "name": "Anthion's Parting Words",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Anthion Harmon",
+    "questGiverZone": null,
+    "prevQuestId": "9015",
+    "nextQuestId": "9032",
+    "rewardsJson": [
+      22107,
+      22111,
+      22112
+    ],
+    "objectives": "Return to Mokvar in Orgimmar with a set of Wildheart Boots, a Wildheart Kilt and Wildheart Spaulders.\n",
+    "classRestriction": [
+      "Druid"
+    ],
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 9017,
+    "dungeonInstanceId": null,
+    "name": "Anthion's Parting Words",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Anthion Harmon",
+    "questGiverZone": null,
+    "prevQuestId": "9015",
+    "nextQuestId": "9032",
+    "rewardsJson": [
+      22061,
+      22017,
+      22016
+    ],
+    "objectives": "Return to Mokvar in Orgimmar with a set of Beaststalker's Boots, Beaststalker's Pants and Beaststalker's Mantle.",
+    "classRestriction": [
+      "Hunter"
+    ],
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 9018,
+    "dungeonInstanceId": null,
+    "name": "Anthion's Parting Words",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Anthion Harmon",
+    "questGiverZone": null,
+    "prevQuestId": "9015",
+    "nextQuestId": "9032",
+    "rewardsJson": [
+      22064,
+      22067,
+      22068
+    ],
+    "objectives": "Return to Mokvar in Orgimmar with a set of Magister's Boots, Magister's Leggings and Magister's Mantle.",
+    "classRestriction": [
+      "Mage"
+    ],
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 9019,
+    "dungeonInstanceId": null,
+    "name": "Anthion's Parting Words",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Anthion Harmon",
+    "questGiverZone": null,
+    "prevQuestId": "9015",
+    "nextQuestId": "9032",
+    "rewardsJson": [
+      22084,
+      22085,
+      22082
+    ],
+    "objectives": "Return to Mokvar in Orgimmar with a set of Devout Sandals, Devout Skirt and Devout Mantle.",
+    "classRestriction": [
+      "Priest"
+    ],
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 9020,
+    "dungeonInstanceId": null,
+    "name": "Anthion's Parting Words",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Anthion Harmon",
+    "questGiverZone": null,
+    "prevQuestId": "9015",
+    "nextQuestId": "9032",
+    "rewardsJson": [
+      22003,
+      22007,
+      22008
+    ],
+    "objectives": "Return to Mokvar in Orgimmar with a set of  Shadowcraft Boots, Shadowcraft Pants and Shadowcraft Spaulders.",
+    "classRestriction": [
+      "Rogue"
+    ],
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 9021,
+    "dungeonInstanceId": null,
+    "name": "Anthion's Parting Words",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Anthion Harmon",
+    "questGiverZone": null,
+    "prevQuestId": "9015",
+    "nextQuestId": "9032",
+    "rewardsJson": [
+      22076,
+      22072,
+      22073
+    ],
+    "objectives": "Return to Mokvar in Orgimmar with a set of Dreadmist Sandals, Dreadmist Leggings and Dreadmist Mantle.",
+    "classRestriction": [
+      "Warlock"
+    ],
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 9022,
+    "dungeonInstanceId": null,
+    "name": "Anthion's Parting Words",
+    "questLevel": 60,
+    "requiredLevel": 58,
+    "expansion": "classic",
+    "questGiverNpc": "Anthion Harmon",
+    "questGiverZone": null,
+    "prevQuestId": "9015",
+    "nextQuestId": "9032",
+    "rewardsJson": [
+      21995,
+      22000,
+      22001
+    ],
+    "objectives": "Return to Mokvar in Orgimmar with a set of Boots of Valor, Legplates of Valor and Spaulders of Valor.",
+    "classRestriction": [
+      "Warrior"
+    ],
+    "raceRestriction": [
+      "Troll",
+      "Tauren",
+      "Undead",
+      "Orc"
+    ],
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 9257,
+    "dungeonInstanceId": null,
+    "name": "Atiesh, Greatstaff of the Guardian",
+    "questLevel": 60,
+    "requiredLevel": 60,
+    "expansion": "classic",
+    "questGiverNpc": "Anachronos",
+    "questGiverZone": null,
+    "prevQuestId": "9251",
+    "nextQuestId": null,
+    "rewardsJson": [
+      22631
+    ],
+    "objectives": "Anachronos at the Caverns of Time in Tanaris wants you to take Atiesh, Greatstaff of the Guardian to Stratholme and use it on Consecrated Earth. Defeat the entity that is exorcised from the staff and return to him.",
+    "classRestriction": [
+      "Priest"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 9269,
+    "dungeonInstanceId": null,
+    "name": "Atiesh, Greatstaff of the Guardian",
+    "questLevel": 60,
+    "requiredLevel": 60,
+    "expansion": "classic",
+    "questGiverNpc": "Anachronos",
+    "questGiverZone": null,
+    "prevQuestId": "9251",
+    "nextQuestId": null,
+    "rewardsJson": [
+      22632
+    ],
+    "objectives": "Anachronos at the Caverns of Time in Tanaris wants you to take Atiesh, Greatstaff of the Guardian to Stratholme and use it on Consecrated Earth. Defeat the entity that is exorcised from the staff and return to him.",
+    "classRestriction": [
+      "Druid"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 9270,
+    "dungeonInstanceId": null,
+    "name": "Atiesh, Greatstaff of the Guardian",
+    "questLevel": 60,
+    "requiredLevel": 60,
+    "expansion": "classic",
+    "questGiverNpc": "Anachronos",
+    "questGiverZone": null,
+    "prevQuestId": "9251",
+    "nextQuestId": null,
+    "rewardsJson": [
+      22589
+    ],
+    "objectives": "Anachronos at the Caverns of Time in Tanaris wants you to take Atiesh, Greatstaff of the Guardian to Stratholme and use it on Consecrated Earth. Defeat the entity that is exorcised from the staff and return to him.",
+    "classRestriction": [
+      "Mage"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  },
+  {
+    "questId": 9271,
+    "dungeonInstanceId": null,
+    "name": "Atiesh, Greatstaff of the Guardian",
+    "questLevel": 60,
+    "requiredLevel": 60,
+    "expansion": "classic",
+    "questGiverNpc": "Anachronos",
+    "questGiverZone": null,
+    "prevQuestId": "9251",
+    "nextQuestId": null,
+    "rewardsJson": [
+      22630
+    ],
+    "objectives": "Anachronos at the Caverns of Time in Tanaris wants you to take Atiesh, Greatstaff of the Guardian to Stratholme and use it on Consecrated Earth. Defeat the entity that is exorcised from the staff and return to him.",
+    "classRestriction": [
+      "Warlock"
+    ],
+    "raceRestriction": null,
+    "startsInsideDungeon": false,
+    "sharable": true
+  }
+]

--- a/api/src/plugins/wow-common/dungeon-quest-seeder.spec.ts
+++ b/api/src/plugins/wow-common/dungeon-quest-seeder.spec.ts
@@ -1,0 +1,61 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DungeonQuestSeeder } from './dungeon-quest-seeder';
+import { DrizzleAsyncProvider } from '../../drizzle/drizzle.module';
+
+describe('DungeonQuestSeeder', () => {
+  let seeder: DungeonQuestSeeder;
+  let mockDb: {
+    insert: jest.Mock;
+    delete: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    const mockReturning = jest.fn().mockResolvedValue([{ id: 1 }]);
+    const mockOnConflictDoNothing = jest
+      .fn()
+      .mockReturnValue({ returning: mockReturning });
+    const mockValues = jest
+      .fn()
+      .mockReturnValue({ onConflictDoNothing: mockOnConflictDoNothing });
+
+    mockDb = {
+      insert: jest.fn().mockReturnValue({ values: mockValues }),
+      delete: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DungeonQuestSeeder,
+        { provide: DrizzleAsyncProvider, useValue: mockDb },
+      ],
+    }).compile();
+
+    seeder = module.get<DungeonQuestSeeder>(DungeonQuestSeeder);
+  });
+
+  describe('seed()', () => {
+    it('should insert dungeon quests from bundled data', async () => {
+      const result = await seeder.seed();
+
+      expect(result).toHaveProperty('inserted');
+      expect(result).toHaveProperty('total');
+      expect(result.total).toBeGreaterThan(0);
+      expect(mockDb.insert).toHaveBeenCalled();
+    });
+
+    it('should return total matching the bundled data count', async () => {
+      const result = await seeder.seed();
+
+      // The bundled data should have a reasonable number of quests
+      expect(result.total).toBeGreaterThanOrEqual(100);
+    });
+  });
+
+  describe('drop()', () => {
+    it('should delete all dungeon quest data', async () => {
+      await seeder.drop();
+
+      expect(mockDb.delete).toHaveBeenCalled();
+    });
+  });
+});

--- a/api/src/plugins/wow-common/dungeon-quest-seeder.ts
+++ b/api/src/plugins/wow-common/dungeon-quest-seeder.ts
@@ -1,0 +1,98 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+
+import * as schema from '../../drizzle/schema';
+import { wowClassicDungeonQuests } from '../../drizzle/schema';
+import { DrizzleAsyncProvider } from '../../drizzle/drizzle.module';
+
+/**
+ * Seeds the wow_classic_dungeon_quests table from the bundled JSON snapshot.
+ * Called on plugin install; data dropped on plugin uninstall.
+ *
+ * ROK-245: Variant-Aware Dungeon Quest Database
+ */
+@Injectable()
+export class DungeonQuestSeeder {
+  private readonly logger = new Logger(DungeonQuestSeeder.name);
+
+  constructor(
+    @Inject(DrizzleAsyncProvider)
+    private db: PostgresJsDatabase<typeof schema>,
+  ) { }
+
+  /**
+   * Seed all dungeon quests from the bundled data file.
+   * Uses upsert (ON CONFLICT DO NOTHING) to be idempotent.
+   */
+  async seed(): Promise<{ inserted: number; total: number }> {
+    const dataPath = join(__dirname, 'data', 'dungeon-quest-data.json');
+    const raw = await readFile(dataPath, 'utf-8');
+    const quests = JSON.parse(raw) as Array<{
+      questId: number;
+      dungeonInstanceId: number | null;
+      name: string;
+      questLevel: number | null;
+      requiredLevel: number | null;
+      expansion: string;
+      questGiverNpc: string | null;
+      questGiverZone: string | null;
+      prevQuestId: number | null;
+      nextQuestId: number | null;
+      rewardsJson: number[] | null;
+      objectives: string | null;
+      classRestriction: string[] | null;
+      raceRestriction: string[] | null;
+      startsInsideDungeon: boolean;
+      sharable: boolean;
+    }>;
+
+    this.logger.log(`Seeding ${quests.length} dungeon quests...`);
+
+    // Batch insert in chunks of 100 to avoid param limits
+    const BATCH_SIZE = 100;
+    let inserted = 0;
+
+    for (let i = 0; i < quests.length; i += BATCH_SIZE) {
+      const batch = quests.slice(i, i + BATCH_SIZE);
+      const result = await this.db
+        .insert(wowClassicDungeonQuests)
+        .values(
+          batch.map((q) => ({
+            questId: q.questId,
+            dungeonInstanceId: q.dungeonInstanceId,
+            name: q.name,
+            questLevel: q.questLevel,
+            requiredLevel: q.requiredLevel,
+            expansion: q.expansion,
+            questGiverNpc: q.questGiverNpc,
+            questGiverZone: q.questGiverZone,
+            prevQuestId: q.prevQuestId,
+            nextQuestId: q.nextQuestId,
+            rewardsJson: q.rewardsJson,
+            objectives: q.objectives,
+            classRestriction: q.classRestriction,
+            raceRestriction: q.raceRestriction,
+            startsInsideDungeon: q.startsInsideDungeon,
+            sharable: q.sharable,
+          })),
+        )
+        .onConflictDoNothing({ target: wowClassicDungeonQuests.questId })
+        .returning({ id: wowClassicDungeonQuests.id });
+
+      inserted += result.length;
+    }
+
+    this.logger.log(`Seeded ${inserted}/${quests.length} dungeon quests`);
+    return { inserted, total: quests.length };
+  }
+
+  /**
+   * Remove all dungeon quest data (called on plugin uninstall).
+   */
+  async drop(): Promise<void> {
+    await this.db.delete(wowClassicDungeonQuests);
+    this.logger.log('Dropped all dungeon quest data');
+  }
+}

--- a/api/src/plugins/wow-common/dungeon-quests.controller.spec.ts
+++ b/api/src/plugins/wow-common/dungeon-quests.controller.spec.ts
@@ -1,0 +1,105 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DungeonQuestsController } from './dungeon-quests.controller';
+import { DungeonQuestsService } from './dungeon-quests.service';
+import { Reflector } from '@nestjs/core';
+import { PluginRegistryService } from '../plugin-host/plugin-registry.service';
+
+describe('DungeonQuestsController', () => {
+  let controller: DungeonQuestsController;
+  let mockService: {
+    getQuestsForInstance: jest.Mock;
+    getQuestChain: jest.Mock;
+  };
+
+  const mockQuests = [
+    {
+      questId: 2040,
+      dungeonInstanceId: 63,
+      name: 'The Defias Brotherhood',
+      questLevel: 18,
+      requiredLevel: 14,
+      expansion: 'classic',
+      questGiverNpc: 'Gryan Stoutmantle',
+      questGiverZone: 'Kalimdor',
+      prevQuestId: 166,
+      nextQuestId: null,
+      rewardsJson: [2041],
+      objectives:
+        'Kill Edwin VanCleef and bring his head to Gryan Stoutmantle.',
+      classRestriction: null,
+      raceRestriction: ['Human', 'Dwarf', 'Night Elf', 'Gnome'],
+      startsInsideDungeon: false,
+      sharable: true,
+    },
+  ];
+
+  beforeEach(async () => {
+    mockService = {
+      getQuestsForInstance: jest.fn().mockResolvedValue(mockQuests),
+      getQuestChain: jest.fn().mockResolvedValue(mockQuests),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [DungeonQuestsController],
+      providers: [
+        { provide: DungeonQuestsService, useValue: mockService },
+        { provide: Reflector, useValue: new Reflector() },
+        {
+          provide: PluginRegistryService,
+          useValue: {
+            getActiveSlugsSync: jest
+              .fn()
+              .mockReturnValue(new Set(['blizzard'])),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<DungeonQuestsController>(DungeonQuestsController);
+  });
+
+  describe('getQuestsForInstance()', () => {
+    it('should return quests for a dungeon instance', async () => {
+      const result = await controller.getQuestsForInstance(63, 'classic_era');
+
+      expect(result).toEqual(mockQuests);
+      expect(mockService.getQuestsForInstance).toHaveBeenCalledWith(
+        63,
+        'classic_era',
+      );
+    });
+
+    it('should default variant to classic_era', async () => {
+      await controller.getQuestsForInstance(63);
+
+      expect(mockService.getQuestsForInstance).toHaveBeenCalledWith(
+        63,
+        'classic_era',
+      );
+    });
+
+    it('should pass the variant parameter through', async () => {
+      await controller.getQuestsForInstance(228, 'classic_anniversary');
+
+      expect(mockService.getQuestsForInstance).toHaveBeenCalledWith(
+        228,
+        'classic_anniversary',
+      );
+    });
+
+    it('should throw BadRequestException for invalid variant', async () => {
+      await expect(
+        controller.getQuestsForInstance(63, 'invalid_variant'),
+      ).rejects.toThrow('Invalid variant');
+    });
+  });
+
+  describe('getQuestChain()', () => {
+    it('should return the quest chain', async () => {
+      const result = await controller.getQuestChain(2040);
+
+      expect(result).toEqual(mockQuests);
+      expect(mockService.getQuestChain).toHaveBeenCalledWith(2040);
+    });
+  });
+});

--- a/api/src/plugins/wow-common/dungeon-quests.controller.ts
+++ b/api/src/plugins/wow-common/dungeon-quests.controller.ts
@@ -1,0 +1,64 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  ParseIntPipe,
+  UseGuards,
+  BadRequestException,
+} from '@nestjs/common';
+import { DungeonQuestsService } from './dungeon-quests.service';
+import {
+  PluginActiveGuard,
+  RequirePlugin,
+} from '../plugin-host/plugin-active.guard';
+import { WOW_COMMON_MANIFEST } from './manifest';
+
+/**
+ * API controller for dungeon quest data.
+ * All routes gated behind PluginActiveGuard — requires Blizzard plugin to be active.
+ *
+ * ROK-245: Variant-Aware Dungeon Quest Database
+ */
+@Controller('plugins/wow-classic')
+@UseGuards(PluginActiveGuard)
+@RequirePlugin(WOW_COMMON_MANIFEST.id)
+export class DungeonQuestsController {
+  constructor(private readonly dungeonQuestsService: DungeonQuestsService) { }
+
+  private static readonly VALID_VARIANTS = new Set([
+    'classic_era', 'classic_anniversary', 'classic', 'retail',
+  ]);
+
+  /**
+   * GET /plugins/wow-classic/instances/:id/quests?variant=classic_era
+   *
+   * Returns dungeon quests for a specific instance, filtered by variant.
+   * Variant determines which expansion's quests are included:
+   *   - classic_era: ['classic']
+   *   - classic_anniversary: ['classic', 'tbc']
+   *   - classic (Cata): ['classic', 'tbc', 'wotlk', 'cata']
+   */
+  @Get('instances/:id/quests')
+  async getQuestsForInstance(
+    @Param('id', ParseIntPipe) instanceId: number,
+    @Query('variant') variant: string = 'classic_era',
+  ) {
+    if (!DungeonQuestsController.VALID_VARIANTS.has(variant)) {
+      throw new BadRequestException(
+        `Invalid variant "${variant}". Valid variants: ${[...DungeonQuestsController.VALID_VARIANTS].join(', ')}`,
+      );
+    }
+    return this.dungeonQuestsService.getQuestsForInstance(instanceId, variant);
+  }
+
+  /**
+   * GET /plugins/wow-classic/quests/:questId/chain
+   *
+   * Returns the full prerequisite chain for a quest.
+   */
+  @Get('quests/:questId/chain')
+  async getQuestChain(@Param('questId', ParseIntPipe) questId: number) {
+    return this.dungeonQuestsService.getQuestChain(questId);
+  }
+}

--- a/api/src/plugins/wow-common/dungeon-quests.service.spec.ts
+++ b/api/src/plugins/wow-common/dungeon-quests.service.spec.ts
@@ -1,0 +1,95 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { DungeonQuestsService } from './dungeon-quests.service';
+import { DungeonQuestSeeder } from './dungeon-quest-seeder';
+import { DrizzleAsyncProvider } from '../../drizzle/drizzle.module';
+
+describe('DungeonQuestsService', () => {
+  let service: DungeonQuestsService;
+  let mockSeeder: { seed: jest.Mock; drop: jest.Mock };
+  let mockDb: { select: jest.Mock };
+
+  beforeEach(async () => {
+    mockSeeder = {
+      seed: jest.fn().mockResolvedValue({ inserted: 10, total: 10 }),
+      drop: jest.fn().mockResolvedValue(undefined),
+    };
+
+    // Build a fluent mock for Drizzle queries: db.select().from().where().orderBy()
+    const mockOrderBy = jest.fn().mockResolvedValue([]);
+    const mockWhere = jest.fn().mockReturnValue({ orderBy: mockOrderBy });
+    const mockFrom = jest.fn().mockReturnValue({ where: mockWhere });
+
+    mockDb = {
+      select: jest.fn().mockReturnValue({ from: mockFrom }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DungeonQuestsService,
+        { provide: DungeonQuestSeeder, useValue: mockSeeder },
+        { provide: DrizzleAsyncProvider, useValue: mockDb },
+      ],
+    }).compile();
+
+    service = module.get<DungeonQuestsService>(DungeonQuestsService);
+  });
+
+  describe('getExpansionsForVariant()', () => {
+    it('should return classic only for classic_era', () => {
+      expect(service.getExpansionsForVariant('classic_era')).toEqual([
+        'classic',
+      ]);
+    });
+
+    it('should return classic+tbc for classic_anniversary', () => {
+      expect(service.getExpansionsForVariant('classic_anniversary')).toEqual([
+        'classic',
+        'tbc',
+      ]);
+    });
+
+    it('should return all expansions for classic (Cata)', () => {
+      expect(service.getExpansionsForVariant('classic')).toEqual([
+        'classic',
+        'tbc',
+        'wotlk',
+        'cata',
+      ]);
+    });
+
+    it('should default to classic_era for unknown variant', () => {
+      expect(service.getExpansionsForVariant('unknown')).toEqual(['classic']);
+    });
+  });
+
+  describe('getQuestsForInstance()', () => {
+    it('should query the database with correct instance ID', async () => {
+      await service.getQuestsForInstance(228, 'classic_era');
+
+      expect(mockDb.select).toHaveBeenCalled();
+    });
+
+    it('should return an empty array when no quests found', async () => {
+      const result = await service.getQuestsForInstance(999, 'classic_era');
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('seedQuests()', () => {
+    it('should delegate to seeder', async () => {
+      const result = await service.seedQuests();
+
+      expect(mockSeeder.seed).toHaveBeenCalled();
+      expect(result).toEqual({ inserted: 10, total: 10 });
+    });
+  });
+
+  describe('dropQuests()', () => {
+    it('should delegate to seeder', async () => {
+      await service.dropQuests();
+
+      expect(mockSeeder.drop).toHaveBeenCalled();
+    });
+  });
+});

--- a/api/src/plugins/wow-common/dungeon-quests.service.ts
+++ b/api/src/plugins/wow-common/dungeon-quests.service.ts
@@ -1,0 +1,172 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { eq, inArray, and } from 'drizzle-orm';
+
+import * as schema from '../../drizzle/schema';
+import { wowClassicDungeonQuests } from '../../drizzle/schema';
+import { DrizzleAsyncProvider } from '../../drizzle/drizzle.module';
+import { DungeonQuestSeeder } from './dungeon-quest-seeder';
+
+/**
+ * Variant-to-expansion-set mapping.
+ * Each variant includes quests from all expansions up to and including its era.
+ */
+const VARIANT_EXPANSIONS: Record<string, string[]> = {
+  classic_era: ['classic'],
+  classic_anniversary: ['classic', 'tbc'],
+  classic: ['classic', 'tbc', 'wotlk', 'cata'],
+  retail: ['classic', 'tbc', 'wotlk', 'cata'],
+};
+
+export interface DungeonQuestDto {
+  questId: number;
+  dungeonInstanceId: number | null;
+  name: string;
+  questLevel: number | null;
+  requiredLevel: number | null;
+  expansion: string;
+  questGiverNpc: string | null;
+  questGiverZone: string | null;
+  prevQuestId: number | null;
+  nextQuestId: number | null;
+  rewardsJson: number[] | null;
+  objectives: string | null;
+  classRestriction: string[] | null;
+  raceRestriction: string[] | null;
+  startsInsideDungeon: boolean;
+  sharable: boolean;
+}
+
+/**
+ * Service for querying dungeon quest data with variant-aware filtering.
+ *
+ * ROK-245: Variant-Aware Dungeon Quest Database
+ */
+@Injectable()
+export class DungeonQuestsService {
+  private readonly logger = new Logger(DungeonQuestsService.name);
+  /** Safety limit for chain walking to prevent infinite loops from circular data */
+  private static readonly MAX_CHAIN_DEPTH = 50;
+
+  constructor(
+    @Inject(DrizzleAsyncProvider)
+    private db: PostgresJsDatabase<typeof schema>,
+    private readonly seeder: DungeonQuestSeeder,
+  ) { }
+
+  /**
+   * Get the expansion set for a given WoW game variant.
+   */
+  getExpansionsForVariant(variant: string): string[] {
+    return VARIANT_EXPANSIONS[variant] ?? VARIANT_EXPANSIONS['classic_era'];
+  }
+
+  /**
+   * Get all quests for a dungeon instance, filtered by variant.
+   */
+  async getQuestsForInstance(
+    instanceId: number,
+    variant: string = 'classic_era',
+  ): Promise<DungeonQuestDto[]> {
+    const expansions = this.getExpansionsForVariant(variant);
+
+    const rows = await this.db
+      .select()
+      .from(wowClassicDungeonQuests)
+      .where(
+        and(
+          eq(wowClassicDungeonQuests.dungeonInstanceId, instanceId),
+          inArray(wowClassicDungeonQuests.expansion, expansions),
+        ),
+      )
+      .orderBy(wowClassicDungeonQuests.questLevel);
+
+    return rows.map((row) => this.toDto(row));
+  }
+
+  /**
+   * Get the full prerequisite chain for a quest.
+   * Walks backwards through prevQuestId and forwards through nextQuestId.
+   */
+  async getQuestChain(questId: number): Promise<DungeonQuestDto[]> {
+    // First, find the quest itself
+    const [quest] = await this.db
+      .select()
+      .from(wowClassicDungeonQuests)
+      .where(eq(wowClassicDungeonQuests.questId, questId))
+      .limit(1);
+
+    if (!quest) return [];
+
+    const chain: (typeof quest)[] = [quest];
+    const visited = new Set<number>([questId]);
+
+    // Walk backwards — find all prev quests
+    let currentPrev = quest.prevQuestId;
+    while (currentPrev !== null && !visited.has(currentPrev) && visited.size < DungeonQuestsService.MAX_CHAIN_DEPTH) {
+      const [prev] = await this.db
+        .select()
+        .from(wowClassicDungeonQuests)
+        .where(eq(wowClassicDungeonQuests.questId, currentPrev))
+        .limit(1);
+      if (!prev) break;
+      visited.add(prev.questId);
+      chain.unshift(prev);
+      currentPrev = prev.prevQuestId;
+    }
+
+    // Walk forwards — find all next quests
+    let currentNext = quest.nextQuestId;
+    while (currentNext !== null && !visited.has(currentNext) && visited.size < DungeonQuestsService.MAX_CHAIN_DEPTH) {
+      const [next] = await this.db
+        .select()
+        .from(wowClassicDungeonQuests)
+        .where(eq(wowClassicDungeonQuests.questId, currentNext))
+        .limit(1);
+      if (!next) break;
+      visited.add(next.questId);
+      chain.push(next);
+      currentNext = next.nextQuestId;
+    }
+
+    return chain.map((row) => this.toDto(row));
+  }
+
+  /**
+   * Map a DB row to a DTO.
+   */
+  private toDto(row: typeof wowClassicDungeonQuests.$inferSelect): DungeonQuestDto {
+    return {
+      questId: row.questId,
+      dungeonInstanceId: row.dungeonInstanceId,
+      name: row.name,
+      questLevel: row.questLevel,
+      requiredLevel: row.requiredLevel,
+      expansion: row.expansion,
+      questGiverNpc: row.questGiverNpc,
+      questGiverZone: row.questGiverZone,
+      prevQuestId: row.prevQuestId,
+      nextQuestId: row.nextQuestId,
+      rewardsJson: row.rewardsJson,
+      objectives: row.objectives,
+      classRestriction: row.classRestriction,
+      raceRestriction: row.raceRestriction,
+      startsInsideDungeon: row.startsInsideDungeon,
+      sharable: row.sharable,
+    };
+  }
+
+  /**
+   * Seed quest data (delegates to seeder).
+   */
+  async seedQuests(): Promise<{ inserted: number; total: number }> {
+    return this.seeder.seed();
+  }
+
+  /**
+   * Drop all quest data (delegates to seeder).
+   */
+  async dropQuests(): Promise<void> {
+    return this.seeder.drop();
+  }
+}

--- a/api/src/plugins/wow-common/wow-common.module.ts
+++ b/api/src/plugins/wow-common/wow-common.module.ts
@@ -1,10 +1,13 @@
-import { Module, OnModuleInit, OnModuleDestroy } from '@nestjs/common';
+import { Module, OnModuleInit, OnModuleDestroy, Logger } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { BlizzardService } from './blizzard.service';
 import { BlizzardController } from './blizzard.controller';
 import { BlizzardCharacterSyncAdapter } from './blizzard-character-sync.adapter';
 import { BlizzardContentProvider } from './blizzard-content.provider';
 import { WowCronRegistrar } from './wow-cron-registrar';
+import { DungeonQuestsController } from './dungeon-quests.controller';
+import { DungeonQuestsService } from './dungeon-quests.service';
+import { DungeonQuestSeeder } from './dungeon-quest-seeder';
 import { SettingsModule } from '../../settings/settings.module';
 import { CharactersModule } from '../../characters/characters.module';
 import { PluginRegistryService } from '../plugin-host/plugin-registry.service';
@@ -14,22 +17,27 @@ import { WOW_COMMON_MANIFEST } from './manifest';
 
 @Module({
   imports: [SettingsModule, CharactersModule],
-  controllers: [BlizzardController],
+  controllers: [BlizzardController, DungeonQuestsController],
   providers: [
     BlizzardService,
     BlizzardCharacterSyncAdapter,
     BlizzardContentProvider,
     WowCronRegistrar,
+    DungeonQuestsService,
+    DungeonQuestSeeder,
   ],
   exports: [
     BlizzardService,
     BlizzardCharacterSyncAdapter,
     BlizzardContentProvider,
+    DungeonQuestsService,
   ],
 })
 export class WowCommonModule implements OnModuleInit, OnModuleDestroy {
+  private readonly logger = new Logger(WowCommonModule.name);
   private activatedHandler?: (payload: { slug: string }) => void;
   private installedHandler?: (payload: { slug: string }) => void;
+  private uninstalledHandler?: (payload: { slug: string }) => void;
 
   constructor(
     private readonly pluginRegistry: PluginRegistryService,
@@ -37,6 +45,7 @@ export class WowCommonModule implements OnModuleInit, OnModuleDestroy {
     private readonly characterSyncAdapter: BlizzardCharacterSyncAdapter,
     private readonly contentProvider: BlizzardContentProvider,
     private readonly cronRegistrar: WowCronRegistrar,
+    private readonly dungeonQuestsService: DungeonQuestsService,
   ) {}
 
   async onModuleInit(): Promise<void> {
@@ -44,16 +53,52 @@ export class WowCommonModule implements OnModuleInit, OnModuleDestroy {
     await this.pluginRegistry.ensureInstalled(WOW_COMMON_MANIFEST.id);
     this.registerAdapters();
 
+    // Seed dungeon quests on first boot
+    try {
+      await this.dungeonQuestsService.seedQuests();
+    } catch (err) {
+      this.logger.warn(
+        `Dungeon quest seed skipped (may already exist): ${err}`,
+      );
+    }
+
     const reRegister = (payload: { slug: string }) => {
       if (payload.slug === WOW_COMMON_MANIFEST.id) {
         this.registerAdapters();
       }
     };
 
+    const handleInstall = (payload: { slug: string }) => {
+      if (payload.slug === WOW_COMMON_MANIFEST.id) {
+        this.registerAdapters();
+        this.dungeonQuestsService
+          .seedQuests()
+          .catch((err) =>
+            this.logger.error(
+              `Failed to seed dungeon quests on install: ${err}`,
+            ),
+          );
+      }
+    };
+
+    const handleUninstall = (payload: { slug: string }) => {
+      if (payload.slug === WOW_COMMON_MANIFEST.id) {
+        this.dungeonQuestsService
+          .dropQuests()
+          .catch((err) =>
+            this.logger.error(
+              `Failed to drop dungeon quests on uninstall: ${err}`,
+            ),
+          );
+      }
+    };
+
     this.activatedHandler = reRegister;
-    this.installedHandler = reRegister;
+    this.installedHandler = handleInstall;
+    this.uninstalledHandler = handleUninstall;
     this.eventEmitter.on(PLUGIN_EVENTS.ACTIVATED, this.activatedHandler);
     this.eventEmitter.on(PLUGIN_EVENTS.INSTALLED, this.installedHandler);
+    this.eventEmitter.on(PLUGIN_EVENTS.UNINSTALLED, this.uninstalledHandler);
   }
 
   onModuleDestroy(): void {
@@ -67,6 +112,12 @@ export class WowCommonModule implements OnModuleInit, OnModuleDestroy {
       this.eventEmitter.removeListener(
         PLUGIN_EVENTS.INSTALLED,
         this.installedHandler,
+      );
+    }
+    if (this.uninstalledHandler) {
+      this.eventEmitter.removeListener(
+        PLUGIN_EVENTS.UNINSTALLED,
+        this.uninstalledHandler,
       );
     }
   }

--- a/packages/contract/src/dungeon-quests.schema.ts
+++ b/packages/contract/src/dungeon-quests.schema.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod';
+
+/**
+ * ROK-245: Dungeon quest API schemas.
+ */
+
+/** Single dungeon quest DTO */
+export const DungeonQuestDtoSchema = z.object({
+    questId: z.number(),
+    dungeonInstanceId: z.number().nullable(),
+    name: z.string(),
+    questLevel: z.number().nullable(),
+    requiredLevel: z.number().nullable(),
+    expansion: z.enum(['classic', 'tbc', 'wotlk', 'cata']),
+    questGiverNpc: z.string().nullable(),
+    questGiverZone: z.string().nullable(),
+    prevQuestId: z.number().nullable(),
+    nextQuestId: z.number().nullable(),
+    rewardsJson: z.array(z.number()).nullable(),
+    objectives: z.string().nullable(),
+    classRestriction: z.array(z.string()).nullable(),
+    raceRestriction: z.array(z.string()).nullable(),
+    startsInsideDungeon: z.boolean(),
+    sharable: z.boolean(),
+});
+
+export type DungeonQuestDto = z.infer<typeof DungeonQuestDtoSchema>;
+
+/** Response schema for GET /plugins/wow-classic/instances/:id/quests */
+export const DungeonQuestsResponseSchema = z.array(DungeonQuestDtoSchema);
+export type DungeonQuestsResponse = z.infer<typeof DungeonQuestsResponseSchema>;
+
+/** Quest chain response schema */
+export const QuestChainResponseSchema = z.array(DungeonQuestDtoSchema);
+export type QuestChainResponse = z.infer<typeof QuestChainResponseSchema>;

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -81,3 +81,6 @@ export * from './backup.schema.js';
 
 // Event Plans (ROK-392)
 export * from './event-plans.schema.js';
+
+// Dungeon Quests (ROK-245)
+export * from './dungeon-quests.schema.js';


### PR DESCRIPTION
## Summary

Import 377 WoW Classic dungeon quests from the TyrsDev dataset into a plugin-owned table with expansion tagging, prerequisite chain resolution, and variant-aware API filtering.

## Changes

### API (Backend)
- **Schema**: New `wow_classic_dungeon_quests` table with Drizzle migration
- **Seeder**: Batch-inserts 377 quests from bundled JSON on plugin install
- **Service**: Variant-aware filtering (`classic_era`, `classic_anniversary`, `classic`, `retail`) and prerequisite chain walking with cycle protection
- **Controller**: Two new endpoints:
  - `GET /plugins/wow-classic/instances/:id/quests?variant=`
  - `GET /plugins/wow-classic/quests/:questId/chain`
- **Module**: Install/uninstall lifecycle hooks for seeding/dropping quest data

### Contract
- Zod response schemas for dungeon quest DTOs

## Testing
- ✅ API build: clean
- ✅ 1447/1447 tests pass (16 new dungeon quest tests)
- ✅ 0 lint errors