### PR TITLE
ROK-972: guard LineupPhaseProcessor.onModuleInit to prevent bootstrap crash

### DIFF
--- a/api/src/lineups/queue/lineup-phase.processor.ts
+++ b/api/src/lineups/queue/lineup-phase.processor.ts
@@ -33,7 +33,14 @@ export class LineupPhaseProcessor extends WorkerHost implements OnModuleInit {
   }
 
   async onModuleInit(): Promise<void> {
-    await this.rehydratePendingJobs();
+    try {
+      await this.rehydratePendingJobs();
+    } catch (err) {
+      this.logger.error(
+        'Failed to rehydrate lineup phase jobs on startup',
+        err,
+      );
+    }
   }
 
   /** Process a phase transition job. */


### PR DESCRIPTION
## What
- Wrap `rehydratePendingJobs()` in try/catch so a transient DB query failure during startup logs an error instead of crashing `NestApplication.listen()`

## Why
- Production outage: the `community_lineups` query failed during `onModuleInit`, the unhandled rejection propagated through `callInitHook → init() → listen()`, and the HTTP server never started (502 on all routes)
- Rehydration is best-effort (re-schedules BullMQ phase transition timers) — it should never block app startup

## Linear
ROK-972

## Test plan
- [x] Build passes (contract + api)
- [x] TypeScript clean (pre-existing issue in unrelated test file)
- [x] Lint clean (0 errors)
- [x] Unit tests pass (340 suites, 4773 tests)
- [ ] Playwright skipped (no web changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)