### PR TITLE
fix: prevent ConfigModule from hijacking integration test DB connection

### DIFF
--- a/api/src/common/testing/integration-setup.ts
+++ b/api/src/common/testing/integration-setup.ts
@@ -13,6 +13,13 @@ process.env.THROTTLE_DEFAULT_LIMIT = '999999';
 
 import { closeTestApp } from './test-app';
 
+// ConfigModule.forRoot() in AppModule reads api/.env during the import above,
+// setting process.env.DATABASE_URL to the dev DB. Delete it so getTestApp()
+// uses Testcontainers for a fresh database instead of hitting the dev DB.
+if (!process.env.CI) {
+  delete process.env.DATABASE_URL;
+}
+
 afterAll(async () => {
   await closeTestApp();
 });


### PR DESCRIPTION
## Summary

- Integration tests were failing locally because `ConfigModule.forRoot()` in `AppModule` reads `api/.env` at import time (during decorator evaluation), setting `process.env.DATABASE_URL` to the dev DB before `getTestApp()` checks it
- This caused `getTestApp()` to take the "CI mode" path (use existing DB) instead of Testcontainers, leading to migration collisions (`relation "ad_hoc_participants" already exists`)
- Fix: delete `process.env.DATABASE_URL` in `integration-setup.ts` after imports, guarded by `!process.env.CI` so CI mode still works

**Result:** All 201 integration tests pass locally via Testcontainers again.

## Test plan

- [x] `npm run test:integration -w api` — 201/201 pass locally
- [x] CI pipeline unaffected (uses `DATABASE_URL` env var from service container + `CI` env var)

🤖 Generated with [Claude Code](https://claude.com/claude-code)