### PR TITLE
fix: start API server in CI smoke tests and restore login form assertion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,23 @@ jobs:
       - name: Run database migrations
         run: npm run db:migrate -w api
 
+      - name: Start API server
+        run: node api/dist/main.js &
+        env:
+          PORT: '3000'
+
+      - name: Wait for API to be ready
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:3000/system/status > /dev/null 2>&1; then
+              echo "API is ready"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "API failed to start within 30s"
+          exit 1
+
       - name: Run Playwright smoke tests
         run: npx playwright test --reporter=github
 

--- a/scripts/verify-ui.spec.ts
+++ b/scripts/verify-ui.spec.ts
@@ -19,8 +19,9 @@ test.describe('Authentication', () => {
     test('login page loads and renders form', async ({ page }) => {
         await page.goto('/login', { waitUntil: 'networkidle' });
         await expect(page).toHaveTitle(/Raid Ledger|Login/i);
-        // Page should not crash (error boundary)
-        await expect(page.locator('body')).not.toHaveText(/something went wrong/i);
+        // Should render at least one interactive element (button or link)
+        const loginAction = page.locator('button, a[href*="discord"], a[href*="auth"]').first();
+        await expect(loginAction).toBeVisible({ timeout: 10_000 });
     });
 
     test('demo admin can log in (DEMO_MODE)', async ({ page }) => {


### PR DESCRIPTION
## Summary

PRs #259–#261 progressively weakened the login smoke test instead of fixing the root cause: the CI smoke-tests job builds the API and runs migrations but never starts the server. The login page's `useSystemStatus()` call fails without the API, preventing form elements from rendering.

- Start the API server in the background before Playwright runs
- Restore the original assertion that checks for actual interactive elements

## Test plan
- [x] CI smoke-tests job should now start the API before running Playwright
- [x] Login smoke test restored to check for actual form elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>