### PR TITLE
fix(ROK-856): handle iLvl=0 in Classic equipment sync

### DIFF
--- a/api/src/plugins/wow-common/blizzard-equipment.helpers.ts
+++ b/api/src/plugins/wow-common/blizzard-equipment.helpers.ts
@@ -83,7 +83,9 @@ function logEquipmentSample(
   if (result.items.length === 0) return;
   const sample = result.items
     .slice(0, 3)
-    .map((i) => `${i.name}: quality=${i.quality}, iLvl=${i.itemLevel}`);
+    .map(
+      (i) => `${i.name}: quality=${i.quality}, iLvl=${i.itemLevel || 'N/A'}`,
+    );
   logger.log(
     `Equipment for ${charName}: ${result.items.length} items. Sample: [${sample.join('; ')}]`,
   );

--- a/web/src/plugins/wow/components/item-comparison.tsx
+++ b/web/src/plugins/wow/components/item-comparison.tsx
@@ -71,7 +71,7 @@ interface ItemComparisonProps {
  * ROK-246: Dungeon Companion — Quest Suggestions UI
  */
 function computeDelta(rewardItemLevel: number | null, equippedItemLevel: number): { deltaClass: string; deltaText: string } {
-    const delta = rewardItemLevel ? rewardItemLevel - equippedItemLevel : null;
+    const delta = rewardItemLevel && equippedItemLevel ? rewardItemLevel - equippedItemLevel : null;
     if (delta === null) return { deltaClass: 'item-comparison__delta--neutral', deltaText: '' };
     if (delta > 0) return { deltaClass: 'item-comparison__delta--upgrade', deltaText: `▲ +${delta} iLvl` };
     if (delta < 0) return { deltaClass: 'item-comparison__delta--downgrade', deltaText: `▼ ${delta} iLvl` };


### PR DESCRIPTION
## What
Fix misleading iLvl=0 output for Classic Era characters in sync logs and item comparison deltas.

## Why
Blizzard Classic API doesn't return `level` for equipment items. The parser defaults to `0`, which produces noisy logs and incorrect upgrade delta calculations in item comparison.

## Changes
- **API** (`blizzard-equipment.helpers.ts`): Log `iLvl=N/A` instead of `iLvl=0` for items without level data
- **Web** (`item-comparison.tsx`): Skip delta computation when equipped item has `iLvl=0` (returns neutral/no badge)

## Test plan
- [x] API tests pass (326 suites, 4505 tests)
- [x] Web tests pass (192 suites, 2680 tests)
- [x] TypeScript compilation clean
- [x] Lint clean (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)