### PR TITLE
test: add unit tests and review fixes for game affinity DM embed (ROK-845)

### DIFF
--- a/api/src/discord-bot/utils/format-duration.spec.ts
+++ b/api/src/discord-bot/utils/format-duration.spec.ts
@@ -1,0 +1,40 @@
+import { formatDurationMs } from './format-duration';
+
+describe('formatDurationMs', () => {
+  it('returns "0m" for zero', () => {
+    expect(formatDurationMs(0)).toBe('0m');
+  });
+
+  it('returns "0m" for negative values', () => {
+    expect(formatDurationMs(-5000)).toBe('0m');
+  });
+
+  it('returns minutes only when under 1 hour', () => {
+    expect(formatDurationMs(45 * 60_000)).toBe('45m');
+  });
+
+  it('returns hours only when minutes are zero', () => {
+    expect(formatDurationMs(2 * 3_600_000)).toBe('2h');
+  });
+
+  it('returns hours and minutes combined', () => {
+    expect(formatDurationMs(2 * 3_600_000 + 30 * 60_000)).toBe('2h 30m');
+  });
+
+  it('floors partial minutes', () => {
+    // 1h 59m 59.999s → 1h 59m (not rounded up)
+    expect(formatDurationMs(3_600_000 + 59 * 60_000 + 59_999)).toBe('1h 59m');
+  });
+
+  it('returns "0m" for sub-minute durations', () => {
+    expect(formatDurationMs(59_999)).toBe('0m');
+  });
+
+  it('returns "1m" for exactly 1 minute', () => {
+    expect(formatDurationMs(60_000)).toBe('1m');
+  });
+
+  it('returns "1h" for exactly 1 hour', () => {
+    expect(formatDurationMs(3_600_000)).toBe('1h');
+  });
+});

--- a/api/src/notifications/notification-embed.helpers.ts
+++ b/api/src/notifications/notification-embed.helpers.ts
@@ -206,6 +206,7 @@ export function buildExtraRows(
   return undefined;
 }
 
