### PR TITLE
ROK-939: fix Ollama setup — BusyBox tar missing zstd support

### DIFF
--- a/api/src/ai/providers/ollama-native.helpers.spec.ts
+++ b/api/src/ai/providers/ollama-native.helpers.spec.ts
@@ -85,13 +85,10 @@ describe('downloadAndExtractBinary', () => {
     );
     expect(mockMkdtemp).toHaveBeenCalled();
     expect(mockExecFile).toHaveBeenCalledWith(
-      'tar',
+      '/bin/sh',
       [
-        '--zstd',
-        '-xf',
-        '/usr/local/bin/ollama.tar.zst.tmp',
-        '-C',
-        '/tmp/ollama-abc123',
+        '-c',
+        'zstd -dc "/usr/local/bin/ollama.tar.zst.tmp" | tar -xf - -C "/tmp/ollama-abc123"',
       ],
       expect.objectContaining({ timeout: 300_000 }),
       expect.any(Function),

--- a/api/src/ai/providers/ollama-native.helpers.ts
+++ b/api/src/ai/providers/ollama-native.helpers.ts
@@ -44,12 +44,16 @@ export async function downloadAndExtractBinary(
   }
 }
 
-/** Extract a .tar.zst archive to a directory using tar CLI. */
+/**
+ * Extract a .tar.zst archive to a directory.
+ * Uses `zstd -dc | tar -xf -` instead of `tar --zstd` because
+ * BusyBox tar (Alpine/allinone image) does not support the --zstd flag.
+ */
 function extractTarZst(archive: string, dest: string): Promise<void> {
   return new Promise((resolve, reject) => {
     execFile(
-      'tar',
-      ['--zstd', '-xf', archive, '-C', dest],
+      '/bin/sh',
+      ['-c', `zstd -dc "${archive}" | tar -xf - -C "${dest}"`],
       { timeout: DOWNLOAD_TIMEOUT_MS },
       (err) => {
         if (err) reject(new Error(err.message));


### PR DESCRIPTION
## Summary
- Ollama setup fails in production (allinone image) because BusyBox tar doesn't support `--zstd` flag
- Changed extraction to pipe through `zstd -dc | tar -xf -` which works on both GNU tar and BusyBox
- Root cause found in production logs: `tar: unrecognized option: zstd` (BusyBox v1.37.0)

## Linear
ROK-939

## Test plan
- [x] Build passes (contract + api)
- [x] TypeScript clean
- [x] Lint clean (0 errors, warnings only)
- [x] Unit tests pass (331 suites, 4686 tests)
- [x] Playwright skipped (API-only, no web changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)