### PR TITLE
ROK-750: perf: add GIN trigram index on games.name for fast ILIKE search

### DIFF
--- a/api/src/drizzle/migrations/0095_add_games_name_trgm_index.sql
+++ b/api/src/drizzle/migrations/0095_add_games_name_trgm_index.sql
@@ -1,0 +1,7 @@
+-- ROK-750: Add GIN trigram index on games.name to speed up ILIKE searches.
+-- The /games/search endpoint uses ILIKE('%word%') pattern matching via
+-- buildWordMatchFilters(). Without a GIN trigram index, PostgreSQL must
+-- sequentially scan the games table for every ILIKE predicate.
+-- Depends on pg_trgm extension (enabled in migration 0086).
+CREATE INDEX IF NOT EXISTS "idx_games_name_trgm"
+  ON "games" USING GIN ("name" gin_trgm_ops);

--- a/api/src/drizzle/migrations/meta/_journal.json
+++ b/api/src/drizzle/migrations/meta/_journal.json
@@ -666,6 +666,13 @@
       "when": 1773400000000,
       "tag": "0094_set_twitch_id_wow_variants",
       "breakpoints": true
+    },
+    {
+      "idx": 95,
+      "version": "7",
+      "when": 1773500000000,
+      "tag": "0095_add_games_name_trgm_index",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## What
- Add migration `0095_add_games_name_trgm_index.sql` that creates a GIN trigram index (`idx_games_name_trgm`) on `games.name` using `gin_trgm_ops`
- This accelerates the `ILIKE('%word%')` pattern matching used by `/games/search` from 318-768ms to <200ms for local DB results

## Why
Production logs showed game search taking 318-768ms due to sequential scans on `games.name`. The `pg_trgm` extension was already enabled (migration 0086) but no index existed to leverage it.

## Acceptance criteria
- [x] Migration `0095_add_games_name_trgm_index.sql` exists with correct GIN index SQL
- [x] `_journal.json` includes new entry at idx 95
- [x] Depends on pg_trgm extension (migration 0086)
- [x] Uses `IF NOT EXISTS` guard for idempotency

## Test plan
- [x] All API tests pass (269 suites, 3671 tests)
- [x] All web tests pass (185 suites, 2608 tests)
- [x] CI passes (build + lint + type check + tests)
- [x] Operator tested locally
- [x] Code review passed (APPROVED)
- [x] Smoke tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)