### PR TITLE
ROK-991: fix Ollama spawn error — replace gcompat with real glibc runtime

### DIFF
--- a/Dockerfile.allinone
+++ b/Dockerfile.allinone
@@ -14,6 +14,27 @@
 # ====================
 
 # ====================
+# Stage 0: glibc runtime donor (for Ollama binary compatibility)
+# ====================
+# Ollama is compiled against glibc; Alpine uses musl. We copy the glibc
+# runtime into /opt/glibc/lib/ so the Ollama binary can be launched with
+# the real glibc dynamic linker at runtime.
+FROM debian:bookworm-slim AS glibc-donor
+RUN apt-get update && apt-get install -y --no-install-recommends libstdc++6 && rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /opt/glibc/lib && \
+    cp /lib/*-linux-gnu*/libc.so.6 /opt/glibc/lib/ && \
+    cp /lib/*-linux-gnu*/libm.so.6 /opt/glibc/lib/ && \
+    cp /lib/*-linux-gnu*/libresolv.so.2 /opt/glibc/lib/ && \
+    cp /lib/*-linux-gnu*/libgcc_s.so.1 /opt/glibc/lib/ && \
+    cp /lib/*-linux-gnu*/libstdc++.so.6 /opt/glibc/lib/ && \
+    (cp /lib/*-linux-gnu*/libpthread.so.0 /opt/glibc/lib/ 2>/dev/null || true) && \
+    (cp /lib/*-linux-gnu*/libdl.so.2 /opt/glibc/lib/ 2>/dev/null || true) && \
+    (cp /lib/*-linux-gnu*/librt.so.1 /opt/glibc/lib/ 2>/dev/null || true) && \
+    (cp /lib64/ld-linux-x86-64.so.2 /opt/glibc/lib/ld-linux.so 2>/dev/null || \
+     cp /lib/ld-linux-aarch64.so.1 /opt/glibc/lib/ld-linux.so 2>/dev/null) && \
+    test -f /opt/glibc/lib/ld-linux.so
+
+# ====================
 # Stage 1: Dependencies
 # ====================
 FROM node:20-alpine AS deps
@@ -59,8 +80,10 @@ RUN apk add --no-cache \
   su-exec \
   gettext \
   logrotate \
-  zstd \
-  gcompat
+  zstd
+
+# Copy glibc runtime for Ollama (replaces gcompat which couldn't provide fcntl64)
+COPY --from=glibc-donor /opt/glibc/lib/ /opt/glibc/lib/
 
 # Create app user and directories
 # Add app user to redis group so API can access Redis Unix socket (ROK-840)

--- a/api/src/ai/providers/ollama-native.helpers.spec.ts
+++ b/api/src/ai/providers/ollama-native.helpers.spec.ts
@@ -17,6 +17,8 @@ jest.mock('fs/promises', () => ({
   chmod: jest.fn().mockResolvedValue(undefined),
   mkdtemp: jest.fn().mockResolvedValue('/tmp/ollama-abc123'),
   rm: jest.fn().mockResolvedValue(undefined),
+  cp: jest.fn().mockResolvedValue(undefined),
+  mkdir: jest.fn().mockResolvedValue(undefined),
 }));
 jest.mock('https');
 jest.mock('http');
@@ -30,6 +32,8 @@ const mockChmod = fsp.chmod as jest.Mock;
 const mockUnlink = fsp.unlink as jest.Mock;
 const mockMkdtemp = fsp.mkdtemp as jest.Mock;
 const mockRm = fsp.rm as jest.Mock;
+const mockCp = fsp.cp as jest.Mock;
+const mockMkdir = fsp.mkdir as jest.Mock;
 const mockExecFile = childProcess.execFile as unknown as jest.Mock;
 
 import { downloadAndExtractBinary } from './ollama-native.helpers';
@@ -119,6 +123,41 @@ describe('downloadAndExtractBinary', () => {
       recursive: true,
       force: true,
     });
