### PR TITLE
fix: exclude declined signups from signupCount and clean up orphaned PUG signups (ROK-652)

### DIFF
--- a/api/src/discord-bot/listeners/pug-invite.listener.ts
+++ b/api/src/discord-bot/listeners/pug-invite.listener.ts
@@ -776,6 +776,19 @@ export class PugInviteListener {
       .limit(1);
 
     if (linkedUser) {
+      // ROK-652: Delete orphaned anonymous signup for this PUG before creating
+      // the real user signup. The anonymous entry was created when the PUG first
+      // accepted the invite; now that we know the linked account, it's redundant.
+      // Roster assignments cascade-delete via FK.
+      await this.db
+        .delete(schema.eventSignups)
+        .where(
+          and(
+            eq(schema.eventSignups.eventId, slot.eventId),
+            eq(schema.eventSignups.discordUserId, discordUserId),
+          ),
+        );
+
       // Linked user — use SignupsService for full signup + roster assignment
       try {
         const result = await this.signupsService.signup(

--- a/api/src/events/events.service.ts
+++ b/api/src/events/events.service.ts
@@ -274,7 +274,7 @@ export class EventsService {
 
     const total = Number(countResult[0].count);
 
-    // Subquery to count signups per event (ROK-421: exclude roached_out, ROK-596: exclude departed)
+    // Subquery to count signups per event (ROK-421: exclude roached_out, ROK-596: exclude departed, ROK-652: exclude declined)
     const signupCountSubquery = this.db
       .select({
         eventId: schema.eventSignups.eventId,
@@ -285,6 +285,7 @@ export class EventsService {
         and(
           ne(schema.eventSignups.status, 'roached_out'),
           ne(schema.eventSignups.status, 'departed'),
+          ne(schema.eventSignups.status, 'declined'),
         ),
       )
       .groupBy(schema.eventSignups.eventId)
@@ -365,7 +366,7 @@ export class EventsService {
         users: schema.users,
         games: schema.games,
         signupCount: sql<number>`coalesce((
-          SELECT count(*) FROM event_signups WHERE event_id = ${schema.events.id} AND status != 'roached_out' AND status != 'departed'
+          SELECT count(*) FROM event_signups WHERE event_id = ${schema.events.id} AND status != 'roached_out' AND status != 'departed' AND status != 'declined'
         ), 0)`,
       })
       .from(schema.events)
@@ -401,6 +402,7 @@ export class EventsService {
           inArray(schema.eventSignups.eventId, ids),
           ne(schema.eventSignups.status, 'roached_out'),
           ne(schema.eventSignups.status, 'departed'),
+          ne(schema.eventSignups.status, 'declined'),
         ),
       )
       .groupBy(schema.eventSignups.eventId)
@@ -448,7 +450,7 @@ export class EventsService {
     }
     const whereCondition = and(...conditions);
 
-    // 2. Get events with signup counts (reuse findAll pattern, ROK-421: exclude roached_out, ROK-596: exclude departed)
+    // 2. Get events with signup counts (ROK-421: exclude roached_out, ROK-596: exclude departed, ROK-652: exclude declined)
     const signupCountSubquery = this.db
       .select({
         eventId: schema.eventSignups.eventId,
@@ -459,6 +461,7 @@ export class EventsService {
         and(
           ne(schema.eventSignups.status, 'roached_out'),
           ne(schema.eventSignups.status, 'departed'),
+          ne(schema.eventSignups.status, 'declined'),
         ),
       )
       .groupBy(schema.eventSignups.eventId)
@@ -714,7 +717,7 @@ export class EventsService {
 
     const total = Number(countResult[0].count);
 
-    // Subquery for signup counts (ROK-421: exclude roached_out, ROK-596: exclude departed)
+    // Subquery for signup counts (ROK-421: exclude roached_out, ROK-596: exclude departed, ROK-652: exclude declined)
     const signupCountSubquery = this.db
       .select({
         eventId: schema.eventSignups.eventId,
@@ -725,6 +728,7 @@ export class EventsService {
         and(
           ne(schema.eventSignups.status, 'roached_out'),
           ne(schema.eventSignups.status, 'departed'),
+          ne(schema.eventSignups.status, 'declined'),
         ),
       )
       .groupBy(schema.eventSignups.eventId)
@@ -1050,10 +1054,18 @@ export class EventsService {
     await this.findOne(eventId);
 
     // Get all signed-up user IDs (filter out anonymous Discord participants)
+    // ROK-652: Exclude declined/roached_out/departed signups from aggregate game time
     const signups = await this.db
       .select({ userId: schema.eventSignups.userId })
       .from(schema.eventSignups)
-      .where(eq(schema.eventSignups.eventId, eventId));
+      .where(
+        and(
+          eq(schema.eventSignups.eventId, eventId),
+          ne(schema.eventSignups.status, 'roached_out'),
+          ne(schema.eventSignups.status, 'departed'),
+          ne(schema.eventSignups.status, 'declined'),
+        ),
+      );
 
     const userIds = signups
       .map((s) => s.userId)


### PR DESCRIPTION
## Summary

- **ROK-652** (Bug, High): signupCount included declined signups, causing inflated count on reschedule UI

### Changes

1. **Primary fix:** Delete orphaned anonymous PUG signups when invite resolves to a real user account (`pug-invite.listener.ts`)
2. **Defensive fix:** Add `ne(status, 'declined')` to all 5 signupCount subqueries (`events.service.ts`)
3. **Audit fix:** Add status filters to `getAggregateGameTime()` — previously had no filters at all

## Validation

- [x] Build passes (contract + api + web)
- [x] TypeScript clean
- [x] Lint clean (0 errors)
- [x] Unit tests pass (api: 2575, web: 1939)
- [x] Integration tests pass (290/290)
- [x] Smoke tests skipped (no UI changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)