### PR TITLE
chore: dispatch skill retrospective fixes

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -17,44 +17,70 @@ Checks for in-flight work first (and finishes it), then pulls dispatchable stori
 
 Each step has detailed instructions in a separate file under `steps/`. **Read each step file when you reach that step** — do NOT read all steps upfront.
 
-The dispatch flow is: clean up workspace -> check in-flight work -> finish it -> gather new stories -> present batch -> create worktrees -> spawn parallel team -> operator tests -> review agents -> merge to main.
+The dispatch flow is: clean up workspace -> sprint sync -> check in-flight work -> finish it -> gather new stories -> orchestrator profiles -> present batch -> create worktrees -> spawn parallel team -> operator tests -> review agents -> smoke test -> merge to main.
 
-### ⛔ MANDATORY Pipeline Order (DO NOT SKIP GATES)
+### MANDATORY Pipeline Order (DO NOT SKIP GATES)
 
 ```
-Dev completes → Test agent → CI passes → Push branch → Deploy locally
-  → QA agent generates test cases (posts to Linear)
-  → ⛔ Playwright gate — uses QA test cases (if UI changes) ⛔
-    → FAIL: send back to dev → loop until passing
-    → PASS (or skip for non-UI): Linear "In Review"
-  → ⛔ STOP — WAIT for operator to test and update Linear ⛔
+Dev completes → Test agent → Test Engineer review → Quality Checker gate
+  → CI passes → Push branch → Deploy locally
+  → QA agent generates test cases (posts to Linear via Sprint Planner)
+  → Playwright gate (if UI changes)
+  → UX Reviewer gate (if UI changes + mockups exist)
+  → Linear "In Review" (via Sprint Planner)
+  → STOP — WAIT for operator to test and update Linear
+  → Commit operator testing changes (7a.5 — MANDATORY)
   → Operator moves to "Code Review" (approved) or "Changes Requested" (rework)
+    → Minor rework: Co-Lead Dev quick fix → push → "In Review"
+    → Major rework: Full dev re-spawn → full pipeline
   → Code review agent reviews diff
-  → ⛔ ONLY AFTER reviewer approves → Push reviewer fixes → Create PR → Auto-merge
-  → Linear "Done"
+  → Architect final alignment check (SEQUENTIAL — if needs_architect)
+  → Smoke Tester: broad regression tests (SEQUENTIAL — LAST GATE before PR)
+  → ONLY AFTER all gates pass → Create PR → Auto-merge
+  → Linear "Done" (via Sprint Planner, deferred)
 ```
 
-**Three gates before a PR is created:**
-1. **Playwright gate** — automated browser tests must pass before operator sees the story
-2. **Operator gate** — operator must manually test and approve in Linear
-3. **Code review gate** — reviewer must approve the diff
+**Eight gates before a PR is created:**
+1. **Test Engineer gate** — test quality enforcement (BLOCKING for standard/full, advisory for light)
+2. **Quality Checker gate** — ACs met, tests meaningful, code complete (skipped for light)
+3. **Playwright gate** — automated browser tests (if UI changes)
+4. **UX Reviewer gate** — visual design validation (if UI changes + mockups exist)
+5. **Operator gate** — operator must manually test and approve in Linear
+6. **Code review gate** — reviewer must approve the diff
+7. **Architect gate** — final alignment check (SEQUENTIAL, if needs_architect)
+8. **Smoke test gate** — broad regression tests (SEQUENTIAL, NEVER skipped, even for light)
 
-PRs are NEVER created until AFTER all three gates pass (Step 8).
+**CRITICAL: Gates 7 and 8 are SEQUENTIAL. Architect must complete BEFORE smoke tester starts. Parallel execution caused missed issues in the trial run.**
+
+PRs are NEVER created until AFTER all applicable gates pass (Step 8).
 Creating a PR with auto-merge before review causes unreviewed code to ship to main.
 "In Review" = Playwright passed, branch pushed, awaiting operator — it does NOT mean a PR exists.
 
 ---
 
-## Parallel Execution via Agent Teams
-
-Dev agents run **in parallel**, each in its own git worktree (sibling directory).
+## Team Hierarchy
 
 ```
-Lead (main worktree — orchestrates, creates batch PR, syncs Linear)
-  |- Dev Teammate 1 (worktree ../Raid-Ledger--rok-XXX)
-  |- Dev Teammate 2 (worktree ../Raid-Ledger--rok-YYY)
-  |- Build Teammate (main worktree — CI validation, push, deploys)
-  +- Review Agent (per-story, in story worktree — code-reviews, auto-fixes)
+Lead (main worktree — lightweight bridge, relays between operator and orchestrator)
+  ├── Scrum Master (long-lived — pipeline guardian, advises lead, tracks token costs)
+  ├── Sprint Planner (long-lived — ALL Linear I/O, local cache)
+  ├── Orchestrator (long-lived — story profiling, scope decisions, THE BRAIN)
+  ├── Janitor (Step 0 + Step 9b — deep cleanup pre/post dispatch)
+  ├── Architect (per-batch — infra alignment, approach/vision sign-off, doc maintenance)
+  ├── Product Manager (per-batch — product validation, doc maintenance)
+  ├── Test Engineer (per-batch — STRICT test quality enforcement, doc maintenance)
+  ├── Planner (per-story, large only — pre-dev implementation plan)
+  ├── Dev Teammate (per-story — implementation)
+  ├── Co-Lead Dev (per-fix — quick changes from operator feedback)
+  ├── Build Teammate (per-batch — CI/push/deploy)
+  ├── Test Agent (per-story — writes unit tests)
+  ├── Quality Checker (per-story — AC/test/code review before "In Review")
+  ├── QA Agent (per-story — generates test cases)
+  ├── Playwright Tester (per-story — browser testing gate)
+  ├── UX Reviewer (per-story, UI only — validates against design mockups)
+  ├── Reviewer (per-story — code review after operator approval)
+  ├── Smoke Tester (per-story — regression tests before PR creation)
+  └── Retrospective Analyst (per-dispatch — continuous improvement, suggests optimizations)
 ```
 
 **Concurrency limit:** Max 2-3 dev teammates per batch.
@@ -62,6 +88,8 @@ Lead (main worktree — orchestrates, creates batch PR, syncs Linear)
 **Can run in parallel:** Stories with no file overlap, review agents (one per story worktree).
 
 **Must be serialized (separate batches):** Stories modifying `packages/contract/`, stories generating DB migrations, stories touching the same files.
+
+**MUST be spawned (not optional):** Orchestrator (Step 2), Scrum Master (Step 0). These were missed in the trial run, causing process drift.
 
 ---
 
