### PR TITLE
feat(ROK-480): shared test infrastructure + audit report

### DIFF
--- a/api/src/common/testing/drizzle-mock.ts
+++ b/api/src/common/testing/drizzle-mock.ts
@@ -1,0 +1,64 @@
+/**
+ * Shared Drizzle ORM mock for unit tests.
+ *
+ * Creates a flat chain mock where every query-builder method returns `this`.
+ * Control results by overriding terminal methods:
+ *
+ *   mockDb.limit.mockResolvedValue([row]);           // single query
+ *   mockDb.limit.mockResolvedValueOnce([row1])       // sequential queries
+ *                .mockResolvedValueOnce([row2]);
+ *
+ * Pattern lifted from users.service.spec.ts:13-34 and generalised to cover
+ * all Drizzle chain methods observed across the codebase.
+ */
+export function createDrizzleMock() {
+  const mock: Record<string, jest.Mock> = {};
+
+  const chainMethods = [
+    // Core query builder
+    'select',
+    'from',
+    'where',
+    'orderBy',
+    'limit',
+    'offset',
+    // Joins
+    'leftJoin',
+    'innerJoin',
+    // Insert chain
+    'insert',
+    'values',
+    'returning',
+    'onConflictDoNothing',
+    'onConflictDoUpdate',
+    // Update chain
+    'update',
+    'set',
+    // Delete
+    'delete',
+    // Advanced
+    'groupBy',
+    '$dynamic',
+    'execute',
+    'as',
+  ];
+
+  for (const m of chainMethods) {
+    mock[m] = jest.fn().mockReturnThis();
+  }
+
+  // Transaction support — executes the callback with the mock as the tx arg
+  mock.transaction = jest.fn().mockImplementation(
+    async (cb: (tx: typeof mock) => Promise<unknown>) => cb(mock),
+  );
+
+  // Relational query API (used by some services)
+  mock.query = {
+    users: { findFirst: jest.fn(), findMany: jest.fn() },
+    events: { findFirst: jest.fn(), findMany: jest.fn() },
+  } as unknown as jest.Mock;
+
+  return mock;
+}
+
+export type MockDb = ReturnType<typeof createDrizzleMock>;

--- a/api/src/common/testing/factories.ts
+++ b/api/src/common/testing/factories.ts
@@ -1,0 +1,81 @@
+/**
+ * Shared mock data factories for backend tests.
+ *
+ * These replace the ad-hoc mock objects duplicated across 20+ spec files.
+ * Each factory returns a plain object matching the Drizzle row shape
+ * (database columns, not API response DTOs).
+ */
+
+export function createMockUser(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    username: 'testuser',
+    displayName: null,
+    avatar: null,
+    discordId: '123456789',
+    customAvatarUrl: null,
+    role: 'member' as const,
+    onboardingCompletedAt: null,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    updatedAt: new Date('2026-01-01T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+export function createMockEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    title: 'Test Event',
+    description: 'Test description',
+    gameId: 1,
+    creatorId: 1,
+    duration: [
+      new Date('2026-02-10T18:00:00Z'),
+      new Date('2026-02-10T20:00:00Z'),
+    ] as [Date, Date],
+    maxAttendees: null,
+    slotConfig: null,
+    autoUnbench: false,
+    contentInstances: null,
+    recurrenceGroupId: null,
+    recurrenceRule: null,
+    reminder15min: true,
+    reminder1hour: false,
+    reminder24hour: false,
+    cancelledAt: null,
+    cancellationReason: null,
+    createdAt: new Date('2026-01-15T00:00:00Z'),
+    updatedAt: new Date('2026-01-15T00:00:00Z'),
+    ...overrides,
+  };
+}
+
+export function createMockSignup(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    eventId: 1,
+    userId: 1,
+    note: null,
+    signedUpAt: new Date('2026-02-01T12:00:00Z'),
+    characterId: null,
+    confirmationStatus: 'pending' as const,
+    status: 'signed_up' as const,
+    preferredRoles: null,
+    isAnonymous: false,
+    discordUserId: null,
+    discordUsername: null,
+    discordAvatarHash: null,
+    ...overrides,
+  };
+}
+
+export function createMockGame(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    igdbId: 1234,
+    name: 'World of Warcraft',
+    slug: 'world-of-warcraft',
+    coverUrl: 'https://images.igdb.com/igdb/image/upload/t_cover_big/abc.jpg',
+    ...overrides,
+  };
+}

