### PR TITLE
fix: make video name optional in GameDetail schema (ROK-616)

### DIFF
--- a/packages/contract/src/games.schema.ts
+++ b/packages/contract/src/games.schema.ts
@@ -40,7 +40,7 @@ export const GameDetailSchema = z.object({
     platforms: z.array(z.number()).default([]),
     screenshots: z.array(z.string()).default([]),
     videos: z.array(z.object({
-        name: z.string(),
+        name: z.string().optional(),
         videoId: z.string(),
     })).default([]),
     firstReleaseDate: z.string().nullable(),


### PR DESCRIPTION
## Summary

- IGDB sometimes omits the `name` field on video objects in game data
- The `GameDetailSchema` Zod schema required `name: z.string()`, causing `schema.parse()` to throw on the frontend
- This silently discarded the entire search response — the API returned 18 results with status 200, but the UI showed "No games found"
- Fix: change `name` to `z.string().optional()` in the video sub-schema

## Root cause

The previous fix (ROK-616 in PR #325) addressed IGDB 401 token retry, but the actual bug was a **frontend Zod validation failure** — not an API issue. The API logs confirmed successful searches the entire time.

## Test plan

- [ ] Search "golf with" on Games Discover tab — should show results
- [ ] Verify game detail page still renders video titles (falls back gracefully when name is missing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)