### PR TITLE
fix: skip Discord consent screen for returning users

### DIFF
--- a/api/src/plugins/discord/discord-auth.helpers.ts
+++ b/api/src/plugins/discord/discord-auth.helpers.ts
@@ -15,6 +15,19 @@ import type { Response, Request } from 'express';
 export class DiscordAuthGuard extends AuthGuard('discord') {
   private readonly guardLogger = new Logger('DiscordAuthGuard');
 
+  /**
+   * Pass prompt=none to skip Discord's consent screen for returning users.
+   * If the user hasn't authorized before, Discord returns consent_required
+   * and we retry without it (see handleRequest).
+   */
+  getAuthenticateOptions(context: ExecutionContext) {
+    const req = context.switchToHttp().getRequest<Request>();
+    if (req.query.consent !== '1') {
+      return { prompt: 'none' };
+    }
+    return {};
+  }
+
   /** Handle authentication result, redirecting on failure. */
   handleRequest<TUser>(
     err: Error | null,
@@ -32,6 +45,14 @@ export class DiscordAuthGuard extends AuthGuard('discord') {
       const httpCtx = context.switchToHttp();
       const req = httpCtx.getRequest<Request>();
       const res = httpCtx.getResponse<Response>();
+
+      // First-time users need to authorize — retry with the consent screen
+      const errCode = (err as unknown as Record<string, unknown>)?.code;
+      if (errCode === 'consent_required' || errCode === 'interaction_required') {
+        res.redirect('/auth/discord?consent=1');
+        return undefined as unknown as TUser;
+      }
+
       const clientUrl =
         process.env.CLIENT_URL ||
         `${(req.headers['x-forwarded-proto'] as string)?.split(',')[0]?.trim() || req.protocol || 'http'}://${req.headers.host || 'localhost'}`;

--- a/api/src/plugins/discord/discord-auth.strategy.ts
+++ b/api/src/plugins/discord/discord-auth.strategy.ts
@@ -112,8 +112,6 @@ export class DiscordAuthStrategy
     // Ensure callback URL is current before authenticating
     if (this.isStrategyConfigured) {
       const strategy = this as unknown as { _callbackURL: string };
-      // The callbackURL stored in the strategy should already be up to date
-      // via reloadConfig, but we log for debugging
       this.logger.debug(
         `Authenticating with callback URL: ${strategy._callbackURL}`,
       );


### PR DESCRIPTION
## What
Add `prompt=none` to the Discord OAuth login flow so returning users skip the authorization consent screen.

## Why
Every login via "Continue with Discord" was showing the Discord authorization screen, even for users who had already authorized the app. This added unnecessary friction to every login.

## How
- Override `getAuthenticateOptions()` in `DiscordAuthGuard` to pass `prompt: 'none'` to passport-discord
- Discord auto-redirects returning users without showing consent
- First-time users who get `consent_required` error are automatically retried with the consent screen
- Link and invite flows are unchanged (they always show consent)

## Test plan
- [x] Returning user: logout → Continue with Discord → redirects through Discord instantly (no consent click)
- [x] Verified twice locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)