### PR TITLE
fix: change Set Absence button to destructive variant (ROK-500)

### DIFF
--- a/web/src/components/features/game-time/GameTimePanel.tsx
+++ b/web/src/components/features/game-time/GameTimePanel.tsx
@@ -102,7 +102,7 @@ export function GameTimePanel({
                     <div className="flex items-center gap-2">
                         <button
                             onClick={() => setShowAbsenceForm(!showAbsenceForm)}
-                            className="px-4 py-2.5 text-sm font-medium rounded-lg transition-colors bg-panel text-muted hover:bg-overlay"
+                            className="px-4 py-2.5 text-sm font-medium rounded-lg transition-colors bg-red-600 text-foreground hover:bg-red-500"
                         >
                             {showAbsenceForm ? 'Cancel' : 'Absence'}
                         </button>


### PR DESCRIPTION
## Summary
- Changes the "Set Absence" button on the game time screen to use the `destructive` variant, making it red to better communicate the action marks a player as absent.

## Test plan
- [ ] Navigate to game time screen, verify "Set Absence" button is red/destructive
- [ ] Verify no other buttons on the screen are affected
- [ ] Verify button still functions correctly (marks absence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)