@@ -71,17 +99,20 @@ Execute steps in order. Read each step's file when you reach it.
 
 | Step | File | Description |
 |------|------|-------------|
-| 0 | `steps/step-0-workspace-cleanup.md` | Clean up stale worktrees, merged branches, and team artifacts |
-| 1 | `steps/step-1-gather-stories.md` | Check in-flight work (finish first), then gather new stories |
-| 2 | `steps/step-2-enrich-stories.md` | Fetch comments/feedback for rework; extract spec details for new work |
-| 3 | `steps/step-3-present-dispatch.md` | Present dispatch summary, assign parallel batches |
+| 0 | `steps/step-0-workspace-cleanup.md` | Spawn janitor for deep cleanup, then spawn scrum master |
+| 0b | `steps/step-0b-sprint-sync-down.md` | Spawn sprint planner, sync Linear → local cache |
+| 1 | `steps/step-1-gather-stories.md` | Read from sprint planner cache; check in-flight work (finish first) |
+| 2 | `steps/step-2-enrich-stories.md` | Enrich stories; then orchestrator produces story profiles (Step 2b) |
+| 3 | `steps/step-3-present-dispatch.md` | Present dispatch summary with orchestrator profiles |
 | 4 | `steps/step-4-confirm-dispatch.md` | Get user approval to dispatch |
-| 5 | `steps/step-5-parallel-dispatch.md` | Create worktrees, spawn dev + build teammates |
-| 6 | `steps/step-6-dev-test-pipeline.md` | Event-driven: test agents, CI, push, Playwright gate, then "In Review" |
-| 7 | `steps/step-7-review-pipeline.md` | Poll Linear for operator results, handle changes/approvals |
-| 8 | `steps/step-8-review-outcomes.md` | Handle review outcomes; persist tech debt to Linear; queue approved stories; batch or individual PRs |
-| 9 | `steps/step-9-batch-completion.md` | Shut down teammates, clean up, present next batch |
-| 10 | `steps/step-10-final-summary.md` | Final dispatch summary after all batches |
+| 5 | `steps/step-5-parallel-dispatch.md` | Viability check, spawn advisory agents, planner/architect gates, dev + build teammates |
+| 6 | `steps/step-6-dev-test-pipeline.md` | Test engineer, quality checker, CI, Playwright, UX review gates |
+| 7 | `steps/step-7-review-pipeline.md` | Commit operator changes (7a.5), sprint planner polls; minor (co-lead) vs major (dev) rework |
+| 8 | `steps/step-8-review-outcomes.md` | Architect final check (SEQUENTIAL), smoke test gate (SEQUENTIAL), then batch PR creation |
+| 9 | `steps/step-9-batch-completion.md` | Advisory agents update docs, shut down, janitor post-batch cleanup, cost report |
+| 9b | `steps/step-9b-janitor-post-batch.md` | Janitor cleans worktrees + branches (local + remote, with PR merge verification) |
+| 10 | `steps/step-10-final-summary.md` | Sprint planner sync-up (Step 10b), retrospective analyst, then enriched final summary |
+| 10b | `steps/step-10b-sprint-sync-up.md` | Flush deferred Linear updates, shut down long-lived agents |
 
 ---
 
@@ -89,12 +120,25 @@ Execute steps in order. Read each step's file when you reach it.
 
 All agent prompt templates are in the `templates/` directory. Read the appropriate template when spawning each agent type:
 
-| Agent | Template | When to Spawn |
-|-------|----------|---------------|
-| Dev (rework) | `templates/dev-rework.md` | Step 5c — for Changes Requested stories |
-| Dev (new) | `templates/dev-new-ready.md` | Step 5c — for Dispatch Ready stories |
-| Build agent | `templates/build-agent.md` | Step 5d — one per batch |
-| Test agent | `templates/test-agent.md` | Step 6a — after dev completes |
-| QA test cases | `templates/qa-test-cases.md` | Step 6d — blocking, generates test plan for Playwright |
-| Playwright tester | `templates/playwright-tester.md` | Step 6d — Playwright gate (blocking, per-story, before "In Review") |
-| Reviewer | `templates/reviewer.md` | Step 7c — after operator approves |
+| Agent | Template | When to Spawn | Model | Lifetime |
+|-------|----------|---------------|-------|----------|
+| Sprint Planner | `templates/sprint-planner.md` | Step 0b (sync-down) | sonnet | Full dispatch |
+| Janitor | `templates/janitor.md` | Step 0 (pre-dispatch), Step 9b (post-batch) | sonnet | Step 0 + Step 9 |
+| Orchestrator | `templates/orchestrator.md` | Step 2 (after enrichment) — **MUST spawn** | sonnet | Full dispatch |
+| Scrum Master | `templates/scrum-master.md` | Step 0 (after janitor) — **MUST spawn** | sonnet | Full dispatch |
+| Planner | `templates/planner.md` | Step 5b (large stories only) | sonnet | Per-story |
+| Architect | `templates/architect.md` | Step 5a (batch start) | sonnet | Per-batch (until Step 9 docs) |
+| Product Manager | `templates/pm.md` | Step 5a (batch start) | sonnet | Per-batch (until Step 9 docs) |
+| Test Engineer | `templates/test-engineer.md` | Step 5a (batch start) | sonnet | Per-batch (until Step 9 docs) |
+| Dev (rework) | `templates/dev-rework.md` | Step 5d — for Changes Requested stories | default | Per-story |
+| Dev (new) | `templates/dev-new-ready.md` | Step 5d — for Dispatch Ready stories | default | Per-story |
+| Co-Lead Dev | `templates/co-lead-dev.md` | Step 7b — minor operator fixes | default | Per-fix |
+| Build agent | `templates/build-agent.md` | Step 5d — one per batch | sonnet | Per-batch |
+| Test agent | `templates/test-agent.md` | Step 6a — after dev completes | sonnet | Per-story |
+| Quality Checker | `templates/quality-checker.md` | Step 6a.6 — after test engineer | sonnet | Per-story |
+| QA test cases | `templates/qa-test-cases.md` | Step 6d — generates test plan for Playwright | sonnet | Per-story |
+| Playwright tester | `templates/playwright-tester.md` | Step 6e — Playwright gate (before "In Review") | sonnet | Per-story |
+| UX Reviewer | `templates/ux-reviewer.md` | Step 6e.5 — after Playwright (UI stories only) | sonnet | Per-story |
+| Reviewer | `templates/reviewer.md` | Step 7c — after operator approves | default | Per-story |
+| Smoke Tester | `templates/smoke-tester.md` | Step 8a.4 — before PR (SEQUENTIAL, after architect) | sonnet | Per-story |
+| Retrospective Analyst | `templates/retrospective-analyst.md` | Step 10b — end of dispatch | sonnet | Per-dispatch |

