### PR TITLE
ROK-990: suppress Phase 2 no-show escalation on partially-filled rosters

### DIFF
--- a/api/src/notifications/live-noshow.helpers.ts
+++ b/api/src/notifications/live-noshow.helpers.ts
@@ -3,8 +3,9 @@
  * Extracted from live-noshow.service.ts for file size compliance (ROK-711).
  */
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
-import { eq, and, sql, inArray } from 'drizzle-orm';
+import { eq, and, sql, inArray, notInArray } from 'drizzle-orm';
 import * as schema from '../drizzle/schema';
+import { resolveEventCapacity } from '../events/signups-signup.helpers';
 
 /** Minimum voice presence (seconds) to count as "showed up". */
 export const PRESENCE_THRESHOLD_SEC = 120;
@@ -22,6 +23,8 @@ export interface LiveEvent {
   endTime: Date;
   gameId: number | null;
   recurrenceGroupId: string | null;
+  slotConfig: unknown;
+  maxAttendees: number | null;
 }
 
 /** Map a raw event row to the LiveEvent shape. */
@@ -32,6 +35,8 @@ function mapToLiveEvent(r: {
   gameId: number | null;
   recurrenceGroupId: string | null;
   duration: [Date, Date];
+  slotConfig: unknown;
+  maxAttendees: number | null;
 }): LiveEvent {
   return {
     id: r.id,
@@ -41,6 +46,8 @@ function mapToLiveEvent(r: {
     recurrenceGroupId: r.recurrenceGroupId,
     startTime: r.duration[0],
     endTime: r.duration[1],
+    slotConfig: r.slotConfig,
+    maxAttendees: r.maxAttendees,
   };
 }
 
@@ -58,6 +65,8 @@ export async function findLiveEventsInNoShowWindow(
       gameId: schema.events.gameId,
       recurrenceGroupId: schema.events.recurrenceGroupId,
       duration: schema.events.duration,
+      slotConfig: schema.events.slotConfig,
+      maxAttendees: schema.events.maxAttendees,
     })
     .from(schema.events)
     .where(
@@ -69,6 +78,34 @@ export async function findLiveEventsInNoShowWindow(
       ),
     );
   return rows.map(mapToLiveEvent);
+}
+
+/**
+ * Check if the event roster is at capacity.
+ * Returns false when no capacity is configured (suppresses Phase 2).
+ * Uses same exclusion set as wasEventFullBeforeDeparture.
+ */
+export async function isRosterAtCapacity(
+  db: PostgresJsDatabase<typeof schema>,
+  event: LiveEvent,
+): Promise<boolean> {
+  const capacity = resolveEventCapacity(event);
+  if (capacity === null) return false;
+  const [{ count }] = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(schema.eventSignups)
+    .where(
+      and(
+        eq(schema.eventSignups.eventId, event.id),
+        notInArray(schema.eventSignups.status, [
+          'departed',
+          'declined',
+          'roached_out',
+        ]),
+      ),
+    )
+    .limit(1);
+  return Number(count) >= capacity;
 }
 
 type AbsentPlayer = {

--- a/api/src/notifications/live-noshow.service.batching.spec.ts
+++ b/api/src/notifications/live-noshow.service.batching.spec.ts
@@ -167,11 +167,15 @@ describe('LiveNoShowService — batching', () => {
               title: 'Raid Night',
               creatorId: 1,
               duration: [startTime, endTime],
+              slotConfig: null,
+              maxAttendees: 10,
             },
           ]),
         ),
         // hasReminderBeenSent (escalation) -- not sent
         jest.fn().mockReturnValue(makeSelectFromWhereLimit([])),
+        // isRosterAtCapacity: at capacity
+        jest.fn().mockReturnValue(makeSelectFromWhereLimit([{ count: 10 }])),
         // getPhase1RemindedUserIds -- two players
         jest
           .fn()
@@ -254,10 +258,14 @@ describe('LiveNoShowService — batching', () => {
               title: 'Raid Night',
               creatorId: 1,
               duration: [startTime, endTime],
+              slotConfig: null,
+              maxAttendees: 10,
             },
           ]),
         ),
         jest.fn().mockReturnValue(makeSelectFromWhereLimit([])), // hasReminderBeenSent
