### PR TITLE
fix: add pg_dump and backup volume to all-in-one Docker image

### DIFF
--- a/Dockerfile.allinone
+++ b/Dockerfile.allinone
@@ -52,6 +52,7 @@ RUN apk add --no-cache \
   nginx \
   postgresql16 \
   postgresql16-contrib \
+  postgresql16-client \
   redis \
   supervisor \
   bash \
@@ -67,7 +68,7 @@ WORKDIR /app
 # ==================
 # Persistent data volume — mount as -v raid-ledger-data:/data
 # ==================
-RUN mkdir -p /data/postgresql /data/redis /run/postgresql /run/redis && \
+RUN mkdir -p /data/postgresql /data/redis /data/backups/daily /data/backups/migrations /run/postgresql /run/redis && \
   chown -R postgres:postgres /data/postgresql /run/postgresql && \
   chown -R redis:redis /data/redis /run/redis
 VOLUME /data
@@ -257,7 +258,7 @@ set -e
 
 # Ensure /data subdirectories exist and have correct ownership
 # (volume mounts may arrive as root-owned empty dirs)
-mkdir -p /data/postgresql /data/redis
+mkdir -p /data/postgresql /data/redis /data/backups/daily /data/backups/migrations
 chown -R postgres:postgres /data/postgresql
 chown -R redis:redis /data/redis
 
@@ -285,6 +286,7 @@ ENV JWT_SECRET=raid-ledger-default-secret-change-in-production
 ENV DOTENV_CONFIG_QUIET=true
 ENV CORS_ORIGIN=auto
 ENV CLIENT_URL=
+ENV BACKUP_DIR=/data/backups
 ENV ADMIN_PASSWORD=
 
 # Expose port (nginx)


### PR DESCRIPTION
## Summary

- Adds `postgresql16-client` to the all-in-one Docker image — provides `pg_dump` which the daily backup cron needs
- Adds `BACKUP_DIR=/data/backups` env var so `BackupService` writes to the persistent `/data` volume instead of `process.cwd()/backups`
- Creates `/data/backups/daily` and `/data/backups/migrations` directories at both build time and runtime (for existing volumes)

**Root cause:** The production all-in-one image installed `postgresql16` (server) and `postgresql16-contrib` but not `postgresql16-client` (which provides `pg_dump`). The backup cron fired every night at 2 AM, `pg_dump` failed with "command not found", and the error was silently caught. No backup files were ever created.

## Test plan

- [ ] Build the all-in-one image locally: `docker build -f Dockerfile.allinone -t raid-ledger:test .`
- [ ] Verify `pg_dump` exists: `docker run --rm raid-ledger:test which pg_dump`
- [ ] Verify backup directories exist: `docker run --rm raid-ledger:test ls -la /data/backups/`
- [ ] Verify `BACKUP_DIR` env var: `docker run --rm raid-ledger:test env | grep BACKUP_DIR`
- [ ] After deploy, confirm daily backup appears in the Backups admin panel the next morning

🤖 Generated with [Claude Code](https://claude.com/claude-code)