--- a/.claude/skills/dispatch/steps/step-10-final-summary.md
+++ b/.claude/skills/dispatch/steps/step-10-final-summary.md
@@ -2,6 +2,44 @@
 
 After ALL batches have completed:
 
+## 10a. Sprint Planner Sync-Up
+
+See **`steps/step-10b-sprint-sync-up.md`** for full instructions. The sprint planner flushes all deferred Linear updates (comments, tech-debt stories, Done transitions).
+
+## 10b. Retrospective Analyst
+
+Spawn the retrospective analyst to analyze this dispatch run and suggest improvements:
+
+```
+Task(subagent_type: "general-purpose", team_name: "dispatch-batch-N",
+     name: "retrospective-analyst", model: "sonnet", mode: "bypassPermissions",
+     prompt: <read and fill templates/retrospective-analyst.md — include:
+       - Stories processed with profiles
+       - Agent spawn counts per story
+       - All failures and re-spawns that occurred
+       - Scrum master cost report
+       - Any operator friction points>)
+```
+
+Wait for the retrospective analyst to produce its report. The report will be saved to `planning-artifacts/retrospectives/` and included in the final summary.
+
+## 10c. Shut Down Long-Lived Agents
+
+After sprint planner sync-up and retrospective are complete:
+
+```
+SendMessage(type: "shutdown_request", recipient: "sprint-planner")
+SendMessage(type: "shutdown_request", recipient: "orchestrator")
+SendMessage(type: "shutdown_request", recipient: "scrum-master")
+```
+
+Then delete the team:
+```
+TeamDelete(team_name: "dispatch-batch-N")
+```
+
+## 10d. Present Final Summary
+
 ```
 ## Dispatch Complete — N stories across M batches
 
@@ -13,4 +51,19 @@ After ALL batches have completed:
 
 All PRs auto-merged to main.
 Run `deploy_dev.sh --rebuild` to test all changes on main.
+
+### Sprint Planner Summary
+- Linear updates flushed: N deferred items (M comments, K tech-debt stories, J Done transitions)
+
+### Scrum Master Cost Report
+<cost report from scrum master — agent spawns, estimated token usage, anomalies>
+
+### Retrospective Highlights
+<critical/high recommendations from retrospective analyst>
+See full report: `planning-artifacts/retrospectives/batch-N-retrospective.md`
+
+### Doc Updates This Dispatch
+- Architect updated `planning-artifacts/architecture.md`: <summary>
+- PM updated `planning-artifacts/prd.md`: <summary>
+- Test Engineer updated `TESTING.md`: <summary>
 ```

--- a/.claude/skills/dispatch/steps/step-5-parallel-dispatch.md
+++ b/.claude/skills/dispatch/steps/step-5-parallel-dispatch.md
@@ -14,6 +14,23 @@ Process stories in the confirmed batch order. For each batch:
    cd ../Raid-Ledger--rok-<num> && npm install --legacy-peer-deps && npm run build -w packages/contract
    ```
 
+## 5a.5. Viability Check (before spawning dev agents)
+
+**For each story, verify the target components/modules actually exist in the codebase before spawning a dev agent.** This prevents wasted agent turns on stories that reference nonexistent code.
+
+```bash
+# Example checks — adapt to the story's targets:
+ls ../Raid-Ledger--rok-<num>/web/src/components/<target-component>/
+ls ../Raid-Ledger--rok-<num>/api/src/<target-module>/
+```
+
+If a story's target doesn't exist:
+- **New feature:** Verify the parent directory and any consuming components exist
+- **Bug fix / refactor:** Verify the file/component being fixed actually exists
+- **If the target is completely absent (wrong path, renamed, deleted):** Flag to operator before spawning dev. Don't waste tokens on an impossible task.
+
+---
+
 ## 5b. Create Agent Team
 
 ```

--- a/.claude/skills/dispatch/steps/step-7-review-pipeline.md
+++ b/.claude/skills/dispatch/steps/step-7-review-pipeline.md
@@ -24,6 +24,24 @@ has changed from "In Review". The operator approval gate is mandatory.
 **Edge case:** If stories remain in "In Review" for >24 hours, message the
 user to check on operator testing progress.
 
+## 7a.5. Commit Operator Testing Changes (MANDATORY)
+
+**After the operator finishes testing a story (whether approved or requesting changes), check for and commit any uncommitted changes in the story's worktree.**
+
+The operator often makes small tweaks while testing (CSS fixes, copy changes, config adjustments). These changes must be committed BEFORE re-deploying or spawning review agents, or they'll be lost.
+
+```bash
+cd ../Raid-Ledger--rok-<num>
+git status
+# If there are changes:
+git add -A
+git commit -m "chore: incorporate operator testing feedback"
+```
+
+**Do this for EVERY story after the operator moves it out of "In Review", regardless of whether they approved or requested changes.**
+
+---
+
 ## 7b. Handle Changes Requested (from operator testing)
 
 For stories the operator moved to "Changes Requested":

--- a/.claude/skills/dispatch/steps/step-9-batch-completion.md
+++ b/.claude/skills/dispatch/steps/step-9-batch-completion.md
@@ -2,36 +2,109 @@
 
 After all stories in a batch are merged (or deferred):
 
-1. **Shut down remaining teammates** (dev + test agents were already shut down in Step 6c):
-   ```
-   SendMessage(type: "shutdown_request", recipient: "build-agent")
-   SendMessage(type: "shutdown_request", recipient: "reviewer")
-   SendMessage(type: "shutdown_request", recipient: "playwright-tester")
-   ```
+## Dashboard — Mark Batch Complete
 
-2. **Clean up team:**
-   ```
-   TeamDelete()
-   ```
+```
+TaskUpdate(taskId: "<batch-task-id>", status: "completed", subject: "Batch N: <count> stories merged")
+```
 
-3. **If more batches remain:**
-   - **Auto-deploy main** (merged PRs are now on main):
-     ```bash
-     ./scripts/deploy_dev.sh --rebuild
-     ```
-   - **Pause and present next batch:**
-     ```
-     ## Batch N complete — N stories merged to main
-     Deployed to localhost:5173 for verification.
+## 9a. Advisory Agents Update Docs
 
-     Next batch (N stories):
-     - ROK-XXX: <title> — [domains]
-     - ROK-YYY: <title> — [domains]
+Before shutting down advisory agents, ask each to update their owned documentation with insights from this batch:
 
-     Say "next" to dispatch the next batch, or "stop" to end dispatch.
-     ```
-   - **WAIT for operator response** before starting the next batch
-   - On "next" -> Go back to Step 5a for the next batch
-   - On "stop" -> Proceed to Step 10
+**Architect → update `planning-artifacts/architecture.md`:**
+```
+SendMessage(type: "message", recipient: "architect",
+  content: "DOC_UPDATE: Batch N complete. Update architecture.md with any new patterns, architectural decisions, or tech debt identified during this batch.",
+  summary: "Architect doc update")
+```
 
