### PR TITLE
fix: add supervisor [include] for Ollama config discovery (ROK-984)

### DIFF
--- a/Dockerfile.allinone
+++ b/Dockerfile.allinone
@@ -72,7 +72,7 @@ WORKDIR /app
 # ==================
 # Persistent data volume — mount as -v raid-ledger-data:/data
 # ==================
-RUN mkdir -p /data/postgresql /data/redis /data/backups/daily /data/backups/migrations /data/logs /run/postgresql /run/redis && \
+RUN mkdir -p /data/postgresql /data/redis /data/backups/daily /data/backups/migrations /data/logs /data/ollama/models /run/postgresql /run/redis && \
   chown -R postgres:postgres /data/postgresql /run/postgresql && \
   chown -R redis:redis /data/redis /run/redis
 VOLUME /data
@@ -128,7 +128,7 @@ RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 # ==================
 # Supervisor Config
 # ==================
-RUN mkdir -p /etc/supervisor.d
+RUN mkdir -p /etc/supervisor.d /etc/supervisor.d/services
 
 # Create all-in-one supervisor config
 COPY <<'EOF' /etc/supervisor.d/raid-ledger.ini
@@ -196,6 +196,9 @@ startretries=5
 stdout_logfile=/dev/stdout
 stdout_logfile_maxbytes=0
 redirect_stderr=true
+
+[include]
+files = /etc/supervisor.d/services/*.ini
 
 [program:logrotate]
 command=/bin/bash -c 'while true; do /usr/sbin/logrotate /etc/logrotate.d/raid-ledger --state /data/logs/.logrotate.state; sleep 86400; done'
@@ -285,7 +288,7 @@ set -e
 
 # Ensure /data subdirectories exist and have correct ownership
 # (volume mounts may arrive as root-owned empty dirs)
-mkdir -p /data/postgresql /data/redis /data/backups/daily /data/backups/migrations /data/logs
+mkdir -p /data/postgresql /data/redis /data/backups/daily /data/backups/migrations /data/logs /data/ollama/models
 chown -R postgres:postgres /data/postgresql
 chown -R redis:redis /data/redis
 

--- a/api/src/ai/providers/ollama-model.service.ts
+++ b/api/src/ai/providers/ollama-model.service.ts
@@ -27,7 +27,7 @@ export class OllamaModelService {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ name: modelId, stream: false }),
-      timeoutMs: 300_000, // 5 minutes for large model downloads
+      timeoutMs: 600_000, // 10 minutes for large model downloads on NAS bandwidth
     });
   }
 

--- a/api/src/ai/providers/ollama-native.service.spec.ts
+++ b/api/src/ai/providers/ollama-native.service.spec.ts
@@ -126,12 +126,12 @@ describe('OllamaNativeService', () => {
   });
 
   describe('writeSupervisorConfig', () => {
-    it('writes config to /etc/supervisor.d/ollama.ini', () => {
+    it('writes config to /etc/supervisor.d/services/ollama.ini', () => {
       const mockWriteFileSync = fs.writeFileSync as jest.Mock;
       service.writeSupervisorConfig();
 
       expect(mockWriteFileSync).toHaveBeenCalledWith(
-        '/etc/supervisor.d/ollama.ini',
+        '/etc/supervisor.d/services/ollama.ini',
         expect.stringContaining('[program:ollama]'),
       );
     });
@@ -302,14 +302,18 @@ describe('OllamaNativeService', () => {
     });
   });
 
-  describe('execQuick stderr capture (ROK-984)', () => {
+  describe('execQuick stdout+stderr capture (ROK-984)', () => {
     /**
-     * Helper: simulate execFile failing WITH stderr output.
+     * Helper: simulate execFile failing WITH stdout and/or stderr output.
      * Real execFile callbacks receive (err, stdout, stderr).
-     * The err.message is typically "Command failed: ...", but the real
-     * diagnostic is in stderr (e.g., supervisor config parse errors).
+     * supervisorctl errors go to stdout (e.g., "ollama: ERROR (no such process)"),
+     * while system errors go to stderr.
      */
