### PR TITLE
chore: let /push handle PR creation in bulk pipeline

### DIFF
--- a/.claude/skills/bulk/steps/step-4-ship.md
+++ b/.claude/skills/bulk/steps/step-4-ship.md
@@ -4,40 +4,13 @@
 
 ---
 
-## 4a. Create PR
+## 4a. PR (already created by /push in Step 3i)
 
-Create a single PR covering all stories in the batch:
+The PR was created by `/push` in Step 3i. Verify it exists:
 
 ```bash
-gh pr create \
-  --title "chore: batch YYYY-MM-DD" \
-  --body "$(cat <<'EOF'
-## Summary
-
-Batch of tech debt, chores, and performance improvements shipped via bulk pipeline.
-
-| Story | Label | Description |
-|-------|-------|-------------|
-| ROK-XXX | Tech Debt | 1-line summary of what was improved |
-| ROK-YYY | Chore | 1-line summary of what was done |
-
-## Validation
-
-- [x] Build passes (contract + api + web)
-- [x] TypeScript clean
-- [x] Lint clean
-- [x] Unit tests pass (api + web)
-- [x] Integration tests pass
-- [x] Smoke tests pass / skipped (no UI changes)
-
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
-EOF
-)" \
-  --base main \
-  --head batch/YYYY-MM-DD
+gh pr list --head batch/YYYY-MM-DD --json number,url
 ```
-
-Fill in the actual story table from the state file.
 
 ---
 

--- a/.claude/skills/push/SKILL.md
+++ b/.claude/skills/push/SKILL.md
@@ -250,18 +250,15 @@ The push in Step 9 updated it. No action needed unless the PR description needs 
 
 ---
 
-## Step 11: Auto-Merge (ONLY when instructed)
+## Step 11: Enable Auto-Merge
 
-**Do NOT enable auto-merge by default.** Auto-merge is a one-way door.
-
-Only enable auto-merge when:
-- The operator explicitly says to merge
-- All pipeline gates have passed (operator testing, code review, smoke tests)
-- This is the LAST action before the story is "Done"
+**Always enable auto-merge (squash) after creating or pushing to a PR** — this is a project convention from CLAUDE.md.
 
 ```bash
 gh pr merge $(git branch --show-current) --auto --squash
 ```
+
+This is safe to run whether the PR was just created or already existed — it's a no-op if already enabled.
 
 ---
 


### PR DESCRIPTION
## Summary
- Remove `--skip-pr` from bulk step 3i — `/push` always creates the PR
- Simplify step 4a (ship) to just verify the PR exists instead of duplicating PR creation logic
- Update `/push` step 11 to always enable auto-merge per CLAUDE.md convention

## Test plan
- [x] Skills-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)