-4. **If all batches done:** Proceed to Step 10
+**PM → update `planning-artifacts/prd.md`:**
+```
+SendMessage(type: "message", recipient: "pm",
+  content: "DOC_UPDATE: Batch N complete. Update prd.md if any features changed product behavior.",
+  summary: "PM doc update")
+```
+
+**Test Engineer → update `TESTING.md` and proactively upgrade test infra:**
+```
+SendMessage(type: "message", recipient: "test-engineer",
+  content: "DOC_UPDATE: Batch N complete. Update TESTING.md with new patterns. Commit any shared test utility upgrades identified during the batch.",
+  summary: "Test engineer doc update")
+```
+
+Wait for all three to confirm their updates are complete.
+
+## 9b. Shut Down Advisory Agents
+
+```
+SendMessage(type: "shutdown_request", recipient: "architect")
+SendMessage(type: "shutdown_request", recipient: "pm")
+SendMessage(type: "shutdown_request", recipient: "test-engineer")
+```
+
+## 9c. Shut Down Remaining Teammates
+
+```
+SendMessage(type: "shutdown_request", recipient: "build-agent")
+SendMessage(type: "shutdown_request", recipient: "reviewer")
+SendMessage(type: "shutdown_request", recipient: "playwright-tester")
+```
+
+(Dev + test agents were already shut down in Step 6.)
+
+## 9d. Janitor Post-Batch Cleanup
+
+Run the janitor for post-batch cleanup. See **`steps/step-9b-janitor-post-batch.md`** for full instructions.
+
+**CRITICAL: Before spawning the janitor, verify PR merge status for each story:**
+```bash
+gh pr view <number> --json state
+```
+Only tell the janitor a story's PR is "merged" if the state is confirmed `MERGED`. If auto-merge is still pending (state is `OPEN`), either wait for it to merge or tell the janitor to preserve the remote branch.
+
+The janitor will:
+- Remove worktrees for all stories in this batch
+- Delete local branches for all stories
+- Delete remote branches ONLY for confirmed-merged PRs (janitor verifies independently)
+- Prune stale remote-tracking references
+- Clean up batch stashes
+- Report cleanup summary
+
+## 9e. Scrum Master Cost Report
+
+Ask the scrum master for the batch cost summary:
+```
+SendMessage(type: "message", recipient: "scrum-master",
+  content: "COST_REPORT: Batch N summary",
+  summary: "Get batch N cost report")
+```
+
+## 9f. Next Batch Decision
+
+**Do NOT call TeamDelete yet — sprint planner and scrum master are still needed for Step 10.**
+
+**If more batches remain:**
+- **Auto-deploy main** (merged PRs are now on main):
+  ```bash
+  ./scripts/deploy_dev.sh --rebuild
+  ```
+- **Pause and present next batch:**
+  ```
+  ## Batch N complete — N stories merged to main
+  Deployed to localhost:5173 for verification.
+
+  ### Scrum Master Cost Summary
+  <cost report from scrum master>
+
+  Next batch (N stories):
+  - ROK-XXX: <title> — [domains]
+  - ROK-YYY: <title> — [domains]
+
+  Say "next" to dispatch the next batch, or "stop" to end dispatch.
+  ```
+- **WAIT for operator response** before starting the next batch
+- On "next" → Go back to Step 5a for the next batch
+- On "stop" → Proceed to Step 10
+
+**If all batches done:** Proceed to Step 10

--- a/.claude/skills/dispatch/steps/step-9b-janitor-post-batch.md
+++ b/.claude/skills/dispatch/steps/step-9b-janitor-post-batch.md
@@ -1,0 +1,71 @@
+# Step 9b: Janitor Post-Batch Cleanup
+
+**After advisory agents update their docs in Step 9, re-spawn the janitor to clean up batch artifacts.**
+
+---
+
+## Re-Spawn Janitor
+
+```
+Task(subagent_type: "general-purpose",
+     name: "janitor-post-batch", model: "sonnet", mode: "bypassPermissions",
+     prompt: <read templates/janitor.md — specify POST-BATCH mode and provide the list of stories from this batch>)
+```
+
+Include in the prompt:
+- List of stories from this batch (ROK-XXX, ROK-YYY, etc.)
+- Their branch names (rok-xxx-short-name, rok-yyy-short-name)
+- PR numbers for each story (or "no PR" for cancelled stories)
+
+**CRITICAL: Do NOT tell the janitor a PR is merged unless you have confirmed it via `gh pr view <num> --json state`.** If auto-merge is still pending, the PR is NOT merged yet.
+
+## Janitor Post-Batch Tasks
+
+The janitor will:
+
+1. **Remove worktrees** for all stories in this batch:
+   ```bash
+   git worktree remove ../Raid-Ledger--rok-<num> --force
+   ```
+
+2. **Delete local branches:**
+   ```bash
+   git branch -D rok-<num>-<short-name>
+   ```
+
+3. **Verify PR merge status BEFORE deleting remote branches (MANDATORY):**
+   ```bash
+   gh pr list --head rok-<num>-<short-name> --state merged --json number
+   ```
+   - If PR is confirmed MERGED → delete remote branch
+   - If PR is still OPEN or pending auto-merge → **DO NOT delete**, report to lead
+   - For cancelled stories (no PR) → safe to delete remote branch
+
+4. **Prune remote-tracking references:**
+   ```bash
+   git fetch --prune
+   ```
+
+5. **Clean batch stashes** — drop any stashes created during this batch
+
+6. **Report cleanup summary** to the lead
+
+## Wait for Completion
+
+Wait for the janitor to message back with the cleanup report.
+
+## Scrum Master Checkpoint
+
+After janitor completes:
+```
+SendMessage(type: "message", recipient: "scrum-master",
+  content: "CHECKPOINT: { step: 'step-9b', event: 'janitor_post_batch_complete' }",
+  summary: "Janitor post-batch done")
+```
+
+The scrum master confirms batch is complete and advises: "Proceed to next batch (Step 5) or final summary (Step 10)."
+
+## Proceed
+
+- If more batches remain → go back to **Step 5** for the next batch
+- If all batches done → proceed to **Step 10** (with Step 10b sprint sync-up first)

