### PR TITLE
fix: batch fixes 2026-02-28b

### DIFF
--- a/api/src/discord-bot/listeners/event.listener.spec.ts
+++ b/api/src/discord-bot/listeners/event.listener.spec.ts
@@ -106,6 +106,11 @@ describe('DiscordEventListener', () => {
           provide: EmbedPosterService,
           useValue: {
             postEmbed: jest.fn().mockResolvedValue(true),
+            enrichWithLiveRoster: jest
+              .fn()
+              .mockImplementation((_id: number, event: unknown) =>
+                Promise.resolve(event),
+              ),
           },
         },
         {

--- a/api/src/discord-bot/listeners/event.listener.ts
+++ b/api/src/discord-bot/listeners/event.listener.ts
@@ -225,8 +225,13 @@ export class DiscordEventListener {
 
     const context = await this.buildContext();
 
+    // Enrich with live roster data so the embed reflects current signups
+    const eventData = await this.embedPoster.enrichWithLiveRoster(
+      payload.eventId,
+      payload.event,
+    );
+
     // ROK-507: Resolve voice channel so embed updates retain the voice channel line
-    const eventData = { ...payload.event };
     const voiceChannelId =
       await this.channelResolver.resolveVoiceChannelForScheduledEvent(
         payload.gameId,

--- a/api/src/discord-bot/services/embed-poster.service.ts
+++ b/api/src/discord-bot/services/embed-poster.service.ts
@@ -123,7 +123,7 @@ export class EmbedPosterService {
    * hardcodes signupCount: 0). This queries the current state so the embed
    * is accurate at post time.
    */
-  private async enrichWithLiveRoster(
+  async enrichWithLiveRoster(
     eventId: number,
     event: EmbedEventData,
   ): Promise<EmbedEventData> {

--- a/api/src/discord-bot/services/scheduled-event.service.ts
+++ b/api/src/discord-bot/services/scheduled-event.service.ts
@@ -78,7 +78,7 @@ export class ScheduledEventService {
       const startTime = new Date(eventData.startTime);
       if (startTime.getTime() <= Date.now()) {
         this.logger.debug(
-          `Start time in past, skipping scheduled event for event ${eventId}`,
+          `Start time in past (${eventData.startTime}), skipping scheduled event for event ${eventId}`,
         );
         return;
       }
@@ -138,12 +138,27 @@ export class ScheduledEventService {
     isAdHoc?: boolean,
   ): Promise<void> {
     try {
-      if (isAdHoc) return;
+      if (isAdHoc) {
+        this.logger.debug(
+          `Skipping scheduled event update for ad-hoc event ${eventId}`,
+        );
+        return;
+      }
 
-      if (!this.clientService.isConnected()) return;
+      if (!this.clientService.isConnected()) {
+        this.logger.debug(
+          `Bot not connected, skipping scheduled event update for event ${eventId}`,
+        );
+        return;
+      }
 
       const guild = this.clientService.getGuild();
-      if (!guild) return;
+      if (!guild) {
+        this.logger.debug(
+          `No guild available, skipping scheduled event update for event ${eventId}`,
+        );
+        return;
+      }
 
       // Get stored scheduled event ID
       const [event] = await this.db
@@ -156,6 +171,9 @@ export class ScheduledEventService {
 
       if (!event?.discordScheduledEventId) {
         // No scheduled event yet — create one
+        this.logger.debug(
+          `No existing scheduled event for event ${eventId}, creating new one`,
+        );
         await this.createScheduledEvent(eventId, eventData, gameId, isAdHoc);
         return;
       }


### PR DESCRIPTION
## Summary
- **fix: embed update wipes roster data** — Event edits were rebuilding Discord embeds from the sparse lifecycle payload (missing `roleCounts`/`signupMentions`), showing 0/X for all roles. Now calls `enrichWithLiveRoster()` before rebuilding.
- **fix: scheduled event debug logging** — All silent guard returns in `updateScheduledEvent()` now log at debug level so failures are visible in production.
- Includes prior batch: ROK-507 (voice channel on embeds/DMs), ROK-545 (reminder timestamp), ROK-546 (ScheduledEventService cleanup)

## Test plan
- [x] Unit tests pass (52/52 in affected files)
- [ ] Edit an event with signups → verify Discord embed retains roster data
- [ ] Edit an event → check logs for scheduled event creation debug output

🤖 Generated with [Claude Code](https://claude.com/claude-code)