+        // isRosterAtCapacity: at capacity
+        jest.fn().mockReturnValue(makeSelectFromWhereLimit([{ count: 10 }])),
         jest
           .fn()
           .mockReturnValue(
@@ -363,11 +371,15 @@ describe('LiveNoShowService — batching', () => {
               title: 'Raid Night',
               creatorId: 1,
               duration: [startTime, endTime],
+              slotConfig: null,
+              maxAttendees: 10,
             },
           ]),
         ),
         // hasReminderBeenSent -- not sent
         jest.fn().mockReturnValue(makeSelectFromWhereLimit([])),
+        // isRosterAtCapacity: at capacity
+        jest.fn().mockReturnValue(makeSelectFromWhereLimit([{ count: 10 }])),
         // getPhase1RemindedUserIds
         jest.fn().mockReturnValue(makeSelectFromWhere([{ userId: 10 }])),
         // fetchPhase2Data: batch discord IDs -- user has null discordId
@@ -430,11 +442,15 @@ describe('LiveNoShowService — batching', () => {
               title: 'Raid Night',
               creatorId: 1,
               duration: [startTime, endTime],
+              slotConfig: null,
+              maxAttendees: 10,
             },
           ]),
         ),
         // hasReminderBeenSent -- not sent
         jest.fn().mockReturnValue(makeSelectFromWhereLimit([])),
+        // isRosterAtCapacity: at capacity
+        jest.fn().mockReturnValue(makeSelectFromWhereLimit([{ count: 10 }])),
         // getPhase1RemindedUserIds
         jest.fn().mockReturnValue(makeSelectFromWhere([{ userId: 10 }])),
         // fetchPhase2Data: batch discord IDs -- user not found

