### PR TITLE
fix: admin roster assignment includes character/role selection + notification (ROK-461)

### DIFF
--- a/api/src/users/users.controller.ts
+++ b/api/src/users/users.controller.ts
@@ -163,6 +163,28 @@ export class UsersController {
   }
 
   /**
+   * ROK-461: Get a user's characters, optionally filtered by game.
+   * Used by admin roster assignment to select a character on behalf of a player.
+   */
+  @Get(':id/characters')
+  async getUserCharacters(
+    @Param('id', ParseIntPipe) id: number,
+    @Query('gameId') gameId?: string,
+  ): Promise<{ data: import('@raid-ledger/contract').CharacterDto[] }> {
+    const user = await this.usersService.findById(id);
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    const parsedGameId = gameId ? parseInt(gameId, 10) : undefined;
+    const result = await this.charactersService.findAllForUser(
+      id,
+      parsedGameId || undefined,
+    );
+    return { data: result.data };
+  }
+
+  /**
    * ROK-282: Get games a user has hearted.
    * Public endpoint for displaying hearted games on a user's profile.
    */

--- a/packages/contract/src/roster.schema.ts
+++ b/packages/contract/src/roster.schema.ts
@@ -23,6 +23,8 @@ export const RosterAssignmentSchema = z.object({
     position: z.number().int().min(1).default(1),
     /** Override flag for off-spec assignments */
     isOverride: z.boolean().default(false),
+    /** ROK-461: Character ID to set on the signup (admin assignment) */
+    characterId: z.string().uuid().optional(),
 });
 export type RosterAssignment = z.infer<typeof RosterAssignmentSchema>;
 

--- a/web/src/components/roster/AssignmentPopup.test.tsx
+++ b/web/src/components/roster/AssignmentPopup.test.tsx
@@ -1,13 +1,21 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { AssignmentPopup } from './AssignmentPopup';
 import type { RosterAssignmentResponse, RosterRole } from '@raid-ledger/contract';
 import type { ReactElement } from 'react';
 
