### PR TITLE
fix: reorder migration timestamps to unblock ITAD columns (prod down)

### DIFF
--- a/api/src/drizzle/migrations/meta/_journal.json
+++ b/api/src/drizzle/migrations/meta/_journal.json
@@ -628,14 +628,14 @@
     {
       "idx": 89,
       "version": "7",
-      "when": 1773163452079,
+      "when": 1773200100000,
       "tag": "0089_sloppy_wolfsbane",
       "breakpoints": true
     },
     {
       "idx": 90,
       "version": "7",
-      "when": 1773180055423,
+      "when": 1773200200000,
       "tag": "0090_keen_next_avengers",
       "breakpoints": true
     }


### PR DESCRIPTION
## Summary
- Migrations 0089 and 0090 (ITAD columns) had timestamps **before** migration 0088, causing Drizzle to skip them
- Production DB shows "90 applied vs 91 in journal" and crashes on seed: `column "itad_game_id" of relation "games" does not exist`
- Fix: bump timestamps for 0089/0090 to be after 0088

## Test plan
- [ ] CI passes
- [ ] Deploy to production — migrations 0089+0090 apply, seeding succeeds, app starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)