### PR TITLE
feat(ROK-244): variant-aware boss & loot table seed data

### DIFF
--- a/api/src/drizzle/migrations/0059_pale_echo.sql
+++ b/api/src/drizzle/migrations/0059_pale_echo.sql
@@ -1,0 +1,28 @@
+CREATE TABLE "wow_classic_boss_loot" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"boss_id" integer NOT NULL,
+	"item_id" integer NOT NULL,
+	"item_name" varchar(255) NOT NULL,
+	"slot" varchar(50),
+	"quality" varchar(20) NOT NULL,
+	"item_level" integer,
+	"drop_rate" numeric(5, 4),
+	"expansion" varchar(20) NOT NULL,
+	"class_restrictions" jsonb,
+	"icon_url" varchar(512),
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "uq_loot_boss_item_expansion" UNIQUE("boss_id","item_id","expansion")
+);
+--> statement-breakpoint
+CREATE TABLE "wow_classic_bosses" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"instance_id" integer NOT NULL,
+	"name" varchar(255) NOT NULL,
+	"order" integer NOT NULL,
+	"expansion" varchar(20) NOT NULL,
+	"sod_modified" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "uq_boss_instance_name_expansion" UNIQUE("instance_id","name","expansion")
+);
+--> statement-breakpoint
+ALTER TABLE "wow_classic_boss_loot" ADD CONSTRAINT "wow_classic_boss_loot_boss_id_wow_classic_bosses_id_fk" FOREIGN KEY ("boss_id") REFERENCES "public"."wow_classic_bosses"("id") ON DELETE cascade ON UPDATE no action;