-/** Wrap component in MemoryRouter for Link context */
+/** Wrap component in MemoryRouter + QueryClientProvider for hook context */
 function renderWithRouter(ui: ReactElement) {
-    return render(<MemoryRouter>{ui}</MemoryRouter>);
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    return render(
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter>{ui}</MemoryRouter>
+        </QueryClientProvider>
+    );
 }
 
 describe('AssignmentPopup', () => {

--- a/web/src/components/roster/RosterBuilder.a11y.test.tsx
+++ b/web/src/components/roster/RosterBuilder.a11y.test.tsx
@@ -6,6 +6,7 @@
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { RosterBuilder } from './RosterBuilder';
 import type { RosterAssignmentResponse, RosterRole } from '@raid-ledger/contract';
 import type { ReactElement } from 'react';
@@ -15,7 +16,14 @@ vi.mock('sonner', () => ({
 }));
 
 function renderWithRouter(ui: ReactElement) {
-    return render(<MemoryRouter>{ui}</MemoryRouter>);
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    return render(
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter>{ui}</MemoryRouter>
+        </QueryClientProvider>
+    );
 }
 
 function makePlayer(

--- a/web/src/hooks/use-characters.ts
+++ b/web/src/hooks/use-characters.ts
@@ -1,5 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
-import { getMyCharacters } from '../lib/api-client';
+import { getMyCharacters, getUserCharacters } from '../lib/api-client';
 
 /**
  * Hook for fetching current user's characters.
@@ -10,5 +10,17 @@ export function useMyCharacters(gameId?: number, enabled = true) {
         queryKey: ['me', 'characters', gameId],
         queryFn: () => getMyCharacters(gameId),
         enabled,
+    });
+}
+
+/**
+ * ROK-461: Hook for fetching another user's characters.
+ * Used by admin roster assignment to select a character on behalf of a player.
+ */
+export function useUserCharacters(userId: number | null, gameId?: number) {
+    return useQuery({
+        queryKey: ['users', userId, 'characters', gameId],
+        queryFn: () => getUserCharacters(userId!, gameId),
+        enabled: userId != null && userId > 0,
     });
 }

--- a/web/src/hooks/use-roster.ts
+++ b/web/src/hooks/use-roster.ts
@@ -108,10 +108,12 @@ export function useAdminRemoveUser(eventId: number) {
 
 /**
  * Helper to build UpdateRosterDto from component state.
+ * ROK-461: characterId map allows admin assignment to set a character on the signup.
  */
 export function buildRosterUpdate(
     _pool: RosterAssignmentResponse[],
     assignments: RosterAssignmentResponse[],
+    characterIdMap?: Map<number, string>,
 ): UpdateRosterDto {
     return {
         assignments: assignments
@@ -122,6 +124,7 @@ export function buildRosterUpdate(
                 slot: a.slot,
                 position: a.position,
                 isOverride: a.isOverride,
+                characterId: characterIdMap?.get(a.signupId),
             })),
     };
 }

--- a/web/src/lib/api-client.ts
+++ b/web/src/lib/api-client.ts
@@ -443,6 +443,16 @@ export async function deleteCharacter(characterId: string): Promise<void> {
 }
 
 /**
+ * ROK-461: Fetch a user's characters, optionally filtered by game.
+ * Used by admin roster assignment to pick a character on behalf of a player.
+ */
+export async function getUserCharacters(userId: number, gameId?: number): Promise<CharacterDto[]> {
+    const params = gameId ? `?gameId=${gameId}` : '';
+    const result = await fetchApi<{ data: CharacterDto[] }>(`/users/${userId}/characters${params}`);
+    return result.data;
+}
+
+/**
  * Fetch a single character by ID (public — for detail page)
  */
 export async function getCharacterDetail(characterId: string): Promise<CharacterDto> {

--- a/web/src/pages/event-detail-page.tsx
+++ b/web/src/pages/event-detail-page.tsx
@@ -123,9 +123,11 @@ export function EventDetailPage() {
     const isMMOGame = isMMOSlotConfig(rosterAssignments?.slots);
 
     // Handler for roster changes from RosterBuilder
+    // ROK-461: characterIdMap carries admin-selected characters during assignment
     const handleRosterChange = async (
         pool: RosterAssignmentResponse[],
         assignments: RosterAssignmentResponse[],
+        characterIdMap?: Map<number, string>,
     ) => {
         // ROK-466: Defensive guard — only admins/creators should reach this path
         if (!canManageRoster) {
@@ -135,7 +137,7 @@ export function EventDetailPage() {
             return;
         }
         try {
-            await updateRoster.mutateAsync(buildRosterUpdate(pool, assignments));
+            await updateRoster.mutateAsync(buildRosterUpdate(pool, assignments, characterIdMap));
         } catch (err) {
             toast.error('Failed to update roster', {
                 description: err instanceof Error ? err.message : 'Please try again.',
@@ -635,6 +637,8 @@ export function EventDetailPage() {
                         onRegeneratePugLink={canManageRoster ? handleRegeneratePugLink : undefined}
                         eventId={eventId}
                         onRemoveFromEvent={canManageRoster ? handleRemoveFromEvent : undefined}
+                        gameId={event.game?.id}
+                        isMMOEvent={isMMOGame}
                         stickyExtra={isAuthenticated && event.startTime && event.endTime ? (
                             <GameTimeWidget
                                 eventStartTime={event.startTime}


### PR DESCRIPTION
## Summary

- **AssignmentPopup** now shows a character picker (main + alts) and role selector when an admin assigns a player to a roster slot for MMO game events
- Assignment API persists the selected `characterId` on the signup row
- Player receives an in-app `roster_reassigned` notification + Discord DM when assigned
- Non-MMO games and players without characters skip the selection step gracefully

## Key Files Changed (12)

**Contract:** `packages/contract/src/roster.schema.ts` — added optional `characterId` to `RosterAssignmentSchema`

**Backend:** `api/src/events/signups.service.ts` (characterId write-back + notification), `api/src/users/users.controller.ts` (new `/users/:id/characters` endpoint)

**Frontend:** `AssignmentPopup.tsx` (character/role selection step), `RosterBuilder.tsx` (passes gameId/isMMOEvent), `event-detail-page.tsx` (prop plumbing), new `use-characters.ts` hook, updated `use-roster.ts` + `api-client.ts`

**Tests:** Updated `AssignmentPopup.test.tsx`, `RosterBuilder.test.tsx`, `RosterBuilder.a11y.test.tsx`

## Test plan

- [ ] Open an MMO event (e.g., WoW raid) → click empty roster slot → assign a player → verify character picker and role selector appear
- [ ] Confirm assignment → verify characterId is persisted and player receives notification
- [ ] Open a non-MMO event (e.g., Valheim) → assign a player → verify selection step is skipped
- [ ] Verify existing self-signup flow is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)