### PR TITLE
fix(ROK-489): event creator reminder notifications — 4 bugs

### DIFF
--- a/api/src/auth/jwt.strategy.ts
+++ b/api/src/auth/jwt.strategy.ts
@@ -26,7 +26,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
 
   async validate(payload: JwtPayload) {
     const [user] = await this.db
-      .select({ role: schema.users.role })
+      .select({ role: schema.users.role, discordId: schema.users.discordId })
       .from(schema.users)
       .where(eq(schema.users.id, payload.sub))
       .limit(1);
@@ -39,6 +39,7 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       id: payload.sub,
       username: payload.username,
       role: user.role,
+      discordId: user.discordId,
       impersonatedBy: payload.impersonatedBy || null,
     };
   }

--- a/api/src/drizzle/schema/event-plans.ts
+++ b/api/src/drizzle/schema/event-plans.ts
@@ -63,8 +63,8 @@ export const eventPlans = pgTable(
     contentInstances: jsonb('content_instances'),
     /** Reminder settings for the auto-created event. */
     reminder15min: boolean('reminder_15min').default(true).notNull(),
-    reminder1hour: boolean('reminder_1hour').default(false).notNull(),
-    reminder24hour: boolean('reminder_24hour').default(false).notNull(),
+    reminder1hour: boolean('reminder_1hour').default(true).notNull(),
+    reminder24hour: boolean('reminder_24hour').default(true).notNull(),
     pollStartedAt: timestamp('poll_started_at'),
     pollEndsAt: timestamp('poll_ends_at'),
     createdAt: timestamp('created_at').defaultNow().notNull(),

--- a/api/src/drizzle/schema/events.ts
+++ b/api/src/drizzle/schema/events.ts
@@ -69,10 +69,10 @@ export const events = pgTable(
     contentInstances: jsonb('content_instances'),
     /** Send DM reminder 15 minutes before event. Default true (ROK-126). */
     reminder15min: boolean('reminder_15min').default(true).notNull(),
-    /** Send DM reminder 1 hour before event. Default false (ROK-126). */
-    reminder1hour: boolean('reminder_1hour').default(false).notNull(),
-    /** Send DM reminder 24 hours before event. Default false (ROK-126). */
-    reminder24hour: boolean('reminder_24hour').default(false).notNull(),
+    /** Send DM reminder 1 hour before event. Default true (ROK-126, ROK-489). */
+    reminder1hour: boolean('reminder_1hour').default(true).notNull(),
+    /** Send DM reminder 24 hours before event. Default true (ROK-126, ROK-489). */
+    reminder24hour: boolean('reminder_24hour').default(true).notNull(),
     /** Soft-cancel timestamp. Non-null means the event is cancelled (ROK-374). */
     cancelledAt: timestamp('cancelled_at'),
     /** Optional reason provided when the event was cancelled (ROK-374). */

--- a/api/src/notifications/discord-notification.service.ts
+++ b/api/src/notifications/discord-notification.service.ts
@@ -103,7 +103,9 @@ export class DiscordNotificationService {
     }
 
     // Rate limiting (AC-5): check if we already sent this type recently
-    const rateLimitKey = `discord-notif:rate:${input.userId}:${input.type}`;
+    // ROK-489: include reminderWindow in key so each window gets its own rate limit slot
+    const subType = (input.payload?.reminderWindow as string | undefined) ?? '';
+    const rateLimitKey = `discord-notif:rate:${input.userId}:${input.type}${subType ? `:${subType}` : ''}`;
     const recentCount = await this.redis.get(rateLimitKey);
 
     if (recentCount && parseInt(recentCount, 10) > 0) {

--- a/api/src/notifications/event-reminder.service.spec.ts
+++ b/api/src/notifications/event-reminder.service.spec.ts
@@ -318,6 +318,86 @@ describe('EventReminderService', () => {
       );
     });
 
+    it('should send reminders to users without discordId (ROK-489)', async () => {
+      const now = new Date();
+      const soonStart = new Date(now.getTime() + 10 * 60 * 1000);
+      const soonEnd = new Date(soonStart.getTime() + 2 * 60 * 60 * 1000);
+
+      const eventsSelectChain = {
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockResolvedValue([
+            {
+              id: 10,
+              title: 'Raid Night',
+              duration: [soonStart, soonEnd] as [Date, Date],
+              gameId: null,
+              reminder15min: true,
+              reminder1hour: false,
+              reminder24hour: false,
+              cancelledAt: null,
+            },
+          ]),
+        }),
+      };
+
+      const signupsSelectChain = {
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockResolvedValue([
+            { eventId: 10, userId: 1 },
+            { eventId: 10, userId: 2 },
+          ]),
+        }),
+      };
+
+      // User 1 has Discord linked, User 2 does NOT
+      const usersSelectChain = {
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockResolvedValue([
+            { id: 1, discordId: 'discord-1' },
+            { id: 2, discordId: null },
+          ]),
+        }),
+      };
+
+      const charsSelectChain = {
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockResolvedValue([]),
+        }),
+      };
+
+      mockDb.select
+        .mockReturnValueOnce(eventsSelectChain)
+        .mockReturnValueOnce(signupsSelectChain)
+        .mockReturnValueOnce(usersSelectChain)
+        .mockReturnValueOnce(charsSelectChain);
+
+      const trackingRow = {
+        id: 1,
+        eventId: 10,
+        userId: 1,
+        reminderType: '15min',
+        sentAt: new Date(),
+      };
+      mockDb.insert.mockReturnValue({
+        values: jest.fn().mockReturnValue({
+          onConflictDoNothing: jest.fn().mockReturnValue({
+            returning: jest.fn().mockResolvedValue([trackingRow]),
+          }),
+        }),
+      });
+
+      await service.handleReminders();
+
+      // Both users should receive notifications — including user 2 without Discord
+      expect(mockNotificationService.create).toHaveBeenCalledTimes(2);
+      expect(mockNotificationService.create).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 1 }),
+      );
+      expect(mockNotificationService.create).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 2 }),
+      );
+    });
+
     it('should not send reminders when window is disabled for event', async () => {
       const now = new Date();
       const soonStart = new Date(now.getTime() + 10 * 60 * 1000);

--- a/api/src/notifications/event-reminder.service.ts
+++ b/api/src/notifications/event-reminder.service.ts
@@ -203,7 +203,7 @@ export class EventReminderService {
 
       for (const userId of userIds) {
         const user = userMap.get(userId);
-        if (!user?.discordId) continue; // No Discord linked — skip
+        if (!user) continue; // User not found — skip
 
         // Find user's character for this event's game
         const userChars = charsByUser.get(userId) ?? [];


### PR DESCRIPTION
## Summary

Fixes 4 bugs preventing event creators from receiving reminder notifications:

- **Discord-linked gate** (`event-reminder.service.ts:206`): `if (!user?.discordId) continue` blocked ALL notifications (including in-app) for users without Discord linked. Changed to `if (!user) continue` since `notificationService.create()` already handles Discord routing independently.
- **Default reminder flags** (`events.ts`, `event-plans.ts`): Only `reminder15min` defaulted to `true`. Changed `reminder1hour` and `reminder24hour` to also default to `true` for new events.
- **JWT strategy missing discordId** (`jwt.strategy.ts`): `validate()` only selected `role` from DB, so `req.user.discordId` was always `undefined`. This caused `/notifications/channels` to return `available: false`, hiding the Discord column in notification preferences UI and showing "Link your Discord account" even when Discord was linked.
- **Rate limiter key collision** (`discord-notification.service.ts`): Rate limit key was `discord-notif:rate:${userId}:event_reminder` for all 3 reminder windows. Only 1 Discord DM per 5-minute window could send. Now includes `payload.reminderWindow` in the key so each window (15min, 1h, 24h) gets its own rate limit slot.

## Test plan

- [x] New test: users without `discordId` still receive in-app notifications
- [x] All 1579 API tests pass with coverage
- [x] All 1529 web tests pass with coverage
- [x] Build and lint pass (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)