--- a/web/src/test/factories.ts
+++ b/web/src/test/factories.ts
@@ -1,0 +1,51 @@
+/**
+ * Shared mock data factories for frontend tests.
+ *
+ * These return objects matching the contract DTO shapes (API responses),
+ * not raw database rows. Promoted from ad-hoc factories in event-card.test.tsx
+ * and other component tests.
+ */
+import type { EventResponseDto } from '@raid-ledger/contract';
+
+export function createMockEvent(
+    overrides: Partial<EventResponseDto> = {},
+): EventResponseDto {
+    return {
+        id: 1,
+        title: 'Test Raid Night',
+        description: 'Weekly raid session',
+        startTime: '2026-02-10T20:00:00Z',
+        endTime: '2026-02-10T23:00:00Z',
+        creator: {
+            id: 1,
+            username: 'TestUser',
+            avatar: null,
+        },
+        game: {
+            id: 1,
+            name: 'World of Warcraft',
+            slug: 'world-of-warcraft',
+            coverUrl: 'https://example.com/cover.jpg',
+        },
+        signupCount: 3,
+        createdAt: '2026-02-01T00:00:00Z',
+        updatedAt: '2026-02-01T00:00:00Z',
+        ...overrides,
+    };
+}
+
+export function createMockUser(overrides: Record<string, unknown> = {}) {
+    return {
+        id: 1,
+        username: 'TestUser',
+        displayName: null,
+        avatar: null,
+        discordId: '123456789',
+        customAvatarUrl: null,
+        role: 'member' as const,
+        onboardingCompletedAt: null,
+        createdAt: '2026-01-01T00:00:00Z',
+        characters: [],
+        ...overrides,
+    };
+}

--- a/web/src/test/render-helpers.tsx
+++ b/web/src/test/render-helpers.tsx
@@ -1,0 +1,62 @@
+/**
+ * Shared render helpers for frontend component tests.
+ *
+ * Centralises the QueryClient + MemoryRouter wrapper pattern that was
+ * previously copy-pasted across ~15 test files.
+ */
+import { render, type RenderOptions } from '@testing-library/react';
+import { MemoryRouter, type MemoryRouterProps } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { type ReactElement, type ReactNode } from 'react';
+
+/**
+ * Create a QueryClient configured for tests (no retries, no garbage collection).
+ */
+export function createTestQueryClient() {
+    return new QueryClient({
+        defaultOptions: {
+            queries: { retry: false, gcTime: Infinity },
+            mutations: { retry: false },
+        },
+    });
+}
+
+interface ProvidersOptions {
+    /** Initial route entries for MemoryRouter. Default: ['/'] */
+    initialEntries?: MemoryRouterProps['initialEntries'];
+    /** Supply your own QueryClient (e.g., to inspect cache). */
+    queryClient?: QueryClient;
+}
+
+/**
+ * Render a component wrapped in QueryClientProvider + MemoryRouter.
+ *
+ * Returns the standard RTL result plus the `queryClient` used.
+ *
+ * @example
+ * ```ts
+ * const { getByText, queryClient } = renderWithProviders(<MyComponent />);
+ * ```
+ */
+export function renderWithProviders(
+    ui: ReactElement,
+    options?: Omit<RenderOptions, 'wrapper'> & ProvidersOptions,
+) {
+    const {
+        initialEntries = ['/'],
+        queryClient = createTestQueryClient(),
+        ...renderOptions
+    } = options ?? {};
+
+    function Wrapper({ children }: { children: ReactNode }) {
+        return (
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter initialEntries={initialEntries}>
+                    {children}
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    }
+
+    return { ...render(ui, { wrapper: Wrapper, ...renderOptions }), queryClient };
+}


### PR DESCRIPTION
## Summary
- Adds shared backend test utilities (`api/src/common/testing/`): flat Drizzle chain mock and data factories (user, event, signup, game)
- Adds shared frontend test utilities (`web/src/test/`): `renderWithProviders` helper and DTO-shaped factories
- Full audit report generated at `implementation-artifacts/test-audit-report.md` (gitignored) covering all 193 test files with per-file findings, severity ratings, and remediation recipes

## Test plan
- [x] `npm run test -w api` passes (96 suites, 1605 tests)
- [x] `npm run test -w web` passes (97 suites, 1724 tests)
- [x] No existing test files were modified — only new utility files added
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)