### PR TITLE
hotfix: fix su-exec prod crash (ROK-840)

### DIFF
--- a/api/scripts/docker-entrypoint.sh
+++ b/api/scripts/docker-entrypoint.sh
@@ -108,7 +108,8 @@ if [ -n "$DATABASE_URL" ]; then
 
 fi
 
-# Execute the main command as non-root user
+# Execute the main command as non-root user (uid 1001 = nestjs)
+# su-exec can't resolve system users by name, must use uid
 echo "🎮 Starting server..."
-exec su-exec nestjs "$@"
+exec su-exec 1001 "$@"
 


### PR DESCRIPTION
## What

One-line fix: `su-exec nestjs` → `su-exec 1001`

## Why

PR #449 introduced `su-exec nestjs` in the entrypoint to drop privileges after fixing Docker socket permissions. But `nestjs` was created with `adduser --system`, and `su-exec` can't resolve system users by name (`getpwnam` fails). This crashes the API container on startup.

**This is a prod outage hotfix.** `raid.gamernight.net` is currently down.

## Test plan

- [x] `su-exec 1001` resolves to the nestjs user (uid 1001 per Dockerfile)
- [ ] Manual: rebuild and deploy, verify API starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)