### PR TITLE
fix: harden Discord smoke tests — add awaitProcessing + strengthen predicates (ROK-982)

### DIFF
--- a/tools/test-bot/src/smoke/fixtures.ts
+++ b/tools/test-bot/src/smoke/fixtures.ts
@@ -1,3 +1,4 @@
+import { pollForCondition } from '../helpers/polling.js';
 import type { ApiClient } from './api.js';
 import type { DiscordChannel, TestContext } from './types.js';
 
@@ -324,4 +325,33 @@ export async function injectVoiceSession(
   },
 ): Promise<void> {
   await api.post('/admin/test/inject-voice-session', p);
+}
+
+/**
+ * Assert that a condition is never met within a time window.
+ * Used for negative tests — verifying that something does NOT happen.
+ * Polls the check function and fails if it ever returns true.
+ * Succeeds if the poll times out (meaning the condition was never met).
+ */
+export async function assertConditionNeverMet(
+  check: () => Promise<boolean>,
+  windowMs: number,
+  errorMsg: string,
+  opts?: { intervalMs?: number },
+): Promise<void> {
+  try {
+    await pollForCondition(
+      async () => {
+        const r = await check();
+        return r ? true : null;
+      },
+      windowMs,
+      { intervalMs: opts?.intervalMs ?? 2000, backoff: false },
+    );
+    throw new Error(errorMsg);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    if (msg.includes('pollForCondition timed out')) return;
+    throw err;
+  }
 }

