### PR TITLE
fix: address review findings from ROK-844 spike

### DIFF
--- a/tools/mcp-discord/src/cdp.ts
+++ b/tools/mcp-discord/src/cdp.ts
@@ -13,7 +13,7 @@ let page: Page | null = null;
 export async function connectCDP(): Promise<Page> {
   try {
     browser = await chromium.connectOverCDP(CDP_URL, { timeout: 10_000 });
-    console.log('[mcp-discord] Connected to CDP');
+    console.error('[mcp-discord] Connected to CDP');
   } catch (err) {
     throw new Error(
       `Failed to connect to Discord via CDP at ${CDP_URL}. ` +
@@ -37,7 +37,7 @@ export async function connectCDP(): Promise<Page> {
 
   if (!page) throw new Error('No Discord page found in CDP contexts');
 
-  console.log(`[mcp-discord] Connected to page: ${page.url()}`);
+  console.error(`[mcp-discord] Connected to page: ${page.url()}`);
   return page;
 }
 
@@ -51,7 +51,7 @@ export async function disconnectCDP(): Promise<void> {
     await browser.close().catch(() => {});
     browser = null;
     page = null;
-    console.log('[mcp-discord] Disconnected from CDP');
+    console.error('[mcp-discord] Disconnected from CDP');
   }
 }
 

--- a/tools/mcp-discord/src/index.ts
+++ b/tools/mcp-discord/src/index.ts
@@ -128,6 +128,7 @@ async function main() {
   console.error('[mcp-discord] MCP server running on stdio');
 
   process.on('SIGINT', async () => {
+    await server.close();
     await disconnectCDP();
     process.exit(0);
   });

--- a/tools/mcp-discord/src/tools/navigate.ts
+++ b/tools/mcp-discord/src/tools/navigate.ts
@@ -18,10 +18,16 @@ export const TOOL_SCHEMA = {
   required: ['guildId', 'channelId'],
 };
 
+const SNOWFLAKE_RE = /^\d{17,20}$/;
+
 export async function execute(params: {
   guildId: string;
   channelId: string;
-}): Promise<{ success: boolean; url: string }> {
+}): Promise<{ success: boolean; url: string; error?: string }> {
+  if (!SNOWFLAKE_RE.test(params.guildId) || !SNOWFLAKE_RE.test(params.channelId)) {
+    return { success: false, url: '', error: 'Invalid guild or channel ID — must be a Discord snowflake (17-20 digit number)' };
+  }
+
   const page = getPage();
   const url = `https://discord.com/channels/${params.guildId}/${params.channelId}`;
 

--- a/tools/mcp-discord/src/tools/read-messages.ts
+++ b/tools/mcp-discord/src/tools/read-messages.ts
@@ -33,11 +33,11 @@ export async function execute(params: {
   const messages = await page.evaluate((maxCount: number) => {
     const results: ScrapedMessage[] = [];
 
-    // Try multiple selector strategies — Discord DOM changes frequently
-    const messageEls =
-      document.querySelectorAll('[id^="chat-messages-"]') ??
-      document.querySelectorAll('[class*="messageListItem"]') ??
-      document.querySelectorAll('[role="listitem"]');
+    // Try multiple selector strategies — Discord DOM changes frequently.
+    // querySelectorAll always returns a NodeList (never null), so check .length for fallback.
+    let messageEls = document.querySelectorAll('[id^="chat-messages-"]');
+    if (messageEls.length === 0) messageEls = document.querySelectorAll('[class*="messageListItem"]');
+    if (messageEls.length === 0) messageEls = document.querySelectorAll('[role="listitem"]');
 
     const els = Array.from(messageEls).slice(-maxCount);
 

--- a/tools/test-bot/src/client.ts
+++ b/tools/test-bot/src/client.ts
@@ -2,6 +2,7 @@ import {
   Client,
   GatewayIntentBits,
   Guild,
+  Partials,
   type TextChannel,
   type VoiceChannel,
 } from 'discord.js';
@@ -21,6 +22,11 @@ export async function connect(): Promise<Client> {
       GatewayIntentBits.MessageContent,
       GatewayIntentBits.DirectMessages,
     ],
+    partials: [Partials.Channel],
+  });
+
+  client.on('error', (err) => {
+    console.error('[test-bot] Client error:', err);
   });
 
   await new Promise<void>((resolve, reject) => {
@@ -33,7 +39,10 @@ export async function connect(): Promise<Client> {
       console.log(`[test-bot] Ready as ${client!.user?.tag}`);
       resolve();
     });
-    client!.login(BOT_TOKEN).catch(reject);
+    client!.login(BOT_TOKEN).catch((err) => {
+      clearTimeout(timeout);
+      reject(err);
+    });
   });
 
   guild = client.guilds.cache.get(GUILD_ID) ?? null;

--- a/tools/test-bot/src/helpers/messages.ts
+++ b/tools/test-bot/src/helpers/messages.ts
@@ -87,10 +87,16 @@ export async function waitForMessage(
     function handler(msg: Message) {
       if (msg.channelId !== channelId) return;
       const simple = toSimpleMessage(msg);
-      if (predicate(simple)) {
+      try {
+        if (predicate(simple)) {
+          clearTimeout(timer);
+          client.off('messageCreate', handler);
+          resolve(simple);
+        }
+      } catch (err) {
         clearTimeout(timer);
         client.off('messageCreate', handler);
-        resolve(simple);
+        reject(err);
       }
     }
 
@@ -98,13 +104,20 @@ export async function waitForMessage(
   });
 }
 
-/** Read recent DMs sent to the test bot. */
-export async function readDMs(count = 10): Promise<SimpleMessage[]> {
+/**
+ * Read recent DMs between the test bot and a specific user.
+ * Bots cannot browse their own DM inbox — you must specify which user's
+ * DM channel to read from.
+ */
+export async function readDMs(
+  userId: string,
+  count = 10,
+): Promise<SimpleMessage[]> {
   const client = getClient();
-  const user = client.user;
-  if (!user) throw new Error('Bot user not available');
+  if (!userId) throw new Error('userId is required — bots cannot read their own DM inbox');
 
-  const dmChannel = user.dmChannel ?? (await user.createDM());
+  const user = await client.users.fetch(userId);
+  const dmChannel = await user.createDM();
   const msgs = await dmChannel.messages.fetch({ limit: count });
   return msgs.map(toSimpleMessage).reverse();
 }

--- a/tools/test-bot/src/helpers/voice.ts
+++ b/tools/test-bot/src/helpers/voice.ts
@@ -22,7 +22,12 @@ export async function joinVoice(channelId: string): Promise<void> {
     selfMute: true,
   });
 
-  await entersState(connection, VoiceConnectionStatus.Ready, 10_000);
+  try {
+    await entersState(connection, VoiceConnectionStatus.Ready, 10_000);
+  } catch (err) {
+    connection.destroy();
+    throw err;
+  }
   console.log(`[test-bot] Joined voice channel: ${channel.name}`);
 }
 


### PR DESCRIPTION
## What
Fixes 6 critical/high issues identified during code review of the Discord E2E testing toolset (ROK-844) that merged without review fixes applied.

## Why
The spike shipped with bugs that would cause failures in real usage — broken DM reading, dead DOM fallback code, potential URL injection, and MCP protocol corruption.

## Changes

### test-bot
- **readDMs() broken** — was calling `user.createDM()` on the bot's own user (opens DM with itself). Redesigned to require a `userId` param to open a DM with a specific user.
- **Missing `Partials.Channel`** — discord.js v14 requires this for DM messages to fire. Without it, the `DirectMessages` intent is silently a no-op.
- **No error listener** — unhandled gateway errors would crash the process with no diagnostics. Added `client.on('error', ...)`.
- **Login timeout leak** — timeout wasn't cleared on `.catch` path.
- **Predicate exceptions in waitForMessage** — if the user's predicate throws, the promise would hang forever. Now rejects with the error.
- **Zombie voice connections** — `entersState` rejection left undestroyed connections. Now destroys on failure.

### mcp-discord
- **URL injection in navigate** — `guildId`/`channelId` were interpolated into `window.location.href` without validation. Now validates as Discord snowflakes (`/^\d{17,20}$/`).
- **Dead querySelectorAll fallback** — `??` operator never triggers because `querySelectorAll` always returns a NodeList. Fixed to check `.length === 0`.
- **console.log corrupts MCP protocol** — stdout is reserved for MCP stdio transport. Switched all diagnostic logging to `console.error`.
- **SIGINT handler** — now closes the MCP server before disconnecting CDP.

## Test plan
- [x] `npx tsc --noEmit` passes in both `tools/test-bot/` and `tools/mcp-discord/`
- [ ] Manual: run `npx tsx src/demo.ts` in test-bot (requires bot token)
- [ ] Manual: run `npx tsx src/probe-cdp.ts` in mcp-discord (requires Discord with CDP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)