### PR TITLE
fix: resolve Ollama setup failures in containerized prod (ROK-840)

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -37,7 +37,9 @@ FROM node:20-alpine AS production
 WORKDIR /app
 
 # Install PostgreSQL client for pg_dump (used by backup service and entrypoint)
-RUN apk add --no-cache postgresql-client
+# Install Docker CLI for Ollama container management (ROK-840)
+# Install su-exec for dropping privileges after socket permission fix
+RUN apk add --no-cache postgresql-client docker-cli su-exec
 
 # Create non-root user for security
 RUN addgroup --system --gid 1001 nodejs \
@@ -76,8 +78,8 @@ COPY --from=builder /app/api/assets ./assets
 RUN mkdir -p /data/avatars /data/backups/daily /data/backups/migrations \
     && chown -R nestjs:nodejs /data
 
-# Switch to non-root user
-USER nestjs
+# Note: entrypoint runs as root to fix Docker socket permissions,
+# then drops to nestjs via su-exec (ROK-840)
 
 # Expose port
 EXPOSE 3000

--- a/api/scripts/docker-entrypoint.sh
+++ b/api/scripts/docker-entrypoint.sh
@@ -3,6 +3,17 @@ set -e
 
 echo "🚀 Starting Raid-Ledger API..."
 
+# Grant nestjs user access to Docker socket if mounted (ROK-840: Ollama setup)
+if [ -S /var/run/docker.sock ]; then
+    SOCK_GID=$(stat -c '%g' /var/run/docker.sock 2>/dev/null || echo "")
+    if [ -n "$SOCK_GID" ] && [ "$SOCK_GID" != "0" ]; then
+        addgroup -g "$SOCK_GID" docker_host 2>/dev/null || true
+        addgroup nestjs docker_host 2>/dev/null || true
+    else
+        chmod 666 /var/run/docker.sock 2>/dev/null || true
+    fi
+fi
+
 # Run database migrations if DATABASE_URL is set
 if [ -n "$DATABASE_URL" ]; then
     # Create backup directories (idempotent)
@@ -97,7 +108,7 @@ if [ -n "$DATABASE_URL" ]; then
 
 fi
 
-# Execute the main command
+# Execute the main command as non-root user
 echo "🎮 Starting server..."
-exec "$@"
+exec su-exec nestjs "$@"
 

--- a/api/src/ai/providers/ollama-setup.service.spec.ts
+++ b/api/src/ai/providers/ollama-setup.service.spec.ts
@@ -3,8 +3,15 @@ import { OllamaSetupService } from './ollama-setup.service';
 import { OllamaDockerService } from './ollama-docker.service';
 import { OllamaModelService } from './ollama-model.service';
 import { SettingsService } from '../../settings/settings.service';
-import { LlmProviderRegistry } from '../llm-provider-registry';
 import { AI_DEFAULTS, AI_SETTING_KEYS } from '../llm.constants';