+  });
+
+  it('installs runner libs when lib/ollama exists in archive', async () => {
+    mockSuccessfulDownload();
+    mockTarSuccess();
+    mockExistsSync.mockReturnValue(true);
+
+    await downloadAndExtractBinary(
+      'https://example.com/ollama.tar.zst',
+      '/usr/local/bin/ollama',
+    );
+
+    expect(mockMkdir).toHaveBeenCalledWith('/usr/local/lib/ollama', {
+      recursive: true,
+    });
+    expect(mockCp).toHaveBeenCalledWith(
+      '/tmp/ollama-abc123/lib/ollama',
+      '/usr/local/lib/ollama',
+      { recursive: true, force: true },
+    );
+  });
+
+  it('skips runner lib install when lib/ollama is absent', async () => {
+    mockSuccessfulDownload();
+    mockTarSuccess();
+    mockExistsSync.mockImplementation((p: string) =>
+      p.includes('bin/ollama'),
+    );
+
+    await downloadAndExtractBinary(
+      'https://example.com/ollama.tar.zst',
+      '/usr/local/bin/ollama',
+    );
+
+    expect(mockCp).not.toHaveBeenCalled();
   });
 
   it('throws when bin/ollama not found in archive', async () => {

--- a/api/src/ai/providers/ollama-native.helpers.ts
+++ b/api/src/ai/providers/ollama-native.helpers.ts
@@ -1,5 +1,5 @@
 import { createWriteStream } from 'fs';
-import { rename, unlink, chmod, mkdtemp, rm } from 'fs/promises';
+import { rename, unlink, chmod, mkdtemp, rm, cp, mkdir } from 'fs/promises';
 import { existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -14,8 +14,11 @@ const MAX_REDIRECTS = 5;
 /** Download timeout in milliseconds (5 minutes for large binaries). */
 const DOWNLOAD_TIMEOUT_MS = 300_000;
 
+/** Directory for Ollama runner shared libraries (CPU inference backends). */
+const OLLAMA_LIB_DIR = '/usr/local/lib/ollama';
+
 /**
- * Download a .tar.zst archive, extract the ollama binary, and place it at dest.
+ * Download a .tar.zst archive, extract the ollama binary and runner libs.
  * Cleans up temp files (archive + extract dir) on both success and failure.
  * @param url - URL to the .tar.zst archive
  * @param dest - Final binary destination path (e.g. /usr/local/bin/ollama)
@@ -36,12 +39,20 @@ export async function downloadAndExtractBinary(
     }
     await chmod(binaryPath, 0o755);
     await rename(binaryPath, dest);
+    await installRunnerLibs(join(extractDir, 'lib', 'ollama'));
   } finally {
     await unlink(archivePath).catch(() => {});
     if (extractDir) {
       await rm(extractDir, { recursive: true, force: true }).catch(() => {});
     }
   }
+}
+
+/** Copy runner shared libraries (CPU backends) to the lib directory. */
+async function installRunnerLibs(srcDir: string): Promise<void> {
+  if (!existsSync(srcDir)) return;
+  await mkdir(OLLAMA_LIB_DIR, { recursive: true });
+  await cp(srcDir, OLLAMA_LIB_DIR, { recursive: true, force: true });
 }
 
 /**

--- a/api/src/ai/providers/ollama-native.service.spec.ts
+++ b/api/src/ai/providers/ollama-native.service.spec.ts
@@ -144,9 +144,11 @@ describe('OllamaNativeService', () => {
       service.writeSupervisorConfig();
 
       const content = mockWriteFileSync.mock.calls[0][1] as string;
-      expect(content).toContain('command=/usr/local/bin/ollama serve');
+      expect(content).toContain('/opt/glibc/lib/ld-linux.so');
+      expect(content).toContain('/usr/local/bin/ollama serve');
       expect(content).toContain('OLLAMA_MODELS="/data/ollama/models"');
       expect(content).toContain('OLLAMA_HOST="0.0.0.0:11434"');
+      expect(content).toContain('LD_LIBRARY_PATH=');
       expect(content).toContain('autostart=false');
       expect(content).toContain('autorestart=true');
     });

--- a/api/src/ai/providers/ollama-native.service.ts
+++ b/api/src/ai/providers/ollama-native.service.ts
@@ -12,6 +12,12 @@ const ALLINONE_SENTINEL = '/etc/supervisor.d/raid-ledger.ini';
 /** Path where the Ollama binary is installed. */
 const OLLAMA_BINARY_PATH = '/usr/local/bin/ollama';
 
+/** glibc dynamic linker copied from Debian at build time. */
+const GLIBC_LD_LINUX = '/opt/glibc/lib/ld-linux.so';
+
+/** Library search path for the glibc loader (glibc runtime + Ollama runner libs). */
+const GLIBC_LIB_PATH = '/opt/glibc/lib:/usr/local/lib/ollama';
+
 /** Supervisor config path for Ollama (inside services/ so [include] picks it up). */
 const SUPERVISOR_CONFIG_PATH = '/etc/supervisor.d/services/ollama.ini';
 
@@ -23,11 +29,15 @@ export function getOllamaDownloadUrl(): string {
 
 /**
  * Supervisor config template for the Ollama process.
+ * Uses the glibc dynamic linker because Ollama is compiled against glibc
+ * and Alpine's musl cannot run it (fcntl64 symbol missing, segfaults).
  * autostart=false because binary may not exist after image rebuild.
+ * --library-path: for ld-linux.so to resolve Ollama's own deps.
+ * LD_LIBRARY_PATH: inherited by child processes (runner backends).
  */
 const SUPERVISOR_CONFIG = `[program:ollama]
-command=/usr/local/bin/ollama serve
-environment=OLLAMA_MODELS="/data/ollama/models",OLLAMA_HOST="0.0.0.0:11434"
+command=${GLIBC_LD_LINUX} --library-path ${GLIBC_LIB_PATH} ${OLLAMA_BINARY_PATH} serve
+environment=OLLAMA_MODELS="/data/ollama/models",OLLAMA_HOST="0.0.0.0:11434",LD_LIBRARY_PATH="${GLIBC_LIB_PATH}"
 autostart=false
 autorestart=true
 stdout_logfile=/data/logs/ollama.log


### PR DESCRIPTION
## What

- Replace Alpine's `gcompat` with a real glibc runtime copied from `debian:bookworm-slim` at Docker build time
- Launch Ollama via the glibc dynamic linker (`/opt/glibc/lib/ld-linux.so`) instead of directly
- Extract runner libs (`lib/ollama/`) from the tar.zst archive for CPU inference backends

## Why

Ollama is compiled against glibc. Alpine uses musl. The `gcompat` shim (added in ROK-984) is missing the `fcntl64` symbol Ollama needs — every setup attempt fails with `supervisorctl start ollama → ERROR (spawn error)`. Even hand-rolled shims segfault due to deeper glibc/musl ABI differences.

## Acceptance criteria

- [x] Ollama binary executes inside the allinone container (verified locally: `Listening on 127.0.0.1:11434 v0.19.0`)
- [x] Multi-arch support: Dockerfile handles both amd64 and arm64 glibc linker paths
- [x] Build-time guard: `test -f /opt/glibc/lib/ld-linux.so` fails the build if linker copy fails
- [x] Runner libs extracted alongside binary for CPU inference

## Linear

ROK-991

## Test plan

- [x] Build passes (contract + api)
- [x] TypeScript clean
- [x] Lint clean (0 errors)
- [x] Unit tests pass (358 suites, 4932 tests)
- [x] Allinone image builds and serves healthy (`/api/health` → ok)
- [x] Ollama v0.19.0 starts inside allinone container with CPU inference detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)