### PR TITLE
fix: revert broken infra changes, fix allinone Redis perms, add container CI (ROK-840)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,85 @@ jobs:
           path: playwright-report/
           retention-days: 7
 
+  # Container startup validation — runs on PRs that touch Docker/entrypoint files
+  # Builds the allinone image and verifies the API starts and responds to health checks
+  container-startup:
+    if: |
+      github.event_name == 'pull_request' && (
+        contains(github.event.pull_request.title, 'Docker') ||
+        contains(github.event.pull_request.title, 'docker') ||
+        contains(github.event.pull_request.title, 'entrypoint') ||
+        contains(github.event.pull_request.title, 'Ollama') ||
+        contains(github.event.pull_request.title, 'ollama') ||
+        contains(github.event.pull_request.title, 'allinone') ||
+        contains(github.event.pull_request.title, 'Dockerfile')
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build allinone image
+        run: docker build -f Dockerfile.allinone -t raid-ledger:ci-test --build-arg COMMIT_SHA=${{ github.sha }} .
+
+      - name: Start container
+        run: |
+          docker run -d --name rl-ci-test \
+            -p 8080:80 \
+            -e ADMIN_PASSWORD=ci-test-password \
+            raid-ledger:ci-test
+
+      - name: Wait for health check (max 90s)
+        run: |
+          echo "Waiting for container to become healthy..."
+          for i in $(seq 1 90); do
+            STATUS=$(docker inspect rl-ci-test --format '{{.State.Health.Status}}' 2>/dev/null || echo "starting")
+            if [ "$STATUS" = "healthy" ]; then
+              echo "✅ Container healthy after ${i}s"
+              exit 0
+            fi
+            if [ "$STATUS" = "unhealthy" ]; then
+              echo "❌ Container unhealthy after ${i}s"
+              docker logs rl-ci-test --tail 50
+              exit 1
+            fi
+            # Also check if container exited
+            RUNNING=$(docker inspect rl-ci-test --format '{{.State.Running}}' 2>/dev/null || echo "false")
+            if [ "$RUNNING" = "false" ]; then
+              echo "❌ Container exited unexpectedly"
+              docker logs rl-ci-test --tail 50
+              exit 1
+            fi
+            sleep 1
+          done
+          echo "❌ Timed out waiting for healthy status"
+          docker logs rl-ci-test --tail 50
+          exit 1
+
+      - name: Verify API responds
+        run: |
+          # Hit the health endpoint through nginx
+          HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/api/health)
+          if [ "$HTTP_CODE" = "200" ]; then
+            echo "✅ API health check returned 200"
+          else
+            echo "❌ API health check returned $HTTP_CODE"
+            docker logs rl-ci-test --tail 30
+            exit 1
+          fi
+
+      - name: Verify Redis connectivity
+        run: |
+          # Check that Redis is accessible from inside the container
+          docker exec rl-ci-test redis-cli -s /tmp/redis.sock ping | grep -q PONG
+          echo "✅ Redis responding on Unix socket"
+
+      - name: Cleanup
+        if: always()
+        run: |
+          docker stop rl-ci-test 2>/dev/null || true
+          docker rm rl-ci-test 2>/dev/null || true
+
   # Docker image build — only on main after all tests pass
   docker-build:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/Dockerfile.allinone
+++ b/Dockerfile.allinone
@@ -61,8 +61,10 @@ RUN apk add --no-cache \
   logrotate
 
 # Create app user and directories
+# Add app user to redis group so API can access Redis Unix socket (ROK-840)
 RUN addgroup -g 1001 -S app && \
-  adduser -S -D -H -u 1001 -G app app
+  adduser -S -D -H -u 1001 -G app app && \
+  addgroup app redis
 
 WORKDIR /app
 
@@ -162,7 +164,7 @@ killasgroup=true
 stopasgroup=true
 
 [program:redis]
-command=/bin/bash -c '/usr/bin/redis-server --dir /data/redis --daemonize no --port 0 --unixsocket /tmp/redis.sock --unixsocketperm 700 2>&1 | tee -a /data/logs/redis.log'
+command=/bin/bash -c '/usr/bin/redis-server --dir /data/redis --daemonize no --port 0 --unixsocket /tmp/redis.sock --unixsocketperm 770 2>&1 | tee -a /data/logs/redis.log'
 user=redis
 autostart=true
 autorestart=true

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -37,9 +37,7 @@ FROM node:20-alpine AS production
 WORKDIR /app
 
 # Install PostgreSQL client for pg_dump (used by backup service and entrypoint)
