### PR TITLE
fix: correct API dist path in CI smoke tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
         run: npm run db:migrate -w api
 
       - name: Start API server
-        run: node api/dist/main.js &
+        run: node api/dist/src/main.js &
         env:
           PORT: '3000'
 


### PR DESCRIPTION
## Summary

`nest build` outputs to `api/dist/src/main.js` (because `sourceRoot` is `"src"` in `nest-cli.json`), not `api/dist/main.js`. PR #262 introduced the API server startup step with the wrong path.

One-line fix: `api/dist/main.js` → `api/dist/src/main.js`

## Test plan
- [x] Verified locally: `ls api/dist/src/main.js` exists after `npm run build -w api`
- [x] `api/dist/main.js` does NOT exist — confirmed root cause of smoke test failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>