### PR TITLE
fix: add scroll arrows to Common Ground nomination grid

### DIFF
--- a/web/src/components/lineups/CommonGroundPanel.tsx
+++ b/web/src/components/lineups/CommonGroundPanel.tsx
@@ -2,7 +2,7 @@
  * Common Ground panel — shows games owned by multiple community members (ROK-934).
  * Renders filter controls, a horizontal-scroll game grid, and handles nomination.
  */
-import { type JSX, useState, useMemo, useCallback } from 'react';
+import { type JSX, useRef, useState, useEffect, useMemo, useCallback } from 'react';
 import type { CommonGroundResponseDto } from '@raid-ledger/contract';
 import type { CommonGroundParams } from '../../lib/api-client';
 import { useActiveLineup, useCommonGround, useNominateGame } from '../../hooks/use-lineups';
@@ -68,7 +68,20 @@ function PanelHeader({ nominated, max }: { nominated: number; max: number }): JS
     );
 }
 
-/** Game card grid — horizontal scroll. */
+const ARROW_CLS = 'absolute top-1/2 -translate-y-1/2 z-10 w-10 h-10 bg-surface/90 border border-edge rounded-full flex items-center justify-center text-foreground shadow-lg opacity-0 group-hover/carousel:opacity-100 transition-opacity hover:bg-panel';
+
+function ScrollArrow({ direction, onClick }: { direction: 'left' | 'right'; onClick: () => void }) {
+    const path = direction === 'left' ? 'M15 19l-7-7 7-7' : 'M9 5l7 7-7 7';
+    return (
+        <button onClick={onClick} className={`${ARROW_CLS} ${direction === 'left' ? 'left-0' : 'right-0'}`} aria-label={`Scroll ${direction}`}>
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d={path} />
+            </svg>
+        </button>
+    );
+}
+
+/** Game card grid — horizontal scroll with arrow navigation. */
 function GameGrid({
     games,
     onNominate,
@@ -80,18 +93,46 @@ function GameGrid({
     nominatingId: number | null;
     atCap: boolean;
 }): JSX.Element {
-    const items = games;
+    const scrollRef = useRef<HTMLDivElement>(null);
+    const [canLeft, setCanLeft] = useState(false);
+    const [canRight, setCanRight] = useState(false);
+
+    const check = useCallback(() => {
+        const el = scrollRef.current;
+        if (!el) return;
+        setCanLeft(el.scrollLeft > 0);
+        setCanRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+    }, []);
+
+    useEffect(() => {
+        check();
+        const el = scrollRef.current;
+        if (!el) return;
+        el.addEventListener('scroll', check, { passive: true });
+        return () => el.removeEventListener('scroll', check);
+    }, [games, check]);
+
+    const scroll = (dir: 'left' | 'right') => {
+        const el = scrollRef.current;
+        if (!el) return;
+        el.scrollBy({ left: dir === 'left' ? -el.clientWidth * 0.8 : el.clientWidth * 0.8, behavior: 'smooth' });
+    };
+
     return (
-        <div className="flex gap-3 overflow-x-auto overflow-y-hidden pb-2 scrollbar-hide" style={{ scrollbarWidth: 'none' }}>
-            {items.map((g) => (
-                <CommonGroundGameCard
-                    key={g.gameId}
-                    game={g}
-                    onNominate={onNominate}
-                    isNominating={nominatingId === g.gameId}
-                    atCap={atCap}
-                />
-            ))}
+        <div className="relative group/carousel">
+            {canLeft && <ScrollArrow direction="left" onClick={() => scroll('left')} />}
+            <div ref={scrollRef} className="flex gap-3 overflow-x-auto overflow-y-hidden pb-2 scrollbar-hide" style={{ scrollbarWidth: 'none' }}>
+                {games.map((g) => (
+                    <CommonGroundGameCard
+                        key={g.gameId}
+                        game={g}
+                        onNominate={onNominate}
+                        isNominating={nominatingId === g.gameId}
+                        atCap={atCap}
+                    />
+                ))}
+            </div>
+            {canRight && <ScrollArrow direction="right" onClick={() => scroll('right')} />}
         </div>
     );
 }


### PR DESCRIPTION
## Summary
- Add left/right scroll arrow buttons to the nomination game card row in the Community Lineup detail page
- Follows the existing `GameCarousel` pattern (hover-to-reveal arrows, smooth scroll)

## Linear
ROK-976 (follow-up UX fix)

## Test plan
- [x] Lint clean (0 errors)
- [x] Visually verified via Chrome — arrows appear on hover, scroll works

🤖 Generated with [Claude Code](https://claude.com/claude-code)