-# Install Docker CLI for Ollama container management (ROK-840)
-# Install su-exec for dropping privileges after socket permission fix
-RUN apk add --no-cache postgresql-client docker-cli su-exec
+RUN apk add --no-cache postgresql-client
 
 # Create non-root user for security
 RUN addgroup --system --gid 1001 nodejs \
@@ -78,8 +76,8 @@ COPY --from=builder /app/api/assets ./assets
 RUN mkdir -p /data/avatars /data/backups/daily /data/backups/migrations \
     && chown -R nestjs:nodejs /data
 
-# Note: entrypoint runs as root to fix Docker socket permissions,
-# then drops to nestjs via su-exec (ROK-840)
+# Switch to non-root user
+USER nestjs
 
 # Expose port
 EXPOSE 3000

--- a/api/scripts/docker-entrypoint.sh
+++ b/api/scripts/docker-entrypoint.sh
@@ -3,17 +3,6 @@ set -e
 
 echo "🚀 Starting Raid-Ledger API..."
 
-# Grant nestjs user access to Docker socket if mounted (ROK-840: Ollama setup)
-if [ -S /var/run/docker.sock ]; then
-    SOCK_GID=$(stat -c '%g' /var/run/docker.sock 2>/dev/null || echo "")
-    if [ -n "$SOCK_GID" ] && [ "$SOCK_GID" != "0" ]; then
-        addgroup -g "$SOCK_GID" docker_host 2>/dev/null || true
-        addgroup nestjs docker_host 2>/dev/null || true
-    else
-        chmod 666 /var/run/docker.sock 2>/dev/null || true
-    fi
-fi
-
 # Run database migrations if DATABASE_URL is set
 if [ -n "$DATABASE_URL" ]; then
     # Create backup directories (idempotent)
@@ -76,17 +65,17 @@ if [ -n "$DATABASE_URL" ]; then
 
     # Always seed games (needed for event creation, even without IGDB keys)
     echo "🎮 Seeding games cache..."
-    
+
     # Seed IGDB games cache (enables game search without API keys)
     node ./dist/scripts/seed-igdb-games.js 2>&1 || {
         echo "ℹ️ IGDB games seeding skipped (may already exist)"
     }
-    
+
     # Seed game registry
     node ./dist/scripts/seed-games.js 2>&1 || {
         echo "ℹ️ Game seeding skipped (may already exist)"
     }
-    
+
     echo "✅ Games seeded"
 
     # Flush stale IGDB search cache so seed data takes precedence
@@ -108,8 +97,6 @@ if [ -n "$DATABASE_URL" ]; then
 
 fi
 
-# Execute the main command as non-root user (uid 1001 = nestjs)
-# su-exec can't resolve system users by name, must use uid
+# Execute the main command
 echo "🎮 Starting server..."
-exec su-exec 1001 "$@"
-
+exec "$@"


### PR DESCRIPTION
## What

Properly resolves the prod outage caused by PR #449.

## Why

PR #449 changed the api/Dockerfile and entrypoint to support Docker CLI for Ollama. These changes were incompatible with the allinone production topology:

1. **`su-exec` can't resolve system users by name** — `getpwnam(nestjs)` fails, crashing the container
2. **After uid fix, Redis socket EACCES** — Redis socket has `700` perms (owner-only), API process (uid 1001) isn't in the `redis` group
3. **No CI caught this** — no existing CI step builds or starts the allinone container

## Root cause chain

```
PR #449 merged without CI validation
  → Removed USER nestjs, added su-exec in entrypoint
  → su-exec getpwnam(nestjs) fails (system user)
  → Hotfix: use uid 1001 instead
  → API process can't access /tmp/redis.sock (700 perms, redis:redis owner)
  → EACCES crash loop
```

## Fixes

| Change | File | Description |
|--------|------|-------------|
| Revert | `api/Dockerfile` | Restore `USER nestjs`, remove docker-cli/su-exec |
| Revert | `api/scripts/docker-entrypoint.sh` | Restore `exec "$@"`, remove socket permission logic |
| Fix | `Dockerfile.allinone` | Add `app` user to `redis` group, socket perms `700→770` |
| Add | `.github/workflows/ci.yml` | Container startup CI job on PRs touching Docker/entrypoint |

Frontend error handling and health check URL fixes from PR #449 are preserved.

## Test plan

- [x] TypeScript clean
- [x] All 75 Ollama tests pass
- [x] `api/Dockerfile` matches pre-PR-449 state
- [x] Entrypoint matches pre-PR-449 state
- [ ] Container startup CI: builds allinone, starts it, verifies health + Redis

🤖 Generated with [Claude Code](https://claude.com/claude-code)