### PR TITLE
fix: move Docker builds into CI pipeline + parallelize tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
 
   smoke-tests:
     runs-on: ubuntu-latest
-    needs: [unit-tests, integration-tests]
+    needs: lint
 
     services:
       postgres:
@@ -261,3 +261,119 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 7
+
+  # Docker image builds — only on main after all tests pass
+  docker-build:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: [unit-tests, integration-tests, smoke-tests]
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            platform: linux/amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+    runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Lowercase image name
+        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ env.IMAGE_NAME }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.allinone
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            COMMIT_SHA=${{ github.sha }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=allinone-${{ matrix.platform }}
+          cache-to: type=gha,mode=max,scope=allinone-${{ matrix.platform }}
+          outputs: type=image,"name=ghcr.io/${{ env.IMAGE_NAME }}",push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Merge platform digests into a single multi-arch manifest
+  docker-merge:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: docker-build
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Lowercase image name
+        run: echo "IMAGE_NAME=${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix=
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          tags=$(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON")
+          digests=$(printf 'ghcr.io/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+          # shellcheck disable=SC2086
+          docker buildx imagetools create $tags $digests
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,11 +1,6 @@
-name: Build and Push Docker Images
+name: Release
 
 on:
-  # Only build Docker images after CI passes (lint + tests + smoke)
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
-    branches: [main]
   push:
     tags:
       - 'v*'
@@ -16,8 +11,6 @@ env:
 jobs:
   # Build each platform natively in parallel (no QEMU emulation)
   build:
-    # Skip if triggered by workflow_run and CI failed
-    if: ${{ github.event_name == 'push' || github.event.workflow_run.conclusion == 'success' }}
     strategy:
       fail-fast: false
       matrix:
@@ -114,8 +107,6 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
-            type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=sha,prefix=
@@ -136,7 +127,6 @@ jobs:
   release:
     runs-on: ubuntu-latest
     needs: merge
-    if: startsWith(github.ref, 'refs/tags/v')
     permissions:
       contents: write
 


### PR DESCRIPTION
## Summary
- Moves Docker image builds from a separate `workflow_run` workflow into `ci.yml` so they show up in the CI checks UI
- Parallelizes all test jobs (unit, integration, smoke) after lint instead of running smoke last
- Docker builds only run on main branch pushes, after all tests pass
- `docker-publish.yml` slimmed down to handle only tag-based releases

Pipeline order:
```
lint → [unit-tests, integration-tests, smoke-tests] → [docker-build (amd64 + arm64)] → docker-merge
```

## Test plan
- CI runs on this PR will show lint + 3 parallel test jobs (no docker-build since it's a PR)
- After merge to main, docker-build + docker-merge will appear in the checks UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)