### PR TITLE
fix: CI ordering — remove claude-review + gate Docker builds on test completion

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,9 +1,12 @@
 name: Build and Push Docker Images
 
 on:
+  # Only build Docker images after CI passes (lint + tests + smoke)
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+    branches: [main]
   push:
-    branches:
-      - main
     tags:
       - 'v*'
 
@@ -13,6 +16,8 @@ env:
 jobs:
   # Build each platform natively in parallel (no QEMU emulation)
   build:
+    # Skip if triggered by workflow_run and CI failed
+    if: ${{ github.event_name == 'push' || github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What

- Remove the `claude-review` CI job and all its dependencies (`needs`, `if` conditions, `permissions` block)
- Fix `check-pr-description` to fetch the live PR body from the GitHub API instead of the stale webhook payload
- Gate Docker image builds on CI completion using `workflow_run` trigger

## Why

- Claude AI review step was requested to be disabled
- `check-pr-description` was failing on PRs where the body was edited after creation (webhook payload is stale)
- Docker images were building in parallel with tests on push to main — wasting resources when tests fail and publishing untested images

## Acceptance criteria

- `claude-review` job no longer appears in CI
- `check-pr-description` reads the current PR body, not the webhook snapshot
- Docker builds only start after CI (lint + tests + smoke) passes on main
- Tag pushes still trigger Docker builds directly

## Test plan

- [x] `check-pr-description` passes on this PR
- [x] No `claude-review` job in CI output
- [ ] Verify Docker builds wait for CI on next push to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)