--- a/tools/test-bot/src/smoke/tests/channel-embeds.test.ts
+++ b/tools/test-bot/src/smoke/tests/channel-embeds.test.ts
@@ -69,6 +69,7 @@ const embedFilling: SmokeTest = {
     try {
       await embedInChannel(ch.channelId, ev.title, ctx.config.timeoutMs);
       await signup(ctx.api, ev.id, mmoSignupOpts(ctx, ['dps']));
+      await awaitProcessing(ctx.api);
       await waitForEmbedUpdate(
         ch.channelId,
         (m) =>
@@ -94,6 +95,7 @@ const embedTentative: SmokeTest = {
     try {
       await embedInChannel(ch.channelId, ev.title, ctx.config.timeoutMs);
       await signup(ctx.api, ev.id, mmoSignupOpts(ctx, ['healer']));
+      await awaitProcessing(ctx.api);
       await waitForEmbedUpdate(
         ch.channelId,
         (m) =>
@@ -119,6 +121,7 @@ const embedCancelSignup: SmokeTest = {
     try {
       await embedInChannel(ch.channelId, ev.title, ctx.config.timeoutMs);
       await signup(ctx.api, ev.id, mmoSignupOpts(ctx, ['tank']));
+      await awaitProcessing(ctx.api);
       // Wait for embed to show the signup in the roster
       await waitForEmbedUpdate(
         ch.channelId,
@@ -131,6 +134,7 @@ const embedCancelSignup: SmokeTest = {
         ctx.config.timeoutMs,
       );
       await cancelSignup(ctx.api, ev.id);
+      await awaitProcessing(ctx.api);
       // After cancel, roster count drops to 0: MMO shows "ROSTER: 0/",
       // non-MMO removes the roster section entirely
       await waitForEmbedUpdate(
@@ -159,6 +163,7 @@ const embedCancelled: SmokeTest = {
     try {
       await embedInChannel(ch.channelId, ev.title, ctx.config.timeoutMs);
       await cancelEvent(ctx.api, ev.id);
+      await awaitProcessing(ctx.api);
       await waitForEmbedUpdate(
         ch.channelId,
         (m) => m.embeds.some((e) => e.title?.includes('CANCELLED')),
@@ -186,6 +191,7 @@ const embedReschedule: SmokeTest = {
       const originalDesc = original.embeds[0]?.description ?? '';
       const originalTs = originalDesc.match(/<t:(\d+):f>/)?.[1] ?? '';
       await rescheduleEvent(ctx.api, ev.id, 180);
+      await awaitProcessing(ctx.api);
       // Wait for the embed timestamp to change from the original
       await waitForEmbedUpdate(
         ch.channelId,

--- a/tools/test-bot/src/smoke/tests/dm-notifications.test.ts
+++ b/tools/test-bot/src/smoke/tests/dm-notifications.test.ts
@@ -23,6 +23,7 @@ import {
   getNotificationsFor,
   futureTime,
   awaitProcessing,
+  assertConditionNeverMet,
 } from '../fixtures.js';
 import type { SmokeTest, TestContext } from '../types.js';
 
@@ -140,17 +141,14 @@ const departureNotifSuppressedNotFull: SmokeTest = {
       const signupId = (res as { id?: number }).id;
       if (!signupId) throw new Error('No signup ID returned');
       await triggerDeparture(ctx.api, ev.id, signupId, 'smoke-depart-1');
-      // Poll briefly — expect NO notification to appear (negative check)
-      const found = await pollForCondition(
-        async () => await hasSlotVacatedForEvent(ctx, ev.id) || null,
+      await awaitProcessing(ctx.api);
+      // Assert NO notification appears (negative check)
+      await assertConditionNeverMet(
+        () => hasSlotVacatedForEvent(ctx, ev.id),
         10_000,
+        'slot_vacated notification was sent for a non-full event',
         { intervalMs: 2000 },
-      ).then(() => true).catch(() => false);
-      if (found) {
-        throw new Error(
-          'slot_vacated notification was sent for a non-full event',
-        );
-      }
+      );
     } finally {
       await deleteEvent(ctx.api, ev.id);
     }
@@ -180,6 +178,7 @@ const departureNotifSentWhenFull: SmokeTest = {
       const signupId = (res as { id?: number }).id;
       if (!signupId) throw new Error('No signup ID returned');
       await triggerDeparture(ctx.api, ev.id, signupId, 'smoke-depart-2');
+      await awaitProcessing(ctx.api);
       // Poll until slot_vacated notification appears
       await pollForCondition(
         async () => await hasSlotVacatedForEvent(ctx, ev.id) || null,
@@ -440,16 +439,13 @@ const departureNotifSuppressedDpsFull: SmokeTest = {
       if (!signupId) throw new Error('No signup ID returned');
       // Depart a DPS — should NOT trigger notification (DPS is not critical)
       await triggerDeparture(ctx.api, ev.id, signupId, 'smoke-dps-depart');
-      const found = await pollForCondition(
-        async () => await hasSlotVacatedForEvent(ctx, ev.id) || null,
+      await awaitProcessing(ctx.api);
+      await assertConditionNeverMet(
+        () => hasSlotVacatedForEvent(ctx, ev.id),
         10_000,
+        'slot_vacated notification sent for DPS departure — role filter not applied',
         { intervalMs: 2000 },
-      ).then(() => true).catch(() => false);
-      if (found) {
-        throw new Error(
-          'slot_vacated notification sent for DPS departure — role filter not applied',
-        );
-      }
+      );
     } finally {
       await deleteEvent(ctx.api, ev.id);
     }
@@ -478,6 +474,7 @@ const departureNotifSentHealerMmo: SmokeTest = {
       if (!signupId) throw new Error('No signup ID returned');
       // Depart healer — should trigger even though event is NOT full
       await triggerDeparture(ctx.api, ev.id, signupId, 'smoke-heal-depart');
+      await awaitProcessing(ctx.api);
       await pollForCondition(
         async () => await hasSlotVacatedForEvent(ctx, ev.id) || null,
         ctx.config.timeoutMs,
@@ -513,6 +510,7 @@ const departureNotifSentGenericFull: SmokeTest = {
       const signupId = (res as { id?: number }).id;
       if (!signupId) throw new Error('No signup ID returned');
       await triggerDeparture(ctx.api, ev.id, signupId, 'smoke-gen-depart');
+      await awaitProcessing(ctx.api);
       await pollForCondition(
         async () => await hasSlotVacatedForEvent(ctx, ev.id) || null,
         ctx.config.timeoutMs,
@@ -547,16 +545,13 @@ const departureNotifSuppressedGenericNotFull: SmokeTest = {
       const signupId = (res as { id?: number }).id;
       if (!signupId) throw new Error('No signup ID returned');
       await triggerDeparture(ctx.api, ev.id, signupId, 'smoke-gen-notfull');
-      const found = await pollForCondition(
-        async () => await hasSlotVacatedForEvent(ctx, ev.id) || null,
+      await awaitProcessing(ctx.api);
+      await assertConditionNeverMet(
+        () => hasSlotVacatedForEvent(ctx, ev.id),
         10_000,
+        'slot_vacated sent for departure from non-full generic event',
         { intervalMs: 2000 },
-      ).then(() => true).catch(() => false);
-      if (found) {
-        throw new Error(
-          'slot_vacated sent for departure from non-full generic event',
-        );
-      }
+      );
     } finally {
       await deleteEvent(ctx.api, ev.id);
     }
@@ -585,16 +580,12 @@ const cancelSuppressedGenericNotFull: SmokeTest = {
       await flushNotificationBuffer(ctx.api);
       await awaitProcessing(ctx.api);
       // Verify NO slot_vacated notification (event was NOT full)
-      const found = await pollForCondition(
-        async () => await hasSlotVacatedForEvent(ctx, ev.id) || null,
+      await assertConditionNeverMet(
+        () => hasSlotVacatedForEvent(ctx, ev.id),
         8_000,
+        'slot_vacated sent after cancel from non-full generic event — the Palworld bug is back',
         { intervalMs: 2000 },
-      ).then(() => true).catch(() => false);
-      if (found) {
-        throw new Error(
-          'slot_vacated sent after cancel from non-full generic event — the Palworld bug is back',
-        );
-      }
+      );
     } finally {
       await deleteEvent(ctx.api, ev.id);
     }
@@ -621,16 +612,12 @@ const cancelSuppressedDpsMmo: SmokeTest = {
       await cancelSignupAs(ctx.api, ev.id, users[2]);
       await flushNotificationBuffer(ctx.api);
       await awaitProcessing(ctx.api);
-      const found = await pollForCondition(
-        async () => await hasSlotVacatedForEvent(ctx, ev.id) || null,
+      await assertConditionNeverMet(
+        () => hasSlotVacatedForEvent(ctx, ev.id),
         8_000,
+        'slot_vacated sent after DPS cancel from MMO event — role filter not applied on cancel path',
         { intervalMs: 2000 },
-      ).then(() => true).catch(() => false);
-      if (found) {
-        throw new Error(
-          'slot_vacated sent after DPS cancel from MMO event — role filter not applied on cancel path',
-        );
-      }
+      );
     } finally {
       await deleteEvent(ctx.api, ev.id);
     }

--- a/tools/test-bot/src/smoke/tests/interaction-flows.test.ts
+++ b/tools/test-bot/src/smoke/tests/interaction-flows.test.ts
@@ -12,6 +12,7 @@ import {
   deleteEvent,
   channelForTest,
   channelForGame,
+  awaitProcessing,
 } from '../fixtures.js';
 import type { SmokeTest, TestContext } from '../types.js';
 
@@ -49,7 +50,9 @@ const signupCancelFlow: SmokeTest = {
         ctx.config.timeoutMs,
       );
       await signup(ctx.api, ev.id, { preferredRoles: ['dps'] });
+      await awaitProcessing(ctx.api);
       await cancelSignup(ctx.api, ev.id);
+      await awaitProcessing(ctx.api);
       await pollForEmbed(
         ch.channelId,
         (m) => m.embeds.some((e) => e.title?.includes(ev.title)),
@@ -77,11 +80,13 @@ const slotVacatedFlow: SmokeTest = {
         ctx.config.timeoutMs,
       );
       const res = await signupAs(ctx.api, ev.id, users[0], ['tank']);
+      await awaitProcessing(ctx.api);
       // Admin removes the signup
       const signupId = (res as { id?: number }).id;
       if (signupId) {
         await ctx.api.delete(`/events/${ev.id}/signups/${signupId}`);
       }
+      await awaitProcessing(ctx.api);
       await pollForEmbed(
         ch.channelId,
         (m) => m.embeds.some((e) => e.title?.includes(ev.title)),
@@ -116,11 +121,13 @@ const benchPromotionFlow: SmokeTest = {
       await signupAs(ctx.api, ev.id, users[1], ['dps']);
       // 3rd goes to bench
       await signupAs(ctx.api, ev.id, users[2], ['dps']);
+      await awaitProcessing(ctx.api);
       // Remove first player — bench player should auto-promote (5-min delay)
       const signupId = (res1 as { id?: number }).id;
       if (signupId) {
         await ctx.api.delete(`/events/${ev.id}/signups/${signupId}`);
       }
+      await awaitProcessing(ctx.api);
       // Verify embed still exists and reflects roster change
       await pollForEmbed(
         ch.channelId,
@@ -147,6 +154,7 @@ const embedSyncBatchFlush: SmokeTest = {
         ctx.config.timeoutMs,
       );
       await signup(ctx.api, ev.id, { preferredRoles: ['dps'] });
+      await awaitProcessing(ctx.api);
       await pollForEmbed(
         ch.channelId,
         (m) => m.embeds.some((e) => e.title?.includes(ev.title)),
@@ -176,6 +184,7 @@ const multiUserSignupFlow: SmokeTest = {
       await signupAs(ctx.api, ev.id, users[0], ['tank']);
       await signupAs(ctx.api, ev.id, users[1], ['healer']);
       await signupAs(ctx.api, ev.id, users[2], ['dps']);
+      await awaitProcessing(ctx.api);
       const found = await pollForEmbed(
         ch.channelId,
         (m) => {
@@ -208,6 +217,7 @@ const eventDeleteCleansEmbed: SmokeTest = {
       );
       // Delete the event — embed should be removed from channel
       await deleteEvent(ctx.api, ev.id);
+      await awaitProcessing(ctx.api);
       // Poll for embed removal — let network/unexpected errors propagate naturally.
       // Only catch the specific timeout error to produce a clear assertion message.
       try {

--- a/tools/test-bot/src/smoke/tests/roster-calculation.test.ts
+++ b/tools/test-bot/src/smoke/tests/roster-calculation.test.ts
@@ -12,6 +12,7 @@ import {
   signupAs,
   deleteEvent,
   channelForGame,
+  awaitProcessing,
 } from '../fixtures.js';
 import { assertEmbedHasField } from '../assert.js';
 import type { SmokeTest, TestContext } from '../types.js';
@@ -38,6 +39,28 @@ function demoUsers(ctx: TestContext) {
   return ctx.demoUserIds ?? [];
 }
 
+/**
+ * Check if a role section in the embed description contains user mentions.
+ * Extracts the text between startMarker and endMarker (or end of string)
+ * and checks for Discord mentions (<@id>) or usernames (4+ word chars).
+ */
+function hasMentionInSection(
+  desc: string,
+  startMarker: string,
+  endMarker: string | null,
+): boolean {
+  const startIdx = desc.search(new RegExp(startMarker, 'i'));
+  if (startIdx === -1) return false;
+  const afterStart = desc.slice(startIdx);
+  const section = endMarker
+    ? afterStart.split(new RegExp(endMarker, 'i'))[0]
+    : afterStart;
+  return (
+    section.includes('<@') ||
+    /\w{4,}/.test(section.replace(/Tank|Heal|DPS|Bench/gi, ''))
+  );
+}
+
 const multiPreferredRoles: SmokeTest = {
   name: 'Multi-preferred-roles assigns to first available',
   category: 'embed',
@@ -52,21 +75,21 @@ const multiPreferredRoles: SmokeTest = {
       await embedInChannel(channelForGame(ctx, ctx.mmoGameId), ev.title, ctx.config.timeoutMs);
       // Sign up with ['tank', 'healer'] — should get tank (first pref)
       await signupAs(ctx.api, ev.id, users[0], ['tank', 'healer']);
+      await awaitProcessing(ctx.api);
       const found = await pollForEmbed(
         channelForGame(ctx, ctx.mmoGameId),
-        (m) => m.embeds.some((e) => e.title?.includes(ev.title)),
+        (m) => {
+          const e = m.embeds.find((x) => x.title?.includes(ev.title));
+          if (!e) return false;
+          return hasMentionInSection(e.description ?? '', 'Tank', 'Heal');
+        },
         ctx.config.timeoutMs,
       );
       const embed = found.embeds.find((e) => e.title?.includes(ev.title));
       if (!embed) throw new Error('Embed not found');
-      // Roster is in the description, not fields — check for tank assignment
       const desc = embed.description ?? '';
-      if (!desc.includes('Tanks') || !desc.includes('1/1')) {
-        // Check if tank slot has a player (not just "—")
-        const tankSection = desc.split(/Tank/i)[1]?.split(/Heal/i)[0] ?? '';
-        if (tankSection.includes('—') && !tankSection.includes('<@')) {
-          throw new Error('Tank slot still empty after signup with tank pref');
-        }
+      if (!hasMentionInSection(desc, 'Tank', 'Heal')) {
+        throw new Error('Tank slot still empty after signup with tank pref');
       }
     } finally {
       await deleteEvent(ctx.api, ev.id);
@@ -92,30 +115,34 @@ const fullRosterFill: SmokeTest = {
       await signupAs(ctx.api, ev.id, users[2], ['dps']);
       await signupAs(ctx.api, ev.id, users[3], ['dps']);
       await signupAs(ctx.api, ev.id, users[4], ['dps']);
+      await awaitProcessing(ctx.api);
       const rosterMsg = await pollForEmbed(
         channelForGame(ctx, ctx.mmoGameId),
         (m) => {
           const e = m.embeds.find((x) => x.title?.includes(ev.title));
           if (!e) return false;
-          const match = (e.description ?? '').match(/ROSTER:\s*(\d+)/);
-          return match ? parseInt(match[1], 10) >= 5 : false;
+          const desc = e.description ?? '';
+          const rosterMatch = desc.match(/ROSTER:\s*(\d+)/);
+          if (!rosterMatch || parseInt(rosterMatch[1], 10) < 5) return false;
+          // Ensure all role sections have player mentions
+          return (
+            hasMentionInSection(desc, 'Tank', 'Heal') &&
+            hasMentionInSection(desc, 'Heal', 'DPS') &&
+            hasMentionInSection(desc, 'DPS', null)
+          );
         },
         ctx.config.timeoutMs,
       );
       const embed = rosterMsg.embeds.find((e) => e.title?.includes(ev.title));
       if (!embed) throw new Error('Embed not found');
       const desc = embed.description ?? '';
-      // Verify tank, healer, dps slots have players (contain <@ mentions)
-      const tankSection = desc.split(/Tank/i)[1]?.split(/Heal/i)[0] ?? '';
-      const healerSection = desc.split(/Heal/i)[1]?.split(/DPS/i)[0] ?? '';
-      const dpsSection = desc.split(/DPS/i)[1] ?? '';
-      if (!tankSection.includes('<') && !tankSection.match(/\w{3,}/)) {
+      if (!hasMentionInSection(desc, 'Tank', 'Heal')) {
         throw new Error('Tank slot empty in full roster');
       }
-      if (!healerSection.includes('<') && !healerSection.match(/\w{3,}/)) {
+      if (!hasMentionInSection(desc, 'Heal', 'DPS')) {
         throw new Error('Healer slot empty in full roster');
       }
-      if (!dpsSection.includes('<') && !dpsSection.match(/\w{3,}/)) {
+      if (!hasMentionInSection(desc, 'DPS', null)) {
         throw new Error('DPS slots empty in full roster');
       }
     } finally {
@@ -146,21 +173,27 @@ const roleShiftChain: SmokeTest = {
       await signupAs(ctx.api, ev.id, users[2], ['healer', 'dps']);
       // User 3 prefers tank and dps — should get tank
       await signupAs(ctx.api, ev.id, users[3], ['tank', 'dps']);
+      await awaitProcessing(ctx.api);
       const shiftMsg = await pollForEmbed(
         channelForGame(ctx, ctx.mmoGameId),
-        (m) => m.embeds.some((e) => e.title?.includes(ev.title)),
+        (m) => {
+          const e = m.embeds.find((x) => x.title?.includes(ev.title));
+          if (!e) return false;
+          const d = e.description ?? '';
+          return (
+            hasMentionInSection(d, 'Tank', 'Heal') &&
+            hasMentionInSection(d, 'Heal', 'DPS')
+          );
+        },
         ctx.config.timeoutMs,
       );
       const embed = shiftMsg.embeds.find((e) => e.title?.includes(ev.title));
       if (!embed) throw new Error('Embed not found');
       const desc = embed.description ?? '';
-      // Verify tank and healer slots are filled (not just "—")
-      const tankSection = desc.split(/Tank/i)[1]?.split(/Heal/i)[0] ?? '';
-      const healerSection = desc.split(/Heal/i)[1]?.split(/DPS/i)[0] ?? '';
-      if (!tankSection.match(/\w{4,}/) && !tankSection.includes('<')) {
+      if (!hasMentionInSection(desc, 'Tank', 'Heal')) {
         throw new Error('Tank slot empty — shift chain failed');
       }
-      if (!healerSection.match(/\w{4,}/) && !healerSection.includes('<')) {
+      if (!hasMentionInSection(desc, 'Heal', 'DPS')) {
         throw new Error('Healer slot empty — shift chain failed');
       }
     } finally {
@@ -193,6 +226,7 @@ const tentativeDisplacement: SmokeTest = {
       });
       // User 5 signs up CONFIRMED for dps — tentative should be displaced
       await signupAs(ctx.api, ev.id, users[5], ['dps']);
+      await awaitProcessing(ctx.api);
       const dispMsg = await pollForEmbed(
         channelForGame(ctx, ctx.mmoGameId),
         (m) => {


### PR DESCRIPTION
## What

Fix 3 confirmed flaky Discord smoke tests and proactively harden 4 test files against the same anti-patterns.

## Why

CI audit of the last 100 runs revealed 3 intermittent Discord smoke test failures:
- `Full roster shows FULL with all slots filled` — 4/6 smoke runs failed (`Tank slot empty in full roster`)
- `Role shift chain when last player joins` — 4/6 smoke runs failed (`Tank slot empty — shift chain failed`)
- `Embed updates when signup cancelled` — 2/6 smoke runs failed (timeout after 185s)

Root cause: tests polled for embed state before BullMQ embed sync queue had drained, and used weak polling predicates that checked signup count/title instead of actual slot allocation content.

## Acceptance criteria

- [x] `roster-calculation.test.ts`: All 4 tests have `awaitProcessing()` + strengthened predicates checking slot content
- [x] `channel-embeds.test.ts`: 5 tests have `awaitProcessing()` after signup/cancel/reschedule
- [x] `interaction-flows.test.ts`: 5 tests have `awaitProcessing()` after mutations
- [x] `dm-notifications.test.ts`: 5 negative tests use `assertConditionNeverMet` (no more `.catch(() => false)`), 3 positive tests have `awaitProcessing()` after `triggerDeparture()`
- [x] TypeScript compiles cleanly
- [x] `lint:no-sleep` passes

## Test plan

- [ ] CI Discord Smoke Tests workflow passes (the 3 previously-flaky tests now pass)
- [ ] CI lint/typecheck passes
- [ ] No new test failures introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)