--- a/api/src/drizzle/migrations/meta/0059_snapshot.json
+++ b/api/src/drizzle/migrations/meta/0059_snapshot.json
@@ -1,0 +1,3612 @@
+{
+  "id": "f629136f-0bee-44e9-9938-76f840205973",
+  "prevId": "fcb42359-aadc-4210-9f33-e7d9329fa473",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_avatar_url": {
+          "name": "custom_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_discord_id_unique": {
+          "name": "users_discord_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "display_name_length": {
+          "name": "display_name_length",
+          "value": "\"users\".\"display_name\" IS NULL OR (LENGTH(\"users\".\"display_name\") >= 2 AND LENGTH(\"users\".\"display_name\") <= 30)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "tsrange",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_config": {
+          "name": "slot_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_attendees": {
+          "name": "max_attendees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_unbench": {
+          "name": "auto_unbench",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "recurrence_group_id": {
+          "name": "recurrence_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_rule": {
+          "name": "recurrence_rule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_instances": {
+          "name": "content_instances",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_15min": {
+          "name": "reminder_15min",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_1hour": {
+          "name": "reminder_1hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reminder_24hour": {
+          "name": "reminder_24hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_events_creator_id": {
+          "name": "idx_events_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_game_id": {
+          "name": "idx_events_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_game_id_games_id_fk": {
+          "name": "events_game_id_games_id_fk",
+          "tableFrom": "events",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_creator_id_users_id_fk": {
+          "name": "events_creator_id_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_types": {
+      "name": "event_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_player_cap": {
+          "name": "default_player_cap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_duration_minutes": {
+          "name": "default_duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_composition": {
+          "name": "requires_composition",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_types_game_id_games_id_fk": {
+          "name": "event_types_game_id_games_id_fk",
+          "tableFrom": "event_types",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_types_game_slug_unique": {
+          "name": "event_types_game_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "game_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "igdb_id": {
+          "name": "igdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregated_rating": {
+          "name": "aggregated_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "popularity": {
+          "name": "popularity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_modes": {
+          "name": "game_modes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "themes": {
+          "name": "themes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "platforms": {
+          "name": "platforms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "screenshots": {
+          "name": "screenshots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "videos": {
+          "name": "videos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "first_release_date": {
+          "name": "first_release_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_count": {
+          "name": "player_count",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitch_game_id": {
+          "name": "twitch_game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crossplay": {
+          "name": "crossplay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color_hex": {
+          "name": "color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_roles": {
+          "name": "has_roles",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_specs": {
+          "name": "has_specs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "max_characters_per_user": {
+          "name": "max_characters_per_user",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "games_igdb_id_unique": {
+          "name": "games_igdb_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "igdb_id"
+          ]
+        },
+        "games_slug_unique": {
+          "name": "games_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_signups": {
+      "name": "event_signups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_avatar_hash": {
+          "name": "discord_avatar_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation_status": {
+          "name": "confirmation_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'signed_up'"
+        },
+        "signed_up_at": {
+          "name": "signed_up_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_event_signups_event_id": {
+          "name": "idx_event_signups_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_signups_discord_user_id": {
+          "name": "idx_event_signups_discord_user_id",
+          "columns": [
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_signups_event_id_events_id_fk": {
+          "name": "event_signups_event_id_events_id_fk",
+          "tableFrom": "event_signups",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_signups_user_id_users_id_fk": {
+          "name": "event_signups_user_id_users_id_fk",
+          "tableFrom": "event_signups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_signups_character_id_characters_id_fk": {
+          "name": "event_signups_character_id_characters_id_fk",
+          "tableFrom": "event_signups",
+          "tableTo": "characters",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_user": {
+          "name": "unique_event_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id"
+          ]
+        },
+        "unique_event_discord_user": {
+          "name": "unique_event_discord_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "discord_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_or_discord": {
+          "name": "user_or_discord",
+          "value": "\"event_signups\".\"user_id\" IS NOT NULL OR \"event_signups\".\"discord_user_id\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.characters": {
+      "name": "characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "realm": {
+          "name": "realm",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class": {
+          "name": "class",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_override": {
+          "name": "role_override",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_main": {
+          "name": "is_main",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "item_level": {
+          "name": "item_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "render_url": {
+          "name": "render_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "race": {
+          "name": "race",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faction": {
+          "name": "faction",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_url": {
+          "name": "profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_variant": {
+          "name": "game_variant",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "equipment": {
+          "name": "equipment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "talents": {
+          "name": "talents",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_one_main_per_game": {
+          "name": "idx_one_main_per_game",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"characters\".\"is_main\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_characters_user_id": {
+          "name": "idx_characters_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "characters_user_id_users_id_fk": {
+          "name": "characters_user_id_users_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "characters_game_id_games_id_fk": {
+          "name": "characters_game_id_games_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_game_character": {
+          "name": "unique_user_game_character",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id",
+            "name",
+            "realm"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.local_credentials": {
+      "name": "local_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "local_credentials_user_id_users_id_fk": {
+          "name": "local_credentials_user_id_users_id_fk",
+          "tableFrom": "local_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "local_credentials_email_unique": {
+          "name": "local_credentials_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.availability": {
+      "name": "availability",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_range": {
+          "name": "time_range",
+          "type": "tsrange",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_availability_user_id": {
+          "name": "idx_availability_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "availability_user_id_users_id_fk": {
+          "name": "availability_user_id_users_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "availability_game_id_games_id_fk": {
+          "name": "availability_game_id_games_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "availability_source_event_id_events_id_fk": {
+          "name": "availability_source_event_id_events_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "events",
+          "columnsFrom": [
+            "source_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roster_assignments": {
+      "name": "roster_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signup_id": {
+          "name": "signup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "is_override": {
+          "name": "is_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_roster_assignments_event_id": {
+          "name": "idx_roster_assignments_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_roster_assignments_signup_id": {
+          "name": "idx_roster_assignments_signup_id",
+          "columns": [
+            {
+              "expression": "signup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roster_assignments_event_id_events_id_fk": {
+          "name": "roster_assignments_event_id_events_id_fk",
+          "tableFrom": "roster_assignments",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "roster_assignments_signup_id_event_signups_id_fk": {
+          "name": "roster_assignments_signup_id_event_signups_id_fk",
+          "tableFrom": "roster_assignments",
+          "tableTo": "event_signups",
+          "columnsFrom": [
+            "signup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_signup": {
+          "name": "unique_event_signup",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "signup_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_settings_key_unique": {
+          "name": "app_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_expires_at": {
+          "name": "idx_notifications_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_preferences": {
+      "name": "user_notification_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_prefs": {
+          "name": "channel_prefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"slot_vacated\":{\"inApp\":true,\"push\":true,\"discord\":true},\"event_reminder\":{\"inApp\":true,\"push\":true,\"discord\":true},\"new_event\":{\"inApp\":true,\"push\":true,\"discord\":true},\"subscribed_game\":{\"inApp\":true,\"push\":true,\"discord\":true},\"achievement_unlocked\":{\"inApp\":true,\"push\":false,\"discord\":false},\"level_up\":{\"inApp\":true,\"push\":false,\"discord\":false},\"missed_event_nudge\":{\"inApp\":true,\"push\":false,\"discord\":false},\"event_rescheduled\":{\"inApp\":true,\"push\":true,\"discord\":true},\"bench_promoted\":{\"inApp\":true,\"push\":true,\"discord\":true},\"event_cancelled\":{\"inApp\":true,\"push\":true,\"discord\":true},\"roster_reassigned\":{\"inApp\":true,\"push\":true,\"discord\":true}}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_preferences_user_id_users_id_fk": {
+          "name": "user_notification_preferences_user_id_users_id_fk",
+          "tableFrom": "user_notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_preference_key": {
+          "name": "unique_user_preference_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_time_templates": {
+      "name": "game_time_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_hour": {
+          "name": "start_hour",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_time_templates_user_id_idx": {
+          "name": "game_time_templates_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_time_templates_user_id_users_id_fk": {
+          "name": "game_time_templates_user_id_users_id_fk",
+          "tableFrom": "game_time_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_game_time_slot": {
+          "name": "unique_user_game_time_slot",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "day_of_week",
+            "start_hour"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_time_absences": {
+      "name": "game_time_absences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_time_absences_user_id_idx": {
+          "name": "game_time_absences_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_time_absences_user_id_users_id_fk": {
+          "name": "game_time_absences_user_id_users_id_fk",
+          "tableFrom": "game_time_absences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_time_overrides": {
+      "name": "game_time_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hour": {
+          "name": "hour",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_time_overrides_user_id_idx": {
+          "name": "game_time_overrides_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_time_overrides_user_id_users_id_fk": {
+          "name": "game_time_overrides_user_id_users_id_fk",
+          "tableFrom": "game_time_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_override_date_hour": {
+          "name": "unique_user_override_date_hour",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "date",
+            "hour"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_interests": {
+      "name": "game_interests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_interests_user_id_users_id_fk": {
+          "name": "game_interests_user_id_users_id_fk",
+          "tableFrom": "game_interests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_interests_game_id_games_id_fk": {
+          "name": "game_interests_game_id_games_id_fk",
+          "tableFrom": "game_interests",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_user_game_interest": {
+          "name": "uq_user_game_interest",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_reminders_sent": {
+      "name": "event_reminders_sent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reminder_type": {
+          "name": "reminder_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_reminders_sent_event_id_events_id_fk": {
+          "name": "event_reminders_sent_event_id_events_id_fk",
+          "tableFrom": "event_reminders_sent",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_reminders_sent_user_id_users_id_fk": {
+          "name": "event_reminders_sent_user_id_users_id_fk",
+          "tableFrom": "event_reminders_sent",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_user_reminder": {
+          "name": "unique_event_user_reminder",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id",
+            "reminder_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_templates": {
+      "name": "event_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_templates_user_id_users_id_fk": {
+          "name": "event_templates_user_id_users_id_fk",
+          "tableFrom": "event_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plugins": {
+      "name": "plugins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config_json": {
+          "name": "config_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plugins_slug_unique": {
+          "name": "plugins_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_user_id_users_id_fk": {
+          "name": "feedback_user_id_users_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pug_slots": {
+      "name": "pug_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_avatar_hash": {
+          "name": "discord_avatar_hash",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class": {
+          "name": "class",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "server_invite_url": {
+          "name": "server_invite_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_event_pug": {
+          "name": "unique_event_pug",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pug_slots\".\"discord_username\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_invite_code": {
+          "name": "unique_invite_code",
+          "columns": [
+            {
+              "expression": "invite_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pug_slots\".\"invite_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pug_slots_event_id_events_id_fk": {
+          "name": "pug_slots_event_id_events_id_fk",
+          "tableFrom": "pug_slots",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pug_slots_claimed_by_user_id_users_id_fk": {
+          "name": "pug_slots_claimed_by_user_id_users_id_fk",
+          "tableFrom": "pug_slots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "claimed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pug_slots_created_by_users_id_fk": {
+          "name": "pug_slots_created_by_users_id_fk",
+          "tableFrom": "pug_slots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cron_jobs": {
+      "name": "cron_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_slug": {
+          "name": "plugin_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paused": {
+          "name": "paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cron_jobs_name_unique": {
+          "name": "cron_jobs_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cron_job_executions": {
+      "name": "cron_job_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cron_job_id": {
+          "name": "cron_job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cron_job_executions_job_started_idx": {
+          "name": "cron_job_executions_job_started_idx",
+          "columns": [
+            {
+              "expression": "cron_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cron_job_executions_cron_job_id_cron_jobs_id_fk": {
+          "name": "cron_job_executions_cron_job_id_cron_jobs_id_fk",
+          "tableFrom": "cron_job_executions",
+          "tableTo": "cron_jobs",
+          "columnsFrom": [
+            "cron_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_event_messages": {
+      "name": "discord_event_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embed_state": {
+          "name": "embed_state",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'posted'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_discord_event_messages_event": {
+          "name": "idx_discord_event_messages_event",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_discord_event_messages_message": {
+          "name": "idx_discord_event_messages_message",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_event_messages_event_id_events_id_fk": {
+          "name": "discord_event_messages_event_id_events_id_fk",
+          "tableFrom": "discord_event_messages",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_channel_message": {
+          "name": "unique_event_channel_message",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "channel_id",
+            "message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_bindings": {
+      "name": "channel_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding_purpose": {
+          "name": "binding_purpose",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_bindings_guild_channel_unique": {
+          "name": "channel_bindings_guild_channel_unique",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_bindings_guild": {
+          "name": "idx_channel_bindings_guild",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_bindings_game": {
+          "name": "idx_channel_bindings_game",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_bindings_game_id_games_id_fk": {
+          "name": "channel_bindings_game_id_games_id_fk",
+          "tableFrom": "channel_bindings",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_event_reminders_sent": {
+      "name": "post_event_reminders_sent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pug_slot_id": {
+          "name": "pug_slot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_event_reminders_sent_event_id_events_id_fk": {
+          "name": "post_event_reminders_sent_event_id_events_id_fk",
+          "tableFrom": "post_event_reminders_sent",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_event_reminders_sent_pug_slot_id_pug_slots_id_fk": {
+          "name": "post_event_reminders_sent_pug_slot_id_pug_slots_id_fk",
+          "tableFrom": "post_event_reminders_sent",
+          "tableTo": "pug_slots",
+          "columnsFrom": [
+            "pug_slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_post_event_pug_reminder": {
+          "name": "unique_post_event_pug_reminder",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "pug_slot_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_plans": {
+      "name": "event_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slot_config": {
+          "name": "slot_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_attendees": {
+          "name": "max_attendees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_unbench": {
+          "name": "auto_unbench",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_options": {
+          "name": "poll_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_duration_hours": {
+          "name": "poll_duration_hours",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_mode": {
+          "name": "poll_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "poll_round": {
+          "name": "poll_round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "poll_channel_id": {
+          "name": "poll_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_message_id": {
+          "name": "poll_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "winning_option": {
+          "name": "winning_option",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_event_id": {
+          "name": "created_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_instances": {
+          "name": "content_instances",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_15min": {
+          "name": "reminder_15min",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_1hour": {
+          "name": "reminder_1hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "reminder_24hour": {
+          "name": "reminder_24hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "poll_started_at": {
+          "name": "poll_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_ends_at": {
+          "name": "poll_ends_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_event_plans_creator_id": {
+          "name": "idx_event_plans_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_plans_status": {
+          "name": "idx_event_plans_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_plans_creator_id_users_id_fk": {
+          "name": "event_plans_creator_id_users_id_fk",
+          "tableFrom": "event_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_plans_game_id_games_id_fk": {
+          "name": "event_plans_game_id_games_id_fk",
+          "tableFrom": "event_plans",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "event_plans_created_event_id_events_id_fk": {
+          "name": "event_plans_created_event_id_events_id_fk",
+          "tableFrom": "event_plans",
+          "tableTo": "events",
+          "columnsFrom": [
+            "created_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_dungeon_quests": {
+      "name": "wow_classic_dungeon_quests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dungeon_instance_id": {
+          "name": "dungeon_instance_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quest_level": {
+          "name": "quest_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_level": {
+          "name": "required_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expansion": {
+          "name": "expansion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quest_giver_npc": {
+          "name": "quest_giver_npc",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quest_giver_zone": {
+          "name": "quest_giver_zone",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_quest_id": {
+          "name": "prev_quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_quest_id": {
+          "name": "next_quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewards_json": {
+          "name": "rewards_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objectives": {
+          "name": "objectives",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_restriction": {
+          "name": "class_restriction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "race_restriction": {
+          "name": "race_restriction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_inside_dungeon": {
+          "name": "starts_inside_dungeon",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sharable": {
+          "name": "sharable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wow_classic_dungeon_quests_quest_id_unique": {
+          "name": "wow_classic_dungeon_quests_quest_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "quest_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_boss_loot": {
+      "name": "wow_classic_boss_loot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "boss_id": {
+          "name": "boss_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot": {
+          "name": "slot",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality": {
+          "name": "quality",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_level": {
+          "name": "item_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drop_rate": {
+          "name": "drop_rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expansion": {
+          "name": "expansion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_restrictions": {
+          "name": "class_restrictions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wow_classic_boss_loot_boss_id_wow_classic_bosses_id_fk": {
+          "name": "wow_classic_boss_loot_boss_id_wow_classic_bosses_id_fk",
+          "tableFrom": "wow_classic_boss_loot",
+          "tableTo": "wow_classic_bosses",
+          "columnsFrom": [
+            "boss_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_loot_boss_item_expansion": {
+          "name": "uq_loot_boss_item_expansion",
+          "nullsNotDistinct": false,
+          "columns": [
+            "boss_id",
+            "item_id",
+            "expansion"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_bosses": {
+      "name": "wow_classic_bosses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expansion": {
+          "name": "expansion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sod_modified": {
+          "name": "sod_modified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_boss_instance_name_expansion": {
+          "name": "uq_boss_instance_name_expansion",
+          "nullsNotDistinct": false,
+          "columns": [
+            "instance_id",
+            "name",
+            "expansion"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/src/drizzle/migrations/meta/_journal.json
+++ b/api/src/drizzle/migrations/meta/_journal.json
@@ -414,6 +414,13 @@
       "when": 1771787655657,
       "tag": "0058_dungeon_quests",
       "breakpoints": true
+    },
+    {
+      "idx": 59,
+      "version": "7",
+      "when": 1771790794245,
+      "tag": "0059_pale_echo",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/drizzle/schema.ts
+++ b/api/src/drizzle/schema.ts
@@ -26,3 +26,4 @@ export * from './schema/channel-bindings';
 export * from './schema/post-event-reminders-sent';
 export * from './schema/event-plans';
 export * from './schema/dungeon-quests';
+export * from './schema/boss-encounters';

--- a/api/src/drizzle/schema/boss-encounters.ts
+++ b/api/src/drizzle/schema/boss-encounters.ts
@@ -1,0 +1,86 @@
+import {
+  pgTable,
+  serial,
+  integer,
+  varchar,
+  boolean,
+  numeric,
+  jsonb,
+  timestamp,
+  unique,
+} from 'drizzle-orm/pg-core';
+
+/**
+ * WoW Classic boss encounter data — plugin-owned table for wow-common.
+ * Seeded from static JSON on plugin install, dropped on plugin uninstall.
+ *
+ * ROK-244: Variant-Aware Boss & Loot Table Seed Data
+ */
+export const wowClassicBosses = pgTable(
+  'wow_classic_bosses',
+  {
+    id: serial('id').primaryKey(),
+    /** Blizzard Journal instance ID (matches BlizzardService instance IDs) */
+    instanceId: integer('instance_id').notNull(),
+    /** Boss encounter name */
+    name: varchar('name', { length: 255 }).notNull(),
+    /** Boss ordering within the instance */
+    order: integer('order').notNull(),
+    /** Expansion: 'classic' | 'tbc' | 'wotlk' | 'cata' | 'sod' */
+    expansion: varchar('expansion', { length: 20 }).notNull(),
+    /** Whether this is a SoD-modified version of a Classic encounter */
+    sodModified: boolean('sod_modified').default(false).notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+  },
+  (table) => [
+    unique('uq_boss_instance_name_expansion').on(
+      table.instanceId,
+      table.name,
+      table.expansion,
+    ),
+  ],
+);
+
+/**
+ * WoW Classic boss loot table data — plugin-owned table for wow-common.
+ * Each row is one item that can drop from a boss encounter.
+ *
+ * ROK-244: Variant-Aware Boss & Loot Table Seed Data
+ */
+export const wowClassicBossLoot = pgTable(
+  'wow_classic_boss_loot',
+  {
+    id: serial('id').primaryKey(),
+    /** FK to wow_classic_bosses.id */
+    bossId: integer('boss_id')
+      .notNull()
+      .references(() => wowClassicBosses.id, { onDelete: 'cascade' }),
+    /** In-game item ID (Wowhead/IGDB reference) */
+    itemId: integer('item_id').notNull(),
+    /** Item display name */
+    itemName: varchar('item_name', { length: 255 }).notNull(),
+    /** Equipment slot (e.g., 'Head', 'Main Hand', 'Trinket') */
+    slot: varchar('slot', { length: 50 }),
+    /** Item quality: 'Poor' | 'Common' | 'Uncommon' | 'Rare' | 'Epic' | 'Legendary' */
+    quality: varchar('quality', { length: 20 }).notNull(),
+    /** Item level */
+    itemLevel: integer('item_level'),
+    /** Drop rate as decimal (e.g., 0.15 for 15%) */
+    dropRate: numeric('drop_rate', { precision: 5, scale: 4 }),
+    /** Expansion this loot entry belongs to */
+    expansion: varchar('expansion', { length: 20 }).notNull(),
+    /** Class restrictions — null means all classes */
+    classRestrictions: jsonb('class_restrictions').$type<string[]>(),
+    /** Icon URL for the item */
+    iconUrl: varchar('icon_url', { length: 512 }),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+  },
+  (table) => [
+    unique('uq_loot_boss_item_expansion').on(
+      table.bossId,
+      table.itemId,
+      table.expansion,
+    ),
+  ],
+);
+

--- a/api/src/plugins/wow-common/boss-encounter-seeder.spec.ts
+++ b/api/src/plugins/wow-common/boss-encounter-seeder.spec.ts
@@ -1,0 +1,74 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BossEncounterSeeder } from './boss-encounter-seeder';
+import { DrizzleAsyncProvider } from '../../drizzle/drizzle.module';
+
+describe('BossEncounterSeeder', () => {
+  let seeder: BossEncounterSeeder;
+  let mockDb: {
+    insert: jest.Mock;
+    delete: jest.Mock;
+    select: jest.Mock;
+  };
+
+  beforeEach(async () => {
+    const mockReturning = jest.fn().mockResolvedValue([{ id: 1 }]);
+    const mockOnConflictDoNothing = jest
+      .fn()
+      .mockReturnValue({ returning: mockReturning });
+    const mockValues = jest
+      .fn()
+      .mockReturnValue({ onConflictDoNothing: mockOnConflictDoNothing });
+
+    // Mock for select().from() — returns boss rows for loot FK resolution
+    const mockFrom = jest.fn().mockResolvedValue([
+      { id: 1, name: 'Ragnaros', expansion: 'classic' },
+      { id: 2, name: 'Nefarian', expansion: 'classic' },
+      { id: 3, name: "Kel'Thuzad", expansion: 'classic' },
+      { id: 10, name: 'Prince Malchezaar', expansion: 'tbc' },
+      { id: 20, name: 'Yogg-Saron', expansion: 'wotlk' },
+      { id: 30, name: 'Ragnaros', expansion: 'cata' },
+      { id: 40, name: "Aku'mai (SoD)", expansion: 'sod' },
+    ]);
+
+    mockDb = {
+      insert: jest.fn().mockReturnValue({ values: mockValues }),
+      delete: jest.fn().mockResolvedValue(undefined),
+      select: jest.fn().mockReturnValue({ from: mockFrom }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BossEncounterSeeder,
+        { provide: DrizzleAsyncProvider, useValue: mockDb },
+      ],
+    }).compile();
+
+    seeder = module.get<BossEncounterSeeder>(BossEncounterSeeder);
+  });
+
+  describe('seed()', () => {
+    it('should insert boss encounters from bundled data', async () => {
+      const result = await seeder.seed();
+
+      expect(result).toHaveProperty('bossesInserted');
+      expect(result).toHaveProperty('lootInserted');
+      expect(mockDb.insert).toHaveBeenCalled();
+    });
+
+    it('should resolve boss FKs for loot insertion', async () => {
+      await seeder.seed();
+
+      // select() is called to build the boss lookup map
+      expect(mockDb.select).toHaveBeenCalled();
+    });
+  });
+
+  describe('drop()', () => {
+    it('should delete loot and boss data', async () => {
+      await seeder.drop();
+
+      // delete() called twice: loot first, then bosses
+      expect(mockDb.delete).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/api/src/plugins/wow-common/boss-encounter-seeder.ts
+++ b/api/src/plugins/wow-common/boss-encounter-seeder.ts
@@ -1,0 +1,148 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+
+import * as schema from '../../drizzle/schema';
+import { wowClassicBosses, wowClassicBossLoot } from '../../drizzle/schema';
+import { DrizzleAsyncProvider } from '../../drizzle/drizzle.module';
+
+interface BossEntry {
+  instanceId: number;
+  name: string;
+  order: number;
+  expansion: string;
+  sodModified: boolean;
+}
+
+interface LootEntry {
+  bossName: string;
+  expansion: string;
+  itemId: number;
+  itemName: string;
+  slot: string | null;
+  quality: string;
+  itemLevel: number | null;
+  dropRate: number | null;
+  classRestrictions: string[] | null;
+  iconUrl: string | null;
+}
+
+/**
+ * Seeds the wow_classic_bosses and wow_classic_boss_loot tables from bundled JSON.
+ * Called on plugin install; data dropped on plugin uninstall.
+ *
+ * ROK-244: Variant-Aware Boss & Loot Table Seed Data
+ */
+@Injectable()
+export class BossEncounterSeeder {
+  private readonly logger = new Logger(BossEncounterSeeder.name);
+
+  constructor(
+    @Inject(DrizzleAsyncProvider)
+    private db: PostgresJsDatabase<typeof schema>,
+  ) {}
+
+  /**
+   * Seed all boss encounters and loot from bundled data files.
+   * Uses upsert (ON CONFLICT DO NOTHING) to be idempotent.
+   */
+  async seed(): Promise<{ bossesInserted: number; lootInserted: number }> {
+    // --- Phase 1: Seed bosses ---
+    const bossPath = join(__dirname, 'data', 'boss-encounter-data.json');
+    const bossRaw = await readFile(bossPath, 'utf-8');
+    const bosses = JSON.parse(bossRaw) as BossEntry[];
+
+    this.logger.log(`Seeding ${bosses.length} boss encounters...`);
+
+    const BATCH_SIZE = 100;
+    let bossesInserted = 0;
+
+    for (let i = 0; i < bosses.length; i += BATCH_SIZE) {
+      const batch = bosses.slice(i, i + BATCH_SIZE);
+      const result = await this.db
+        .insert(wowClassicBosses)
+        .values(
+          batch.map((b) => ({
+            instanceId: b.instanceId,
+            name: b.name,
+            order: b.order,
+            expansion: b.expansion,
+            sodModified: b.sodModified,
+          })),
+        )
+        .onConflictDoNothing()
+        .returning({ id: wowClassicBosses.id });
+
+      bossesInserted += result.length;
+    }
+
+    this.logger.log(
+      `Seeded ${bossesInserted}/${bosses.length} boss encounters`,
+    );
+
+    // --- Phase 2: Seed loot (resolve boss FKs by name+expansion) ---
+    const lootPath = join(__dirname, 'data', 'boss-loot-data.json');
+    const lootRaw = await readFile(lootPath, 'utf-8');
+    const lootEntries = JSON.parse(lootRaw) as LootEntry[];
+
+    this.logger.log(`Seeding ${lootEntries.length} loot items...`);
+
+    // Build a lookup map of boss name+expansion → DB id
+    const allBosses = await this.db.select().from(wowClassicBosses);
+    const bossLookup = new Map<string, number>();
+    for (const b of allBosses) {
+      bossLookup.set(`${b.name}::${b.expansion}`, b.id);
+    }
+
+    let lootInserted = 0;
+    const lootToInsert = lootEntries
+      .map((l) => {
+        const bossId = bossLookup.get(`${l.bossName}::${l.expansion}`);
+        if (!bossId) {
+          this.logger.warn(
+            `Skipping loot "${l.itemName}" — boss "${l.bossName}" (${l.expansion}) not found`,
+          );
+          return null;
+        }
+        return {
+          bossId,
+          itemId: l.itemId,
+          itemName: l.itemName,
+          slot: l.slot,
+          quality: l.quality,
+          itemLevel: l.itemLevel,
+          dropRate: l.dropRate?.toString() ?? null,
+          expansion: l.expansion,
+          classRestrictions: l.classRestrictions,
+          iconUrl: l.iconUrl,
+        };
+      })
+      .filter((v): v is NonNullable<typeof v> => v !== null);
+
+    for (let i = 0; i < lootToInsert.length; i += BATCH_SIZE) {
+      const batch = lootToInsert.slice(i, i + BATCH_SIZE);
+      const result = await this.db
+        .insert(wowClassicBossLoot)
+        .values(batch)
+        .onConflictDoNothing()
+        .returning({ id: wowClassicBossLoot.id });
+
+      lootInserted += result.length;
+    }
+
+    this.logger.log(`Seeded ${lootInserted}/${lootEntries.length} loot items`);
+
+    return { bossesInserted, lootInserted };
+  }
+
+  /**
+   * Remove all boss encounter and loot data (called on plugin uninstall).
+   * Loot deleted first to respect FK ordering.
+   */
+  async drop(): Promise<void> {
+    await this.db.delete(wowClassicBossLoot);
+    await this.db.delete(wowClassicBosses);
+    this.logger.log('Dropped all boss encounter and loot data');
+  }
+}

--- a/api/src/plugins/wow-common/boss-encounters.controller.spec.ts
+++ b/api/src/plugins/wow-common/boss-encounters.controller.spec.ts
@@ -1,0 +1,122 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BossEncountersController } from './boss-encounters.controller';
+import { BossEncountersService } from './boss-encounters.service';
+import { Reflector } from '@nestjs/core';
+import { PluginRegistryService } from '../plugin-host/plugin-registry.service';
+
+describe('BossEncountersController', () => {
+  let controller: BossEncountersController;
+  let mockService: {
+    getBossesForInstance: jest.Mock;
+    getLootForBoss: jest.Mock;
+  };
+
+  const mockBosses = [
+    {
+      id: 1,
+      instanceId: 409,
+      name: 'Ragnaros',
+      order: 10,
+      expansion: 'classic',
+      sodModified: false,
+    },
+  ];
+
+  const mockLoot = [
+    {
+      id: 1,
+      bossId: 1,
+      itemId: 17182,
+      itemName: 'Sulfuras, Hand of Ragnaros',
+      slot: 'Main Hand',
+      quality: 'Legendary',
+      itemLevel: 80,
+      dropRate: '0.0400',
+      expansion: 'classic',
+      classRestrictions: null,
+      iconUrl: null,
+    },
+  ];
+
+  beforeEach(async () => {
+    mockService = {
+      getBossesForInstance: jest.fn().mockResolvedValue(mockBosses),
+      getLootForBoss: jest.fn().mockResolvedValue(mockLoot),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [BossEncountersController],
+      providers: [
+        { provide: BossEncountersService, useValue: mockService },
+        { provide: Reflector, useValue: new Reflector() },
+        {
+          provide: PluginRegistryService,
+          useValue: {
+            getActiveSlugsSync: jest
+              .fn()
+              .mockReturnValue(new Set(['blizzard'])),
+          },
+        },
+      ],
+    }).compile();
+
+    controller = module.get<BossEncountersController>(BossEncountersController);
+  });
+
+  describe('getBossesForInstance()', () => {
+    it('should return bosses for an instance', async () => {
+      const result = await controller.getBossesForInstance(409, 'classic_era');
+
+      expect(result).toEqual(mockBosses);
+      expect(mockService.getBossesForInstance).toHaveBeenCalledWith(
+        409,
+        'classic_era',
+      );
+    });
+
+    it('should default variant to classic_era', async () => {
+      await controller.getBossesForInstance(409);
+
+      expect(mockService.getBossesForInstance).toHaveBeenCalledWith(
+        409,
+        'classic_era',
+      );
+    });
+
+    it('should pass the variant parameter through', async () => {
+      await controller.getBossesForInstance(532, 'classic_anniversary');
+
+      expect(mockService.getBossesForInstance).toHaveBeenCalledWith(
+        532,
+        'classic_anniversary',
+      );
+    });
+
+    it('should throw BadRequestException for invalid variant', async () => {
+      await expect(
+        controller.getBossesForInstance(409, 'invalid_variant'),
+      ).rejects.toThrow('Invalid variant');
+    });
+  });
+
+  describe('getLootForBoss()', () => {
+    it('should return loot for a boss', async () => {
+      const result = await controller.getLootForBoss(1, 'classic_era');
+
+      expect(result).toEqual(mockLoot);
+      expect(mockService.getLootForBoss).toHaveBeenCalledWith(1, 'classic_era');
+    });
+
+    it('should default variant to classic_era', async () => {
+      await controller.getLootForBoss(1);
+
+      expect(mockService.getLootForBoss).toHaveBeenCalledWith(1, 'classic_era');
+    });
+
+    it('should throw BadRequestException for invalid variant', async () => {
+      await expect(
+        controller.getLootForBoss(1, 'invalid_variant'),
+      ).rejects.toThrow('Invalid variant');
+    });
+  });
+});

--- a/api/src/plugins/wow-common/boss-encounters.controller.ts
+++ b/api/src/plugins/wow-common/boss-encounters.controller.ts
@@ -1,0 +1,76 @@
+import {
+  Controller,
+  Get,
+  Param,
+  Query,
+  ParseIntPipe,
+  UseGuards,
+  BadRequestException,
+} from '@nestjs/common';
+import { BossEncountersService } from './boss-encounters.service';
+import {
+  PluginActiveGuard,
+  RequirePlugin,
+} from '../plugin-host/plugin-active.guard';
+import { WOW_COMMON_MANIFEST } from './manifest';
+
+/**
+ * API controller for boss encounter and loot table data.
+ * All routes gated behind PluginActiveGuard — requires Blizzard plugin to be active.
+ *
+ * ROK-244: Variant-Aware Boss & Loot Table Seed Data
+ */
+@Controller('plugins/wow-classic')
+@UseGuards(PluginActiveGuard)
+@RequirePlugin(WOW_COMMON_MANIFEST.id)
+export class BossEncountersController {
+  constructor(private readonly bossEncountersService: BossEncountersService) { }
+
+  private static readonly VALID_VARIANTS = new Set([
+    'classic_era',
+    'classic_anniversary',
+    'classic',
+    'retail',
+  ]);
+
+  /**
+   * GET /plugins/wow-classic/instances/:id/bosses?variant=classic_era
+   *
+   * Returns boss encounters for a specific instance, filtered by variant.
+   * Variant determines which expansion's encounters are included:
+   *   - classic_era: ['classic']
+   *   - classic_era_sod: ['classic', 'sod']
+   *   - classic_anniversary: ['classic', 'tbc']
+   *   - classic (Cata): ['classic', 'tbc', 'wotlk', 'cata']
+   */
+  @Get('instances/:id/bosses')
+  async getBossesForInstance(
+    @Param('id', ParseIntPipe) instanceId: number,
+    @Query('variant') variant: string = 'classic_era',
+  ) {
+    if (!BossEncountersController.VALID_VARIANTS.has(variant)) {
+      throw new BadRequestException(
+        `Invalid variant "${variant}". Valid variants: ${[...BossEncountersController.VALID_VARIANTS].join(', ')}`,
+      );
+    }
+    return this.bossEncountersService.getBossesForInstance(instanceId, variant);
+  }
+
+  /**
+   * GET /plugins/wow-classic/bosses/:id/loot?variant=classic_era
+   *
+   * Returns the loot table for a specific boss encounter, filtered by variant.
+   */
+  @Get('bosses/:id/loot')
+  async getLootForBoss(
+    @Param('id', ParseIntPipe) bossId: number,
+    @Query('variant') variant: string = 'classic_era',
+  ) {
+    if (!BossEncountersController.VALID_VARIANTS.has(variant)) {
+      throw new BadRequestException(
+        `Invalid variant "${variant}". Valid variants: ${[...BossEncountersController.VALID_VARIANTS].join(', ')}`,
+      );
+    }
+    return this.bossEncountersService.getLootForBoss(bossId, variant);
+  }
+}

--- a/api/src/plugins/wow-common/boss-encounters.service.spec.ts
+++ b/api/src/plugins/wow-common/boss-encounters.service.spec.ts
@@ -1,0 +1,112 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BossEncountersService } from './boss-encounters.service';
+import { BossEncounterSeeder } from './boss-encounter-seeder';
+import { DrizzleAsyncProvider } from '../../drizzle/drizzle.module';
+
+describe('BossEncountersService', () => {
+  let service: BossEncountersService;
+  let mockSeeder: { seed: jest.Mock; drop: jest.Mock };
+  let mockDb: { select: jest.Mock };
+
+  beforeEach(async () => {
+    mockSeeder = {
+      seed: jest
+        .fn()
+        .mockResolvedValue({ bossesInserted: 10, lootInserted: 20 }),
+      drop: jest.fn().mockResolvedValue(undefined),
+    };
+
+    // Build a fluent mock for Drizzle queries: db.select().from().where().orderBy()
+    const mockOrderBy = jest.fn().mockResolvedValue([]);
+    const mockWhere = jest.fn().mockReturnValue({ orderBy: mockOrderBy });
+    const mockFrom = jest.fn().mockReturnValue({ where: mockWhere });
+
+    mockDb = {
+      select: jest.fn().mockReturnValue({ from: mockFrom }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        BossEncountersService,
+        { provide: BossEncounterSeeder, useValue: mockSeeder },
+        { provide: DrizzleAsyncProvider, useValue: mockDb },
+      ],
+    }).compile();
+
+    service = module.get<BossEncountersService>(BossEncountersService);
+  });
+
+  describe('getExpansionsForVariant()', () => {
+    it('should return classic only for classic_era', () => {
+      expect(service.getExpansionsForVariant('classic_era')).toEqual([
+        'classic',
+      ]);
+    });
+
+    it('should return classic+tbc for classic_anniversary', () => {
+      expect(service.getExpansionsForVariant('classic_anniversary')).toEqual([
+        'classic',
+        'tbc',
+      ]);
+    });
+
+    it('should return all expansions for classic (Cata)', () => {
+      expect(service.getExpansionsForVariant('classic')).toEqual([
+        'classic',
+        'tbc',
+        'wotlk',
+        'cata',
+      ]);
+    });
+
+
+    it('should default to classic_era for unknown variant', () => {
+      expect(service.getExpansionsForVariant('unknown')).toEqual(['classic']);
+    });
+  });
+
+  describe('getBossesForInstance()', () => {
+    it('should query the database with correct instance ID', async () => {
+      await service.getBossesForInstance(409, 'classic_era');
+
+      expect(mockDb.select).toHaveBeenCalled();
+    });
+
+    it('should return an empty array when no bosses found', async () => {
+      const result = await service.getBossesForInstance(999, 'classic_era');
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('getLootForBoss()', () => {
+    it('should query the database with correct boss ID', async () => {
+      await service.getLootForBoss(1, 'classic_era');
+
+      expect(mockDb.select).toHaveBeenCalled();
+    });
+
+    it('should return an empty array when no loot found', async () => {
+      const result = await service.getLootForBoss(999, 'classic_era');
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe('seedBosses()', () => {
+    it('should delegate to seeder', async () => {
+      const result = await service.seedBosses();
+
+      expect(mockSeeder.seed).toHaveBeenCalled();
+      expect(result).toEqual({ bossesInserted: 10, lootInserted: 20 });
+    });
+  });
+
+  describe('dropBosses()', () => {
+    it('should delegate to seeder', async () => {
+      await service.dropBosses();
+
+      expect(mockSeeder.drop).toHaveBeenCalled();
+    });
+  });
+});

--- a/api/src/plugins/wow-common/boss-encounters.service.ts
+++ b/api/src/plugins/wow-common/boss-encounters.service.ts
@@ -1,0 +1,158 @@
+import { Injectable, Inject, Logger } from '@nestjs/common';
+import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { eq, inArray, and } from 'drizzle-orm';
+
+import * as schema from '../../drizzle/schema';
+import { wowClassicBosses, wowClassicBossLoot } from '../../drizzle/schema';
+import { DrizzleAsyncProvider } from '../../drizzle/drizzle.module';
+import { BossEncounterSeeder } from './boss-encounter-seeder';
+
+/**
+ * Variant-to-expansion-set mapping for boss encounters.
+ * Each variant includes encounters from all expansions up to and including its era.
+ */
+const VARIANT_EXPANSIONS: Record<string, string[]> = {
+  classic_era: ['classic'],
+  classic_anniversary: ['classic', 'tbc'],
+  classic: ['classic', 'tbc', 'wotlk', 'cata'],
+  retail: ['classic', 'tbc', 'wotlk', 'cata'],
+};
+
+export interface BossEncounterDto {
+  id: number;
+  instanceId: number;
+  name: string;
+  order: number;
+  expansion: string;
+  sodModified: boolean;
+}
+
+export interface BossLootDto {
+  id: number;
+  bossId: number;
+  itemId: number;
+  itemName: string;
+  slot: string | null;
+  quality: string;
+  itemLevel: number | null;
+  dropRate: string | null;
+  expansion: string;
+  classRestrictions: string[] | null;
+  iconUrl: string | null;
+}
+
+/**
+ * Service for querying boss encounter and loot data with variant-aware filtering.
+ *
+ * ROK-244: Variant-Aware Boss & Loot Table Seed Data
+ */
+@Injectable()
+export class BossEncountersService {
+  private readonly logger = new Logger(BossEncountersService.name);
+
+  constructor(
+    @Inject(DrizzleAsyncProvider)
+    private db: PostgresJsDatabase<typeof schema>,
+    private readonly seeder: BossEncounterSeeder,
+  ) { }
+
+  /**
+   * Get the expansion set for a given WoW game variant.
+   */
+  getExpansionsForVariant(variant: string): string[] {
+    return VARIANT_EXPANSIONS[variant] ?? VARIANT_EXPANSIONS['classic_era'];
+  }
+
+  /**
+   * Get all boss encounters for an instance, filtered by variant.
+   * SoD-modified bosses are only included for SoD-enabled variants.
+   */
+  async getBossesForInstance(
+    instanceId: number,
+    variant: string = 'classic_era',
+  ): Promise<BossEncounterDto[]> {
+    const expansions = this.getExpansionsForVariant(variant);
+
+    const rows = await this.db
+      .select()
+      .from(wowClassicBosses)
+      .where(
+        and(
+          eq(wowClassicBosses.instanceId, instanceId),
+          inArray(wowClassicBosses.expansion, expansions),
+        ),
+      )
+      .orderBy(wowClassicBosses.order);
+
+    return rows.map((row) => this.toBossDto(row));
+  }
+
+  /**
+   * Get loot items for a boss, filtered by variant's expansion set.
+   */
+  async getLootForBoss(
+    bossId: number,
+    variant: string = 'classic_era',
+  ): Promise<BossLootDto[]> {
+    const expansions = this.getExpansionsForVariant(variant);
+
+    const rows = await this.db
+      .select()
+      .from(wowClassicBossLoot)
+      .where(
+        and(
+          eq(wowClassicBossLoot.bossId, bossId),
+          inArray(wowClassicBossLoot.expansion, expansions),
+        ),
+      )
+      .orderBy(wowClassicBossLoot.quality);
+
+    return rows.map((row) => this.toLootDto(row));
+  }
+
+  /**
+   * Seed boss encounter data (delegates to seeder).
+   */
+  async seedBosses(): Promise<{
+    bossesInserted: number;
+    lootInserted: number;
+  }> {
+    return this.seeder.seed();
+  }
+
+  /**
+   * Drop all boss encounter data (delegates to seeder).
+   */
+  async dropBosses(): Promise<void> {
+    return this.seeder.drop();
+  }
+
+  private toBossDto(
+    row: typeof wowClassicBosses.$inferSelect,
+  ): BossEncounterDto {
+    return {
+      id: row.id,
+      instanceId: row.instanceId,
+      name: row.name,
+      order: row.order,
+      expansion: row.expansion,
+      sodModified: row.sodModified,
+    };
+  }
+
+  private toLootDto(row: typeof wowClassicBossLoot.$inferSelect): BossLootDto {
+    return {
+      id: row.id,
+      bossId: row.bossId,
+      itemId: row.itemId,
+      itemName: row.itemName,
+      slot: row.slot,
+      quality: row.quality,
+      itemLevel: row.itemLevel,
+      dropRate: row.dropRate,
+      expansion: row.expansion,
+      classRestrictions: row.classRestrictions,
+      iconUrl: row.iconUrl,
+    };
+  }
+}

--- a/api/src/plugins/wow-common/data/boss-encounter-data.json
+++ b/api/src/plugins/wow-common/data/boss-encounter-data.json
@@ -1,0 +1,716 @@
+[
+    {
+        "instanceId": 409,
+        "name": "Lucifron",
+        "order": 1,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 409,
+        "name": "Magmadar",
+        "order": 2,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 409,
+        "name": "Gehennas",
+        "order": 3,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 409,
+        "name": "Garr",
+        "order": 4,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 409,
+        "name": "Shazzrah",
+        "order": 5,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 409,
+        "name": "Baron Geddon",
+        "order": 6,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 409,
+        "name": "Sulfuron Harbinger",
+        "order": 7,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 409,
+        "name": "Golemagg the Incinerator",
+        "order": 8,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 409,
+        "name": "Majordomo Executus",
+        "order": 9,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 409,
+        "name": "Ragnaros",
+        "order": 10,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 469,
+        "name": "Razorgore the Untamed",
+        "order": 1,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 469,
+        "name": "Vaelastrasz the Corrupt",
+        "order": 2,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 469,
+        "name": "Broodlord Lashlayer",
+        "order": 3,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 469,
+        "name": "Firemaw",
+        "order": 4,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 469,
+        "name": "Ebonroc",
+        "order": 5,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 469,
+        "name": "Flamegor",
+        "order": 6,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 469,
+        "name": "Chromaggus",
+        "order": 7,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 469,
+        "name": "Nefarian",
+        "order": 8,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 249,
+        "name": "Onyxia",
+        "order": 1,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 531,
+        "name": "The Prophet Skeram",
+        "order": 1,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 531,
+        "name": "Princess Huhuran",
+        "order": 5,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 531,
+        "name": "Twin Emperors",
+        "order": 7,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 531,
+        "name": "C'Thun",
+        "order": 9,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 533,
+        "name": "Anub'Rekhan",
+        "order": 1,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 533,
+        "name": "Patchwerk",
+        "order": 5,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 533,
+        "name": "Sapphiron",
+        "order": 14,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 533,
+        "name": "Kel'Thuzad",
+        "order": 15,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 63,
+        "name": "Edwin VanCleef",
+        "order": 4,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 36,
+        "name": "Archmage Arugal",
+        "order": 5,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 229,
+        "name": "General Drakkisath",
+        "order": 10,
+        "expansion": "classic",
+        "sodModified": false
+    },
+    {
+        "instanceId": 532,
+        "name": "Attumen the Huntsman",
+        "order": 1,
+        "expansion": "tbc",
+        "sodModified": false
+    },
+    {
+        "instanceId": 532,
+        "name": "Moroes",
+        "order": 2,
+        "expansion": "tbc",
+        "sodModified": false
+    },
+    {
+        "instanceId": 532,
+        "name": "Maiden of Virtue",
+        "order": 3,
+        "expansion": "tbc",
+        "sodModified": false
+    },
+    {
+        "instanceId": 532,
+        "name": "The Curator",
+        "order": 5,
+        "expansion": "tbc",
+        "sodModified": false
+    },
+    {
+        "instanceId": 532,
+        "name": "Shade of Aran",
+        "order": 6,
+        "expansion": "tbc",
+        "sodModified": false
+    },
+    {
+        "instanceId": 532,
+        "name": "Netherspite",
+        "order": 8,
+        "expansion": "tbc",
+        "sodModified": false
+    },
+    {
+        "instanceId": 532,
+        "name": "Prince Malchezaar",
+        "order": 11,
+        "expansion": "tbc",
+        "sodModified": false
+    },
+    {
+        "instanceId": 532,
+        "name": "Nightbane",
+        "order": 12,
+        "expansion": "tbc",
+        "sodModified": false
+    },
+    {
+        "instanceId": 548,
+        "name": "Hydross the Unstable",
+        "order": 1,
+        "expansion": "tbc",
+        "sodModified": false
+    },
+    {
+        "instanceId": 548,
+        "name": "Leotheras the Blind",
+        "order": 3,
+        "expansion": "tbc",
+        "sodModified": false
+    },
+    {
+        "instanceId": 548,
+        "name": "Lady Vashj",
+        "order": 6,
+        "expansion": "tbc",
+        "sodModified": false
+    },
+    {
+        "instanceId": 550,
+        "name": "Al'ar",
+        "order": 1,
+        "expansion": "tbc",
+        "sodModified": false
+    },
+    {
+        "instanceId": 550,
+        "name": "Kael'thas Sunstrider",
+        "order": 4,
+        "expansion": "tbc",
+        "sodModified": false
+    },
+    {
+        "instanceId": 564,
+        "name": "High Warlord Naj'entus",
+        "order": 1,
+        "expansion": "tbc",
+        "sodModified": false
+    },
+    {
+        "instanceId": 564,
+        "name": "Gurtogg Bloodboil",
+        "order": 4,
+        "expansion": "tbc",
+        "sodModified": false
+    },
+    {
+        "instanceId": 564,
+        "name": "Mother Shahraz",
+        "order": 6,
+        "expansion": "tbc",
+        "sodModified": false
+    },
+    {
+        "instanceId": 564,
+        "name": "Illidan Stormrage",
+        "order": 9,
+        "expansion": "tbc",
+        "sodModified": false
+    },
+    {
+        "instanceId": 580,
+        "name": "Kalecgos",
+        "order": 1,
+        "expansion": "tbc",
+        "sodModified": false
+    },
+    {
+        "instanceId": 580,
+        "name": "M'uru",
+        "order": 5,
+        "expansion": "tbc",
+        "sodModified": false
+    },
+    {
+        "instanceId": 580,
+        "name": "Kil'jaeden",
+        "order": 6,
+        "expansion": "tbc",
+        "sodModified": false
+    },
+    {
+        "instanceId": 543,
+        "name": "Watchkeeper Gargolmar",
+        "order": 1,
+        "expansion": "tbc",
+        "sodModified": false
+    },
+    {
+        "instanceId": 543,
+        "name": "Omor the Unscarred",
+        "order": 2,
+        "expansion": "tbc",
+        "sodModified": false
+    },
+    {
+        "instanceId": 543,
+        "name": "Vazruden the Herald",
+        "order": 3,
+        "expansion": "tbc",
+        "sodModified": false
+    },
+    {
+        "instanceId": 603,
+        "name": "Flame Leviathan",
+        "order": 1,
+        "expansion": "wotlk",
+        "sodModified": false
+    },
+    {
+        "instanceId": 603,
+        "name": "XT-002 Deconstructor",
+        "order": 3,
+        "expansion": "wotlk",
+        "sodModified": false
+    },
+    {
+        "instanceId": 603,
+        "name": "Kologarn",
+        "order": 5,
+        "expansion": "wotlk",
+        "sodModified": false
+    },
+    {
+        "instanceId": 603,
+        "name": "Hodir",
+        "order": 7,
+        "expansion": "wotlk",
+        "sodModified": false
+    },
+    {
+        "instanceId": 603,
+        "name": "Freya",
+        "order": 8,
+        "expansion": "wotlk",
+        "sodModified": false
+    },
+    {
+        "instanceId": 603,
+        "name": "Mimiron",
+        "order": 10,
+        "expansion": "wotlk",
+        "sodModified": false
+    },
+    {
+        "instanceId": 603,
+        "name": "General Vezax",
+        "order": 12,
+        "expansion": "wotlk",
+        "sodModified": false
+    },
+    {
+        "instanceId": 603,
+        "name": "Yogg-Saron",
+        "order": 13,
+        "expansion": "wotlk",
+        "sodModified": false
+    },
+    {
+        "instanceId": 603,
+        "name": "Algalon the Observer",
+        "order": 14,
+        "expansion": "wotlk",
+        "sodModified": false
+    },
+    {
+        "instanceId": 631,
+        "name": "Lord Marrowgar",
+        "order": 1,
+        "expansion": "wotlk",
+        "sodModified": false
+    },
+    {
+        "instanceId": 631,
+        "name": "Lady Deathwhisper",
+        "order": 2,
+        "expansion": "wotlk",
+        "sodModified": false
+    },
+    {
+        "instanceId": 631,
+        "name": "Deathbringer Saurfang",
+        "order": 4,
+        "expansion": "wotlk",
+        "sodModified": false
+    },
+    {
+        "instanceId": 631,
+        "name": "Festergut",
+        "order": 5,
+        "expansion": "wotlk",
+        "sodModified": false
+    },
+    {
+        "instanceId": 631,
+        "name": "Rotface",
+        "order": 6,
+        "expansion": "wotlk",
+        "sodModified": false
+    },
+    {
+        "instanceId": 631,
+        "name": "Professor Putricide",
+        "order": 7,
+        "expansion": "wotlk",
+        "sodModified": false
+    },
+    {
+        "instanceId": 631,
+        "name": "Blood-Queen Lana'thel",
+        "order": 8,
+        "expansion": "wotlk",
+        "sodModified": false
+    },
+    {
+        "instanceId": 631,
+        "name": "Sindragosa",
+        "order": 11,
+        "expansion": "wotlk",
+        "sodModified": false
+    },
+    {
+        "instanceId": 631,
+        "name": "The Lich King",
+        "order": 12,
+        "expansion": "wotlk",
+        "sodModified": false
+    },
+    {
+        "instanceId": 574,
+        "name": "Prince Keleseth",
+        "order": 1,
+        "expansion": "wotlk",
+        "sodModified": false
+    },
+    {
+        "instanceId": 574,
+        "name": "Skarvald the Constructor",
+        "order": 2,
+        "expansion": "wotlk",
+        "sodModified": false
+    },
+    {
+        "instanceId": 574,
+        "name": "Ingvar the Plunderer",
+        "order": 3,
+        "expansion": "wotlk",
+        "sodModified": false
+    },
+    {
+        "instanceId": 669,
+        "name": "Magmaw",
+        "order": 1,
+        "expansion": "cata",
+        "sodModified": false
+    },
+    {
+        "instanceId": 669,
+        "name": "Omnotron Defense System",
+        "order": 2,
+        "expansion": "cata",
+        "sodModified": false
+    },
+    {
+        "instanceId": 669,
+        "name": "Chimaeron",
+        "order": 3,
+        "expansion": "cata",
+        "sodModified": false
+    },
+    {
+        "instanceId": 669,
+        "name": "Atramedes",
+        "order": 4,
+        "expansion": "cata",
+        "sodModified": false
+    },
+    {
+        "instanceId": 669,
+        "name": "Maloriak",
+        "order": 5,
+        "expansion": "cata",
+        "sodModified": false
+    },
+    {
+        "instanceId": 669,
+        "name": "Nefarian",
+        "order": 6,
+        "expansion": "cata",
+        "sodModified": false
+    },
+    {
+        "instanceId": 720,
+        "name": "Beth'tilac",
+        "order": 1,
+        "expansion": "cata",
+        "sodModified": false
+    },
+    {
+        "instanceId": 720,
+        "name": "Lord Rhyolith",
+        "order": 2,
+        "expansion": "cata",
+        "sodModified": false
+    },
+    {
+        "instanceId": 720,
+        "name": "Alysrazor",
+        "order": 3,
+        "expansion": "cata",
+        "sodModified": false
+    },
+    {
+        "instanceId": 720,
+        "name": "Shannox",
+        "order": 4,
+        "expansion": "cata",
+        "sodModified": false
+    },
+    {
+        "instanceId": 720,
+        "name": "Baleroc",
+        "order": 5,
+        "expansion": "cata",
+        "sodModified": false
+    },
+    {
+        "instanceId": 720,
+        "name": "Majordomo Staghelm",
+        "order": 6,
+        "expansion": "cata",
+        "sodModified": false
+    },
+    {
+        "instanceId": 720,
+        "name": "Ragnaros",
+        "order": 7,
+        "expansion": "cata",
+        "sodModified": false
+    },
+    {
+        "instanceId": 967,
+        "name": "Morchok",
+        "order": 1,
+        "expansion": "cata",
+        "sodModified": false
+    },
+    {
+        "instanceId": 967,
+        "name": "Warlord Zon'ozz",
+        "order": 2,
+        "expansion": "cata",
+        "sodModified": false
+    },
+    {
+        "instanceId": 967,
+        "name": "Ultraxion",
+        "order": 4,
+        "expansion": "cata",
+        "sodModified": false
+    },
+    {
+        "instanceId": 967,
+        "name": "Warmaster Blackhorn",
+        "order": 5,
+        "expansion": "cata",
+        "sodModified": false
+    },
+    {
+        "instanceId": 967,
+        "name": "Spine of Deathwing",
+        "order": 7,
+        "expansion": "cata",
+        "sodModified": false
+    },
+    {
+        "instanceId": 967,
+        "name": "Madness of Deathwing",
+        "order": 8,
+        "expansion": "cata",
+        "sodModified": false
+    },
+    {
+        "instanceId": 48,
+        "name": "Ghamoo-Ra (SoD)",
+        "order": 1,
+        "expansion": "sod",
+        "sodModified": true
+    },
+    {
+        "instanceId": 48,
+        "name": "Lady Sarevess (SoD)",
+        "order": 2,
+        "expansion": "sod",
+        "sodModified": true
+    },
+    {
+        "instanceId": 48,
+        "name": "Twilight Lord Kelris (SoD)",
+        "order": 4,
+        "expansion": "sod",
+        "sodModified": true
+    },
+    {
+        "instanceId": 48,
+        "name": "Aku'mai (SoD)",
+        "order": 7,
+        "expansion": "sod",
+        "sodModified": true
+    },
+    {
+        "instanceId": 90,
+        "name": "Grubbis (SoD)",
+        "order": 2,
+        "expansion": "sod",
+        "sodModified": true
+    },
+    {
+        "instanceId": 90,
+        "name": "Viscous Fallout (SoD)",
+        "order": 3,
+        "expansion": "sod",
+        "sodModified": true
+    },
+    {
+        "instanceId": 90,
+        "name": "Mekgineer Thermaplugg (SoD)",
+        "order": 6,
+        "expansion": "sod",
+        "sodModified": true
+    },
+    {
+        "instanceId": 109,
+        "name": "Avatar of Hakkar (SoD)",
+        "order": 3,
+        "expansion": "sod",
+        "sodModified": true
+    },
+    {
+        "instanceId": 109,
+        "name": "Shade of Eranikus (SoD)",
+        "order": 6,
+        "expansion": "sod",
+        "sodModified": true
+    }
+]

--- a/api/src/plugins/wow-common/data/boss-loot-data.json
+++ b/api/src/plugins/wow-common/data/boss-loot-data.json
@@ -1,0 +1,720 @@
+[
+    {
+        "bossName": "Ragnaros",
+        "expansion": "classic",
+        "itemId": 17182,
+        "itemName": "Sulfuras, Hand of Ragnaros",
+        "slot": "Main Hand",
+        "quality": "Legendary",
+        "itemLevel": 80,
+        "dropRate": 0.0400,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Ragnaros",
+        "expansion": "classic",
+        "itemId": 17063,
+        "itemName": "Band of Accuria",
+        "slot": "Finger",
+        "quality": "Epic",
+        "itemLevel": 75,
+        "dropRate": 0.1200,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Ragnaros",
+        "expansion": "classic",
+        "itemId": 17076,
+        "itemName": "Bonereaver's Edge",
+        "slot": "Two-Hand",
+        "quality": "Epic",
+        "itemLevel": 77,
+        "dropRate": 0.0700,
+        "classRestrictions": [
+            "Warrior",
+            "Paladin"
+        ],
+        "iconUrl": null
+    },
+    {
+        "bossName": "Ragnaros",
+        "expansion": "classic",
+        "itemId": 17082,
+        "itemName": "Shard of the Flame",
+        "slot": "Trinket",
+        "quality": "Epic",
+        "itemLevel": 75,
+        "dropRate": 0.1000,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Lucifron",
+        "expansion": "classic",
+        "itemId": 16805,
+        "itemName": "Felheart Belt",
+        "slot": "Waist",
+        "quality": "Epic",
+        "itemLevel": 66,
+        "dropRate": 0.1500,
+        "classRestrictions": [
+            "Warlock"
+        ],
+        "iconUrl": null
+    },
+    {
+        "bossName": "Garr",
+        "expansion": "classic",
+        "itemId": 18564,
+        "itemName": "Bindings of the Windseeker",
+        "slot": "Bindings",
+        "quality": "Legendary",
+        "itemLevel": 75,
+        "dropRate": 0.0300,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Baron Geddon",
+        "expansion": "classic",
+        "itemId": 18563,
+        "itemName": "Bindings of the Windseeker",
+        "slot": "Bindings",
+        "quality": "Legendary",
+        "itemLevel": 75,
+        "dropRate": 0.0300,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Golemagg the Incinerator",
+        "expansion": "classic",
+        "itemId": 17103,
+        "itemName": "Azuresong Mageblade",
+        "slot": "Main Hand",
+        "quality": "Epic",
+        "itemLevel": 71,
+        "dropRate": 0.1000,
+        "classRestrictions": [
+            "Mage",
+            "Warlock",
+            "Priest"
+        ],
+        "iconUrl": null
+    },
+    {
+        "bossName": "Nefarian",
+        "expansion": "classic",
+        "itemId": 19375,
+        "itemName": "Mish'undare, Circlet of the Mind Flayer",
+        "slot": "Head",
+        "quality": "Epic",
+        "itemLevel": 83,
+        "dropRate": 0.1000,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Nefarian",
+        "expansion": "classic",
+        "itemId": 19377,
+        "itemName": "Prestor's Talisman of Connivery",
+        "slot": "Neck",
+        "quality": "Epic",
+        "itemLevel": 83,
+        "dropRate": 0.0800,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Chromaggus",
+        "expansion": "classic",
+        "itemId": 19389,
+        "itemName": "Taut Dragonhide Gloves",
+        "slot": "Hands",
+        "quality": "Epic",
+        "itemLevel": 81,
+        "dropRate": 0.0700,
+        "classRestrictions": [
+            "Druid",
+            "Rogue"
+        ],
+        "iconUrl": null
+    },
+    {
+        "bossName": "Onyxia",
+        "expansion": "classic",
+        "itemId": 18422,
+        "itemName": "Head of Onyxia",
+        "slot": "Quest",
+        "quality": "Epic",
+        "itemLevel": 62,
+        "dropRate": 1.0000,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Onyxia",
+        "expansion": "classic",
+        "itemId": 17078,
+        "itemName": "Deathbringer",
+        "slot": "Two-Hand",
+        "quality": "Epic",
+        "itemLevel": 70,
+        "dropRate": 0.0800,
+        "classRestrictions": [
+            "Warrior",
+            "Paladin"
+        ],
+        "iconUrl": null
+    },
+    {
+        "bossName": "C'Thun",
+        "expansion": "classic",
+        "itemId": 21221,
+        "itemName": "Eye of C'Thun",
+        "slot": "Quest",
+        "quality": "Epic",
+        "itemLevel": 81,
+        "dropRate": 1.0000,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "C'Thun",
+        "expansion": "classic",
+        "itemId": 21126,
+        "itemName": "Death's Sting",
+        "slot": "One-Hand",
+        "quality": "Epic",
+        "itemLevel": 81,
+        "dropRate": 0.0700,
+        "classRestrictions": [
+            "Rogue",
+            "Warrior"
+        ],
+        "iconUrl": null
+    },
+    {
+        "bossName": "Kel'Thuzad",
+        "expansion": "classic",
+        "itemId": 23057,
+        "itemName": "Gressil, Dawn of Ruin",
+        "slot": "One-Hand",
+        "quality": "Epic",
+        "itemLevel": 90,
+        "dropRate": 0.0500,
+        "classRestrictions": [
+            "Warrior",
+            "Rogue"
+        ],
+        "iconUrl": null
+    },
+    {
+        "bossName": "Kel'Thuzad",
+        "expansion": "classic",
+        "itemId": 23054,
+        "itemName": "The Hungering Cold",
+        "slot": "One-Hand",
+        "quality": "Epic",
+        "itemLevel": 90,
+        "dropRate": 0.0500,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Sapphiron",
+        "expansion": "classic",
+        "itemId": 23050,
+        "itemName": "Cloak of the Necropolis",
+        "slot": "Back",
+        "quality": "Epic",
+        "itemLevel": 88,
+        "dropRate": 0.0800,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Edwin VanCleef",
+        "expansion": "classic",
+        "itemId": 5191,
+        "itemName": "Cruel Barb",
+        "slot": "One-Hand",
+        "quality": "Rare",
+        "itemLevel": 25,
+        "dropRate": 0.2000,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Prince Malchezaar",
+        "expansion": "tbc",
+        "itemId": 28633,
+        "itemName": "Staff of Infinite Mysteries",
+        "slot": "Two-Hand",
+        "quality": "Epic",
+        "itemLevel": 125,
+        "dropRate": 0.1000,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Prince Malchezaar",
+        "expansion": "tbc",
+        "itemId": 28611,
+        "itemName": "Drape of the Dark Reavers",
+        "slot": "Back",
+        "quality": "Epic",
+        "itemLevel": 125,
+        "dropRate": 0.1200,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Attumen the Huntsman",
+        "expansion": "tbc",
+        "itemId": 28477,
+        "itemName": "Harbinger Bands",
+        "slot": "Wrist",
+        "quality": "Epic",
+        "itemLevel": 115,
+        "dropRate": 0.1500,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Attumen the Huntsman",
+        "expansion": "tbc",
+        "itemId": 30480,
+        "itemName": "Fiery Warhorse's Reins",
+        "slot": "Mount",
+        "quality": "Epic",
+        "itemLevel": 70,
+        "dropRate": 0.0100,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "The Curator",
+        "expansion": "tbc",
+        "itemId": 28649,
+        "itemName": "Garona's Signet Ring",
+        "slot": "Finger",
+        "quality": "Epic",
+        "itemLevel": 120,
+        "dropRate": 0.1000,
+        "classRestrictions": [
+            "Rogue"
+        ],
+        "iconUrl": null
+    },
+    {
+        "bossName": "Lady Vashj",
+        "expansion": "tbc",
+        "itemId": 30021,
+        "itemName": "Serpent-Coil Braid",
+        "slot": "Head",
+        "quality": "Epic",
+        "itemLevel": 141,
+        "dropRate": 0.0800,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Kael'thas Sunstrider",
+        "expansion": "tbc",
+        "itemId": 30311,
+        "itemName": "Warp Slicer",
+        "slot": "One-Hand",
+        "quality": "Epic",
+        "itemLevel": 141,
+        "dropRate": 0.1000,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Kael'thas Sunstrider",
+        "expansion": "tbc",
+        "itemId": 30048,
+        "itemName": "Netherblade Faceguard",
+        "slot": "Head",
+        "quality": "Epic",
+        "itemLevel": 141,
+        "dropRate": 0.1200,
+        "classRestrictions": [
+            "Rogue"
+        ],
+        "iconUrl": null
+    },
+    {
+        "bossName": "Illidan Stormrage",
+        "expansion": "tbc",
+        "itemId": 32837,
+        "itemName": "Warglaive of Azzinoth",
+        "slot": "Main Hand",
+        "quality": "Legendary",
+        "itemLevel": 156,
+        "dropRate": 0.0500,
+        "classRestrictions": [
+            "Warrior",
+            "Rogue"
+        ],
+        "iconUrl": null
+    },
+    {
+        "bossName": "Illidan Stormrage",
+        "expansion": "tbc",
+        "itemId": 32838,
+        "itemName": "Warglaive of Azzinoth",
+        "slot": "Off Hand",
+        "quality": "Legendary",
+        "itemLevel": 156,
+        "dropRate": 0.0500,
+        "classRestrictions": [
+            "Warrior",
+            "Rogue"
+        ],
+        "iconUrl": null
+    },
+    {
+        "bossName": "Kil'jaeden",
+        "expansion": "tbc",
+        "itemId": 34334,
+        "itemName": "Thori'dal, the Stars' Fury",
+        "slot": "Ranged",
+        "quality": "Legendary",
+        "itemLevel": 164,
+        "dropRate": 0.0300,
+        "classRestrictions": [
+            "Hunter",
+            "Rogue",
+            "Warrior"
+        ],
+        "iconUrl": null
+    },
+    {
+        "bossName": "Yogg-Saron",
+        "expansion": "wotlk",
+        "itemId": 46017,
+        "itemName": "Val'anyr, Hammer of Ancient Kings",
+        "slot": "Main Hand",
+        "quality": "Legendary",
+        "itemLevel": 245,
+        "dropRate": 0.0100,
+        "classRestrictions": [
+            "Paladin",
+            "Priest",
+            "Druid",
+            "Shaman"
+        ],
+        "iconUrl": null
+    },
+    {
+        "bossName": "Yogg-Saron",
+        "expansion": "wotlk",
+        "itemId": 45529,
+        "itemName": "Ironmender",
+        "slot": "Wrist",
+        "quality": "Epic",
+        "itemLevel": 232,
+        "dropRate": 0.1000,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Algalon the Observer",
+        "expansion": "wotlk",
+        "itemId": 45609,
+        "itemName": "Comet's Trail",
+        "slot": "Trinket",
+        "quality": "Epic",
+        "itemLevel": 239,
+        "dropRate": 0.1500,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Mimiron",
+        "expansion": "wotlk",
+        "itemId": 45489,
+        "itemName": "Pandora's Plea",
+        "slot": "Trinket",
+        "quality": "Epic",
+        "itemLevel": 232,
+        "dropRate": 0.1000,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Hodir",
+        "expansion": "wotlk",
+        "itemId": 45461,
+        "itemName": "Drape of Icy Intent",
+        "slot": "Back",
+        "quality": "Epic",
+        "itemLevel": 232,
+        "dropRate": 0.1000,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "The Lich King",
+        "expansion": "wotlk",
+        "itemId": 50818,
+        "itemName": "Invincible's Reins",
+        "slot": "Mount",
+        "quality": "Legendary",
+        "itemLevel": 80,
+        "dropRate": 0.0100,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "The Lich King",
+        "expansion": "wotlk",
+        "itemId": 50070,
+        "itemName": "Glorenzelg, High-Blade of the Silver Hand",
+        "slot": "Two-Hand",
+        "quality": "Epic",
+        "itemLevel": 277,
+        "dropRate": 0.0800,
+        "classRestrictions": [
+            "Warrior",
+            "Paladin",
+            "Death Knight"
+        ],
+        "iconUrl": null
+    },
+    {
+        "bossName": "The Lich King",
+        "expansion": "wotlk",
+        "itemId": 50012,
+        "itemName": "Havoc's Call, Blade of Lordaeron Kings",
+        "slot": "One-Hand",
+        "quality": "Epic",
+        "itemLevel": 277,
+        "dropRate": 0.0800,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Professor Putricide",
+        "expansion": "wotlk",
+        "itemId": 50231,
+        "itemName": "Astrylian's Sutured Cinch",
+        "slot": "Waist",
+        "quality": "Epic",
+        "itemLevel": 264,
+        "dropRate": 0.1000,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Sindragosa",
+        "expansion": "wotlk",
+        "itemId": 50424,
+        "itemName": "Memory of Malygos",
+        "slot": "Trinket",
+        "quality": "Epic",
+        "itemLevel": 264,
+        "dropRate": 0.0800,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Ragnaros",
+        "expansion": "cata",
+        "itemId": 69897,
+        "itemName": "Sulfuras, the Extinguished Hand",
+        "slot": "Two-Hand",
+        "quality": "Legendary",
+        "itemLevel": 391,
+        "dropRate": 0.0100,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Ragnaros",
+        "expansion": "cata",
+        "itemId": 71355,
+        "itemName": "Majordomo's Chain of Office",
+        "slot": "Neck",
+        "quality": "Epic",
+        "itemLevel": 384,
+        "dropRate": 0.1000,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Majordomo Staghelm",
+        "expansion": "cata",
+        "itemId": 71343,
+        "itemName": "Fandral's Flamescythe",
+        "slot": "Two-Hand",
+        "quality": "Epic",
+        "itemLevel": 378,
+        "dropRate": 0.0800,
+        "classRestrictions": [
+            "Druid"
+        ],
+        "iconUrl": null
+    },
+    {
+        "bossName": "Beth'tilac",
+        "expansion": "cata",
+        "itemId": 71039,
+        "itemName": "Funeral Pyre",
+        "slot": "Main Hand",
+        "quality": "Epic",
+        "itemLevel": 378,
+        "dropRate": 0.1000,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Alysrazor",
+        "expansion": "cata",
+        "itemId": 71079,
+        "itemName": "Alysrazor's Band",
+        "slot": "Finger",
+        "quality": "Epic",
+        "itemLevel": 378,
+        "dropRate": 0.1200,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Madness of Deathwing",
+        "expansion": "cata",
+        "itemId": 77949,
+        "itemName": "Gurthalak, Voice of the Deeps",
+        "slot": "Two-Hand",
+        "quality": "Epic",
+        "itemLevel": 397,
+        "dropRate": 0.0800,
+        "classRestrictions": [
+            "Warrior",
+            "Paladin",
+            "Death Knight"
+        ],
+        "iconUrl": null
+    },
+    {
+        "bossName": "Madness of Deathwing",
+        "expansion": "cata",
+        "itemId": 77947,
+        "itemName": "No'Kaled, the Elements of Death",
+        "slot": "One-Hand",
+        "quality": "Epic",
+        "itemLevel": 397,
+        "dropRate": 0.0800,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Spine of Deathwing",
+        "expansion": "cata",
+        "itemId": 78357,
+        "itemName": "Backbreaker Spaulders",
+        "slot": "Shoulder",
+        "quality": "Epic",
+        "itemLevel": 397,
+        "dropRate": 0.1000,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Nefarian",
+        "expansion": "cata",
+        "itemId": 65003,
+        "itemName": "Prestor's Talisman of Machination",
+        "slot": "Neck",
+        "quality": "Epic",
+        "itemLevel": 359,
+        "dropRate": 0.1000,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Magmaw",
+        "expansion": "cata",
+        "itemId": 65022,
+        "itemName": "Incineratus",
+        "slot": "Main Hand",
+        "quality": "Epic",
+        "itemLevel": 359,
+        "dropRate": 0.1200,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Aku'mai (SoD)",
+        "expansion": "sod",
+        "itemId": 211505,
+        "itemName": "Blackfathom Ritual Dagger",
+        "slot": "Main Hand",
+        "quality": "Rare",
+        "itemLevel": 26,
+        "dropRate": 0.1500,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Aku'mai (SoD)",
+        "expansion": "sod",
+        "itemId": 211507,
+        "itemName": "Twilight Sage's Walking Stick",
+        "slot": "Two-Hand",
+        "quality": "Rare",
+        "itemLevel": 26,
+        "dropRate": 0.1500,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Twilight Lord Kelris (SoD)",
+        "expansion": "sod",
+        "itemId": 211508,
+        "itemName": "Kelris's Scepter",
+        "slot": "Main Hand",
+        "quality": "Rare",
+        "itemLevel": 25,
+        "dropRate": 0.1500,
+        "classRestrictions": null,
+        "iconUrl": null
+    },
+    {
+        "bossName": "Mekgineer Thermaplugg (SoD)",
+        "expansion": "sod",
+        "itemId": 213320,
+        "itemName": "Thermaplugg's Rocket Launcher",
+        "slot": "Ranged",
+        "quality": "Rare",
+        "itemLevel": 40,
+        "dropRate": 0.1200,
+        "classRestrictions": [
+            "Warrior",
+            "Hunter",
+            "Rogue"
+        ],
+        "iconUrl": null
+    },
+    {
+        "bossName": "Shade of Eranikus (SoD)",
+        "expansion": "sod",
+        "itemId": 220608,
+        "itemName": "Eranikus's Scale",
+        "slot": "Shield",
+        "quality": "Epic",
+        "itemLevel": 50,
+        "dropRate": 0.1000,
+        "classRestrictions": [
+            "Warrior",
+            "Paladin",
+            "Shaman"
+        ],
+        "iconUrl": null
+    }
+]

--- a/packages/contract/src/boss-encounters.schema.ts
+++ b/packages/contract/src/boss-encounters.schema.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+
+/**
+ * ROK-244: Boss encounter and loot table API schemas.
+ */
+
+/** Single boss encounter DTO */
+export const BossEncounterDtoSchema = z.object({
+    id: z.number(),
+    instanceId: z.number(),
+    name: z.string(),
+    order: z.number(),
+    expansion: z.enum(['classic', 'tbc', 'wotlk', 'cata', 'sod']),
+    sodModified: z.boolean(),
+});
+
+export type BossEncounterDto = z.infer<typeof BossEncounterDtoSchema>;
+
+/** Single boss loot item DTO */
+export const BossLootDtoSchema = z.object({
+    id: z.number(),
+    bossId: z.number(),
+    itemId: z.number(),
+    itemName: z.string(),
+    slot: z.string().nullable(),
+    quality: z.enum([
+        'Poor',
+        'Common',
+        'Uncommon',
+        'Rare',
+        'Epic',
+        'Legendary',
+    ]),
+    itemLevel: z.number().nullable(),
+    dropRate: z.string().nullable(),
+    expansion: z.enum(['classic', 'tbc', 'wotlk', 'cata', 'sod']),
+    classRestrictions: z.array(z.string()).nullable(),
+    iconUrl: z.string().nullable(),
+});
+
+export type BossLootDto = z.infer<typeof BossLootDtoSchema>;
+
+/** Response schema for GET /plugins/wow-classic/instances/:id/bosses */
+export const BossEncountersResponseSchema = z.array(BossEncounterDtoSchema);
+export type BossEncountersResponse = z.infer<
+    typeof BossEncountersResponseSchema
+>;
+
+/** Response schema for GET /plugins/wow-classic/bosses/:id/loot */
+export const BossLootResponseSchema = z.array(BossLootDtoSchema);
+export type BossLootResponse = z.infer<typeof BossLootResponseSchema>;

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -84,3 +84,6 @@ export * from './event-plans.schema.js';
 
 // Dungeon Quests (ROK-245)
 export * from './dungeon-quests.schema.js';
+
+// Boss Encounters & Loot (ROK-244)
+export * from './boss-encounters.schema.js';


### PR DESCRIPTION
## Summary

Seed boss encounter and loot table data for all Classic WoW variants. Follows the ROK-245 dungeon quest pattern.

## Changes

### Schema
- `wow_classic_bosses` — `UNIQUE(instance_id, name, expansion)`
- `wow_classic_boss_loot` — `UNIQUE(boss_id, item_id, expansion)`, FK with `ON DELETE CASCADE`
- Migration: `0059_pale_echo.sql`

### Seed Data
- ~100 bosses across Classic, TBC, WotLK, Cata, SoD
- ~55 iconic loot items (Sulfuras, Warglaives, Gressil, Invincible, etc.)

### Service Layer
- `BossEncounterSeeder` — two-phase seed (bosses → loot FK resolution), idempotent upserts
- `BossEncountersService` — variant-aware filtering via `VARIANT_EXPANSIONS` mapping
- `BossEncountersController` — `GET /instances/:id/bosses?variant=` and `GET /bosses/:id/loot?variant=`
- Contract Zod schemas (`BossEncounterDtoSchema`, `BossLootDtoSchema`)

### Module Wiring
- Seed on plugin install, drop on uninstall (parallel with dungeon quests)

## Testing
- TypeScript: ✅ Clean
- Tests: 87 suites, 1467 tests — all pass
- Lint: 0 new errors