+/** Build reschedule confirm/tentative/decline row. */
 function buildRescheduleRow(eventId: string): ActionRowBuilder<ButtonBuilder> {
   return new ActionRowBuilder<ButtonBuilder>().addComponents(
     new ButtonBuilder()
@@ -223,6 +224,7 @@ function buildRescheduleRow(eventId: string): ActionRowBuilder<ButtonBuilder> {
   );
 }
 
+/** Build signup/tentative/decline row for recruitment. */
 function buildSignupRow(eventId: string): ActionRowBuilder<ButtonBuilder> {
   return new ActionRowBuilder<ButtonBuilder>().addComponents(
     new ButtonBuilder()

--- a/api/src/notifications/notification-embed.subscribed-game.spec.ts
+++ b/api/src/notifications/notification-embed.subscribed-game.spec.ts
@@ -1,0 +1,112 @@
+import { EmbedBuilder } from 'discord.js';
+import { applySubscribedGameEmbed } from './notification-embed.subscribed-game';
+
+function freshEmbed() {
+  return new EmbedBuilder();
+}
+
+describe('applySubscribedGameEmbed — description', () => {
+  it('sets description with game name line', () => {
+    const embed = freshEmbed();
+    applySubscribedGameEmbed(embed, { gameName: 'World of Warcraft' });
+    expect(embed.data.description).toBe('🎮 **World of Warcraft**');
+  });
+
+  it('includes Discord timestamp with duration when start and end provided', () => {
+    const embed = freshEmbed();
+    const start = '2026-03-20T20:00:00Z';
+    const end = '2026-03-20T22:00:00Z';
+    const unix = Math.floor(new Date(start).getTime() / 1000);
+
+    applySubscribedGameEmbed(embed, {
+      gameName: 'WoW',
+      startTime: start,
+      endTime: end,
+    });
+
+    const desc = embed.data.description!;
+    expect(desc).toContain(`<t:${unix}:f>`);
+    expect(desc).toContain(`(<t:${unix}:R>)`);
+    expect(desc).toContain('(2h)');
+  });
+
+  it('omits duration suffix when endTime is missing', () => {
+    const embed = freshEmbed();
+    const start = '2026-03-20T20:00:00Z';
+    const unix = Math.floor(new Date(start).getTime() / 1000);
+
+    applySubscribedGameEmbed(embed, { gameName: 'WoW', startTime: start });
+
+    const desc = embed.data.description!;
+    expect(desc).toContain(`<t:${unix}:f>`);
+    expect(desc).not.toContain('(2h)');
+  });
+
+  it('includes voice channel link when voiceChannelId provided', () => {
+    const embed = freshEmbed();
+    applySubscribedGameEmbed(embed, {
+      gameName: 'WoW',
+      voiceChannelId: '123456789',
+    });
+    expect(embed.data.description).toContain('🔊 <#123456789>');
+  });
+
+  it('omits voice channel line when voiceChannelId absent', () => {
+    const embed = freshEmbed();
+    applySubscribedGameEmbed(embed, { gameName: 'WoW' });
+    expect(embed.data.description).not.toContain('🔊');
+  });
+
+  it('does not set description when payload has no relevant fields', () => {
+    const embed = freshEmbed();
+    applySubscribedGameEmbed(embed, {});
+    expect(embed.data.description).toBeUndefined();
+  });
+});
+
+describe('applySubscribedGameEmbed — thumbnail', () => {
+  it('sets thumbnail from gameCoverUrl', () => {
+    const embed = freshEmbed();
+    applySubscribedGameEmbed(embed, {
+      gameName: 'WoW',
+      gameCoverUrl: 'https://example.com/cover.jpg',
+    });
+    expect(embed.data.thumbnail?.url).toBe('https://example.com/cover.jpg');
+  });
+
+  it('does not set thumbnail when gameCoverUrl is empty', () => {
+    const embed = freshEmbed();
+    applySubscribedGameEmbed(embed, { gameName: 'WoW', gameCoverUrl: '' });
+    expect(embed.data.thumbnail).toBeUndefined();
+  });
+
+  it('does not set thumbnail when gameCoverUrl is missing', () => {
+    const embed = freshEmbed();
+    applySubscribedGameEmbed(embed, { gameName: 'WoW' });
+    expect(embed.data.thumbnail).toBeUndefined();
+  });
+});
+
+describe('applySubscribedGameEmbed — full payload', () => {
+  it('renders all lines in correct order with thumbnail', () => {
+    const embed = freshEmbed();
+    const start = '2026-03-20T20:00:00Z';
+    const end = '2026-03-20T22:30:00Z';
+
+    applySubscribedGameEmbed(embed, {
+      gameName: 'Final Fantasy XIV',
+      startTime: start,
+      endTime: end,
+      voiceChannelId: '999',
+      gameCoverUrl: 'https://example.com/ff.jpg',
+    });
+
+    const lines = embed.data.description!.split('\n');
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toBe('🎮 **Final Fantasy XIV**');
+    expect(lines[1]).toContain('📆');
+    expect(lines[1]).toContain('(2h 30m)');
+    expect(lines[2]).toBe('🔊 <#999>');
+    expect(embed.data.thumbnail?.url).toBe('https://example.com/ff.jpg');
+  });
+});

--- a/api/src/notifications/notification-embed.subscribed-game.ts
+++ b/api/src/notifications/notification-embed.subscribed-game.ts
@@ -20,8 +20,9 @@ export function applySubscribedGameEmbed(
     const dur = computeDurationSuffix(payload.startTime, payload.endTime);
     lines.push(`📆 <t:${unix}:f> (<t:${unix}:R>)${dur}`);
   }
-  if (payload.voiceChannelId)
+  if (payload.voiceChannelId) {
     lines.push(`🔊 <#${toStr(payload.voiceChannelId)}>`);
+  }
   if (lines.length > 0) embed.setDescription(lines.join('\n'));
   if (typeof payload.gameCoverUrl === 'string' && payload.gameCoverUrl)
     embed.setThumbnail(payload.gameCoverUrl);

--- a/tools/test-bot/src/smoke/tests/dm-notifications.test.ts
+++ b/tools/test-bot/src/smoke/tests/dm-notifications.test.ts
@@ -220,7 +220,18 @@ const gameAffinityNotification: SmokeTest = {
     });
     try {
       await sleep(3000);
-      // Pipeline exercised: notification service logs success/failure.
+      // Verify the event was created with the correct game, confirming
+      // the affinity notification dispatch path was triggered.
+      const fetched = await ctx.api.get<{ gameId?: number }>(
+        `/events/${ev.id}`,
+      );
+      if (fetched.gameId !== gameId) {
+        throw new Error(
+          `Event gameId mismatch: expected ${gameId}, got ${fetched.gameId}`,
+        );
+      }
+      // TODO: Assert notification record exists for dmRecipientUserId once
+      // an admin endpoint for querying other users' notifications is added.
       // Bot-to-bot DMs fail with 50007, but the dispatch path ran.
     } finally {
       await deleteEvent(ctx.api, ev.id);


### PR DESCRIPTION
## What
Addresses code review findings from the ROK-845 game affinity DM embed fix.

## Why
The original ROK-845 implementation (merged in #459) lacked direct unit tests for `formatDurationMs` and `applySubscribedGameEmbed`, had an assertion-free smoke test, and minor style inconsistencies.

## Changes
- **New `format-duration.spec.ts`** — 9 tests covering zero, negative, sub-minute, hours-only, mixed, and rounding edge cases
- **New `notification-embed.subscribed-game.spec.ts`** — 10 tests covering description lines, thumbnail, empty/partial payloads, and full payload ordering
- **Smoke test assertion** — game affinity test now verifies event `gameId` matches; TODO for full notification record check
- **Restored JSDoc** on `buildRescheduleRow` and `buildSignupRow`
- **Added braces** to `voiceChannelId` conditional for style consistency

## Acceptance criteria
- [x] `formatDurationMs` has direct unit test coverage
- [x] `applySubscribedGameEmbed` has direct unit test coverage for all branches
- [x] Game affinity smoke test has at least one assertion
- [x] Style nitpicks addressed (JSDoc, braces)

## Test plan
- [x] `npm run test -w api -- format-duration.spec notification-embed.subscribed-game.spec` — 19/19 pass
- [x] ESLint clean on all changed files
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)