+
+jest.mock('./ollama.helpers', () => ({
+  fetchOllama: jest.fn(),
+}));
+
+import { fetchOllama } from './ollama.helpers';
+
+const mockFetchOllama = fetchOllama as jest.Mock;
 
 describe('Regression: ROK-840', () => {
   describe('OllamaSetupService', () => {
@@ -12,7 +19,6 @@ describe('Regression: ROK-840', () => {
     let mockSettings: Record<string, jest.Mock>;
     let mockDocker: Record<string, jest.Mock>;
     let mockModelService: Record<string, jest.Mock>;
-    let mockRegistry: Record<string, jest.Mock>;
 
     beforeEach(async () => {
       mockSettings = {
@@ -31,11 +37,8 @@ describe('Regression: ROK-840', () => {
       mockModelService = {
         pullModel: jest.fn().mockResolvedValue(undefined),
       };
-      mockRegistry = {
-        resolve: jest.fn().mockReturnValue({
-          isAvailable: jest.fn().mockResolvedValue(true),
-        }),
-      };
+      // Default: health check succeeds immediately
+      mockFetchOllama.mockResolvedValue({ models: [] });
 
       const module = await Test.createTestingModule({
         providers: [
@@ -43,11 +46,14 @@ describe('Regression: ROK-840', () => {
           { provide: SettingsService, useValue: mockSettings },
           { provide: OllamaDockerService, useValue: mockDocker },
           { provide: OllamaModelService, useValue: mockModelService },
-          { provide: LlmProviderRegistry, useValue: mockRegistry },
         ],
       }).compile();
 
       service = module.get(OllamaSetupService);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
     });
 
     describe('getSetupState', () => {
@@ -218,15 +224,28 @@ describe('Regression: ROK-840', () => {
         expect(mockDocker.startContainer).not.toHaveBeenCalled();
       });
 
+      it('should use container URL for health check, not provider settings', async () => {
+        mockDocker.getContainerStatus.mockResolvedValue('not-found');
+        mockDocker.getApiNetwork.mockResolvedValue('my-network');
+        mockDocker.getContainerUrl.mockReturnValue(
+          'http://raid-ledger-ollama:11434',
+        );
+
+        await service.runSetup();
+
+        expect(mockFetchOllama).toHaveBeenCalledWith(
+          'http://raid-ledger-ollama:11434',
+          '/api/tags',
+          expect.objectContaining({ timeoutMs: 3_000 }),
+        );
+      });
+
       it('should abort and persist error when health check times out', async () => {
         jest.useFakeTimers();
         mockDocker.getContainerStatus.mockResolvedValue('not-found');
-        mockRegistry.resolve.mockReturnValue({
-          isAvailable: jest.fn().mockResolvedValue(false),
-        });
+        mockFetchOllama.mockRejectedValue(new Error('ECONNREFUSED'));
 
         const setupPromise = service.runSetup();
-        // Advance through all 30 health check retries (30 × 2000ms)
         for (let i = 0; i < 30; i++) {
           await jest.advanceTimersByTimeAsync(2000);
         }
@@ -240,7 +259,6 @@ describe('Regression: ROK-840', () => {
           AI_SETTING_KEYS.OLLAMA_SETUP_ERROR,
           'Health check timed out',
         );
-        // Should NOT have proceeded to model pull
         expect(mockModelService.pullModel).not.toHaveBeenCalled();
         jest.useRealTimers();
       });

--- a/api/src/ai/providers/ollama-setup.service.ts
+++ b/api/src/ai/providers/ollama-setup.service.ts
@@ -2,10 +2,11 @@ import { Injectable, Logger } from '@nestjs/common';
 import { SettingsService } from '../../settings/settings.service';
 import { OllamaDockerService } from './ollama-docker.service';
 import { OllamaModelService } from './ollama-model.service';
-import { LlmProviderRegistry } from '../llm-provider-registry';
 import { AI_DEFAULTS, AI_SETTING_KEYS } from '../llm.constants';
 import type { SettingKey } from '../../drizzle/schema';
 import type { AiOllamaSetupDto } from '@raid-ledger/contract';
+import { fetchOllama } from './ollama.helpers';
+import type { OllamaRawModel } from './ollama.helpers';
 
 /** Steps that indicate setup is actively running. */
 const RUNNING_STEPS = new Set(['pulling_image', 'starting', 'pulling_model']);
@@ -29,7 +30,6 @@ export class OllamaSetupService {
     private readonly settings: SettingsService,
     private readonly docker: OllamaDockerService,
     private readonly ollamaModel: OllamaModelService,
-    private readonly registry: LlmProviderRegistry,
   ) {}
 
   /** Read persisted setup state from DB. */
@@ -119,12 +119,22 @@ export class OllamaSetupService {
     await this.settings.set(AI_SETTING_KEYS.PROVIDER as SettingKey, 'ollama');
   }
 
-  /** Wait for Ollama to respond to health checks. Throws on timeout. */
+  /**
+   * Wait for Ollama to respond to health checks. Throws on timeout.
+   * Uses the container URL directly — not the provider's settings-based URL —
+   * because settings haven't been persisted yet at this point in the flow.
+   */
   private async waitForHealth(): Promise<void> {
+    const network = await this.docker.getApiNetwork();
+    const url = this.docker.getContainerUrl(network);
     for (let i = 0; i < 30; i++) {
-      const provider = this.registry.resolve('ollama');
       try {
-        if (provider && (await provider.isAvailable())) return;
+        const data = await fetchOllama<{ models: OllamaRawModel[] }>(
+          url,
+          '/api/tags',
+          { timeoutMs: 3_000 },
+        );
+        if ((data.models ?? []).length >= 0) return;
       } catch {
         /* not ready yet */
       }

--- a/web/src/plugins/ai/slots/ollama-setup-card.tsx
+++ b/web/src/plugins/ai/slots/ollama-setup-card.tsx
@@ -38,18 +38,29 @@ export function OllamaSetupCard({ provider }: OllamaSetupCardProps) {
             await qc.invalidateQueries({ queryKey: ['admin', 'ai', 'providers'] });
             const providers = qc.getQueryData<AiProviderInfoDto[]>(['admin', 'ai', 'providers']);
             const ollama = providers?.find((p) => p.key === 'ollama');
-            if (ollama?.available) {
+            if (!ollama) return;
+            if (ollama.available) {
                 setLocalSetup(false);
                 toast.success('Ollama is ready');
+            } else if (ollama.setupStep === 'error') {
+                setLocalSetup(false);
+                toast.error(ollama.error || 'Ollama setup failed');
+            } else if (!ollama.setupInProgress && localSetup) {
+                // Server says setup is not running but we think it is — clear local state
+                setLocalSetup(false);
             }
         }, 5000);
         return () => { clearInterval(pollTimer); };
-    }, [setting, qc]);
+    }, [setting, localSetup, qc]);
 
     const handleSetup = async () => {
         setLocalSetup(true);
         try {
-            await setup.mutateAsync();
+            const result = await setup.mutateAsync();
+            if (result && !result.success) {
+                setLocalSetup(false);
+                toast.error(result.message || 'Ollama setup failed');
+            }
         } catch {
             setLocalSetup(false);
             toast.error('Failed to start Ollama setup');


### PR DESCRIPTION
## What

Follow-up fix for ROK-840. The initial PR addressed state persistence and Docker networking logic, but missed three prerequisites that prevent the feature from working in production.

## Why

After deploying the initial fix, clicking "Setup Ollama" in prod showed "Setting up..." indefinitely with no progress. Root cause chain:

1. **No Docker CLI in container** — the production Dockerfile never installed `docker-cli`, so all `docker` commands failed with ENOENT
2. **Frontend ignored error responses** — `POST ollama/setup` returns `{ success: false }` on failure, but frontend only caught HTTP errors. `localSetup` stayed `true` forever
3. **Health check URL catch-22** — `waitForHealth()` used the provider's `isAvailable()` which reads the Ollama URL from settings. But settings haven't been persisted yet during setup (that happens after health check). So it always pinged `localhost:11434` instead of the container URL

## Acceptance criteria

- [x] Docker CLI installed in production image (`docker-cli` Alpine package)
- [x] Docker socket permissions handled in entrypoint (detect GID, add user to group)
- [x] Entrypoint drops to `nestjs` user via `su-exec` after permission setup
- [x] Frontend checks `response.success` from setup endpoint, shows error toast on failure
- [x] Frontend polling detects error states and `setupInProgress === false`, clears `localSetup`
- [x] Health check uses `fetchOllama()` directly with container URL, not provider settings

## Test plan

- [x] TypeScript clean (api + web)
- [x] `ollama-setup.service.spec.ts`: 14 tests pass including new "should use container URL for health check"
- [ ] Manual: rebuild Docker image, deploy to NAS, click Setup Ollama, verify progress advances

🤖 Generated with [Claude Code](https://claude.com/claude-code)