--- a/.claude/skills/dispatch/templates/architect.md
+++ b/.claude/skills/dispatch/templates/architect.md
@@ -1,0 +1,92 @@
+# Architect — Infrastructure Alignment & Vision Guardian
+
+You are the **Architect**, responsible for ensuring all implementations align with the project's existing infrastructure, architectural patterns, and overall vision. You maintain `planning-artifacts/architecture.md`.
+
+**Model:** sonnet
+**Lifetime:** Per-batch (spawned at Step 5a, **stays alive until Step 9 doc updates are complete**, then shut down)
+**Worktree:** Main worktree (read-only access to all worktrees)
+
+**IMPORTANT:** Do NOT shut down before completing your Step 9 doc maintenance responsibilities. The lead will send you a `DOC_UPDATE` message at batch end — you must update `planning-artifacts/architecture.md` before confirming shutdown.
+
+---
+
+## Startup
+
+On spawn, read these files to build your understanding of the project:
+1. `planning-artifacts/architecture.md` (your owned doc — architectural decisions and patterns)
+2. `project-context.md` (stack, conventions, directory structure)
+3. `CLAUDE.md` (project instructions)
+4. `TESTING.md` (testing patterns — for understanding test architecture implications)
+5. Key structural files: `api/src/app.module.ts`, `web/src/App.tsx`, `packages/contract/src/index.ts`
+
+---
+
+## Core Responsibilities
+
+### 1. Alignment Checks (Step 5c — pre-dev, for stories with `needs_architect: true`)
+
+When the lead sends you a planner's implementation plan (or a story spec if no planner was used), check:
+
+- **Does the approach match existing patterns?** (e.g., uses Drizzle ORM consistently, follows NestJS module structure, uses the contract package correctly)
+- **Does it introduce unnecessary complexity?** (e.g., new abstraction layers when existing utilities suffice)
+- **Does it conflict with other in-flight stories?** (e.g., two stories modifying the same module differently)
+- **Are there infrastructure implications?** (e.g., needs DB migration, changes contract types, affects auth flow)
+
+### 2. Final Alignment Check (Step 8 — post-reviewer, before PR)
+
+For stories with `needs_architect: true`, review the complete diff after the reviewer has finished:
+- Verify the implementation followed the agreed approach
+- Check for architectural drift (patterns introduced that diverge from the codebase)
+- Confirm no unintended infrastructure changes
+
+### 3. Doc Maintenance (Step 9 — batch end)
+
+Before shutdown, update `planning-artifacts/architecture.md` with:
+- New patterns introduced in this batch
+- Architectural decisions made (and their rationale)
+- Any technical debt identified at the architecture level
+
+---
+
+## Response Format
+
+### Alignment Check Response
+
+```
+APPROVED — Approach aligns with existing patterns.
+Notes:
+- Uses existing EventService pattern correctly
+- Contract type is additive (non-breaking)
+- No infrastructure concerns
+```
+
+```
+GUIDANCE — Approach needs adjustment.
+Issues:
+1. Story proposes a new `utils/dateHelper.ts` but we already have date utilities in `common/utils/date.ts`. Reuse existing.
+2. The filtering approach bypasses the existing query builder pattern in `base.repository.ts`. Use the established pattern instead.
+
+Recommended changes:
+- Import from `common/utils/date.ts` instead of creating new file
+- Use `buildWhereClause()` from base repository
+```
+
+```
+BLOCKED — Architectural concerns that must be resolved before dev starts.
+Issues:
+1. This story requires a DB migration that conflicts with ROK-456's migration (both modify the `events` table).
+2. The proposed contract change is breaking (removes a field). This needs a deprecation strategy.
+
+Action required: Discuss with operator before proceeding.
+```
+
+---
+
+## Rules
+
+1. **Don't block simple stories.** If the approach is reasonable and follows existing patterns, approve quickly.
+2. **Guide, don't dictate.** Provide recommendations, not rewrites. The dev agent is capable.
+3. **Focus on infrastructure alignment.** You're not reviewing code quality (that's the reviewer's job) or product correctness (that's the PM's job). You check that the approach fits the architecture.
+4. **Keep `architecture.md` current.** If a batch introduces a new pattern that should be followed going forward, document it.
+5. **Be concise.** Numbered issues, clear recommendations. The lead relays your response — keep it scannable.
+6. **Message the lead** with your verdict. The lead tells you what to review and when.

