### PR TITLE
fix: auto-detect CLIENT_URL for all-in-one Docker containers

### DIFF
--- a/api/src/discord-bot/listeners/event-link.listener.ts
+++ b/api/src/discord-bot/listeners/event-link.listener.ts
@@ -97,9 +97,10 @@ export class EventLinkListener {
       return;
     }
 
-    const clientUrl = (
-      process.env.CLIENT_URL || process.env.CORS_ORIGIN
-    )?.replace(/\/+$/, ''); // strip trailing slash(es)
+    const rawClientUrl =
+      process.env.CLIENT_URL || process.env.CORS_ORIGIN || '';
+    const clientUrl =
+      rawClientUrl !== 'auto' ? rawClientUrl.replace(/\/+$/, '') : '';
     if (!clientUrl) {
       this.logger.warn(
         'Neither CLIENT_URL nor CORS_ORIGIN is set — link unfurl disabled',
@@ -277,7 +278,10 @@ export class EventLinkListener {
     ]);
     return {
       communityName: branding.communityName,
-      clientUrl: process.env.CLIENT_URL || process.env.CORS_ORIGIN || null,
+      clientUrl:
+        (process.env.CLIENT_URL || process.env.CORS_ORIGIN || null) === 'auto'
+          ? null
+          : process.env.CLIENT_URL || process.env.CORS_ORIGIN || null,
       timezone,
     };
   }

--- a/api/src/events/event-plans.service.ts
+++ b/api/src/events/event-plans.service.ts
@@ -952,7 +952,7 @@ export class EventPlansService {
       .setColor(0x8b5cf6); // EMBED_COLORS.ROSTER_UPDATE (purple — planning context)
 
     const clientUrl = process.env.CLIENT_URL || process.env.CORS_ORIGIN;
-    if (clientUrl) {
+    if (clientUrl && clientUrl !== 'auto') {
       embed.setURL(`${clientUrl}/events?tab=plans`);
     }
 

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -95,6 +95,36 @@ async function bootstrap() {
     httpAdapter.getInstance().set('trust proxy', 1);
   }
 
+  // Auto-detect CLIENT_URL from the first external HTTP request when CORS_ORIGIN=auto.
+  // The all-in-one Docker image runs frontend + API behind nginx on any hostname,
+  // so CLIENT_URL can't be known at build time. We capture the hostname from the
+  // first real request (skipping Docker health-check localhost calls).
+  if (isAutoOrigin && !process.env.CLIENT_URL) {
+    app.use(
+      (
+        req: { headers: Record<string, string | string[] | undefined> },
+        _res: unknown,
+        next: () => void,
+      ) => {
+        if (!process.env.CLIENT_URL) {
+          const host = req.headers.host as string | undefined;
+          if (
+            host &&
+            !host.startsWith('localhost') &&
+            !host.startsWith('127.0.0.1')
+          ) {
+            const proto =
+              ((req.headers['x-forwarded-proto'] as string) || 'http')
+                .split(',')[0]
+                .trim() || 'http';
+            process.env.CLIENT_URL = `${proto}://${host}`;
+          }
+        }
+        next();
+      },
+    );
+  }
+
   // Serve uploaded avatars as static files (ROK-220)
   const avatarDir =
     process.env.AVATAR_UPLOAD_DIR ||


### PR DESCRIPTION
## Summary
- Adds lightweight middleware in `main.ts` that captures `Host` + `X-Forwarded-Proto` from the first non-localhost HTTP request and sets `process.env.CLIENT_URL` when `CORS_ORIGIN=auto`
- Guards `event-link.listener.ts` and `event-plans.service.ts` against the literal `"auto"` value falling through from `CORS_ORIGIN`, which caused `new URL("auto")` errors and invalid Discord embed URLs
- Enables the all-in-one Docker image to work on any hostname without users needing to configure `CLIENT_URL`

## Test plan
- [x] `event-link.listener.spec` — 17 tests pass
- [x] `event-plans.service.spec` — 45 tests pass
- [x] TypeScript compilation clean
- [ ] Deploy to NAS, verify Discord bot embeds show correct URLs after first web request

🤖 Generated with [Claude Code](https://claude.com/claude-code)