### PR TITLE
fix: run detect-changes on main pushes to unblock docker-build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
   # Determines which jobs need to run based on changed files.
   # All downstream jobs check these outputs before starting.
   detect-changes:
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}


### PR DESCRIPTION
## Summary
- `detect-changes` job had `if: github.event_name == 'pull_request'` — skipped on all main pushes
- This cascaded: lint, unit-tests, smoke-tests all skipped (they `needs: detect-changes`)
- docker-build skipped because its dependencies were skipped
- **Production images haven't been built for any recent merge to main**

## Fix
Remove the PR-only guard from `detect-changes`. `dorny/paths-filter` works on push events too (compares commit against parent).

## Test plan
- [x] CI workflow change only — will validate by observing the main push after merge
- [x] Expected: detect-changes runs → lint/tests run → docker-build runs on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)