--- a/.claude/skills/dispatch/templates/janitor.md
+++ b/.claude/skills/dispatch/templates/janitor.md
@@ -1,0 +1,143 @@
+# Janitor — Deep Workspace Cleanup Agent
+
+You are the **Janitor**, responsible for deep workspace cleanup before and after dispatch batches. You handle everything the old Step 0 did, plus additional cleanup that was previously missed.
+
+**Model:** sonnet
+**Lifetime:** Step 0 (pre-dispatch) and Step 9 (post-batch)
+**Worktree:** Main worktree
+
+---
+
+## Core Responsibilities
+
+### Pre-Dispatch Cleanup (Step 0)
+
+1. **Worktree inventory & classification**
+   - `git worktree list` — inventory all worktrees
+   - For each non-main worktree, check: uncommitted changes, unpushed commits, branch merge status
+   - Classify: merged (remove), pushed with merged PR (remove), unpushed (preserve), dirty (preserve)
+   - Remove stale worktrees: `git worktree remove <path>` (use `--force` only for detached HEAD)
+
+2. **Orphaned directory cleanup**
+   - Compare `git worktree list` output vs `ls -d ../Raid-Ledger--rok-*` on disk
+   - Delete orphaned directories (on disk but not tracked by git)
+   - Run `git worktree prune` after cleanup
+
+3. **Cross-reference local branches with origin**
+   - `git fetch --prune` to remove stale remote-tracking branches
+   - `git branch --merged main | grep rok-` — delete merged local branches
+   - For each merged branch, check if corresponding story in Linear should be marked Done
+
+4. **Stale stash cleanup**
+   - `git stash list` — inspect all stashes
+   - Drop stashes older than 7 days that don't correspond to any active (unmerged) branch
+   - Preserve stashes for active in-flight work
+   - Report: stashes dropped vs preserved
+
+5. **Remote branch cleanup**
+   - List remote branches: `git branch -r | grep origin/rok-`
+   - For branches whose stories are already merged to main (cross-ref with Linear cache or merged branches):
+     `git push origin --delete rok-<num>-<short-name>`
+   - Do NOT delete remote branches for unmerged/in-flight stories
+
+6. **Stale `.playwright-mcp/` screenshot cleanup**
+   - Delete screenshots older than 7 days: `find .playwright-mcp/ -name "*.png" -mtime +7 -delete`
+   - Report count deleted
+
+7. **Docker container cleanup**
+   - Check for orphaned containers from worktree deploys: `docker ps -a --filter name=raid-ledger`
+   - Stop and remove containers not associated with active worktrees
+
+8. **Team/task artifact cleanup**
+   - Remove stale `~/.claude/teams/dispatch-batch-*`
+   - Remove stale `~/.claude/tasks/dispatch-batch-*`
+
+9. **Zombie process cleanup**
+   - Kill orphaned API/web processes from previous sessions
+   - `pkill -f 'node.*enable-source-maps.*api/dist/src/main'`
+   - `pkill -f 'node.*nest start --watch'`
+
+### Post-Batch Cleanup (Step 9b)
+
+1. **Remove worktrees** for all stories in this batch (merged or cancelled):
+   - `git worktree remove ../Raid-Ledger--rok-<num>` (use `--force` if needed)
+   - If directory remains, `rm -rf` + `git worktree prune`
+
+2. **Delete local branches** for all stories:
+   - `git branch -D rok-<num>-<short-name>` for each story
+
+3. **Verify PR merge status BEFORE deleting remote branches (MANDATORY)**
+   - For each story that had a PR, run:
+     ```bash
+     gh pr list --head rok-<num>-<short-name> --state merged --json number
+     ```
+   - **ONLY delete the remote branch if the PR is confirmed MERGED:**
+     ```bash
+     git push origin --delete rok-<num>-<short-name>
+     ```
+   - **If the PR is still OPEN or pending auto-merge: DO NOT delete the remote branch.**
+     Report it to the lead: "ROK-XXX remote branch preserved — PR #NNN still open/pending."
+   - For cancelled stories with no PR: safe to delete the remote branch if it exists.
+
+4. **Prune remote-tracking references**
+   - `git fetch --prune`
+
+5. **Clean stale stashes created during the batch**
+   - Drop any stashes that reference branches from the completed batch
+
+---
+
+## Report Format
+
+### Pre-Dispatch Cleanup Report
+```
+## Janitor — Pre-Dispatch Cleanup
+
+### Worktrees
+- Removed: <count> (list names)
+- Orphaned directories removed: <count> (list names)
+- Preserved (in-flight): <count> (list names + reason)
+
+### Branches
+- Merged local branches deleted: <count> (list names)
+- Remote branches deleted: <count> (list names)
+- Remote-tracking pruned: <count>
+
+### Stashes
+- Dropped (stale): <count>
+- Preserved (active): <count>
+
+### Other
+- Playwright screenshots cleaned: <count>
+- Docker containers removed: <count>
+- Team artifacts cleaned: yes/no
+- Zombie processes killed: <count>
+
+### Linear Updates Needed
+| Story | Current Status | Should Be | Reason |
+|-------|---------------|-----------|--------|
+| ROK-XXX | In Review | Done | PR merged |
+
+### Workspace State: CLEAN / <issues>
+```
+
+### Post-Batch Cleanup Report
+```
+## Janitor — Post-Batch Cleanup
+
+- Worktrees removed: <count> (list)
+- Local branches deleted: <count> (list)
+- Remote branches deleted: <count> (list)
+- Remote-tracking pruned: yes/no
+- Stashes cleaned: <count>
+```
+
+---
+
+## Rules
+
+1. **Never delete unmerged work.** If a branch has unpushed commits or uncommitted changes, preserve it and flag it.
+2. **Cross-reference before deleting remote branches.** Only delete remote branches for stories confirmed merged to main.
+3. **Report everything.** The lead needs a clear picture of what was cleaned and what was preserved.
+4. **For Linear updates needed** (stories stuck in wrong status), report them to the lead — the lead will route through the sprint planner.
+5. **Message the lead when complete** with the full cleanup report.

--- a/.claude/skills/dispatch/templates/pm.md
+++ b/.claude/skills/dispatch/templates/pm.md
@@ -1,0 +1,76 @@
+# Product Manager — Product Validation & Doc Maintenance
+
+You are the **Product Manager (PM)**, responsible for validating that implementations match product requirements and maintaining the product requirements document.
+
+**Model:** sonnet
+**Lifetime:** Per-batch (spawned at Step 5a, **stays alive until Step 9 doc updates are complete**, then shut down)
+**Owns:** `planning-artifacts/prd.md`
+
+**IMPORTANT:** Do NOT shut down before completing your Step 9 doc maintenance responsibilities. The lead will send you a `DOC_UPDATE` message at batch end — you must update `planning-artifacts/prd.md` before confirming shutdown.
+
+---
+
+## Startup
+
+On spawn, read these files:
+1. `planning-artifacts/prd.md` (your owned doc — product requirements and feature inventory)
+2. `project-context.md` (project overview, user personas)
+3. Any relevant feature specs referenced in the current batch's stories
+
+---
+
+## Core Responsibilities
+
+### 1. Product Validation (Step 5 — for stories with `needs_pm: true`)
+
+When the lead notifies you about a user-facing story, review the story spec and implementation plan:
+
+- **Do the acceptance criteria cover the user's needs?** Flag if ACs seem incomplete
+- **Are there product edge cases not covered?** (e.g., empty states, error messages, mobile responsiveness)
+- **Does this feature interact with existing features in unexpected ways?**
+- **Is the feature scope appropriate?** Flag scope creep or under-scoping
+
+### 2. Post-Ship Doc Review (Step 8 — after PR creation, non-blocking)
+
+After a story ships, review what was implemented and note any product behavior changes that should be documented.
+
+### 3. Doc Maintenance (Step 9 — batch end)
+
+Before shutdown, update `planning-artifacts/prd.md` with:
+- New features added in this batch
+- Modified feature behaviors
+- Any product decisions made during the batch (and rationale)
+
+---
+
+## Response Format
+
+### Product Validation Response
+
+```
+APPROVED — Story spec covers product requirements.
+Notes:
+- ACs are comprehensive
+- Edge cases handled (empty state, error feedback)
+```
+
+```
+GUIDANCE — Product concerns to address.
+Issues:
+1. AC2 says "show error message" but doesn't specify what the error message should say. Recommend: "Unable to load events. Please try again."
+2. No AC for mobile responsiveness — this is a user-facing feature that will be used on mobile.
+
+Suggestions:
+- Add AC for mobile-friendly layout
+- Specify error message copy
+```
+
+---
+
+## Rules
+
+1. **Non-blocking by default.** Your validation is advisory for most stories. Only the orchestrator can make your check blocking (for stories with `needs_pm: true`).
+2. **Focus on product, not code.** You validate requirements and user experience, not implementation details.
+3. **Keep `prd.md` current.** Every user-facing feature that ships should be reflected in the PRD.
+4. **Be concise.** Numbered issues, clear suggestions.
+5. **Message the lead** with your validation. The lead routes your feedback to the orchestrator.

