### PR TITLE
chore: CI efficiency — split unit tests, concurrency groups, discord path filter

### DIFF
--- a/.claude/skills/bulk/steps/step-3-validate.md
+++ b/.claude/skills/bulk/steps/step-3-validate.md
@@ -153,15 +153,15 @@ Update state: `gates.smoke: PASS` (or `FAIL`)
 
 ---
 
-## 3i. Push Batch Branch
+## 3i. Push Batch Branch and Create PR
 
-**Use the `/push` skill** — NEVER use raw `git push`. The skill runs full local CI before pushing.
+**Use the `/push` skill** — NEVER use raw `git push`. The skill runs full local CI before pushing AND creates the PR.
 
 ```
-/push --skip-pr
+/push
 ```
 
-The `--skip-pr` flag skips PR creation — the PR is created in Step 4.
+`/push` handles PR creation. When it asks for PR details, use the batch format from Step 4a (story table + validation checklist). Title: `chore: batch YYYY-MM-DD`.
 
 ---
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # ─── Scope Detection ──────────────────────────────────────────────
   # Determines which jobs need to run based on changed files.
@@ -59,7 +63,6 @@ jobs:
               - 'api/Dockerfile'
               - 'api/scripts/docker-entrypoint.sh'
               - 'nginx/**'
-              - '.github/workflows/ci.yml'
               - 'api/src/ai/providers/ollama-docker*'
               - 'api/src/ai/providers/ollama-setup*'
 
@@ -104,13 +107,13 @@ jobs:
       - name: Lint
         run: npm run lint --workspaces
 
-  # ─── Unit Tests ────────────────────────────────────────────────────
-  unit-tests:
+  # ─── Unit Tests (API) ──────────────────────────────────────────────
+  unit-tests-api:
     runs-on: ubuntu-latest
     needs: [detect-changes, lint]
     if: >-
       github.event_name == 'push' ||
-      needs.detect-changes.outputs.code == 'true'
+      needs.detect-changes.outputs.api == 'true'
 
     steps:
       - name: Checkout code
@@ -138,9 +141,56 @@ jobs:
       - name: Test API (with coverage)
         run: npm run test:cov -w api -- --passWithNoTests
 
+  # ─── Unit Tests (Web) ──────────────────────────────────────────────
+  unit-tests-web:
+    runs-on: ubuntu-latest
+    needs: [detect-changes, lint]
+    if: >-
+      github.event_name == 'push' ||
+      needs.detect-changes.outputs.web == 'true'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-modules-
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build contract
+        run: npm run build -w packages/contract
+
       - name: Test web (with coverage)
         run: npx vitest run --coverage
         working-directory: web
+
+  # ─── Unit Tests (summary — required status check) ─────────────────
+  unit-tests:
+    runs-on: ubuntu-latest
+    needs: [unit-tests-api, unit-tests-web]
+    if: always()
+    steps:
+      - name: Check results
+        run: |
+          API="${{ needs.unit-tests-api.result }}"
+          WEB="${{ needs.unit-tests-web.result }}"
+          if [ "$API" = "failure" ] || [ "$WEB" = "failure" ]; then
+            echo "Unit tests failed (api=$API, web=$WEB)"
+            exit 1
+          fi
+          echo "Unit tests passed (api=$API, web=$WEB)"
 
   # ─── Integration Tests (sharded) ───────────────────────────────────
   integration-test-shard:

--- a/.github/workflows/discord-smoke.yml
+++ b/.github/workflows/discord-smoke.yml
@@ -9,10 +9,39 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: discord-smoke-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      discord: ${{ steps.filter.outputs.discord }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Detect changed paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            discord:
+              - 'api/src/discord-bot/**'
+              - 'api/src/notifications/**'
+              - 'api/src/events/signups*'
+              - 'api/src/events/event-lifecycle*'
+              - 'api/src/admin/demo-test*'
+              - 'tools/test-bot/**'
+              - 'packages/contract/**'
+
   discord-smoke:
     runs-on: ubuntu-latest
-    needs: [] # Runs independently — does not block main CI
+    needs: detect-changes
+    if: >-
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      needs.detect-changes.outputs.discord == 'true'
 
     services:
       postgres:


### PR DESCRIPTION
## What
Reduce wasted CI minutes with four low-risk workflow changes.

## Why
API-only PRs were running the full web test suite (~3-4 min wasted). Rapid pushes stacked duplicate runs. Discord smoke tests ran on every PR regardless of relevance (~8-10 min wasted). CI-config-only PRs triggered unnecessary Docker builds.

## Changes
1. **Split `unit-tests` into `unit-tests-api` + `unit-tests-web`** — each gated on its respective path filter (`api`/`web`). Added `unit-tests` summary job to preserve branch protection.
2. **Concurrency groups** on `ci.yml` and `discord-smoke.yml` — auto-cancels in-progress PR runs when a new push arrives.
3. **Path filtering on `discord-smoke.yml`** — skips the full Discord smoke suite when no discord-related files changed. Still runs on push to main and workflow_dispatch.
4. **Narrowed container filter** — removed `.github/workflows/ci.yml` from the `container` path list so CI-config PRs don't trigger Docker build validation.

## Test plan
- [x] YAML lint passes on both workflow files
- [ ] CI runs on this PR and correctly identifies scope (only CI config changed → unit-tests-api/web should skip, discord-smoke should skip)
- [ ] Verify `unit-tests` summary job reports correctly when sub-jobs are skipped
- [ ] Verify concurrency cancellation works on a rapid double-push (can test on next feature PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)