### PR TITLE
fix: bump @types/node to 24.10.13 to resolve npm 403 on CI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6859,9 +6859,9 @@
             }
         },
         "node_modules/@types/node": {
-            "version": "22.19.8",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.8.tgz",
-            "integrity": "sha512-ebO/Yl+EAvVe8DnMfi+iaAyIqYdK0q/q0y0rw82INWEKJOBe6b/P3YWE8NW7oOlF/nXFNrHwhARrN/hdgDkraA==",
+            "version": "22.19.11",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
+            "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
             "license": "MIT",
             "dependencies": {
                 "undici-types": "~6.21.0"
@@ -18389,9 +18389,9 @@
             }
         },
         "web/node_modules/@types/node": {
-            "version": "24.10.10",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.10.tgz",
-            "integrity": "sha512-+0/4J266CBGPUq/ELg7QUHhN25WYjE0wYTPSQJn1xeu8DOlIOPxXxrNGiLmfAWl7HMMgWFWXpt9IDjMWrF5Iow==",
+            "version": "24.10.13",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.13.tgz",
+            "integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {


### PR DESCRIPTION
## Summary
- Bumps `@types/node` from 24.10.10 to 24.10.13 in the lockfile
- The previous version started returning HTTP 403 from the npm registry, breaking the `smoke-tests` CI job

## Test plan
- [ ] CI smoke-tests pass (npm ci no longer fails on forbidden package)

🤖 Generated with [Claude Code](https://claude.com/claude-code)