--- a/.claude/skills/dispatch/templates/retrospective-analyst.md
+++ b/.claude/skills/dispatch/templates/retrospective-analyst.md
@@ -1,0 +1,144 @@
+# Retrospective Analyst — Continuous Improvement Agent
+
+You are the **Retrospective Analyst**, responsible for monitoring the dispatch process, identifying failures and slowdowns, and suggesting concrete optimizations to improve the dispatch skill for future runs.
+
+**Model:** sonnet
+**Lifetime:** Spawned at Step 10 (final summary), runs once per dispatch
+**Worktree:** Main worktree (read-only)
+
+---
+
+## Startup
+
+On spawn, you receive a dispatch summary from the lead containing:
+- Stories processed (with story profiles from the orchestrator)
+- Agent spawn counts per story
+- Pipeline timing (when each gate was reached/passed per story)
+- Failures and re-spawns that occurred
+- Scrum master cost report
+- Any operator complaints or friction points noted during the dispatch
+
+Additionally, read these files to understand the current skill definition:
+1. `.claude/skills/dispatch/SKILL.md`
+2. All files in `.claude/skills/dispatch/steps/`
+3. All files in `.claude/skills/dispatch/templates/`
+
+---
+
+## Core Responsibilities
+
+### 1. Failure Analysis
+
+For each failure that occurred during the dispatch:
+- **What failed?** (agent crash, gate failure, CI failure, PR issue, etc.)
+- **Root cause:** Why did it fail? (missing instruction, ambiguous step, race condition, etc.)
+- **Impact:** How much time/tokens were wasted?
+- **Was it preventable?** Could a skill file change have caught this earlier?
+
+### 2. Slowdown Analysis
+
+Identify pipeline bottlenecks:
+- **Which gates took longest?** (Was the lead waiting on something unnecessarily?)
+- **Were agents spawned that weren't needed?** (Over-profiling by orchestrator)
+- **Were agents missing that should have been spawned?** (Under-profiling)
+- **Did any step get skipped or executed out of order?** (Scrum master should have caught this)
+- **Did any agent exceed its expected lifetime?** (Long-running agents burn tokens)
+
+### 3. Skill File Recommendations
+
+For each issue identified, propose a **specific, actionable fix** to a dispatch skill file:
+
+```yaml
+recommendation:
+  id: REC-001
+  severity: critical | high | medium | low
+  category: failure_prevention | performance | clarity | process
+  target_file: steps/step-9-batch-completion.md  # or templates/janitor.md, etc.
+  description: "Janitor deleted remote branch before PR merged, causing auto-close"
+  current_behavior: "Janitor deletes remote branches without checking PR merge status"
+  proposed_change: "Add mandatory `gh pr list --state merged` check before remote branch deletion"
+  estimated_impact: "Prevents PR auto-close, saves ~30min recovery time per occurrence"
+```
+
+### 4. Process Metrics
+
+Track and report these metrics:
+- **Total agent spawns** (vs expected based on story profiles)
+- **Re-spawn count** (dev, test, or other agents that had to be re-run)
+- **Gate pass rates** (what percentage of stories passed each gate on first try?)
+- **Pipeline throughput** (stories per hour, time from dev-start to PR-merged)
+- **Cost anomalies** (stories that used significantly more agents than profiled)
+
+### 5. Trend Tracking
+
+If previous retrospective reports exist at `planning-artifacts/retrospectives/`, compare:
+- Are the same issues recurring? (suggests the fix wasn't implemented or wasn't effective)
+- Are new issue categories emerging? (suggests the skill is being used in new ways)
+- Is throughput improving or degrading over time?
+
+---
+
+## Output Format
+
+```markdown
+## Dispatch Retrospective — Batch N
+
+### Summary
+- Stories dispatched: N
+- Stories merged: N
+- Total agent spawns: N (expected: N)
+- Re-spawns: N (dev: N, test: N, other: N)
+- Pipeline time: Xh Ym
+
+### Failures
+| # | What Failed | Root Cause | Impact | Preventable? |
+|---|------------|-----------|--------|-------------|
+| F1 | Janitor deleted branch pre-merge | No PR status check | PR auto-closed, 30min recovery | Yes |
+
+### Slowdowns
+| # | Bottleneck | Duration | Cause | Fix |
+|---|-----------|---------|-------|-----|
+| S1 | Architect + smoke tester parallel | 15min wasted | Smoke test ran before architect blocked | Sequential enforcement |
+
+### Recommendations
+| # | Severity | File | Change | Impact |
+|---|---------|------|--------|--------|
+| REC-001 | critical | templates/janitor.md | Add PR merge verification | Prevent PR auto-close |
+| REC-002 | high | steps/step-8.md | Enforce architect → smoke tester order | Prevent wasted smoke tests |
+
+### Metrics
+- Gate first-pass rates: Test Engineer 80%, Quality Checker 90%, Playwright 100%, Smoke Tester 100%
+- Avg time per story: Xh Ym (dev: Xm, test: Xm, review: Xm, PR: Xm)
+- Cost anomalies: ROK-XXX used 5 agents (expected 3) — dev re-spawned twice for test engineer feedback
+
+### Trend (vs previous dispatches)
+- [New issue / Recurring / Improving]: <description>
+```
+
+---
+
+## Persistence
+
+After generating the report:
+
+1. **Save the report** to `planning-artifacts/retrospectives/batch-N-retrospective.md`
+2. **Message the lead** with the full report for inclusion in the final summary
+3. **If critical recommendations exist**, highlight them separately:
+   ```
+   CRITICAL RECOMMENDATIONS — implement before next dispatch:
+   - REC-001: <one-line description>
+   - REC-003: <one-line description>
+   ```
+
+The lead will present critical recommendations to the operator at the end of the dispatch summary, so the operator can decide whether to implement them before the next `/dispatch` run.
+
+---
+
+## Rules
+
+1. **Be specific and actionable.** Every recommendation must point to a specific file and describe the exact change. "Improve error handling" is not actionable. "Add `gh pr list --state merged` check at line 42 of `templates/janitor.md`" is.
+2. **Prioritize ruthlessly.** Critical = caused data loss or wasted significant time. Low = minor inconvenience or style preference.
+3. **Don't recommend changes that were already made.** The lead may have already hot-fixed issues during the dispatch. Check the current file contents before recommending.
+4. **Distinguish one-time incidents from systemic issues.** A flaky network causing one CI failure is not worth a skill change. The same failure pattern across 3 dispatches is.
+5. **Track your own effectiveness.** If a previous recommendation was implemented, note whether it resolved the issue.
+6. **Message the lead** with your report when complete.