--- a/api/src/notifications/live-noshow.service.phase2.spec.ts
+++ b/api/src/notifications/live-noshow.service.phase2.spec.ts
@@ -64,6 +64,8 @@ describe('LiveNoShowService — phase2', () => {
       creatorId: number;
       startTime: Date;
       endTime: Date;
+      slotConfig: unknown;
+      maxAttendees: number | null;
     }> = {},
   ) => {
     const startTime =
@@ -76,6 +78,11 @@ describe('LiveNoShowService — phase2', () => {
       creatorId: overrides.creatorId ?? 1,
       startTime,
       endTime,
+      slotConfig: 'slotConfig' in overrides ? overrides.slotConfig : null,
+      maxAttendees:
+        'maxAttendees' in overrides
+          ? (overrides.maxAttendees as number | null)
+          : 10,
     };
   };
 
@@ -128,6 +135,9 @@ describe('LiveNoShowService — phase2', () => {
       dbVoiceDuration?: number | null;
       displayName?: string;
       role?: string | null;
+      maxAttendees?: number | null;
+      slotConfig?: unknown;
+      activeSignupCount?: number;
     } = {},
   ) => {
     const {
@@ -138,11 +148,16 @@ describe('LiveNoShowService — phase2', () => {
       dbVoiceDuration = null,
       displayName = 'PlayerOne',
       role = 'Tank',
+      maxAttendees = 10,
+      slotConfig = null,
+      activeSignupCount = 10,
     } = options;
 
     const event = makeEvent({
       startTime: new Date(Date.now() - 16 * 60 * 1000),
       creatorId: 1,
+      maxAttendees,
+      slotConfig,
     });
 
     const selectMocks: jest.Mock[] = [];
@@ -156,6 +171,8 @@ describe('LiveNoShowService — phase2', () => {
             title: event.title,
             creatorId: event.creatorId,
             duration: [event.startTime, event.endTime],
+            slotConfig: event.slotConfig,
+            maxAttendees: event.maxAttendees,
           },
         ]),
       ),
@@ -172,76 +189,97 @@ describe('LiveNoShowService — phase2', () => {
         ),
     );
 
+    // Determine if capacity is resolvable (mirrors resolveEventCapacity logic)
+    const hasCapacity = slotConfig !== null || maxAttendees !== null;
+    const atCapacity = hasCapacity && activeSignupCount >= (maxAttendees ?? 0);
+
     if (!alreadyEscalated) {
-      // 3. getPhase1RemindedUserIds
-      selectMocks.push(
-        jest
-          .fn()
-          .mockReturnValue(
-            makeSelectFromWhere(phase1Reminded.map((uid) => ({ userId: uid }))),
-          ),
-      );
-
-      if (phase1Reminded.length > 0) {
-        // 4. fetchPhase2Data: batch-fetch discord IDs
+      // 3. isRosterAtCapacity: count active signups -- .limit(1)
+      // Only queried when resolveEventCapacity returns non-null
+      if (hasCapacity) {
         selectMocks.push(
-          jest.fn().mockReturnValue(
-            makeSelectFromWhere(
-              phase1Reminded.map((uid) => ({
-                id: uid,
-                discordId: userDiscordId,
-              })),
+          jest
+            .fn()
+            .mockReturnValue(
+              makeSelectFromWhereLimit([{ count: activeSignupCount }]),
             ),
-          ),
+        );
+      }
+
+      // Remaining Phase 2 mocks only added when capacity gate passes
+      if (atCapacity) {
+        // 4. getPhase1RemindedUserIds
+        selectMocks.push(
+          jest
+            .fn()
+            .mockReturnValue(
+              makeSelectFromWhere(
+                phase1Reminded.map((uid) => ({ userId: uid })),
+              ),
+            ),
         );
 
-        // 5. fetchPhase2Data: batch-fetch voice sessions
-        selectMocks.push(
-          jest.fn().mockReturnValue(
-            makeSelectFromWhere(
-              userDiscordId && dbVoiceDuration !== null
-                ? [
-                    {
-                      discordUserId: userDiscordId,
-                      totalDurationSec: dbVoiceDuration,
-                    },
-                  ]
-                : [],
-            ),
-          ),
-        );
-
-        const isAbsent =
-          userDiscordId === null ||
-          (!voiceActiveForUser &&
-            (dbVoiceDuration === null || dbVoiceDuration < 120));
-
-        if (isAbsent) {
-          // 6. batchFetchPlayerDisplayInfo: batch user lookup
+        if (phase1Reminded.length > 0) {
+          // 5. fetchPhase2Data: batch-fetch discord IDs
           selectMocks.push(
             jest.fn().mockReturnValue(
               makeSelectFromWhere(
                 phase1Reminded.map((uid) => ({
                   id: uid,
-                  username: displayName,
-                  displayName,
+                  discordId: userDiscordId,
                 })),
               ),
             ),
           );
 
-          // 7. batchFetchPlayerDisplayInfo: batch roster assignment
+          // 6. fetchPhase2Data: batch-fetch voice sessions
           selectMocks.push(
-            jest
-              .fn()
-              .mockReturnValue(
-                makeSelectFromJoinWhere(
-                  role
-                    ? phase1Reminded.map((uid) => ({ userId: uid, role }))
-                    : [],
+            jest.fn().mockReturnValue(
+              makeSelectFromWhere(
+                userDiscordId && dbVoiceDuration !== null
+                  ? [
+                      {
+                        discordUserId: userDiscordId,
+                        totalDurationSec: dbVoiceDuration,
+                      },
+                    ]
+                  : [],
+              ),
+            ),
+          );
+
+          const isAbsent =
+            userDiscordId === null ||
+            (!voiceActiveForUser &&
+              (dbVoiceDuration === null || dbVoiceDuration < 120));
+
+          if (isAbsent) {
+            // 7. batchFetchPlayerDisplayInfo: batch user lookup
+            selectMocks.push(
+              jest.fn().mockReturnValue(
+                makeSelectFromWhere(
+                  phase1Reminded.map((uid) => ({
+                    id: uid,
+                    username: displayName,
+                    displayName,
+                  })),
                 ),
               ),
-          );
+            );
+
+            // 8. batchFetchPlayerDisplayInfo: batch roster assignment
+            selectMocks.push(
+              jest
+                .fn()
+                .mockReturnValue(
+                  makeSelectFromJoinWhere(
+                    role
+                      ? phase1Reminded.map((uid) => ({ userId: uid, role }))
+                      : [],
+                  ),
+                ),
+            );
+          }
         }
       }
     }
@@ -428,6 +466,7 @@ describe('LiveNoShowService — phase2', () => {
       const event = makeEvent({
         startTime: new Date(Date.now() - 16 * 60 * 1000),
         creatorId: 1,
+        maxAttendees: 10,
       });
 
       const selectCalls: jest.Mock[] = [
@@ -439,11 +478,15 @@ describe('LiveNoShowService — phase2', () => {
               title: event.title,
               creatorId: 1,
               duration: [event.startTime, event.endTime],
+              slotConfig: event.slotConfig,
+              maxAttendees: event.maxAttendees,
             },
           ]),
         ),
         // hasReminderBeenSent (escalation) -- not sent
         jest.fn().mockReturnValue(makeSelectFromWhereLimit([])),
+        // isRosterAtCapacity: count active signups -- at capacity
+        jest.fn().mockReturnValue(makeSelectFromWhereLimit([{ count: 10 }])),
         // getPhase1RemindedUserIds -- creator user 1 was reminded
         jest.fn().mockReturnValue(makeSelectFromWhere([{ userId: 1 }])),
         // fetchPhase2Data: batch discord IDs
@@ -517,24 +560,12 @@ describe('LiveNoShowService — phase2', () => {
 
   describe('Phase 2 roster capacity suppression (ROK-990)', () => {
     it('should suppress Phase 2 when roster is below capacity', async () => {
-      // Full Phase 2 scenario: absent player, Phase 1 already reminded.
-      // Current code sends the nudge — this test asserts it should NOT,
-      // which will pass once the isRosterAtCapacity gate is added.
-      setupPhase2Flow();
-
-      mockDb.insert.mockReturnValue({
-        values: jest.fn().mockReturnValue({
-          onConflictDoNothing: jest.fn().mockReturnValue({
-            returning: jest.fn().mockResolvedValue([{ id: 1 }]),
-          }),
-        }),
-      });
+      // Roster has 3 active signups out of 10 capacity — below threshold.
+      // isRosterAtCapacity returns false, Phase 2 should be suppressed.
+      setupPhase2Flow({ maxAttendees: 10, activeSignupCount: 3 });
 
       await service.checkNoShows();
 
-      // ROK-990: Phase 2 should be suppressed when roster is below capacity.
-      // The dev must add a capacity gate in checkPhase2 and update the mock
-      // sequence (setupPhase2Flow + event data) to include capacity fields.
       const nudgeCalls = mockNotificationService.create.mock.calls.filter(
         (call: unknown[]) =>
           (call[0] as { type: string }).type === 'missed_event_nudge',
@@ -543,20 +574,12 @@ describe('LiveNoShowService — phase2', () => {
     });
 
     it('should suppress Phase 2 when event has no capacity set', async () => {
-      // Same scenario but with no capacity limit — should also suppress.
-      setupPhase2Flow();
-
-      mockDb.insert.mockReturnValue({
-        values: jest.fn().mockReturnValue({
-          onConflictDoNothing: jest.fn().mockReturnValue({
-            returning: jest.fn().mockResolvedValue([{ id: 1 }]),
-          }),
-        }),
-      });
+      // No capacity set (maxAttendees null, slotConfig null).
+      // resolveEventCapacity returns null, isRosterAtCapacity returns false.
+      setupPhase2Flow({ maxAttendees: null, slotConfig: null });
 
       await service.checkNoShows();
 
-      // ROK-990: No capacity set → resolveEventCapacity returns null → suppress.
       const nudgeCalls = mockNotificationService.create.mock.calls.filter(
         (call: unknown[]) =>
           (call[0] as { type: string }).type === 'missed_event_nudge',

--- a/api/src/notifications/live-noshow.service.ts
+++ b/api/src/notifications/live-noshow.service.ts
@@ -18,6 +18,7 @@ import {
   getPhase1RemindedUserIds,
   batchFetchPlayerDisplayInfo,
   fetchPhase2Data,
+  isRosterAtCapacity,
 } from './live-noshow.helpers';
 
 /**
@@ -114,6 +115,7 @@ export class LiveNoShowService {
       )
     )
       return;
+    if (!(await isRosterAtCapacity(this.db, event))) return;
     const phase1Reminded = await getPhase1RemindedUserIds(this.db, event.id);
     if (phase1Reminded.length === 0) return;
     const stillAbsent = await this.findStillAbsentPlayers(


### PR DESCRIPTION
## Summary
- Add roster capacity gate to Phase 2 no-show escalation — creator DMs only fire when the event is at capacity
- Events with no capacity configured are also suppressed (same pattern as departure-grace)
- Phase 1 player reminders are unchanged — they always fire

## Linear
ROK-990

## Test plan
- [x] Build passes (contract + api)
- [x] TypeScript clean
- [x] Lint clean (0 errors)
- [x] Unit tests pass (4901 across 355 suites)
- [ ] Playwright smoke tests (N/A — API-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)