### PR TITLE
fix: add Redis service to integration-tests CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,8 +105,19 @@ jobs:
           --health-timeout 5s
           --health-retries 5
 
+      redis:
+        image: redis:alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+
     env:
       DATABASE_URL: postgresql://user:password@localhost:5432/raid_ledger_test
+      REDIS_URL: redis://localhost:6379
       JWT_SECRET: ci-test-secret
       CLIENT_URL: http://localhost:5173
       CORS_ORIGIN: http://localhost:5173


### PR DESCRIPTION
## Summary
- BullMQ requires Redis connectivity even in integration tests
- The `integration-tests` CI job (added in #272) had Postgres but was missing the Redis service
- This caused `ECONNREFUSED` errors on port 6379 and TestApp singleton corruption, failing 20/25 tests
- Adds the same Redis service config that `build-lint-test` and `smoke-tests` already had

## Test plan
- [ ] CI `integration-tests` job passes (all 25 tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)