### PR TITLE
perf: batch demo seed N+1 queries (ROK-799)

### DIFF
--- a/api/src/admin/demo-data-install-secondary.helpers.ts
+++ b/api/src/admin/demo-data-install-secondary.helpers.ts
@@ -271,7 +271,7 @@ export async function reassignEventCreators(
   await reassignGenEventsRandomly(db, allUsers, genEvents);
 }
 
-/** Reassign first 2 original events to the raid leader. */
+/** Reassign first 2 original events to the raid leader (single query). */
 async function reassignOrigEventsToRaidLeader(
   db: Db,
   userByName: Map<string, typeof schema.users.$inferSelect>,
@@ -279,12 +279,11 @@ async function reassignOrigEventsToRaidLeader(
 ): Promise<void> {
   const raidLeader = userByName.get(ROLE_ACCOUNTS[0].username);
   if (!raidLeader || origEvents.length < 2) return;
-  for (const event of origEvents.slice(0, 2)) {
-    await db
-      .update(schema.events)
-      .set({ creatorId: raidLeader.id })
-      .where(eq(schema.events.id, event.id));
-  }
+  const eventIds = origEvents.slice(0, 2).map((e) => e.id);
+  await db
+    .update(schema.events)
+    .set({ creatorId: raidLeader.id })
+    .where(inArray(schema.events.id, eventIds));
 }
 
 /** Randomly reassign ~30% of generated events to non-admin creators. */

--- a/api/src/admin/demo-data-roster.helpers.ts
+++ b/api/src/admin/demo-data-roster.helpers.ts
@@ -2,7 +2,7 @@
  * Helper functions for demo data roster assignments and event reassignment.
  * Extracted from DemoDataService to keep file size within ESLint limits.
  */
-import { eq, inArray } from 'drizzle-orm';
+import { inArray } from 'drizzle-orm';
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import * as schema from '../drizzle/schema';
 import { createRng } from './demo-data-generator';
@@ -131,18 +131,17 @@ function assignEventRoster(
   }
 }
 
-/** Reassign original events to a raid leader user. */
+/** Reassign original events to a raid leader user (single query). */
 async function reassignOriginalEvents(
   db: Db,
   origEvents: (typeof schema.events.$inferSelect)[],
   raidLeader: { id: number },
 ): Promise<void> {
-  for (const event of origEvents.slice(0, 2)) {
-    await db
-      .update(schema.events)
-      .set({ creatorId: raidLeader.id })
-      .where(eq(schema.events.id, event.id));
-  }
+  const eventIds = origEvents.slice(0, 2).map((e) => e.id);
+  await db
+    .update(schema.events)
+    .set({ creatorId: raidLeader.id })
+    .where(inArray(schema.events.id, eventIds));
 }
 
 /** Reassign ~30% of generated events to random non-admin users. */


### PR DESCRIPTION
## Summary

Batch of performance fixes shipped via fix-batch pipeline.

| Story | Label | Description |
|-------|-------|-------------|
| ROK-799 | Performance | Batch individual `UPDATE events SET creator_id` queries into single `UPDATE ... WHERE id IN (...)` in demo seed — eliminates N+1 pattern flagged by Sentry |

## Validation

- [x] Build passes (contract + api + web)
- [x] TypeScript clean
- [x] Lint clean (0 errors)
- [x] Unit tests pass (api: 250 suites / 3455 tests, web: 158 suites / 2235 tests)
- [x] Integration tests pass (26 suites / 296 tests)
- [x] Smoke tests pass (25/25 Playwright)

🤖 Generated with [Claude Code](https://claude.com/claude-code)