### PR TITLE
fix: map Twitch game ID to all WoW variant entries

### DIFF
--- a/api/src/drizzle/migrations/0094_set_twitch_id_wow_variants.sql
+++ b/api/src/drizzle/migrations/0094_set_twitch_id_wow_variants.sql
@@ -1,0 +1,23 @@
+-- Set twitch_game_id on all WoW variant game rows so Twitch streams
+-- appear on every variant's game detail page.
+-- Twitch uses a single "World of Warcraft" category (ID 18122) for all variants.
+--
+-- Rollback: UPDATE games SET twitch_game_id = NULL WHERE slug IN (...) AND twitch_game_id = '18122';
+
+UPDATE games
+SET twitch_game_id = '18122'
+WHERE slug IN (
+  'world-of-warcraft-burning-crusade-classic-anniversary-edition',
+  'world-of-warcraft-burning-crusade-classic',
+  'world-of-warcraft-wrath-of-the-lich-king',
+  'world-of-warcraft-wrath-of-the-lich-king-classic',
+  'world-of-warcraft-cataclysm-classic',
+  'world-of-warcraft-mists-of-pandaria-classic',
+  'world-of-warcraft-classic-season-of-discovery',
+  'world-of-warcraft-the-war-within',
+  'world-of-warcraft-dragonflight',
+  'world-of-warcraft-shadowlands',
+  'world-of-warcraft-midnight',
+  'world-of-warcraft-the-last-titan'
+)
+AND (twitch_game_id IS NULL OR twitch_game_id = '');

--- a/api/src/drizzle/migrations/meta/_journal.json
+++ b/api/src/drizzle/migrations/meta/_journal.json
@@ -659,6 +659,13 @@
       "when": 1773350000000,
       "tag": "0093_add_tbc_anniversary_event_types",
       "breakpoints": true
+    },
+    {
+      "idx": 94,
+      "version": "7",
+      "when": 1773400000000,
+      "tag": "0094_set_twitch_id_wow_variants",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## What
Data migration to set `twitch_game_id = '18122'` on 12 WoW variant game rows.

## Why
Twitch uses a single "World of Warcraft" category (ID 18122) for all WoW variants. After the WoW Classic variant migration (ROK-777), new game entries like TBC Anniversary had no `twitch_game_id`, so the Community Activity section on their game detail pages showed no streams.

## Test plan
- [x] Migration applied locally — verified all 12 targeted rows now have `twitch_game_id = '18122'`
- [x] `GET /games/8363/streams` (TBC Anniversary) returns live Twitch streams
- [x] Idempotent — only updates rows where `twitch_game_id IS NULL OR twitch_game_id = ''`

🤖 Generated with [Claude Code](https://claude.com/claude-code)