-    function mockExecErrorWithStderr(message: string, stderr: string) {
+    function mockExecErrorWithOutput(
+      message: string,
+      stdout: string,
+      stderr: string,
+    ) {
       mockExecFile.mockImplementation(
         (
           _cmd: string,
@@ -317,7 +321,7 @@ describe('OllamaNativeService', () => {
           _opts: Record<string, unknown>,
           cb: (err: Error | null, stdout: string, stderr: string) => void,
         ) => {
-          cb(new Error(message), '', stderr);
+          cb(new Error(message), stdout, stderr);
         },
       );
     }
@@ -327,7 +331,7 @@ describe('OllamaNativeService', () => {
       const stderr =
         "error: <class 'FileNotFoundError'>, [Errno 2] No such file or directory: file: /usr/lib/python3/supervisord/options.py";
 
-      mockExecErrorWithStderr(errMsg, stderr);
+      mockExecErrorWithOutput(errMsg, '', stderr);
 
       await expect(service.startService()).rejects.toThrow(
         expect.objectContaining({
@@ -336,27 +340,38 @@ describe('OllamaNativeService', () => {
       );
     });
 
-    it('includes stderr in error when stopService fails', async () => {
-      const errMsg = 'Command failed: supervisorctl stop ollama';
-      const stderr = 'ollama: ERROR (not running)';
+    it('includes stdout in error (supervisor errors go to stdout)', async () => {
+      const errMsg = 'Command failed: supervisorctl start ollama';
+      const stdout = 'ollama: ERROR (no such process)';
 
-      mockExecErrorWithStderr(errMsg, stderr);
+      mockExecErrorWithOutput(errMsg, stdout, '');
 
-      await expect(service.stopService()).rejects.toThrow(
+      await expect(service.startService()).rejects.toThrow(
         expect.objectContaining({
-          message: expect.stringContaining(stderr),
+          message: expect.stringContaining('no such process'),
         }),
       );
     });
 
-    it('includes stderr in error when getServiceStatus underlying call fails with stderr', async () => {
-      // getServiceStatus catches errors and returns 'not-found', but
-      // we verify the error that execQuick rejects with contains stderr
-      // by testing startService which does NOT catch
+    it('includes both stdout and stderr in error when both are present', async () => {
+      const errMsg = 'Command failed: supervisorctl stop ollama';
+      const stdout = 'ollama: ERROR (not running)';
+      const stderr = 'Warning: config parse issue';
+
+      mockExecErrorWithOutput(errMsg, stdout, stderr);
+
+      await expect(service.stopService()).rejects.toThrow(
+        expect.objectContaining({
+          message: expect.stringMatching(/not running.*config parse issue/s),
+        }),
+      );
+    });
+
+    it('includes stderr in error when connection refused', async () => {
       const errMsg = 'Command failed: supervisorctl reread';
       const stderr = 'unix:///var/run/supervisor.sock refused connection';
 
-      mockExecErrorWithStderr(errMsg, stderr);
+      mockExecErrorWithOutput(errMsg, '', stderr);
 
       await expect(service.startService()).rejects.toThrow(
         expect.objectContaining({

--- a/api/src/ai/providers/ollama-native.service.ts
+++ b/api/src/ai/providers/ollama-native.service.ts
@@ -12,8 +12,8 @@ const ALLINONE_SENTINEL = '/etc/supervisor.d/raid-ledger.ini';
 /** Path where the Ollama binary is installed. */
 const OLLAMA_BINARY_PATH = '/usr/local/bin/ollama';
 
-/** Supervisor config path for Ollama. */
-const SUPERVISOR_CONFIG_PATH = '/etc/supervisor.d/ollama.ini';
+/** Supervisor config path for Ollama (inside services/ so [include] picks it up). */
+const SUPERVISOR_CONFIG_PATH = '/etc/supervisor.d/services/ollama.ini';
 
 /** Download URL for the Ollama Linux binary archive. */
 export const OLLAMA_DOWNLOAD_URL =
@@ -103,7 +103,7 @@ export class OllamaNativeService {
   private execQuick(cmd: string, args: string[]): Promise<string> {
     return new Promise((resolve, reject) => {
       execFile(cmd, args, { timeout: 10_000 }, (err, stdout, stderr) => {
-        if (err) reject(new Error(`${err.message}\n${stderr}`));
+        if (err) reject(new Error(`${err.message}\n${stdout}${stderr}`));
         else resolve(stdout);
       });
     });


### PR DESCRIPTION
## What

Fix Ollama setup failing with "Command failed: supervisorctl start ollama" after PR #552 resolved the socket/auth mismatch.

## Why

PR #552 changed the entrypoint to use `raid-ledger.ini` directly, but that file had no `[include]` directive. supervisord never discovered the dynamically-written `ollama.ini`, so `supervisorctl start ollama` failed with "no such process".

## Changes

- Add `[include] files = /etc/supervisor.d/services/*.ini` to `raid-ledger.ini`
- Move Ollama config path to `services/` subdir (avoids self-include of `raid-ledger.ini`)
- Create `/data/ollama/models` in Dockerfile + entrypoint (was missing)
- Capture stdout in `execQuick` errors (supervisor errors go to stdout, not stderr)
- Increase model pull timeout from 5min to 10min for NAS bandwidth

## Acceptance criteria

- [x] `supervisorctl reread` discovers `ollama.ini` after it's written
- [x] `supervisorctl update` adds the Ollama process group
- [x] Error messages include both stdout and stderr
- [x] `/data/ollama/models` directory exists at runtime
- [x] Verified: built allinone image locally, full supervisor flow works

## Test plan

- [x] Build passes (contract + api)
- [x] TypeScript clean (pre-existing error in unrelated file)
- [x] Lint clean (0 errors)
- [x] Unit tests pass (355 suites, 4896 tests)
- [x] Local allinone container verified: reread → "ollama: available", update → "ollama: added process group"

## Linear

ROK-984

🤖 Generated with [Claude Code](https://claude.com/claude-code)