### PR TITLE
fix: add GuildScheduledEvents intent for scheduled event creation

### DIFF
--- a/api/src/discord-bot/discord-bot-client.service.ts
+++ b/api/src/discord-bot/discord-bot-client.service.ts
@@ -82,6 +82,7 @@ export class DiscordBotClientService {
         GatewayIntentBits.GuildMembers,
         GatewayIntentBits.GuildVoiceStates,
         GatewayIntentBits.GuildPresences,
+        GatewayIntentBits.GuildScheduledEvents,
         GatewayIntentBits.DirectMessages,
         GatewayIntentBits.MessageContent,
       ],


### PR DESCRIPTION
## Summary
- Discord API returns 50013 (Missing Permissions) when creating scheduled events without the `GuildScheduledEvents` gateway intent, even with all OAuth2 permissions granted
- Added `GatewayIntentBits.GuildScheduledEvents` to the bot client's intent list

## Test plan
- [x] Unit tests pass (31/31)
- [ ] Deploy → edit event → verify Discord Scheduled Event is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)