### PR TITLE
ROK-884: tech-debt: clean up smoke test error handling and spec file structure

### DIFF
--- a/api/src/events/event-lifecycle.helpers.spec.ts
+++ b/api/src/events/event-lifecycle.helpers.spec.ts
@@ -14,62 +14,75 @@ function createMockNotificationService() {
   };
 }
 
+/** Drizzle chain methods shared across all mock DB builders. */
+const CHAIN_METHODS = [
+  'select',
+  'from',
+  'orderBy',
+  'offset',
+  'leftJoin',
+  'innerJoin',
+  'insert',
+  'values',
+  'returning',
+  'onConflictDoNothing',
+  'onConflictDoUpdate',
+  'update',
+  'set',
+  'delete',
+  'groupBy',
+  'having',
+  '$dynamic',
+  'execute',
+  'as',
+] as const;
+
+type MockDb = Record<string, jest.Mock>;
+
 /**
- * Build a mock DB that handles the rescheduleEvent query chain:
- * 1. findExistingOrThrow: select().from().where().limit() → [event]
- * 2. update().set().where() (event update) → void
- * 3. delete().where() (reset reminders) → void
- * 4. update().set().where() (reset signups) → void
- * 5. select().from().where() (getSignedUpUserIds) → signups
+ * Build a generic mock DB with chainable methods and a configurable
+ * `where` handler. Reduces duplication across test-specific builders.
+ */
+function buildGenericMockDb(opts: {
+  limitResult: unknown[];
+  whereHandler: (callCount: number, db: MockDb) => unknown;
+}): MockDb {
+  let whereCallCount = 0;
+  const mockDb: MockDb = {};
+  for (const m of CHAIN_METHODS) {
+    mockDb[m] = jest.fn().mockReturnThis();
+  }
+  mockDb.limit = jest.fn().mockResolvedValue(opts.limitResult);
+  mockDb.where = jest.fn().mockImplementation(() => {
+    whereCallCount++;
+    return opts.whereHandler(whereCallCount, mockDb);
+  });
+  mockDb.transaction = jest
+    .fn()
+    .mockImplementation(async (cb: (tx: MockDb) => Promise<unknown>) =>
+      cb(mockDb),
+    );
+  return mockDb;
+}
+
+/**
+ * Build a mock DB for rescheduleEvent (5 where() calls):
+ * 1. findExistingOrThrow chain → mockDb (for .limit())
+ * 2-4. update/delete terminals → void
+ * 5. getSignedUpUserIds terminal → signups
  */
 function buildRescheduleMockDb(
   event: Record<string, unknown>,
   signups: { userId: number }[],
 ) {
-  let whereCallCount = 0;
-  const mockDb: Record<string, jest.Mock> = {};
-  const chainMethods = [
-    'select',
-    'from',
-    'orderBy',
-    'offset',
-    'leftJoin',
-    'innerJoin',
-    'insert',
-    'values',
-    'returning',
-    'onConflictDoNothing',
-    'onConflictDoUpdate',
-    'update',
-    'set',
-    'delete',
-    'groupBy',
-    'having',
-    '$dynamic',
-    'execute',
-    'as',
-  ];
-  for (const m of chainMethods) {
-    mockDb[m] = jest.fn().mockReturnThis();
-  }
-  // limit is terminal for findExistingOrThrow
-  mockDb.limit = jest.fn().mockResolvedValue([event]);
-  // where: returns this for chaining (calls 1-4), returns signups for call 5
-  mockDb.where = jest.fn().mockImplementation(() => {
-    whereCallCount++;
-    // Call 1: findExistingOrThrow chain (needs .limit())
-    if (whereCallCount === 1) return mockDb;
-    // Calls 2-4: update/delete terminals (awaited, resolve to mock)
-    if (whereCallCount < 5) return Promise.resolve();
-    // Call 5: getSignedUpUserIds terminal
-    return Promise.resolve(signups);
+  return buildGenericMockDb({
+    limitResult: [event],
+    whereHandler: (n, db) => {
+      if (n === 1) return db;
+      if (n < 5) return Promise.resolve();
+      return Promise.resolve(signups);
+    },
   });
-  mockDb.transaction = jest
-    .fn()
-    .mockImplementation(async (cb: (tx: typeof mockDb) => Promise<unknown>) =>
-      cb(mockDb),
-    );
-  return mockDb;
 }
 
 describe('Regression: ROK-828', () => {
@@ -150,181 +163,135 @@ describe('Regression: ROK-828', () => {
 });
 
 /**
- * Build a mock DB for deleteEvent:
- * 1. findExistingOrThrow: select().from().where().limit() → [event]
- * 2. delete().where() → void
+ * Build a mock DB for deleteEvent (2 where() calls):
+ * 1. findExistingOrThrow chain → mockDb (for .limit())
+ * 2. delete terminal → void
  */
 function buildDeleteMockDb(event: Record<string, unknown> | null) {
-  let whereCallCount = 0;
-  const mockDb: Record<string, jest.Mock> = {};
-  const chainMethods = [
-    'select',
-    'from',
-    'update',
-    'set',
-    'insert',
-    'values',
-    'returning',
-    'delete',
-    'orderBy',
-    'offset',
-    'leftJoin',
-    'innerJoin',
-    'groupBy',
-    'having',
-    '$dynamic',
-    'execute',
-    'as',
-    'onConflictDoNothing',
-    'onConflictDoUpdate',
-  ];
-  for (const m of chainMethods) {
-    mockDb[m] = jest.fn().mockReturnThis();
-  }
-  // limit is terminal for findExistingOrThrow
-  mockDb.limit = jest.fn().mockResolvedValue(event !== null ? [event] : []);
-  // where: call 1 returns this (for chaining into .limit()), call 2 resolves (DB delete)
-  mockDb.where = jest.fn().mockImplementation(() => {
-    whereCallCount++;
-    if (whereCallCount === 1) return mockDb;
-    return Promise.resolve();
+  return buildGenericMockDb({
+    limitResult: event !== null ? [event] : [],
+    whereHandler: (n, db) => {
+      if (n === 1) return db;
+      return Promise.resolve();
+    },
   });
-  mockDb.transaction = jest
-    .fn()
-    .mockImplementation(async (cb: (tx: typeof mockDb) => Promise<unknown>) =>
-      cb(mockDb),
-    );
-  return mockDb;
+}
+
+function buildMockEmitter() {
+  return {
+    emit: jest.fn(),
+    emitAsync: jest.fn().mockResolvedValue([]),
+  };
+}
+
+/** Shorthand: calls deleteEvent with the given mocks (avoids verbose `as any` casts). */
+function callDelete(
+  db: MockDb,
+  emitter: ReturnType<typeof buildMockEmitter>,
+  evtId: number,
+  uid: number,
+  admin: boolean,
+) {
+  return deleteEvent(db as any, emitter as any, evtId, uid, admin);
 }
 
 describe('Regression: ROK-846 — deleteEvent uses emitAsync before cascade delete', () => {
   const eventId = 99;
   const creatorId = 5;
 
-  function buildMockEmitter() {
-    return {
-      emit: jest.fn(),
-      emitAsync: jest.fn().mockResolvedValue([]),
-    };
-  }
-
-  it('calls emitAsync with DELETED event before DB delete', async () => {
-    const event = createMockEvent({ id: eventId, creatorId });
-    const mockDb = buildDeleteMockDb(event);
-    const emitter = buildMockEmitter();
-    const callOrder: string[] = [];
-
-    emitter.emitAsync.mockImplementation(() => {
-      callOrder.push('emitAsync');
-      return Promise.resolve([]);
-    });
-    mockDb.where.mockImplementation(() => {
-      // The second where() call is the DB delete
-      if (mockDb.where.mock.calls.length === 1) return mockDb;
-      callOrder.push('db.delete');
-      return Promise.resolve();
+  describe('emit ordering', () => {
+    it('calls emitAsync before DB delete', async () => {
+      const event = createMockEvent({ id: eventId, creatorId });
+      const mockDb = buildDeleteMockDb(event);
+      const emitter = buildMockEmitter();
+      const callOrder: string[] = [];
+      emitter.emitAsync.mockImplementation(() => {
+        callOrder.push('emitAsync');
+        return Promise.resolve([]);
+      });
+      mockDb.where.mockImplementation(() => {
+        if (mockDb.where.mock.calls.length === 1) return mockDb;
+        callOrder.push('db.delete');
+        return Promise.resolve();
+      });
+      await callDelete(mockDb, emitter, eventId, creatorId, false);
+      expect(callOrder).toEqual(['emitAsync', 'db.delete']);
     });
 
-    await deleteEvent(mockDb as any, emitter as any, eventId, creatorId, false);
-
-    expect(callOrder).toEqual(['emitAsync', 'db.delete']);
-  });
-
-  it('uses emitAsync (not emit) for the DELETED event', async () => {
-    const event = createMockEvent({ id: eventId, creatorId });
-    const mockDb = buildDeleteMockDb(event);
-    const emitter = buildMockEmitter();
-
-    await deleteEvent(mockDb as any, emitter as any, eventId, creatorId, false);
-
-    expect(emitter.emitAsync).toHaveBeenCalledWith(APP_EVENT_EVENTS.DELETED, {
-      eventId,
-    });
-    expect(emitter.emit).not.toHaveBeenCalled();
-  });
-
-  it('performs DB delete after emitAsync resolves', async () => {
-    const event = createMockEvent({ id: eventId, creatorId });
-    const mockDb = buildDeleteMockDb(event);
-    const emitter = buildMockEmitter();
-
-    await deleteEvent(mockDb as any, emitter as any, eventId, creatorId, false);
-
-    // Both emitAsync and DB delete should have been called
-    expect(emitter.emitAsync).toHaveBeenCalledTimes(1);
-    expect(mockDb.delete).toHaveBeenCalled();
-    expect(mockDb.where).toHaveBeenCalledTimes(2);
-  });
-
-  it('does NOT delete from DB if emitAsync rejects', async () => {
-    const event = createMockEvent({ id: eventId, creatorId });
-    const mockDb = buildDeleteMockDb(event);
-    const emitter = buildMockEmitter();
-    emitter.emitAsync.mockRejectedValue(new Error('handler failed'));
-
-    await expect(
-      deleteEvent(mockDb as any, emitter as any, eventId, creatorId, false),
-    ).rejects.toThrow('handler failed');
-
-    // DB delete should NOT have been called since emitAsync threw
-    expect(mockDb.delete).not.toHaveBeenCalled();
-  });
-
-  it('throws NotFoundException when event does not exist', async () => {
-    const mockDb = buildDeleteMockDb(null);
-    const emitter = buildMockEmitter();
-
-    await expect(
-      deleteEvent(mockDb as any, emitter as any, eventId, creatorId, false),
-    ).rejects.toThrow(NotFoundException);
-
-    expect(emitter.emitAsync).not.toHaveBeenCalled();
-    expect(mockDb.delete).not.toHaveBeenCalled();
-  });
-
-  it('throws ForbiddenException when non-owner non-admin tries to delete', async () => {
-    const event = createMockEvent({ id: eventId, creatorId: 999 });
-    const mockDb = buildDeleteMockDb(event);
-    const emitter = buildMockEmitter();
-    const differentUserId = 7;
-
-    await expect(
-      deleteEvent(
-        mockDb as any,
-        emitter as any,
+    it('uses emitAsync (not emit) for the DELETED event', async () => {
+      const event = createMockEvent({ id: eventId, creatorId });
+      const mockDb = buildDeleteMockDb(event);
+      const emitter = buildMockEmitter();
+      await callDelete(mockDb, emitter, eventId, creatorId, false);
+      expect(emitter.emitAsync).toHaveBeenCalledWith(APP_EVENT_EVENTS.DELETED, {
         eventId,
-        differentUserId,
-        false,
-      ),
-    ).rejects.toThrow(ForbiddenException);
+      });
+      expect(emitter.emit).not.toHaveBeenCalled();
+    });
 
-    expect(emitter.emitAsync).not.toHaveBeenCalled();
-    expect(mockDb.delete).not.toHaveBeenCalled();
+    it('performs DB delete after emitAsync resolves', async () => {
+      const event = createMockEvent({ id: eventId, creatorId });
+      const mockDb = buildDeleteMockDb(event);
+      const emitter = buildMockEmitter();
+      await callDelete(mockDb, emitter, eventId, creatorId, false);
+      expect(emitter.emitAsync).toHaveBeenCalledTimes(1);
+      expect(mockDb.delete).toHaveBeenCalled();
+      expect(mockDb.where).toHaveBeenCalledTimes(2);
+    });
+
+    it('does NOT delete from DB if emitAsync rejects', async () => {
+      const event = createMockEvent({ id: eventId, creatorId });
+      const mockDb = buildDeleteMockDb(event);
+      const emitter = buildMockEmitter();
+      emitter.emitAsync.mockRejectedValue(new Error('handler failed'));
+      await expect(
+        callDelete(mockDb, emitter, eventId, creatorId, false),
+      ).rejects.toThrow('handler failed');
+      expect(mockDb.delete).not.toHaveBeenCalled();
+    });
   });
 
-  it("allows admin to delete another user's event", async () => {
-    const event = createMockEvent({ id: eventId, creatorId: 999 });
-    const mockDb = buildDeleteMockDb(event);
-    const emitter = buildMockEmitter();
-    const adminUserId = 7;
+  describe('access control', () => {
+    it('throws NotFoundException when event does not exist', async () => {
+      const mockDb = buildDeleteMockDb(null);
+      const emitter = buildMockEmitter();
+      await expect(
+        callDelete(mockDb, emitter, eventId, creatorId, false),
+      ).rejects.toThrow(NotFoundException);
+      expect(emitter.emitAsync).not.toHaveBeenCalled();
+      expect(mockDb.delete).not.toHaveBeenCalled();
+    });
 
-    await expect(
-      deleteEvent(mockDb as any, emitter as any, eventId, adminUserId, true),
-    ).resolves.toBeUndefined();
+    it('throws ForbiddenException for non-owner non-admin', async () => {
+      const event = createMockEvent({ id: eventId, creatorId: 999 });
+      const mockDb = buildDeleteMockDb(event);
+      const emitter = buildMockEmitter();
+      await expect(
+        callDelete(mockDb, emitter, eventId, 7, false),
+      ).rejects.toThrow(ForbiddenException);
+      expect(emitter.emitAsync).not.toHaveBeenCalled();
+      expect(mockDb.delete).not.toHaveBeenCalled();
+    });
 
-    expect(emitter.emitAsync).toHaveBeenCalledTimes(1);
-    expect(mockDb.delete).toHaveBeenCalled();
-  });
+    it("allows admin to delete another user's event", async () => {
+      const event = createMockEvent({ id: eventId, creatorId: 999 });
+      const mockDb = buildDeleteMockDb(event);
+      const emitter = buildMockEmitter();
+      await expect(
+        callDelete(mockDb, emitter, eventId, 7, true),
+      ).resolves.toBeUndefined();
+      expect(emitter.emitAsync).toHaveBeenCalledTimes(1);
+      expect(mockDb.delete).toHaveBeenCalled();
+    });
 
-  it('allows owner to delete their own event', async () => {
-    const event = createMockEvent({ id: eventId, creatorId });
-    const mockDb = buildDeleteMockDb(event);
-    const emitter = buildMockEmitter();
-
-    await expect(
-      deleteEvent(mockDb as any, emitter as any, eventId, creatorId, false),
-    ).resolves.toBeUndefined();
-
-    expect(emitter.emitAsync).toHaveBeenCalledTimes(1);
+    it('allows owner to delete their own event', async () => {
+      const event = createMockEvent({ id: eventId, creatorId });
+      const mockDb = buildDeleteMockDb(event);
+      const emitter = buildMockEmitter();
+      await expect(
+        callDelete(mockDb, emitter, eventId, creatorId, false),
+      ).resolves.toBeUndefined();
+      expect(emitter.emitAsync).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/tools/test-bot/src/smoke/tests/interaction-flows.test.ts
+++ b/tools/test-bot/src/smoke/tests/interaction-flows.test.ts
@@ -205,20 +205,25 @@ const eventDeleteCleansEmbed: SmokeTest = {
       );
       // Delete the event — embed should be removed from channel
       await deleteEvent(ctx.api, ev.id);
-      // Poll for embed removal — check if embed disappears
-      const gone = await pollForCondition(
-        async () => {
-          const msgs = await readLastMessages(ctx.defaultChannelId, 50);
-          const has = msgs.some((m) =>
-            m.embeds.some((e) => e.title?.includes(ev.title)),
-          );
-          return has ? null : true;
-        },
-        ctx.config.timeoutMs,
-      ).then(() => true).catch(() => false);
-      const stillThere = !gone;
-      if (stillThere) {
-        throw new Error('Embed still present after event deletion');
+      // Poll for embed removal — let network/unexpected errors propagate naturally.
+      // Only catch the specific timeout error to produce a clear assertion message.
+      try {
+        await pollForCondition(
+          async () => {
+            const msgs = await readLastMessages(ctx.defaultChannelId, 50);
+            const has = msgs.some((m) =>
+              m.embeds.some((e) => e.title?.includes(ev.title)),
+            );
+            return has ? null : true;
+          },
+          ctx.config.timeoutMs,
+        );
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes('pollForCondition timed out')) {
+          throw new Error('Embed still present after event deletion');
+        }
+        throw err; // re-throw network/unexpected errors as-is
       }
     } finally {
       // Already deleted above


### PR DESCRIPTION
## Summary
- Fix smoke test `eventDeleteCleansEmbed` error handling — timeout errors now properly distinguished from network/unexpected errors instead of being silently swallowed
- Extract shared `buildGenericMockDb` factory to eliminate duplication between `buildDeleteMockDb` and `buildRescheduleMockDb` in event-lifecycle spec
- Split oversized describe block into focused nested describes (`emit ordering`, `access control`)

## Linear
ROK-884

## Test plan
- [x] CI passes (4542/4542 tests, 0 lint errors)
- [x] Code review passed (APPROVED, no critical issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)