### PR TITLE
fix: confirm pending signups when placed in roster slots (ROK-620)

### DIFF
--- a/api/src/events/signups.service.ts
+++ b/api/src/events/signups.service.ts
@@ -9,7 +9,7 @@ import {
   ConflictException,
 } from '@nestjs/common';
 import { EventEmitter2 } from '@nestjs/event-emitter';
-import { eq, and, or, sql, isNull, ne } from 'drizzle-orm';
+import { eq, and, or, sql, isNull, ne, inArray } from 'drizzle-orm';
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
 import * as schema from '../drizzle/schema';
@@ -1577,6 +1577,20 @@ export class SignupsService {
       });
 
       await this.db.insert(schema.rosterAssignments).values(assignmentValues);
+
+      // Confirm pending signups placed in non-bench slots (mirrors ROK-598 auto-slot logic)
+      const nonBenchSignupIds = dto.assignments
+        .filter((a) => a.slot && a.slot !== 'bench')
+        .map((a) => signupByUserId.get(a.userId)!)
+        .filter((s) => s.confirmationStatus === 'pending')
+        .map((s) => s.id);
+
+      if (nonBenchSignupIds.length > 0) {
+        await this.db
+          .update(schema.eventSignups)
+          .set({ confirmationStatus: 'confirmed' })
+          .where(inArray(schema.eventSignups.id, nonBenchSignupIds));
+      }
 
       // ROK-229: Cancel pending bench promotions for any non-bench slots that are now filled
       for (const a of dto.assignments) {


### PR DESCRIPTION
## Summary
- `updateRoster()` only set `confirmationStatus` to `'confirmed'` when a `characterId` was provided alongside the slot assignment
- Signups dragged into non-bench roster slots without a character stayed `'pending'`, causing the Attendees section to show them as "Pending" despite being slotted in the roster
- Added bulk confirmation of pending signups placed in non-bench slots after roster assignment insertion, mirroring the existing ROK-598 auto-slot logic

## Test plan
- [x] Existing signups tests pass (65/65)
- [ ] Create event, signup without character, drag into roster slot → verify Attendees shows "Confirmed"
- [ ] Verify bench assignments still show as "Pending" (intentional — user may need to confirm character)

Closes ROK-620

🤖 Generated with [Claude Code](https://claude.com/claude-code)