### PR TITLE
ROK-975: split lineup contract schema and extract shared PHASES constant

### DIFF
--- a/packages/contract/src/lineup-match.schema.ts
+++ b/packages/contract/src/lineup-match.schema.ts
@@ -1,0 +1,123 @@
+import { z } from 'zod';
+
+// ============================================================
+// Match & Scheduling Enums (ROK-964)
+// ============================================================
+
+/** Match lifecycle: suggested -> scheduling -> scheduled -> archived */
+export const MatchStatusSchema = z.enum([
+    'suggested',
+    'scheduling',
+    'scheduled',
+    'archived',
+]);
+
+export type MatchStatusDto = z.infer<typeof MatchStatusSchema>;
+
+/** How well the match group fills its player requirements. */
+export const FitTypeSchema = z.enum([
+    'perfect',
+    'normal',
+    'oversubscribed',
+    'undersubscribed',
+]);
+
+export type FitTypeDto = z.infer<typeof FitTypeSchema>;
+
+/** How a member was added to a match group. */
+export const MemberSourceSchema = z.enum(['voted', 'bandwagon']);
+
+export type MemberSourceDto = z.infer<typeof MemberSourceSchema>;
+
+/** Who proposed a schedule slot. */
+export const SlotSuggesterSchema = z.enum(['system', 'user']);
+
+export type SlotSuggesterDto = z.infer<typeof SlotSuggesterSchema>;
+
+// ============================================================
+// Match & Scheduling Response Schemas (ROK-964)
+// ============================================================
+
+/** A game match group within a lineup. */
+export const LineupMatchSchema = z.object({
+    id: z.number(),
+    lineupId: z.number(),
+    gameId: z.number(),
+    status: MatchStatusSchema,
+    thresholdMet: z.boolean(),
+    voteCount: z.number(),
+    votePercentage: z.number().nullable(),
+    fitType: FitTypeSchema.nullable(),
+    linkedEventId: z.number().nullable(),
+    createdAt: z.string(),
+    updatedAt: z.string(),
+});
+
+export type LineupMatchDto = z.infer<typeof LineupMatchSchema>;
+
+/** A member assigned to a match group. */
+export const LineupMatchMemberSchema = z.object({
+    id: z.number(),
+    matchId: z.number(),
+    userId: z.number(),
+    source: MemberSourceSchema,
+    createdAt: z.string(),
+});
+
+export type LineupMatchMemberDto = z.infer<typeof LineupMatchMemberSchema>;
+
+/** A proposed time slot for scheduling a match. */
+export const LineupScheduleSlotSchema = z.object({
+    id: z.number(),
+    matchId: z.number(),
+    proposedTime: z.string(),
+    overlapScore: z.number().nullable(),
+    suggestedBy: SlotSuggesterSchema,
+    createdAt: z.string(),
+});
+
+export type LineupScheduleSlotDto = z.infer<typeof LineupScheduleSlotSchema>;
+
+/** A user vote on a schedule time slot. */
+export const LineupScheduleVoteSchema = z.object({
+    id: z.number(),
+    slotId: z.number(),
+    userId: z.number(),
+    createdAt: z.string(),
+});
+
+export type LineupScheduleVoteDto = z.infer<typeof LineupScheduleVoteSchema>;
+
+// ============================================================
+// Composite DTOs (ROK-964)
+// ============================================================
+
+/** Match detail with game info and enriched members. */
+export const MatchDetailResponseSchema = LineupMatchSchema.extend({
+    gameName: z.string(),
+    gameCoverUrl: z.string().nullable(),
+    members: z.array(
+        LineupMatchMemberSchema.extend({
+            displayName: z.string(),
+        }),
+    ),
+});
+
+export type MatchDetailResponseDto = z.infer<typeof MatchDetailResponseSchema>;
+
+/** Schedule poll with slots and voter details. */
+export const SchedulePollResponseSchema = z.object({
+    matchId: z.number(),
+    slots: z.array(
+        LineupScheduleSlotSchema.extend({
+            votes: z.array(
+                z.object({
+                    userId: z.number(),
+                    displayName: z.string(),
+                }),
+            ),
+        }),
+    ),
+});
+
+export type SchedulePollResponseDto = z.infer<typeof SchedulePollResponseSchema>;