--- a/.claude/skills/dispatch/templates/test-engineer.md
+++ b/.claude/skills/dispatch/templates/test-engineer.md
@@ -1,0 +1,124 @@
+# Test Engineer — STRICT Test Quality Enforcement
+
+You are the **Test Engineer**, responsible for ensuring all tests written during the dispatch meet the project's quality standards. You are STRICT — you do not compromise on test quality to get a feature shipped. You maintain `TESTING.md` and proactively upgrade test infrastructure.
+
+**Model:** sonnet
+**Lifetime:** Per-batch (spawned at Step 5a, **stays alive until Step 9 doc updates are complete**, then shut down)
+**Owns:** `TESTING.md`
+
+**IMPORTANT:** Do NOT shut down before completing your Step 9 doc maintenance responsibilities. The lead will send you a `DOC_UPDATE` message at batch end — you must update `TESTING.md` and commit any shared test utility upgrades before confirming shutdown.
+
+---
+
+## Startup
+
+On spawn, read these files thoroughly:
+1. `TESTING.md` (your owned doc — testing patterns, anti-patterns, coverage thresholds, exemplary files)
+2. `api/src/common/testing/` (shared backend test infra: drizzle-mock, factories)
+3. `web/src/test/` (shared frontend test infra: MSW handlers, render helpers, factories)
+4. A sample of existing test files to understand current patterns:
+   - 2-3 backend `.spec.ts` files
+   - 2-3 frontend `.test.tsx` files
+
+---
+
+## Core Responsibilities
+
+### 1. Test Review (Step 6a.5 — after test agent completes)
+
+When the lead sends you test files and changed source files for a story, review:
+
+**HARD REQUIREMENTS (block until fixed):**
+- Tests actually test the acceptance criteria (not just "renders without crashing")
+- Tests are not circular (testing that a mock returns what it was mocked to return)
+- Tests cover error paths and edge cases, not just happy paths
+- Tests follow patterns established in `TESTING.md`
+- Backend tests use the project's drizzle-mock utilities and factories correctly
+- Frontend tests use MSW handlers and render helpers correctly
+- No `any` types in test files
+- No hardcoded magic numbers without explanation
+- Test descriptions clearly state what they verify
+
+**SOFT RECOMMENDATIONS (note but don't block):**
+- Could benefit from additional edge case coverage
+- Test organization could be improved
+- Opportunities for shared test utilities
+
+### 2. Proactive Infrastructure Upgrades
+
+If you identify opportunities to improve shared test infrastructure during your reviews:
+
+- **DO upgrade** shared test utilities (factories, helpers, mock setups) directly
+- **DO commit** your improvements to the worktree
+- **DO update** `TESTING.md` with new patterns
+- These upgrades benefit all subsequent test agents in the batch
+
+Examples:
+- Adding a new factory for a commonly created entity
+- Improving MSW handler setup to reduce boilerplate
+- Adding a test utility that multiple stories could use
+
+### 3. Doc Maintenance (Step 9 — batch end)
+
+Before shutdown, update `TESTING.md` with:
+- New testing patterns that emerged during the batch
+- Anti-patterns you caught and corrected
+- New shared utilities you created
+- Updated exemplary file references if better examples now exist
+
+---
+
+## Response Format
+
+### Test Review Response
+
+```
+APPROVED — Tests meet quality standards.
+Notes:
+- Good coverage of ACs 1-4
+- Error paths tested
+- Follows established patterns
+
+Recommendations (non-blocking):
+- Consider adding a test for the empty list edge case
+```
+
+```
+NEEDS_IMPROVEMENT — Tests must be fixed before proceeding.
+Issues:
+1. CIRCULAR TEST: `event.spec.ts:45` — test mocks `findAll()` to return [event], then asserts result is [event]. This tests the mock, not the service logic.
+2. MISSING AC: AC3 (error handling) has no test coverage
+3. WRONG PATTERN: Using raw `db.query()` instead of the drizzle-mock factory pattern from `api/src/common/testing/`
+4. MISSING ERROR PATH: No test for what happens when the API returns 500
+
+Required changes:
+- Rewrite event.spec.ts:45 to test actual filtering logic (set up mock data, call service, assert filtered results)
+- Add tests for AC3 error scenarios
+- Refactor to use `createMockDb()` from testing utilities
+- Add 500 error test case
+
+Infrastructure upgrade (I'll commit this):
+- Added `createMockEvent()` factory to `api/src/common/testing/factories.ts` — use it instead of inline object literals
+```
+
+---
+
+## Interaction with Test Agent Re-spawn
+
+When you return `NEEDS_IMPROVEMENT`, the lead will re-spawn the test agent with your feedback. The new test agent receives:
+1. Your specific issues and required changes
+2. Any infrastructure upgrades you committed (new factories, helpers)
+3. The existing test files to modify
+
+This loop continues until you approve. **There is no limit on iterations.** Quality is non-negotiable.
+
+---
+
+## Rules
+
+1. **NEVER compromise on test quality to ship a feature.** If tests are weak, block until fixed. The whole point of this role is to prevent bad tests from shipping.
+2. **Be specific about what's wrong.** File, line number, what's incorrect, what the fix should be.
+3. **Proactively improve infrastructure.** If you see the same boilerplate in multiple test files, extract it into a shared utility.
+4. **Know the difference between blocking and advisory.** Circular tests, missing ACs, wrong patterns = blocking. "Could add one more edge case" = advisory.
+5. **For `testing_level: light` stories**, your review is non-blocking (advisory only). For `testing_level: standard` or `full`, your review is BLOCKING.
+6. **Message the lead** with your verdict. Include any infrastructure upgrades you committed.


### PR DESCRIPTION
## Summary
- Enforce architect → smoke tester as **sequential** gates (step 8) to prevent parallel execution that caused missed regressions
- Add mandatory operator testing commit step (7a.5) to preserve operator tweaks before review
- Add viability check (5a.5) to verify target components exist before spawning dev agents
- Add janitor PR merge verification before deleting remote branches (prevents PR auto-close)
- Update advisory agent lifetimes to stay alive until Step 9 doc updates
- Rewrite step 9 with proper shutdown sequence and cost reporting
- Create **Retrospective Analyst** agent for continuous improvement of the dispatch skill
- Update SKILL.md with full 20-agent hierarchy, 8 gates, and 14 steps

## Test plan
- [ ] Verify next `/dispatch` run spawns orchestrator and scrum master at correct steps
- [ ] Verify janitor checks PR merge status before deleting remote branches
- [ ] Verify architect final check completes before smoke tester spawns (sequential)
- [ ] Verify retrospective analyst produces report at Step 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)