### PR TITLE
chore: add smoke test verification rules from ROK-935 incident

### DIFF
--- a/.claude/skills/build/steps/step-3-validate.md
+++ b/.claude/skills/build/steps/step-3-validate.md
@@ -27,11 +27,20 @@ npm run lint -w web --prefix $WORKTREE
 # Tests
 npm run test -w api --prefix $WORKTREE
 npm run test -w web --prefix $WORKTREE
+
+# Smoke tests — BOTH desktop AND mobile (matches CI exactly)
+# MANDATORY for any story with UI changes. Do NOT use --project=desktop.
+cd $WORKTREE && npx playwright test && cd -
 ```
+
+**Smoke test verification is MANDATORY before pushing.** CI runs both desktop and mobile
+Playwright projects. If you only verify desktop locally, mobile failures will fail CI and
+waste GitHub Actions minutes. See CLAUDE.md "Smoke Test Verification" for details.
 
 If CI fails:
 - **Lint/type errors:** Fix directly in the worktree, commit as `fix: resolve CI issues (ROK-XXX)`
 - **Test failures:** Assess — if trivial, fix. If complex, re-spawn dev for the failing story.
+- **Smoke test failures:** Run `npx playwright test` (both projects) locally, fix ALL failures before re-pushing. Do NOT re-run CI hoping for a different result.
 
 Update state: `gates.ci: PASS` (or `FAIL`)
 

--- a/.claude/skills/push/SKILL.md
+++ b/.claude/skills/push/SKILL.md
@@ -167,13 +167,20 @@ npm run test -w web
 Only if `web/src/` files changed:
 
 ```bash
+# CRITICAL: Do NOT add --project=desktop. CI runs BOTH desktop AND mobile.
+# Running only desktop locally and pushing will fail CI on mobile tests.
 npx playwright test
 ```
 
+**This runs BOTH desktop and mobile projects (~450 tests).** Takes ~3 minutes.
+
 If Playwright fails:
-- Diagnose the failure
+- Check the error: "element not found" vs "strict mode" vs "timeout"
+- "Strict mode" = your new DOM elements collided with selectors in OTHER test files
+- New components on shared pages (Games, Events, Layout) affect tests in other files — run the FULL suite
 - Fix the code or the test
 - **NEVER skip and proceed**
+- **NEVER re-push and re-run CI hoping it passes** — fix locally first
 
 If the branch is API-only (no web changes), this step can be skipped.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,9 +81,33 @@ Three custom MCP servers provide tools for environment management, story trackin
 - **Read `TESTING.md` before writing or modifying any test file.**
 - Shared test infra: `api/src/common/testing/` (drizzle-mock, factories), `web/src/test/` (MSW handlers, render helpers, factories)
 
+### Smoke Test Verification (STRICT — learned from ROK-935 incident)
+
+**CI runs BOTH desktop AND mobile Playwright projects.** Local verification MUST match CI:
+
+```bash
+# WRONG — only tests desktop, mobile failures will surprise you in CI
+npx playwright test --project=desktop
+
+# RIGHT — tests both projects, matches CI exactly
+npx playwright test
+```
+
+**Before pushing ANY branch with UI changes:**
+1. Run `npx playwright test` (both projects) locally — not `--project=desktop`
+2. If any test fails, fix it BEFORE pushing — do NOT use CI as a debugger
+3. New components on shared pages (layout, nav, Games page) break selectors in OTHER test files — run the FULL suite, not just your feature's tests
+
+**When smoke tests fail in CI:**
+1. Check the ACTUAL error message — is it "element not found", "strict mode", or "timeout"?
+2. "Element not found" = the selector is wrong or the UI differs in CI (missing data, unconfigured services)
+3. "Strict mode" = selector matches 2+ elements (new DOM from your changes collided with existing selectors)
+4. "Timeout" with correct selector = CI runner is slow, increase timeout or add retry
+5. **NEVER re-run CI hoping it passes** — investigate the failure first
+
 ### Test Failure Rules (STRICT — applies to ALL agents)
 
-- **NEVER dismiss test failures as "pre-existing" or "unrelated to this change."** Every test failure must be investigated and either fixed or tracked in a Linear story with root cause.
+- **NEVER dismiss test failures as "pre-existing" or "unrelated to this change."** Every test failure must be investigated and either fixed or tracked in a Linear story with root cause. This rule was violated during ROK-935 and cost 6 hours — it exists for a reason.
 - **NEVER use `sleep()` in smoke tests.** Use deterministic wait helpers (`waitForEmbedUpdate`, `pollForCondition`, etc.).
 - **NEVER skip or weaken a test assertion to make CI pass.** Fix the code or fix the test infrastructure.
 - **Every feature/fix MUST include an end-to-end test:**


### PR DESCRIPTION
## Summary
- Add "Smoke Test Verification (STRICT)" section to CLAUDE.md
- Update push skill with mobile viewport warning
- Update build skill step 3 with mandatory both-project Playwright check

## Why
ROK-935 took 8 hours because smoke tests were only verified on desktop locally while CI runs both desktop AND mobile. These rules enforce matching CI behavior locally.

## Test plan
- [x] Documentation only — no code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)