--- a/packages/contract/src/lineup.schema.ts
+++ b/packages/contract/src/lineup.schema.ts
@@ -1,10 +1,13 @@
 import { z } from 'zod';
 
+// Re-export match & scheduling schemas for backward compatibility (ROK-975)
+export * from './lineup-match.schema.js';
+
 // ============================================================
 // Community Lineup Schemas (ROK-933)
 // ============================================================
 
-/** Valid lineup statuses. Flow: building → voting → scheduling → decided → archived */
+/** Valid lineup statuses. Flow: building -> voting -> scheduling -> decided -> archived */
 export const LineupStatusSchema = z.enum([
     'building',
     'voting',
@@ -14,128 +17,6 @@ export const LineupStatusSchema = z.enum([
 ]);
 
 export type LineupStatusDto = z.infer<typeof LineupStatusSchema>;
-
-// ============================================================
-// Match & Scheduling Enums (ROK-964)
-// ============================================================
-
-/** Match lifecycle: suggested → scheduling → scheduled → archived */
-export const MatchStatusSchema = z.enum([
-    'suggested',
-    'scheduling',
-    'scheduled',
-    'archived',
-]);
-
-export type MatchStatusDto = z.infer<typeof MatchStatusSchema>;
-
-/** How well the match group fills its player requirements. */
-export const FitTypeSchema = z.enum([
-    'perfect',
-    'normal',
-    'oversubscribed',
-    'undersubscribed',
-]);
-
-export type FitTypeDto = z.infer<typeof FitTypeSchema>;
-
-/** How a member was added to a match group. */
-export const MemberSourceSchema = z.enum(['voted', 'bandwagon']);
-
-export type MemberSourceDto = z.infer<typeof MemberSourceSchema>;
-
-/** Who proposed a schedule slot. */
-export const SlotSuggesterSchema = z.enum(['system', 'user']);
-
-export type SlotSuggesterDto = z.infer<typeof SlotSuggesterSchema>;
-
-// ============================================================
-// Match & Scheduling Response Schemas (ROK-964)
-// ============================================================
-
-/** A game match group within a lineup. */
-export const LineupMatchSchema = z.object({
-    id: z.number(),
-    lineupId: z.number(),
-    gameId: z.number(),
-    status: MatchStatusSchema,
-    thresholdMet: z.boolean(),
-    voteCount: z.number(),
-    votePercentage: z.number().nullable(),
-    fitType: FitTypeSchema.nullable(),
-    linkedEventId: z.number().nullable(),
-    createdAt: z.string(),
-    updatedAt: z.string(),
-});
-
-export type LineupMatchDto = z.infer<typeof LineupMatchSchema>;
-
-/** A member assigned to a match group. */
-export const LineupMatchMemberSchema = z.object({
-    id: z.number(),
-    matchId: z.number(),
-    userId: z.number(),
-    source: MemberSourceSchema,
-    createdAt: z.string(),
-});
-
-export type LineupMatchMemberDto = z.infer<typeof LineupMatchMemberSchema>;
-
-/** A proposed time slot for scheduling a match. */
-export const LineupScheduleSlotSchema = z.object({
-    id: z.number(),
-    matchId: z.number(),
-    proposedTime: z.string(),
-    overlapScore: z.number().nullable(),
-    suggestedBy: SlotSuggesterSchema,
-    createdAt: z.string(),
-});
-
-export type LineupScheduleSlotDto = z.infer<typeof LineupScheduleSlotSchema>;
-
-/** A user vote on a schedule time slot. */
-export const LineupScheduleVoteSchema = z.object({
-    id: z.number(),
-    slotId: z.number(),
-    userId: z.number(),
-    createdAt: z.string(),
-});
-
-export type LineupScheduleVoteDto = z.infer<typeof LineupScheduleVoteSchema>;
-
-// ============================================================
-// Composite DTOs (ROK-964)
-// ============================================================
-
-/** Match detail with game info and enriched members. */
-export const MatchDetailResponseSchema = LineupMatchSchema.extend({
-    gameName: z.string(),
-    gameCoverUrl: z.string().nullable(),
-    members: z.array(
-        LineupMatchMemberSchema.extend({
-            displayName: z.string(),
-        }),
-    ),
-});
-
-export type MatchDetailResponseDto = z.infer<typeof MatchDetailResponseSchema>;
-
-/** Schedule poll with slots and voter details. */
-export const SchedulePollResponseSchema = z.object({
-    matchId: z.number(),
-    slots: z.array(
-        LineupScheduleSlotSchema.extend({
-            votes: z.array(
-                z.object({
-                    userId: z.number(),
-                    displayName: z.string(),
-                }),
-            ),
-        }),
-    ),
-});
-
-export type SchedulePollResponseDto = z.infer<typeof SchedulePollResponseSchema>;
 
 // ============================================================
 // Request Schemas

--- a/web/src/components/lineups/LineupDetailHeader.tsx
+++ b/web/src/components/lineups/LineupDetailHeader.tsx
@@ -5,16 +5,12 @@ import { useTransitionLineupStatus } from '../../hooks/use-lineups';
 import { useAuth, isOperatorOrAdmin } from '../../hooks/use-auth';
 import { LineupStatusBadge } from './LineupStatusBadge';
 import { PhaseCountdown } from './phase-countdown';
+import { PHASES, PHASE_LABELS } from './lineup-phases';
 import { toast } from '../../lib/toast';
 
 interface Props {
   lineup: LineupDetailResponseDto;
 }
-
-const PHASES: LineupStatusDto[] = ['building', 'voting', 'scheduling', 'decided', 'archived'];
-const PHASE_LABELS: Record<LineupStatusDto, string> = {
-  building: 'Nominating', voting: 'Voting', scheduling: 'Scheduling', decided: 'Decided', archived: 'Archived',
-};
 
 /** SVG circle progress indicator — fills 33/66/100% with red→yellow→green. */
 function PhaseCircle({ status }: { status: string }): JSX.Element {

--- a/web/src/components/lineups/LineupProgressBar.tsx
+++ b/web/src/components/lineups/LineupProgressBar.tsx
@@ -1,19 +1,11 @@
 import type { JSX } from 'react';
 import type { LineupDetailResponseDto, LineupStatusDto } from '@raid-ledger/contract';
 import { useAuth, isOperatorOrAdmin } from '../../hooks/use-auth';
+import { PHASES, PHASE_LABELS } from './lineup-phases';
 
 interface Props {
   lineup: LineupDetailResponseDto;
 }
-
-const PHASES: LineupStatusDto[] = ['building', 'voting', 'scheduling', 'decided', 'archived'];
-const PHASE_LABELS: Record<LineupStatusDto, string> = {
-  building: 'Nominating',
-  voting: 'Voting',
-  scheduling: 'Scheduling',
-  decided: 'Decided',
-  archived: 'Archived',
-};
 
 function phaseIndex(status: string): number {
   return PHASES.indexOf(status as LineupStatusDto);

--- a/web/src/components/lineups/lineup-phases.ts
+++ b/web/src/components/lineups/lineup-phases.ts
@@ -1,0 +1,19 @@
+import type { LineupStatusDto } from '@raid-ledger/contract';
+
+/** Ordered lineup phase progression: building -> voting -> scheduling -> decided -> archived */
+export const PHASES: LineupStatusDto[] = [
+  'building',
+  'voting',
+  'scheduling',
+  'decided',
+  'archived',
+];
+
+/** Human-readable labels for each lineup phase. */
+export const PHASE_LABELS: Record<LineupStatusDto, string> = {
+  building: 'Nominating',
+  voting: 'Voting',
+  scheduling: 'Scheduling',
+  decided: 'Decided',
+  archived: 'Archived',
+};


### PR DESCRIPTION
## Summary
- Split `packages/contract/src/lineup.schema.ts` (337→217 lines) by extracting match/scheduling schemas into `lineup-match.schema.ts` (123 lines), resolving the 300-line limit violation
- Re-exports from `lineup.schema.ts` preserve full backward compatibility
- Extracted duplicate `PHASES`/`PHASE_LABELS` constants from `LineupDetailHeader` and `LineupProgressBar` into shared `lineup-phases.ts`

## Linear
ROK-975

## Test plan
- [x] Build passes (contract + api + web)
- [x] TypeScript clean
- [x] Lint clean (0 errors)
- [x] Unit tests pass — API: 4891, Web: 2859
- [x] Playwright smoke tests pass — 359 passed (desktop + mobile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)