### PR TITLE
ROK-978: add database-backed notification dedup guard

### DIFF
--- a/api/src/drizzle/migrations/0106_notification_dedup.sql
+++ b/api/src/drizzle/migrations/0106_notification_dedup.sql
@@ -1,0 +1,12 @@
+-- ROK-978: Database-backed notification dedup guard.
+-- Survives Redis restarts by persisting dedup state in PostgreSQL.
+
+CREATE TABLE IF NOT EXISTS "notification_dedup" (
+  "id" serial PRIMARY KEY NOT NULL,
+  "dedup_key" varchar(255) NOT NULL,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "expires_at" timestamp with time zone
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS "uq_notification_dedup_key" ON "notification_dedup" ("dedup_key");
+CREATE INDEX IF NOT EXISTS "idx_notification_dedup_expires_at" ON "notification_dedup" ("expires_at");

--- a/api/src/drizzle/migrations/meta/_journal.json
+++ b/api/src/drizzle/migrations/meta/_journal.json
@@ -743,6 +743,13 @@
       "when": 1774500100000,
       "tag": "0105_lineup_matches_and_scheduling",
       "breakpoints": true
+    },
+    {
+      "idx": 106,
+      "version": "7",
+      "when": 1774600000000,
+      "tag": "0106_notification_dedup",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/drizzle/schema.ts
+++ b/api/src/drizzle/schema.ts
@@ -39,3 +39,4 @@ export * from './schema/ai-request-logs';
 export * from './schema/community-lineups';
 export * from './schema/community-lineup-matches';
 export * from './schema/activity-log';
+export * from './schema/notification-dedup';

--- a/api/src/drizzle/schema/notification-dedup.ts
+++ b/api/src/drizzle/schema/notification-dedup.ts
@@ -1,0 +1,33 @@
+import {
+  pgTable,
+  serial,
+  varchar,
+  timestamp,
+  uniqueIndex,
+  index,
+} from 'drizzle-orm/pg-core';
+
+/**
+ * Tracks notification dedup keys to prevent duplicate sends (ROK-978).
+ * Survives Redis restarts by persisting dedup state in the database.
+ * Uses a unique constraint on dedup_key + ON CONFLICT DO NOTHING
+ * for atomic idempotent inserts.
+ */
+export const notificationDedup = pgTable(
+  'notification_dedup',
+  {
+    id: serial('id').primaryKey(),
+    dedupKey: varchar('dedup_key', { length: 255 }).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+    expiresAt: timestamp('expires_at', { withTimezone: true }),
+  },
+  (table) => [
+    uniqueIndex('uq_notification_dedup_key').on(table.dedupKey),
+    index('idx_notification_dedup_expires_at').on(table.expiresAt),
+  ],
+);
+
+export type NotificationDedupRow = typeof notificationDedup.$inferSelect;
+export type NewNotificationDedupRow = typeof notificationDedup.$inferInsert;

--- a/api/src/notifications/discord-notification.service.spec.ts
+++ b/api/src/notifications/discord-notification.service.spec.ts
@@ -8,6 +8,7 @@ import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
 import { REDIS_CLIENT } from '../redis/redis.module';
 import { DISCORD_NOTIFICATION_QUEUE } from './discord-notification.constants';
 import { createDrizzleMock, type MockDb } from '../common/testing/drizzle-mock';
+import { NotificationDedupService } from './notification-dedup.service';
 
 describe('DiscordNotificationService', () => {
   let service: DiscordNotificationService;
@@ -49,6 +50,10 @@ describe('DiscordNotificationService', () => {
     expire: jest.fn().mockResolvedValue(1),
   };
 
+  const mockDedupService = {
+    checkAndMarkSent: jest.fn().mockResolvedValue(false),
+  };
+
   beforeEach(async () => {
     jest.clearAllMocks();
 
@@ -70,6 +75,7 @@ describe('DiscordNotificationService', () => {
           useValue: mockEmbedService,
         },
         { provide: SettingsService, useValue: mockSettingsService },
+        { provide: NotificationDedupService, useValue: mockDedupService },
         { provide: REDIS_CLIENT, useValue: mockRedis },
       ],
     }).compile();
@@ -199,29 +205,33 @@ describe('DiscordNotificationService', () => {
       expect(mockClientService.sendEmbedDM).not.toHaveBeenCalled();
     });
 
-    it('should skip when already sent (tracked in Redis)', async () => {
+    it('should skip when already sent (DB-backed dedup)', async () => {
       mockDb.limit.mockResolvedValueOnce([{ discordId: '123456' }]);
-      mockRedis.get.mockResolvedValueOnce('1');
+      mockDedupService.checkAndMarkSent.mockResolvedValueOnce(true);
 
       await service.sendWelcomeDM(1);
 
+      expect(mockDedupService.checkAndMarkSent).toHaveBeenCalledWith(
+        'discord-notif:welcome:1',
+        null,
+      );
       expect(mockClientService.sendEmbedDM).not.toHaveBeenCalled();
     });
 
-    it('should send welcome DM and track in Redis', async () => {
+    it('should send welcome DM and mark via dedup service', async () => {
       mockDb.limit.mockResolvedValueOnce([{ discordId: '123456' }]);
-      mockRedis.get.mockResolvedValueOnce(null);
+      mockDedupService.checkAndMarkSent.mockResolvedValueOnce(false);
 
       await service.sendWelcomeDM(1);
 
+      expect(mockDedupService.checkAndMarkSent).toHaveBeenCalledWith(
+        'discord-notif:welcome:1',
+        null,
+      );
       expect(mockClientService.sendEmbedDM).toHaveBeenCalledWith(
         '123456',
         expect.anything(),
         expect.anything(),
-      );
-      expect(mockRedis.set).toHaveBeenCalledWith(
-        'discord-notif:welcome:1',
-        '1',
       );
     });
   });

--- a/api/src/notifications/discord-notification.service.system-type.spec.ts
+++ b/api/src/notifications/discord-notification.service.system-type.spec.ts
@@ -15,6 +15,7 @@ import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
 import { REDIS_CLIENT } from '../redis/redis.module';
 import { DISCORD_NOTIFICATION_QUEUE } from './discord-notification.constants';
 import { createDrizzleMock, type MockDb } from '../common/testing/drizzle-mock';
+import { NotificationDedupService } from './notification-dedup.service';
 
 describe('DiscordNotificationService — system type & failure TTL (ROK-373)', () => {
   let service: DiscordNotificationService;
@@ -77,6 +78,10 @@ describe('DiscordNotificationService — system type & failure TTL (ROK-373)', (
           useValue: mockEmbedService,
         },
         { provide: SettingsService, useValue: mockSettingsService },
+        {
+          provide: NotificationDedupService,
+          useValue: { checkAndMarkSent: jest.fn().mockResolvedValue(false) },
+        },
         { provide: REDIS_CLIENT, useValue: mockRedis },
       ],
     }).compile();

--- a/api/src/notifications/discord-notification.service.ts
+++ b/api/src/notifications/discord-notification.service.ts
@@ -10,6 +10,7 @@ import * as schema from '../drizzle/schema';
 import type { NotificationType } from '../drizzle/schema/notification-preferences';
 import { DiscordBotClientService } from '../discord-bot/discord-bot-client.service';
 import { DiscordNotificationEmbedService } from './discord-notification-embed.service';
+import { NotificationDedupService } from './notification-dedup.service';
 import { SettingsService } from '../settings/settings.service';
 import {
   DISCORD_NOTIFICATION_QUEUE,
@@ -38,6 +39,7 @@ export class DiscordNotificationService {
     @InjectQueue(DISCORD_NOTIFICATION_QUEUE) private queue: Queue,
     private readonly clientService: DiscordBotClientService,
     private readonly embedService: DiscordNotificationEmbedService,
+    private readonly dedupService: NotificationDedupService,
     private readonly settingsService: SettingsService,
     @Inject(REDIS_CLIENT)
     private redis: Redis,
@@ -182,10 +184,10 @@ export class DiscordNotificationService {
       return;
     }
 
-    // Check if we already sent a welcome DM (tracked in Redis)
+    // Check if we already sent a welcome DM (DB-backed dedup, null = no expiry)
     const welcomeKey = `discord-notif:welcome:${userId}`;
-    const alreadySent = await this.redis.get(welcomeKey);
-    if (alreadySent) return;
+    const wasSent = await this.dedupService.checkAndMarkSent(welcomeKey, null);
+    if (wasSent) return;
 
     try {
       const branding = await this.settingsService.getBranding();
@@ -195,9 +197,6 @@ export class DiscordNotificationService {
       );
 
       await this.clientService.sendEmbedDM(user.discordId, embed, row);
-
-      // Mark as sent (no expiry — one-time event)
-      await this.redis.set(welcomeKey, '1');
 
       this.logger.log(`Sent welcome DM to user ${userId}`);
     } catch (error) {

--- a/api/src/notifications/game-affinity-notification.service.ts
+++ b/api/src/notifications/game-affinity-notification.service.ts
@@ -1,11 +1,10 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { sql } from 'drizzle-orm';
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
-import Redis from 'ioredis';
 import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
-import { REDIS_CLIENT } from '../redis/redis.module';
 import * as schema from '../drizzle/schema';
 import { NotificationService } from './notification.service';
+import { NotificationDedupService } from './notification-dedup.service';
 
 /** TTL for game-alert dedup keys: 30 days in seconds */
 const GAME_ALERT_TTL_SECONDS = 30 * 24 * 60 * 60;
@@ -40,9 +39,8 @@ export class GameAffinityNotificationService {
   constructor(
     @Inject(DrizzleAsyncProvider)
     private db: PostgresJsDatabase<typeof schema>,
-    @Inject(REDIS_CLIENT)
-    private redis: Redis,
     private readonly notificationService: NotificationService,
+    private readonly dedupService: NotificationDedupService,
   ) {}
 
   /**
@@ -53,7 +51,11 @@ export class GameAffinityNotificationService {
     input: GameAffinityNotificationInput,
   ): Promise<void> {
     const dedupKey = `game-alert:event:${input.eventId}`;
-    if (await this.redis.get(dedupKey)) {
+    const alreadySent = await this.dedupService.checkAndMarkSent(
+      dedupKey,
+      GAME_ALERT_TTL_SECONDS,
+    );
+    if (alreadySent) {
       this.logger.debug(
         `Game affinity alerts already sent for event ${input.eventId}, skipping`,
       );
@@ -68,7 +70,6 @@ export class GameAffinityNotificationService {
     }
     recipientIds = await this.excludeAbsentUsers(recipientIds, input);
     if (recipientIds.length === 0) return;
-    await this.redis.set(dedupKey, '1', 'EX', GAME_ALERT_TTL_SECONDS);
     await this.dispatchAffinityNotifications(input, recipientIds);
   }
 

--- a/api/src/notifications/notification-dedup.integration.spec.ts
+++ b/api/src/notifications/notification-dedup.integration.spec.ts
@@ -70,10 +70,7 @@ describe('Notification Dedup (integration)', () => {
       const ttlSeconds = 48 * 60 * 60; // 48 hours
 
       // Act
-      const result = await dedupService.checkAndMarkSent(
-        dedupKey,
-        ttlSeconds,
-      );
+      const result = await dedupService.checkAndMarkSent(dedupKey, ttlSeconds);
 
       // Assert: false means "not yet sent, go ahead and send"
       expect(result).toBe(false);
@@ -99,10 +96,7 @@ describe('Notification Dedup (integration)', () => {
       await dedupService.checkAndMarkSent(dedupKey, ttlSeconds);
 
       // Act: second call should hit Redis fast-path
-      const result = await dedupService.checkAndMarkSent(
-        dedupKey,
-        ttlSeconds,
-      );
+      const result = await dedupService.checkAndMarkSent(dedupKey, ttlSeconds);
 
       // Assert: true means "already sent, skip"
       expect(result).toBe(true);
@@ -124,10 +118,7 @@ describe('Notification Dedup (integration)', () => {
       expect(redisValueBefore).toBeNull();
 
       // Act: should fall through to DB lookup
-      const result = await dedupService.checkAndMarkSent(
-        dedupKey,
-        ttlSeconds,
-      );
+      const result = await dedupService.checkAndMarkSent(dedupKey, ttlSeconds);
 
       // Assert: true because DB still has the record
       expect(result).toBe(true);

--- a/api/src/notifications/notification-dedup.service.ts
+++ b/api/src/notifications/notification-dedup.service.ts
@@ -1,0 +1,133 @@
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { sql } from 'drizzle-orm';
+import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import Redis from 'ioredis';
+import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
+import { REDIS_CLIENT } from '../redis/redis.module';
+import * as schema from '../drizzle/schema';
+
+/**
+ * Database-backed notification dedup guard (ROK-978).
+ *
+ * Prevents duplicate notifications by combining a Redis fast-path cache
+ * with PostgreSQL persistence. Redis is checked first for speed; on miss
+ * the DB is consulted. This survives Redis restarts (e.g. daily at 5 AM).
+ *
+ * Rate limits and failure counters remain Redis-only.
+ */
+@Injectable()
+export class NotificationDedupService {
+  private readonly logger = new Logger(NotificationDedupService.name);
+
+  constructor(
+    @Inject(DrizzleAsyncProvider)
+    private db: PostgresJsDatabase<typeof schema>,
+    @Inject(REDIS_CLIENT)
+    private redis: Redis,
+  ) {}
+
+  /**
+   * Check whether a notification has already been sent for the given key.
+   * If not yet sent, atomically marks it as sent in both Redis and DB.
+   *
+   * @param dedupKey - Unique key identifying the notification (e.g. "recruitment-bump:event:42")
+   * @param ttlSeconds - TTL in seconds, or null for permanent dedup (e.g. welcome DMs)
+   * @returns false if not yet sent (caller should send), true if already sent (caller should skip)
+   */
+  async checkAndMarkSent(
+    dedupKey: string,
+    ttlSeconds: number | null,
+  ): Promise<boolean> {
+    // Fast-path: check Redis first
+    const cached = await this.redis.get(dedupKey);
+    if (cached) return true;
+
+    // Slow-path: check DB
+    const dbHit = await this.findValidDbRecord(dedupKey);
+    if (dbHit) {
+      await this.warmRedisCache(dedupKey, ttlSeconds);
+      return true;
+    }
+
+    // Not sent yet — attempt atomic insert
+    return this.attemptInsert(dedupKey, ttlSeconds);
+  }
+
+  /**
+   * Delete all expired dedup rows from the database.
+   * Rows with null expires_at are permanent and never cleaned up.
+   */
+  async cleanupExpiredDedup(): Promise<void> {
+    const result = await this.db.execute<{ count: string }>(sql`
+      DELETE FROM notification_dedup
+      WHERE expires_at IS NOT NULL AND expires_at < NOW()
+    `);
+    const count = result.length;
+    if (count > 0) {
+      this.logger.log(`Cleaned up expired notification dedup rows`);
+    }
+  }
+
+  /** Check if a non-expired DB record exists for the given dedup key. */
+  private async findValidDbRecord(dedupKey: string): Promise<boolean> {
+    const rows = await this.db.execute<{ id: number }>(sql`
+      SELECT id FROM notification_dedup
+      WHERE dedup_key = ${dedupKey}
+        AND (expires_at IS NULL OR expires_at > NOW())
+      LIMIT 1
+    `);
+    return rows.length > 0;
+  }
+
+  /** Re-populate Redis from DB to avoid future DB lookups. */
+  private async warmRedisCache(
+    dedupKey: string,
+    ttlSeconds: number | null,
+  ): Promise<void> {
+    if (ttlSeconds != null) {
+      await this.redis.set(dedupKey, '1', 'EX', ttlSeconds);
+    } else {
+      await this.redis.set(dedupKey, '1');
+    }
+  }
+
+  /**
+   * Attempt to insert a new dedup record. Removes any expired row first,
+   * then uses ON CONFLICT DO NOTHING for concurrent race safety.
+   *
+   * @returns false if insert succeeded (not previously sent), true if conflict (already sent)
+   */
+  private async attemptInsert(
+    dedupKey: string,
+    ttlSeconds: number | null,
+  ): Promise<boolean> {
+    // Remove stale expired row so the fresh insert can succeed
+    await this.db.execute(sql`
+      DELETE FROM notification_dedup
+      WHERE dedup_key = ${dedupKey}
+        AND expires_at IS NOT NULL
+        AND expires_at < NOW()
+    `);
+
+    const expiresAt =
+      ttlSeconds != null
+        ? new Date(Date.now() + ttlSeconds * 1000).toISOString()
+        : null;
+
+    const result = await this.db.execute<{ id: number }>(sql`
+      INSERT INTO notification_dedup (dedup_key, expires_at)
+      VALUES (${dedupKey}, ${expiresAt})
+      ON CONFLICT (dedup_key) DO NOTHING
+      RETURNING id
+    `);
+
+    if (result.length > 0) {
+      // Insert succeeded — we are the winner
+      await this.warmRedisCache(dedupKey, ttlSeconds);
+      return false;
+    }
+
+    // Conflict — another caller already inserted
+    return true;
+  }
+}

--- a/api/src/notifications/notification.module.ts
+++ b/api/src/notifications/notification.module.ts
@@ -12,6 +12,7 @@ import { DiscordNotificationEmbedService } from './discord-notification-embed.se
 import { GameAffinityNotificationService } from './game-affinity-notification.service';
 import { LiveNoShowService } from './live-noshow.service';
 import { RecruitmentReminderService } from './recruitment-reminder.service';
+import { NotificationDedupService } from './notification-dedup.service';
 import { DISCORD_NOTIFICATION_QUEUE } from './discord-notification.constants';
 import { DrizzleModule } from '../drizzle/drizzle.module';
 import { CronJobModule } from '../cron-jobs/cron-job.module';
@@ -41,6 +42,7 @@ import { SettingsModule } from '../settings/settings.module';
     GameAffinityNotificationService,
     LiveNoShowService,
     RecruitmentReminderService,
+    NotificationDedupService,
   ],
   exports: [
     NotificationService,

--- a/api/src/notifications/recruitment-reminder.service.grace-period.spec.ts
+++ b/api/src/notifications/recruitment-reminder.service.grace-period.spec.ts
@@ -41,7 +41,7 @@ describe('RecruitmentReminderService — grace period (ROK-826)', () => {
     const result = await service.checkAndSendReminders();
 
     expect(result).toBe(false);
-    expect(mocks.mockRedis.get).not.toHaveBeenCalled();
+    expect(mocks.mockDedupService.checkAndMarkSent).not.toHaveBeenCalled();
     expect(mocks.mockNotificationService.create).not.toHaveBeenCalled();
     expect(mocks.mockDiscordBotClient.sendEmbed).not.toHaveBeenCalled();
   });
@@ -184,13 +184,7 @@ describe('RecruitmentReminderService — grace period (ROK-826)', () => {
 
     await service.checkAndSendReminders();
 
-    expect(mocks.mockRedis.set).not.toHaveBeenCalledWith(
-      'recruitment-bump:event:77',
-      '1',
-      'EX',
-      expect.any(Number),
-    );
-    expect(mocks.mockRedis.get).not.toHaveBeenCalled();
+    expect(mocks.mockDedupService.checkAndMarkSent).not.toHaveBeenCalled();
   });
 
   it('should only process the non-grace event when batch contains both grace and non-grace events', async () => {
@@ -217,11 +211,13 @@ describe('RecruitmentReminderService — grace period (ROK-826)', () => {
 
     await service.checkAndSendReminders();
 
-    expect(mocks.mockRedis.get).toHaveBeenCalledWith(
+    expect(mocks.mockDedupService.checkAndMarkSent).toHaveBeenCalledWith(
       'recruitment-bump:event:20',
+      172800,
     );
-    expect(mocks.mockRedis.get).not.toHaveBeenCalledWith(
+    expect(mocks.mockDedupService.checkAndMarkSent).not.toHaveBeenCalledWith(
       'recruitment-bump:event:10',
+      172800,
     );
     expect(mocks.mockNotificationService.create).toHaveBeenCalledTimes(1);
   });
@@ -246,7 +242,7 @@ describe('RecruitmentReminderService — grace period (ROK-826)', () => {
     const result = await service.checkAndSendReminders();
 
     expect(result).toBe(false);
-    expect(mocks.mockRedis.get).not.toHaveBeenCalled();
+    expect(mocks.mockDedupService.checkAndMarkSent).not.toHaveBeenCalled();
     expect(mocks.mockDiscordBotClient.sendEmbed).not.toHaveBeenCalled();
     expect(mocks.mockNotificationService.create).not.toHaveBeenCalled();
   });
@@ -268,8 +264,9 @@ describe('RecruitmentReminderService — grace period (ROK-826)', () => {
       .mockResolvedValueOnce([]); // findRecipients (>24h away, DMs deferred)
 
     return service.checkAndSendReminders().then(() => {
-      expect(mocks.mockRedis.get).toHaveBeenCalledWith(
+      expect(mocks.mockDedupService.checkAndMarkSent).toHaveBeenCalledWith(
         'recruitment-bump:event:88',
+        172800,
       );
     });
   });
@@ -291,6 +288,6 @@ describe('RecruitmentReminderService — grace period (ROK-826)', () => {
     const result = await service.checkAndSendReminders();
 
     expect(result).toBe(false);
-    expect(mocks.mockRedis.get).not.toHaveBeenCalled();
+    expect(mocks.mockDedupService.checkAndMarkSent).not.toHaveBeenCalled();
   });
 });

--- a/api/src/notifications/recruitment-reminder.service.spec-helpers.ts
+++ b/api/src/notifications/recruitment-reminder.service.spec-helpers.ts
@@ -1,8 +1,8 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { RecruitmentReminderService } from './recruitment-reminder.service';
 import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
-import { REDIS_CLIENT } from '../redis/redis.module';
 import { NotificationService } from './notification.service';
+import { NotificationDedupService } from './notification-dedup.service';
 import { SettingsService } from '../settings/settings.service';
 import { DiscordBotClientService } from '../discord-bot/discord-bot-client.service';
 import { CronJobService } from '../cron-jobs/cron-job.service';
@@ -51,7 +51,7 @@ export interface RecruitmentReminderTestMocks {
     set: jest.Mock;
     where: jest.Mock;
   };
-  mockRedis: { get: jest.Mock; set: jest.Mock };
+  mockDedupService: { checkAndMarkSent: jest.Mock };
   mockNotificationService: {
     create: jest.Mock;
     resolveVoiceChannelForEvent: jest.Mock;
@@ -75,9 +75,8 @@ export async function createRecruitmentReminderTestModule(): Promise<{
       set: jest.fn().mockReturnThis(),
       where: jest.fn().mockResolvedValue(undefined),
     },
-    mockRedis: {
-      get: jest.fn().mockResolvedValue(null),
-      set: jest.fn().mockResolvedValue('OK'),
+    mockDedupService: {
+      checkAndMarkSent: jest.fn().mockResolvedValue(false),
     },
     mockNotificationService: {
       create: jest.fn().mockResolvedValue({ id: 'notif-uuid-1' }),
@@ -102,7 +101,10 @@ export async function createRecruitmentReminderTestModule(): Promise<{
     providers: [
       RecruitmentReminderService,
       { provide: DrizzleAsyncProvider, useValue: mocks.mockDb },
-      { provide: REDIS_CLIENT, useValue: mocks.mockRedis },
+      {
+        provide: NotificationDedupService,
+        useValue: mocks.mockDedupService,
+      },
       { provide: NotificationService, useValue: mocks.mockNotificationService },
       { provide: SettingsService, useValue: mocks.mockSettingsService },
       {

--- a/api/src/notifications/recruitment-reminder.service.spec.ts
+++ b/api/src/notifications/recruitment-reminder.service.spec.ts
@@ -40,30 +40,32 @@ describe('RecruitmentReminderService', () => {
 
       await service.checkAndSendReminders();
 
-      expect(mocks.mockRedis.get).not.toHaveBeenCalled();
+      expect(mocks.mockDedupService.checkAndMarkSent).not.toHaveBeenCalled();
       expect(mocks.mockNotificationService.create).not.toHaveBeenCalled();
       expect(mocks.mockDiscordBotClient.sendEmbed).not.toHaveBeenCalled();
     });
   });
 
   describe('checkAndSendReminders — deduplication', () => {
-    it('should skip event when both Redis dedup keys already exist', async () => {
+    it('should skip event when both dedup keys already exist', async () => {
       const event = makeEventRow();
       mocks.mockDb.execute.mockResolvedValueOnce([event]);
-      mocks.mockRedis.get.mockResolvedValue('1'); // both bump and dm keys exist
+      mocks.mockDedupService.checkAndMarkSent.mockResolvedValue(true); // both bump and dm already sent
 
       await service.checkAndSendReminders();
 
-      expect(mocks.mockRedis.get).toHaveBeenCalledWith(
+      expect(mocks.mockDedupService.checkAndMarkSent).toHaveBeenCalledWith(
         'recruitment-bump:event:42',
+        48 * 60 * 60,
       );
-      expect(mocks.mockRedis.get).toHaveBeenCalledWith(
+      expect(mocks.mockDedupService.checkAndMarkSent).toHaveBeenCalledWith(
         'recruitment-dm:event:42',
+        48 * 60 * 60,
       );
       expect(mocks.mockNotificationService.create).not.toHaveBeenCalled();
     });
 
-    it('should set Redis DM dedup key with 48h TTL before dispatching DMs', async () => {
+    it('should call checkAndMarkSent for DM dedup key with 48h TTL', async () => {
       const event = makeEventRow();
       mocks.mockDb.execute
         .mockResolvedValueOnce([event]) // findEligibleEvents
@@ -72,10 +74,8 @@ describe('RecruitmentReminderService', () => {
 
       await service.checkAndSendReminders();
 
-      expect(mocks.mockRedis.set).toHaveBeenCalledWith(
+      expect(mocks.mockDedupService.checkAndMarkSent).toHaveBeenCalledWith(
         'recruitment-dm:event:42',
-        '1',
-        'EX',
         48 * 60 * 60,
       );
     });
@@ -89,15 +89,15 @@ describe('RecruitmentReminderService', () => {
         .mockResolvedValueOnce([]) // findRecipients for event2
         .mockResolvedValueOnce([]); // findAbsentUsers — may not be called when no recipients
 
-      mocks.mockRedis.get.mockResolvedValue(null); // neither event deduplicated
-
       await service.checkAndSendReminders();
 
-      expect(mocks.mockRedis.get).toHaveBeenCalledWith(
+      expect(mocks.mockDedupService.checkAndMarkSent).toHaveBeenCalledWith(
         'recruitment-bump:event:10',
+        48 * 60 * 60,
       );
-      expect(mocks.mockRedis.get).toHaveBeenCalledWith(
+      expect(mocks.mockDedupService.checkAndMarkSent).toHaveBeenCalledWith(
         'recruitment-bump:event:20',
+        48 * 60 * 60,
       );
     });
   });

--- a/api/src/notifications/recruitment-reminder.service.ts
+++ b/api/src/notifications/recruitment-reminder.service.ts
@@ -1,7 +1,6 @@
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
-import Redis from 'ioredis';
 import {
   EmbedBuilder,
   ActionRowBuilder,
@@ -10,9 +9,9 @@ import {
 } from 'discord.js';
 import { eq, and } from 'drizzle-orm';
 import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
-import { REDIS_CLIENT } from '../redis/redis.module';
 import * as schema from '../drizzle/schema';
 import { NotificationService } from './notification.service';
+import { NotificationDedupService } from './notification-dedup.service';
 import { SettingsService } from '../settings/settings.service';
 import { DiscordBotClientService } from '../discord-bot/discord-bot-client.service';
 import { CronJobService } from '../cron-jobs/cron-job.service';
@@ -40,8 +39,8 @@ export class RecruitmentReminderService {
 
   constructor(
     @Inject(DrizzleAsyncProvider) private db: PostgresJsDatabase<typeof schema>,
-    @Inject(REDIS_CLIENT) private redis: Redis,
     private readonly notificationService: NotificationService,
+    private readonly dedupService: NotificationDedupService,
     private readonly settingsService: SettingsService,
     private readonly discordBotClient: DiscordBotClientService,
     private readonly cronJobService: CronJobService,
@@ -104,8 +103,11 @@ export class RecruitmentReminderService {
   /** Post channel bump if not already done. */
   private async maybeBumpChannel(event: EligibleEvent): Promise<void> {
     const bumpKey = `recruitment-bump:event:${event.id}`;
-    if (!(await this.redis.get(bumpKey))) {
-      await this.redis.set(bumpKey, '1', 'EX', DEDUP_TTL_SECONDS);
+    const alreadySent = await this.dedupService.checkAndMarkSent(
+      bumpKey,
+      DEDUP_TTL_SECONDS,
+    );
+    if (!alreadySent) {
       await this.postChannelBump(event);
     }
   }
@@ -113,7 +115,11 @@ export class RecruitmentReminderService {
   /** Send recruitment DMs if not already done. */
   private async maybeSendDMs(event: EligibleEvent): Promise<void> {
     const dmKey = `recruitment-dm:event:${event.id}`;
-    if (await this.redis.get(dmKey)) {
+    const alreadySent = await this.dedupService.checkAndMarkSent(
+      dmKey,
+      DEDUP_TTL_SECONDS,
+    );
+    if (alreadySent) {
       this.logger.debug(
         `Recruitment DMs already sent for event ${event.id}, skipping`,
       );
@@ -126,7 +132,6 @@ export class RecruitmentReminderService {
       event.id,
     );
     recipientIds = await this.filterAbsentUsers(recipientIds, event);
-    await this.redis.set(dmKey, '1', 'EX', DEDUP_TTL_SECONDS);
     if (recipientIds.length > 0) {
       await this.sendRecruitmentDMs(event, recipientIds);
     } else {


### PR DESCRIPTION
## Summary
- Add `notification_dedup` PostgreSQL table to persist notification dedup keys across Redis restarts
- Create `NotificationDedupService` with Redis fast-path + DB slow-path `checkAndMarkSent()` helper
- Migrate recruitment bump/DM, game affinity alerts, and welcome DM dedup from Redis-only to DB-backed guard
- Rate limits and failure counters remain Redis-only (acceptable short TTLs)

## Linear
ROK-978

## Test plan
- [x] Build passes (contract + api)
- [x] TypeScript clean
- [x] Lint clean (0 errors)
- [x] Unit tests pass (4852/4852)
- [x] Integration test: 9 tests covering Redis fast-path, DB slow-path, Redis flush recovery, expiry, concurrent race, cleanup cron
- [ ] Playwright smoke tests (N/A — API-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)