### PR TITLE
fix: emoji sync diagnostics and manual re-trigger

### DIFF
--- a/api/src/discord-bot/discord-bot-settings.controller.additional.spec.ts
+++ b/api/src/discord-bot/discord-bot-settings.controller.additional.spec.ts
@@ -9,6 +9,7 @@ import { BadRequestException } from '@nestjs/common';
 import { DiscordBotSettingsController } from './discord-bot-settings.controller';
 import { DiscordBotService } from './discord-bot.service';
 import { DiscordBotClientService } from './discord-bot-client.service';
+import { DiscordEmojiService } from './services/discord-emoji.service';
 import { SetupWizardService } from './services/setup-wizard.service';
 import { SettingsService } from '../settings/settings.service';
 import { CharactersService } from '../characters/characters.service';
@@ -36,6 +37,13 @@ describe('DiscordBotSettingsController — resendSetupWizard (ROK-349)', () => {
           useValue: {
             getTextChannels: jest.fn().mockReturnValue([]),
             isConnected: jest.fn().mockReturnValue(isConnected),
+          },
+        },
+        {
+          provide: DiscordEmojiService,
+          useValue: {
+            syncAllEmojis: jest.fn().mockResolvedValue(undefined),
+            isUsingCustomEmojis: jest.fn().mockReturnValue(false),
           },
         },
         {
@@ -198,6 +206,13 @@ describe('DiscordBotSettingsController — resendSetupWizard (ROK-349)', () => {
             },
           },
           {
+            provide: DiscordEmojiService,
+            useValue: {
+              syncAllEmojis: jest.fn().mockResolvedValue(undefined),
+              isUsingCustomEmojis: jest.fn().mockReturnValue(false),
+            },
+          },
+          {
             provide: SetupWizardService,
             useValue: {
               sendSetupWizardToAdmin: jest.fn(),
@@ -258,6 +273,13 @@ describe('DiscordBotSettingsController — resendSetupWizard (ROK-349)', () => {
             useValue: {
               getTextChannels: jest.fn().mockReturnValue([]),
               isConnected: jest.fn().mockReturnValue(true),
+            },
+          },
+          {
+            provide: DiscordEmojiService,
+            useValue: {
+              syncAllEmojis: jest.fn().mockResolvedValue(undefined),
+              isUsingCustomEmojis: jest.fn().mockReturnValue(false),
             },
           },
           {
@@ -412,6 +434,13 @@ describe('DiscordBotSettingsController — resendSetupWizard (ROK-349)', () => {
             },
           },
           {
+            provide: DiscordEmojiService,
+            useValue: {
+              syncAllEmojis: jest.fn().mockResolvedValue(undefined),
+              isUsingCustomEmojis: jest.fn().mockReturnValue(false),
+            },
+          },
+          {
             provide: SetupWizardService,
             useValue: {
               sendSetupWizardToAdmin: jest.fn(),
@@ -474,6 +503,13 @@ describe('DiscordBotSettingsController — resendSetupWizard (ROK-349)', () => {
             useValue: {
               getTextChannels: jest.fn().mockReturnValue([]),
               isConnected: jest.fn().mockReturnValue(true),
+            },
+          },
+          {
+            provide: DiscordEmojiService,
+            useValue: {
+              syncAllEmojis: jest.fn().mockResolvedValue(undefined),
+              isUsingCustomEmojis: jest.fn().mockReturnValue(false),
             },
           },
           {

--- a/api/src/discord-bot/discord-bot-settings.controller.spec.ts
+++ b/api/src/discord-bot/discord-bot-settings.controller.spec.ts
@@ -4,6 +4,7 @@ import { BadRequestException } from '@nestjs/common';
 import { DiscordBotSettingsController } from './discord-bot-settings.controller';
 import { DiscordBotService } from './discord-bot.service';
 import { DiscordBotClientService } from './discord-bot-client.service';
+import { DiscordEmojiService } from './services/discord-emoji.service';
 import { SetupWizardService } from './services/setup-wizard.service';
 import { SettingsService } from '../settings/settings.service';
 import { CharactersService } from '../characters/characters.service';
@@ -32,6 +33,13 @@ describe('DiscordBotSettingsController', () => {
           useValue: {
             getTextChannels: jest.fn(),
             isConnected: jest.fn().mockReturnValue(true),
+          },
+        },
+        {
+          provide: DiscordEmojiService,
+          useValue: {
+            syncAllEmojis: jest.fn().mockResolvedValue(undefined),
+            isUsingCustomEmojis: jest.fn().mockReturnValue(false),
           },
         },
         {


### PR DESCRIPTION
## Summary
- Replaces shallow `error.message` logging in emoji sync with full Discord API error details (code, status, method, URL)
- Adds debug-only permission diagnostic at sync start (gated behind `DEBUG=true` env var)
- Adds `POST /admin/settings/discord-bot/sync-emojis` endpoint to manually re-trigger emoji sync without container restart

## Context
Production emoji sync fails with "Missing Permissions" despite the permission checker confirming `ManageGuildExpressions` is granted. Current logging only captures the error message string, losing the HTTP status code, Discord error code, and API URL. These changes provide the diagnostics needed to identify the root cause.

## Test plan
- [x] API builds cleanly
- [x] All 42 controller unit tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)