### PR TITLE
fix: container-startup CI triggers on file changes, not PR title

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,19 +278,33 @@ jobs:
           path: playwright-report/
           retention-days: 7
 
-  # Container startup validation — runs on PRs that touch Docker/entrypoint files
+  # Container startup validation — runs on PRs that touch Docker, entrypoint, or CI workflow files
   # Builds the allinone image and verifies the API starts and responds to health checks
+  detect-container-changes:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      should_run: ${{ steps.filter.outputs.container }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Check for container-related changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            container:
+              - 'Dockerfile*'
+              - 'api/Dockerfile'
+              - 'api/scripts/docker-entrypoint.sh'
+              - 'nginx/**'
+              - '.github/workflows/ci.yml'
+              - 'api/src/ai/providers/ollama-docker*'
+              - 'api/src/ai/providers/ollama-setup*'
+
   container-startup:
-    if: |
-      github.event_name == 'pull_request' && (
-        contains(github.event.pull_request.title, 'Docker') ||
-        contains(github.event.pull_request.title, 'docker') ||
-        contains(github.event.pull_request.title, 'entrypoint') ||
-        contains(github.event.pull_request.title, 'Ollama') ||
-        contains(github.event.pull_request.title, 'ollama') ||
-        contains(github.event.pull_request.title, 'allinone') ||
-        contains(github.event.pull_request.title, 'Dockerfile')
-      )
+    needs: detect-container-changes
+    if: needs.detect-container-changes.outputs.should_run == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## What

Fixes the container-startup CI job to trigger based on changed files instead of PR title keywords.

## Why

The title-based `if` condition was fragile — it skipped when the PR title didn't contain magic keywords like "Docker" or "Dockerfile", even when the PR changed those exact files.

## Fix

Uses `dorny/paths-filter` to detect changes to:
- `Dockerfile*`, `api/Dockerfile`
- `api/scripts/docker-entrypoint.sh`
- `nginx/**`
- `.github/workflows/ci.yml`
- `api/src/ai/providers/ollama-docker*`, `ollama-setup*`

🤖 Generated with [Claude Code](https://claude.com/claude-code)