### PR TITLE
ROK-843: fix mobile game cards overlapping — missing padding and spacing

### DIFF
--- a/web/src/components/games/GameCarousel.tsx
+++ b/web/src/components/games/GameCarousel.tsx
@@ -59,7 +59,7 @@ export function GameCarousel({ category, games, pricingMap }: GameCarouselProps)
             <div className="relative">
                 {canScrollLeft && <ScrollArrow direction="left" onClick={() => scroll('left')} />}
                 <div ref={scrollRef} className="flex gap-4 overflow-x-auto scrollbar-hide snap-x snap-mandatory pb-2" style={{ scrollbarWidth: 'none', msOverflowStyle: 'none' }}>
-                    {games.map((game) => <div key={game.id} className="snap-start"><UnifiedGameCard variant="link" game={game} compact showRating showInfoBar pricing={pricingMap?.get(game.id) ?? null} /></div>)}
+                    {games.map((game) => <div key={game.id} className="min-w-[180px] flex-shrink-0 snap-start"><UnifiedGameCard variant="link" game={game} compact showRating showInfoBar pricing={pricingMap?.get(game.id) ?? null} /></div>)}
                 </div>
                 {canScrollRight && <ScrollArrow direction="right" onClick={() => scroll('right')} />}
             </div>

--- a/web/src/pages/games-page.tsx
+++ b/web/src/pages/games-page.tsx
@@ -246,8 +246,8 @@ function DiscoverRows({ filteredRows, pricingMap }: { filteredRows: GameDiscover
         {filteredRows.map((row) => (
           <div key={row.slug}>
             <h2 className="text-lg font-semibold text-foreground mb-3">{row.category}</h2>
-            <div className="flex gap-4 overflow-x-auto snap-x snap-mandatory pb-2" style={{ scrollbarWidth: 'none' }}>
-              {row.games.map((game) => (<div key={game.id} className="w-[140px] flex-shrink-0 snap-start"><UnifiedGameCard variant="link" game={game} compact showRating pricing={pricingMap.get(game.id) ?? null} /></div>))}
+            <div className="flex gap-3 overflow-x-auto snap-x snap-mandatory pb-2 scroll-pl-4" style={{ scrollbarWidth: 'none' }}>
+              {row.games.map((game) => (<div key={game.id} className="min-w-[180px] w-[180px] flex-shrink-0 snap-start"><UnifiedGameCard variant="link" game={game} compact showRating pricing={pricingMap.get(game.id) ?? null} /></div>))}
             </div>
           </div>
         ))}


### PR DESCRIPTION
## Summary
- Aligned mobile discover carousel card wrapper width (`w-[140px]` → `min-w-[180px] w-[180px]`) to match `UnifiedGameCard compact` internal sizing, eliminating overflow/overlap
- Reduced mobile carousel gap from `gap-4` to `gap-3` and added `scroll-pl-4` for proper left scroll padding
- Added defensive `min-w-[180px] flex-shrink-0` to desktop `GameCarousel` wrapper for consistency

## Linear
ROK-843

## Test plan
- [x] CI passes (build + lint + type check + tests)
- [x] Operator tested locally
- [x] Smoke tests passed (312 API + 191 web suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)