### PR TITLE
ROK-993: nudge unlinked members to connect Steam during lineup building

### DIFF
--- a/api/src/admin/admin.module.ts
+++ b/api/src/admin/admin.module.ts
@@ -14,9 +14,10 @@ import { IgdbModule } from '../igdb/igdb.module';
 import { DemoDataService } from './demo-data.service';
 import { DemoTestService } from './demo-test.service';
 import { SlashCommandTestService } from './slash-command-test.service';
+import { LineupsModule } from '../lineups/lineups.module';
 
 @Module({
-  imports: [SettingsModule, AuthModule, IgdbModule],
+  imports: [SettingsModule, AuthModule, IgdbModule, LineupsModule],
   controllers: [
     AdminController,
     AdminSettingsController,

--- a/api/src/admin/demo-test.controller.ts
+++ b/api/src/admin/demo-test.controller.ts
@@ -14,6 +14,7 @@ import { SkipThrottle } from '@nestjs/throttler';
 import { z } from 'zod';
 import { AdminGuard } from '../auth/admin.guard';
 import { DemoTestService } from './demo-test.service';
+import { LineupSteamNudgeService } from '../lineups/lineup-steam-nudge.service';
 
 const LinkDiscordSchema = z.object({
   userId: z.number().int().positive(),
@@ -95,7 +96,10 @@ const CreateTestSignupSchema = z.object({
 @SkipThrottle()
 @UseGuards(AuthGuard('jwt'), AdminGuard)
 export class DemoTestController {
-  constructor(private readonly demoTestService: DemoTestService) {}
+  constructor(
+    private readonly demoTestService: DemoTestService,
+    private readonly steamNudge: LineupSteamNudgeService,
+  ) {}
 
   /** Link a Discord ID to a user -- DEMO_MODE only (smoke tests). */
   @Post('link-discord')
@@ -339,6 +343,16 @@ export class DemoTestController {
       parsed.gameId,
       parsed.steamAppId,
     );
+    return { success: true };
+  }
+
+  /** Trigger steam nudge DMs for a lineup — DEMO_MODE only. */
+  @Post('trigger-steam-nudge')
+  @HttpCode(HttpStatus.OK)
+  async triggerSteamNudge(
+    @Body() body: { lineupId: number },
+  ): Promise<{ success: boolean }> {
+    await this.steamNudge.nudgeUnlinkedMembers(body.lineupId);
     return { success: true };
   }
 

--- a/api/src/auth/auth.controller.ts
+++ b/api/src/auth/auth.controller.ts
@@ -120,6 +120,7 @@ export class AuthController {
       avatar: user.avatar,
       customAvatarUrl: user.customAvatarUrl,
       role: user.role,
+      steamId: user.steamId ?? null,
       onboardingCompletedAt: user.onboardingCompletedAt?.toISOString() ?? null,
       avatarPreference: avatarPref?.value ?? null,
       resolvedAvatarUrl,

--- a/api/src/drizzle/schema/notification-preferences.ts
+++ b/api/src/drizzle/schema/notification-preferences.ts
@@ -20,6 +20,7 @@ export const NOTIFICATION_TYPES = [
   'member_returned',
   'recruitment_reminder',
   'role_gap_alert',
+  'lineup_steam_nudge',
   'system',
 ] as const;
 
@@ -54,6 +55,7 @@ export const DEFAULT_CHANNEL_PREFS: ChannelPrefs = {
   member_returned: { inApp: true, push: true, discord: true },
   recruitment_reminder: { inApp: true, push: true, discord: true },
   role_gap_alert: { inApp: true, push: true, discord: true },
+  lineup_steam_nudge: { inApp: true, push: false, discord: true },
   system: { inApp: true, push: false, discord: false },
 };
 

--- a/api/src/drizzle/schema/notifications.ts
+++ b/api/src/drizzle/schema/notifications.ts
@@ -38,6 +38,7 @@ export const notifications = pgTable(
         'member_returned',
         'recruitment_reminder',
         'role_gap_alert',
+        'lineup_steam_nudge',
         'system',
       ],
     }).notNull(),

--- a/api/src/lineups/common-ground-query.helpers.ts
+++ b/api/src/lineups/common-ground-query.helpers.ts
@@ -81,7 +81,9 @@ function buildWhereConditions(
   filters: CommonGroundFilters,
   excludeGameIds: number[],
 ): ReturnType<typeof sql>[] {
-  const conditions = [sql`1=1`];
+  const conditions = [
+    sql`(g.steam_app_id IS NOT NULL OR g.igdb_id IS NOT NULL)`,
+  ];
 
   if (excludeGameIds.length > 0) {
     conditions.push(

--- a/api/src/lineups/common-ground-query.helpers.ts
+++ b/api/src/lineups/common-ground-query.helpers.ts
@@ -17,6 +17,7 @@ export interface CommonGroundFilters {
   minOwners: number;
   maxPlayers?: number;
   genre?: string;
+  search?: string;
   limit: number;
 }
 
@@ -106,6 +107,10 @@ function buildWhereConditions(
         AND (g.player_count->>'max')::int >= ${filters.maxPlayers}
       )`,
     );
+  }
+
+  if (filters.search) {
+    conditions.push(sql`g.name ILIKE ${'%' + filters.search + '%'}`);
   }
 
   return conditions;

--- a/api/src/lineups/lineup-steam-nudge.service.spec.ts
+++ b/api/src/lineups/lineup-steam-nudge.service.spec.ts
@@ -11,6 +11,7 @@ import { LineupSteamNudgeService } from './lineup-steam-nudge.service';
 import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
 import { NotificationService } from '../notifications/notification.service';
 import { NotificationDedupService } from '../notifications/notification-dedup.service';
+import { SettingsService } from '../settings/settings.service';
 
 /**
  * Mock user rows returned by findNudgeRecipients-style queries.
@@ -39,6 +40,7 @@ describe('LineupSteamNudgeService', () => {
   let mockDb: { execute: jest.Mock; select: jest.Mock };
   let mockNotificationService: { create: jest.Mock };
   let mockDedupService: { checkAndMarkSent: jest.Mock };
+  let mockSettingsService: { getClientUrl: jest.Mock };
 
   beforeEach(async () => {
     mockDb = {
@@ -54,6 +56,10 @@ describe('LineupSteamNudgeService', () => {
       checkAndMarkSent: jest.fn().mockResolvedValue(false),
     };
 
+    mockSettingsService = {
+      getClientUrl: jest.fn().mockResolvedValue('http://localhost:5173'),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         LineupSteamNudgeService,
@@ -63,6 +69,7 @@ describe('LineupSteamNudgeService', () => {
           provide: NotificationDedupService,
           useValue: mockDedupService,
         },
+        { provide: SettingsService, useValue: mockSettingsService },
       ],
     }).compile();
 

--- a/api/src/lineups/lineup-steam-nudge.service.spec.ts
+++ b/api/src/lineups/lineup-steam-nudge.service.spec.ts
@@ -16,17 +16,21 @@ import { NotificationDedupService } from '../notifications/notification-dedup.se
  * Mock user rows returned by findNudgeRecipients-style queries.
  * Shape: { id, discordId, steamId, displayName }
  */
-function makeUser(overrides: Partial<{
-  id: number;
-  discordId: string | null;
-  steamId: string | null;
-  displayName: string;
-}> = {}) {
+function makeUser(
+  overrides: Partial<{
+    id: number;
+    discordId: string | null;
+    steamId: string | null;
+    displayName: string;
+  }> = {},
+) {
   return {
-    id: overrides.id ?? 1,
-    discordId: overrides.discordId ?? '111222333',
-    steamId: overrides.steamId ?? null,
-    displayName: overrides.displayName ?? 'TestUser',
+    id: overrides.id === undefined ? 1 : overrides.id,
+    discordId:
+      overrides.discordId === undefined ? '111222333' : overrides.discordId,
+    steamId: overrides.steamId === undefined ? null : overrides.steamId,
+    displayName:
+      overrides.displayName === undefined ? 'TestUser' : overrides.displayName,
   };
 }
 
@@ -86,7 +90,11 @@ describe('LineupSteamNudgeService', () => {
 
     it('skips users who already have Steam linked', async () => {
       const users = [
-        makeUser({ id: 10, discordId: 'disc-10', steamId: '76561198000000001' }),
+        makeUser({
+          id: 10,
+          discordId: 'disc-10',
+          steamId: '76561198000000001',
+        }),
       ];
       mockDb.execute.mockResolvedValueOnce(users);
 
@@ -96,9 +104,7 @@ describe('LineupSteamNudgeService', () => {
     });
 
     it('skips users without Discord (cannot DM them)', async () => {
-      const users = [
-        makeUser({ id: 10, discordId: null, steamId: null }),
-      ];
+      const users = [makeUser({ id: 10, discordId: null, steamId: null })];
       mockDb.execute.mockResolvedValueOnce(users);
 
       await service.nudgeUnlinkedMembers(42);
@@ -107,9 +113,7 @@ describe('LineupSteamNudgeService', () => {
     });
 
     it('uses permanent dedup key per lineup+user to prevent duplicates', async () => {
-      const users = [
-        makeUser({ id: 10, discordId: 'disc-10', steamId: null }),
-      ];
+      const users = [makeUser({ id: 10, discordId: 'disc-10', steamId: null })];
       mockDb.execute.mockResolvedValueOnce(users);
 
       await service.nudgeUnlinkedMembers(42);
@@ -121,9 +125,7 @@ describe('LineupSteamNudgeService', () => {
     });
 
     it('skips notification when dedup indicates already sent', async () => {
-      const users = [
-        makeUser({ id: 10, discordId: 'disc-10', steamId: null }),
-      ];
+      const users = [makeUser({ id: 10, discordId: 'disc-10', steamId: null })];
       mockDb.execute.mockResolvedValueOnce(users);
       mockDedupService.checkAndMarkSent.mockResolvedValueOnce(true);
 

--- a/api/src/lineups/lineup-steam-nudge.service.spec.ts
+++ b/api/src/lineups/lineup-steam-nudge.service.spec.ts
@@ -1,0 +1,135 @@
+/**
+ * TDD tests for LineupSteamNudgeService (ROK-993).
+ * Validates Discord DM nudge dispatch, dedup, preference checks,
+ * and filtering of users by Steam/Discord link status.
+ *
+ * These tests are written BEFORE the implementation exists.
+ * They MUST fail until the dev agent builds the service.
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { LineupSteamNudgeService } from './lineup-steam-nudge.service';
+import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
+import { NotificationService } from '../notifications/notification.service';
+import { NotificationDedupService } from '../notifications/notification-dedup.service';
+
+/**
+ * Mock user rows returned by findNudgeRecipients-style queries.
+ * Shape: { id, discordId, steamId, displayName }
+ */
+function makeUser(overrides: Partial<{
+  id: number;
+  discordId: string | null;
+  steamId: string | null;
+  displayName: string;
+}> = {}) {
+  return {
+    id: overrides.id ?? 1,
+    discordId: overrides.discordId ?? '111222333',
+    steamId: overrides.steamId ?? null,
+    displayName: overrides.displayName ?? 'TestUser',
+  };
+}
+
+describe('LineupSteamNudgeService', () => {
+  let service: LineupSteamNudgeService;
+  let mockDb: { execute: jest.Mock; select: jest.Mock };
+  let mockNotificationService: { create: jest.Mock };
+  let mockDedupService: { checkAndMarkSent: jest.Mock };
+
+  beforeEach(async () => {
+    mockDb = {
+      execute: jest.fn().mockResolvedValue([]),
+      select: jest.fn(),
+    };
+
+    mockNotificationService = {
+      create: jest.fn().mockResolvedValue({ id: 'notif-1' }),
+    };
+
+    mockDedupService = {
+      checkAndMarkSent: jest.fn().mockResolvedValue(false),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LineupSteamNudgeService,
+        { provide: DrizzleAsyncProvider, useValue: mockDb },
+        { provide: NotificationService, useValue: mockNotificationService },
+        {
+          provide: NotificationDedupService,
+          useValue: mockDedupService,
+        },
+      ],
+    }).compile();
+
+    service = module.get<LineupSteamNudgeService>(LineupSteamNudgeService);
+  });
+
+  describe('nudgeUnlinkedMembers', () => {
+    it('dispatches notification for each user with Discord but no Steam', async () => {
+      const users = [
+        makeUser({ id: 10, discordId: 'disc-10', steamId: null }),
+        makeUser({ id: 11, discordId: 'disc-11', steamId: null }),
+      ];
+      mockDb.execute.mockResolvedValueOnce(users);
+
+      await service.nudgeUnlinkedMembers(42);
+
+      expect(mockNotificationService.create).toHaveBeenCalledTimes(2);
+      expect(mockNotificationService.create).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 10 }),
+      );
+      expect(mockNotificationService.create).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 11 }),
+      );
+    });
+
+    it('skips users who already have Steam linked', async () => {
+      const users = [
+        makeUser({ id: 10, discordId: 'disc-10', steamId: '76561198000000001' }),
+      ];
+      mockDb.execute.mockResolvedValueOnce(users);
+
+      await service.nudgeUnlinkedMembers(42);
+
+      expect(mockNotificationService.create).not.toHaveBeenCalled();
+    });
+
+    it('skips users without Discord (cannot DM them)', async () => {
+      const users = [
+        makeUser({ id: 10, discordId: null, steamId: null }),
+      ];
+      mockDb.execute.mockResolvedValueOnce(users);
+
+      await service.nudgeUnlinkedMembers(42);
+
+      expect(mockNotificationService.create).not.toHaveBeenCalled();
+    });
+
+    it('uses permanent dedup key per lineup+user to prevent duplicates', async () => {
+      const users = [
+        makeUser({ id: 10, discordId: 'disc-10', steamId: null }),
+      ];
+      mockDb.execute.mockResolvedValueOnce(users);
+
+      await service.nudgeUnlinkedMembers(42);
+
+      expect(mockDedupService.checkAndMarkSent).toHaveBeenCalledWith(
+        'lineup-steam-nudge:42:10',
+        null,
+      );
+    });
+
+    it('skips notification when dedup indicates already sent', async () => {
+      const users = [
+        makeUser({ id: 10, discordId: 'disc-10', steamId: null }),
+      ];
+      mockDb.execute.mockResolvedValueOnce(users);
+      mockDedupService.checkAndMarkSent.mockResolvedValueOnce(true);
+
+      await service.nudgeUnlinkedMembers(42);
+
+      expect(mockNotificationService.create).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/api/src/lineups/lineup-steam-nudge.service.spec.ts
+++ b/api/src/lineups/lineup-steam-nudge.service.spec.ts
@@ -1,63 +1,30 @@
 /**
  * TDD tests for LineupSteamNudgeService (ROK-993).
- * Validates Discord DM nudge dispatch, dedup, preference checks,
- * and filtering of users by Steam/Discord link status.
- *
- * These tests are written BEFORE the implementation exists.
- * They MUST fail until the dev agent builds the service.
+ * Validates Discord DM nudge dispatch, dedup, and SQL-level filtering.
  */
 import { Test, TestingModule } from '@nestjs/testing';
 import { LineupSteamNudgeService } from './lineup-steam-nudge.service';
 import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
 import { NotificationService } from '../notifications/notification.service';
 import { NotificationDedupService } from '../notifications/notification-dedup.service';
-import { SettingsService } from '../settings/settings.service';
 
-/**
- * Mock user rows returned by findNudgeRecipients-style queries.
- * Shape: { id, discordId, steamId, displayName }
- */
-function makeUser(
-  overrides: Partial<{
-    id: number;
-    discordId: string | null;
-    steamId: string | null;
-    displayName: string;
-  }> = {},
-) {
-  return {
-    id: overrides.id === undefined ? 1 : overrides.id,
-    discordId:
-      overrides.discordId === undefined ? '111222333' : overrides.discordId,
-    steamId: overrides.steamId === undefined ? null : overrides.steamId,
-    displayName:
-      overrides.displayName === undefined ? 'TestUser' : overrides.displayName,
-  };
+function makeRecipient(id: number, displayName = 'TestUser') {
+  return { id, displayName };
 }
 
 describe('LineupSteamNudgeService', () => {
   let service: LineupSteamNudgeService;
-  let mockDb: { execute: jest.Mock; select: jest.Mock };
+  let mockDb: { execute: jest.Mock };
   let mockNotificationService: { create: jest.Mock };
   let mockDedupService: { checkAndMarkSent: jest.Mock };
-  let mockSettingsService: { getClientUrl: jest.Mock };
 
   beforeEach(async () => {
-    mockDb = {
-      execute: jest.fn().mockResolvedValue([]),
-      select: jest.fn(),
-    };
-
+    mockDb = { execute: jest.fn().mockResolvedValue([]) };
     mockNotificationService = {
       create: jest.fn().mockResolvedValue({ id: 'notif-1' }),
     };
-
     mockDedupService = {
       checkAndMarkSent: jest.fn().mockResolvedValue(false),
-    };
-
-    mockSettingsService = {
-      getClientUrl: jest.fn().mockResolvedValue('http://localhost:5173'),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -65,11 +32,7 @@ describe('LineupSteamNudgeService', () => {
         LineupSteamNudgeService,
         { provide: DrizzleAsyncProvider, useValue: mockDb },
         { provide: NotificationService, useValue: mockNotificationService },
-        {
-          provide: NotificationDedupService,
-          useValue: mockDedupService,
-        },
-        { provide: SettingsService, useValue: mockSettingsService },
+        { provide: NotificationDedupService, useValue: mockDedupService },
       ],
     }).compile();
 
@@ -77,12 +40,11 @@ describe('LineupSteamNudgeService', () => {
   });
 
   describe('nudgeUnlinkedMembers', () => {
-    it('dispatches notification for each user with Discord but no Steam', async () => {
-      const users = [
-        makeUser({ id: 10, discordId: 'disc-10', steamId: null }),
-        makeUser({ id: 11, discordId: 'disc-11', steamId: null }),
-      ];
-      mockDb.execute.mockResolvedValueOnce(users);
+    it('dispatches notification for each eligible recipient', async () => {
+      mockDb.execute.mockResolvedValueOnce([
+        makeRecipient(10),
+        makeRecipient(11),
+      ]);
 
       await service.nudgeUnlinkedMembers(42);
 
@@ -95,33 +57,17 @@ describe('LineupSteamNudgeService', () => {
       );
     });
 
-    it('skips users who already have Steam linked', async () => {
-      const users = [
-        makeUser({
-          id: 10,
-          discordId: 'disc-10',
-          steamId: '76561198000000001',
-        }),
-      ];
-      mockDb.execute.mockResolvedValueOnce(users);
+    it('does nothing when no eligible recipients', async () => {
+      mockDb.execute.mockResolvedValueOnce([]);
 
       await service.nudgeUnlinkedMembers(42);
 
-      expect(mockNotificationService.create).not.toHaveBeenCalled();
-    });
-
-    it('skips users without Discord (cannot DM them)', async () => {
-      const users = [makeUser({ id: 10, discordId: null, steamId: null })];
-      mockDb.execute.mockResolvedValueOnce(users);
-
-      await service.nudgeUnlinkedMembers(42);
-
+      expect(mockDedupService.checkAndMarkSent).not.toHaveBeenCalled();
       expect(mockNotificationService.create).not.toHaveBeenCalled();
     });
 
     it('uses permanent dedup key per lineup+user to prevent duplicates', async () => {
-      const users = [makeUser({ id: 10, discordId: 'disc-10', steamId: null })];
-      mockDb.execute.mockResolvedValueOnce(users);
+      mockDb.execute.mockResolvedValueOnce([makeRecipient(10)]);
 
       await service.nudgeUnlinkedMembers(42);
 
@@ -132,13 +78,22 @@ describe('LineupSteamNudgeService', () => {
     });
 
     it('skips notification when dedup indicates already sent', async () => {
-      const users = [makeUser({ id: 10, discordId: 'disc-10', steamId: null })];
-      mockDb.execute.mockResolvedValueOnce(users);
+      mockDb.execute.mockResolvedValueOnce([makeRecipient(10)]);
       mockDedupService.checkAndMarkSent.mockResolvedValueOnce(true);
 
       await service.nudgeUnlinkedMembers(42);
 
       expect(mockNotificationService.create).not.toHaveBeenCalled();
+    });
+
+    it('includes lineupId in notification payload', async () => {
+      mockDb.execute.mockResolvedValueOnce([makeRecipient(10)]);
+
+      await service.nudgeUnlinkedMembers(42);
+
+      expect(mockNotificationService.create).toHaveBeenCalledWith(
+        expect.objectContaining({ payload: { lineupId: 42 } }),
+      );
     });
   });
 });

--- a/api/src/lineups/lineup-steam-nudge.service.ts
+++ b/api/src/lineups/lineup-steam-nudge.service.ts
@@ -9,6 +9,7 @@ import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
 import * as schema from '../drizzle/schema';
 import { NotificationService } from '../notifications/notification.service';
 import { NotificationDedupService } from '../notifications/notification-dedup.service';
+import { SettingsService } from '../settings/settings.service';
 
 /** Shape of a member row from the nudge query. */
 interface NudgeMember {
@@ -27,19 +28,23 @@ export class LineupSteamNudgeService {
     private readonly db: PostgresJsDatabase<typeof schema>,
     private readonly notificationService: NotificationService,
     private readonly dedupService: NotificationDedupService,
+    private readonly settingsService: SettingsService,
   ) {}
 
   /** Send nudge DMs to members without Steam linked. */
   async nudgeUnlinkedMembers(lineupId: number): Promise<void> {
-    const members = (await this.db.execute(sql`
-      SELECT u.id, u.discord_id AS "discordId", u.steam_id AS "steamId",
-             COALESCE(u.display_name, u.username) AS "displayName"
-      FROM users u
-    `)) as unknown as NudgeMember[];
+    const [clientUrl, members] = await Promise.all([
+      this.settingsService.getClientUrl(),
+      this.db.execute(sql`
+        SELECT u.id, u.discord_id AS "discordId", u.steam_id AS "steamId",
+               COALESCE(u.display_name, u.username) AS "displayName"
+        FROM users u
+      `) as Promise<unknown> as Promise<NudgeMember[]>,
+    ]);
 
     for (const member of members) {
       if (!member.discordId || member.steamId) continue;
-      await this.sendNudge(member, lineupId);
+      await this.sendNudge(member, lineupId, clientUrl);
     }
   }
 
@@ -47,6 +52,7 @@ export class LineupSteamNudgeService {
   private async sendNudge(
     member: NudgeMember,
     lineupId: number,
+    clientUrl: string,
   ): Promise<void> {
     const dedupKey = `lineup-steam-nudge:${lineupId}:${member.id}`;
     const alreadySent = await this.dedupService.checkAndMarkSent(
@@ -55,12 +61,13 @@ export class LineupSteamNudgeService {
     );
     if (alreadySent) return;
 
+    const lineupUrl = `${clientUrl}/community-lineup/${lineupId}`;
     await this.notificationService.create({
       userId: member.id,
       type: 'lineup_steam_nudge',
       title: 'Link your Steam account',
       message:
-        'A new community lineup is being built! Link your Steam account so we can include your library in game suggestions.',
+        `A new community lineup is being built! Link your Steam account so we can include your library in game suggestions.\n\n${lineupUrl}`,
     });
   }
 }

--- a/api/src/lineups/lineup-steam-nudge.service.ts
+++ b/api/src/lineups/lineup-steam-nudge.service.ts
@@ -1,0 +1,66 @@
+/**
+ * Service to nudge unlinked Steam members during lineup building (ROK-993).
+ * Sends Discord DM nudges to lineup members who have Discord but no Steam linked.
+ */
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { sql } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
+import * as schema from '../drizzle/schema';
+import { NotificationService } from '../notifications/notification.service';
+import { NotificationDedupService } from '../notifications/notification-dedup.service';
+
+/** Shape of a member row from the nudge query. */
+interface NudgeMember {
+  id: number;
+  discordId: string | null;
+  steamId: string | null;
+  displayName: string;
+}
+
+@Injectable()
+export class LineupSteamNudgeService {
+  private readonly logger = new Logger(LineupSteamNudgeService.name);
+
+  constructor(
+    @Inject(DrizzleAsyncProvider)
+    private readonly db: PostgresJsDatabase<typeof schema>,
+    private readonly notificationService: NotificationService,
+    private readonly dedupService: NotificationDedupService,
+  ) {}
+
+  /** Send nudge DMs to members without Steam linked. */
+  async nudgeUnlinkedMembers(lineupId: number): Promise<void> {
+    const members = (await this.db.execute(sql`
+      SELECT u.id, u.discord_id AS "discordId", u.steam_id AS "steamId",
+             COALESCE(u.display_name, u.username) AS "displayName"
+      FROM users u
+    `)) as unknown as NudgeMember[];
+
+    for (const member of members) {
+      if (!member.discordId || member.steamId) continue;
+      await this.sendNudge(member, lineupId);
+    }
+  }
+
+  /** Send a single nudge, skipping if already sent. */
+  private async sendNudge(
+    member: NudgeMember,
+    lineupId: number,
+  ): Promise<void> {
+    const dedupKey = `lineup-steam-nudge:${lineupId}:${member.id}`;
+    const alreadySent = await this.dedupService.checkAndMarkSent(
+      dedupKey,
+      null,
+    );
+    if (alreadySent) return;
+
+    await this.notificationService.create({
+      userId: member.id,
+      type: 'lineup_steam_nudge',
+      title: 'Link your Steam account',
+      message:
+        'A new community lineup is being built! Link your Steam account so we can include your library in game suggestions.',
+    });
+  }
+}

--- a/api/src/lineups/lineup-steam-nudge.service.ts
+++ b/api/src/lineups/lineup-steam-nudge.service.ts
@@ -1,6 +1,6 @@
 /**
  * Service to nudge unlinked Steam members during lineup building (ROK-993).
- * Sends Discord DM nudges to lineup members who have Discord but no Steam linked.
+ * Sends Discord DM nudges to all community members who have Discord but no Steam linked.
  */
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { sql } from 'drizzle-orm';
@@ -9,15 +9,14 @@ import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
 import * as schema from '../drizzle/schema';
 import { NotificationService } from '../notifications/notification.service';
 import { NotificationDedupService } from '../notifications/notification-dedup.service';
-import { SettingsService } from '../settings/settings.service';
 
-/** Shape of a member row from the nudge query. */
-interface NudgeMember {
+/** Shape of an eligible nudge recipient. */
+interface NudgeRecipient {
   id: number;
-  discordId: string | null;
-  steamId: string | null;
   displayName: string;
 }
+
+const BATCH_SIZE = 10;
 
 @Injectable()
 export class LineupSteamNudgeService {
@@ -28,33 +27,36 @@ export class LineupSteamNudgeService {
     private readonly db: PostgresJsDatabase<typeof schema>,
     private readonly notificationService: NotificationService,
     private readonly dedupService: NotificationDedupService,
-    private readonly settingsService: SettingsService,
   ) {}
 
-  /** Send nudge DMs to members without Steam linked. */
+  /** Send nudge DMs to all community members with Discord but no Steam. */
   async nudgeUnlinkedMembers(lineupId: number): Promise<void> {
-    const [clientUrl, members] = await Promise.all([
-      this.settingsService.getClientUrl(),
-      this.db.execute(sql`
-        SELECT u.id, u.discord_id AS "discordId", u.steam_id AS "steamId",
-               COALESCE(u.display_name, u.username) AS "displayName"
-        FROM users u
-      `) as Promise<unknown> as Promise<NudgeMember[]>,
-    ]);
+    const recipients = await this.findNudgeRecipients();
+    if (!recipients.length) return;
 
-    for (const member of members) {
-      if (!member.discordId || member.steamId) continue;
-      await this.sendNudge(member, lineupId, clientUrl);
+    for (let i = 0; i < recipients.length; i += BATCH_SIZE) {
+      const batch = recipients.slice(i, i + BATCH_SIZE);
+      await Promise.allSettled(
+        batch.map((r) => this.sendNudge(r, lineupId)),
+      );
     }
+  }
+
+  /** Find users with Discord linked but no Steam. */
+  private async findNudgeRecipients(): Promise<NudgeRecipient[]> {
+    return (await this.db.execute(sql`
+      SELECT u.id, COALESCE(u.display_name, u.username) AS "displayName"
+      FROM users u
+      WHERE u.discord_id IS NOT NULL AND u.steam_id IS NULL
+    `)) as unknown as NudgeRecipient[];
   }
 
   /** Send a single nudge, skipping if already sent. */
   private async sendNudge(
-    member: NudgeMember,
+    recipient: NudgeRecipient,
     lineupId: number,
-    clientUrl: string,
   ): Promise<void> {
-    const dedupKey = `lineup-steam-nudge:${lineupId}:${member.id}`;
+    const dedupKey = `lineup-steam-nudge:${lineupId}:${recipient.id}`;
     const alreadySent = await this.dedupService.checkAndMarkSent(
       dedupKey,
       null,
@@ -62,7 +64,7 @@ export class LineupSteamNudgeService {
     if (alreadySent) return;
 
     await this.notificationService.create({
-      userId: member.id,
+      userId: recipient.id,
       type: 'lineup_steam_nudge',
       title: 'Link your Steam account',
       message:

--- a/api/src/lineups/lineup-steam-nudge.service.ts
+++ b/api/src/lineups/lineup-steam-nudge.service.ts
@@ -61,13 +61,13 @@ export class LineupSteamNudgeService {
     );
     if (alreadySent) return;
 
-    const lineupUrl = `${clientUrl}/community-lineup/${lineupId}`;
     await this.notificationService.create({
       userId: member.id,
       type: 'lineup_steam_nudge',
       title: 'Link your Steam account',
       message:
-        `A new community lineup is being built! Link your Steam account so we can include your library in game suggestions.\n\n${lineupUrl}`,
+        'A new community lineup is being built! Link your Steam account so we can include your library in game suggestions.',
+      payload: { lineupId },
     });
   }
 }

--- a/api/src/lineups/lineups-enrichment.helpers.ts
+++ b/api/src/lineups/lineups-enrichment.helpers.ts
@@ -116,3 +116,32 @@ export async function countTotalMembers(db: Db): Promise<number> {
 
   return row?.count ?? 0;
 }
+
+/** Member without a linked Steam account. */
+export interface UnlinkedSteamMember {
+  id: number;
+  displayName: string;
+}
+
+/**
+ * Count members without a linked Steam account (ROK-993).
+ */
+export async function countUnlinkedSteamMembers(db: Db): Promise<number> {
+  const rows = (await db.execute(sql`
+    SELECT count(*)::int AS count FROM users WHERE steam_id IS NULL
+  `)) as unknown as { count: number }[];
+  return Number(rows[0]?.count ?? 0);
+}
+
+/**
+ * Find members without a linked Steam account (ROK-993).
+ */
+export async function findUnlinkedSteamMembers(
+  db: Db,
+): Promise<UnlinkedSteamMember[]> {
+  const rows = (await db.execute(sql`
+    SELECT id, COALESCE(display_name, username) AS display_name
+    FROM users WHERE steam_id IS NULL
+  `)) as unknown as { id: number; display_name: string }[];
+  return rows.map((r) => ({ id: r.id, displayName: r.display_name }));
+}

--- a/api/src/lineups/lineups-response.helpers.ts
+++ b/api/src/lineups/lineups-response.helpers.ts
@@ -22,7 +22,10 @@ import {
   countWishlistPerGame,
   fetchPricingMetadata,
   countTotalMembers,
+  countUnlinkedSteamMembers,
+  findUnlinkedSteamMembers,
   type GamePricing,
+  type UnlinkedSteamMember,
 } from './lineups-enrichment.helpers';
 import { findUserVotes } from './lineups-voting.helpers';
 
@@ -34,6 +37,8 @@ interface EnrichmentMaps {
   wishlistMap: Map<number, number>;
   pricingMap: Map<number, GamePricing>;
   totalMembers: number;
+  unlinkedSteamCount: number;
+  unlinkedSteamMembers: UnlinkedSteamMember[];
 }
 
 /** Map a single entry row to the response shape with enrichment. */
@@ -67,6 +72,29 @@ function mapEntry(
   };
 }
 
+/** Extract core lineup metadata fields. */
+function mapLineupCore(
+  lineup: typeof schema.communityLineups.$inferSelect,
+  creator: Awaited<ReturnType<typeof findUserById>>,
+  decidedGame: Awaited<ReturnType<typeof findGameName>>,
+) {
+  return {
+    id: lineup.id,
+    status: lineup.status,
+    targetDate: lineup.targetDate?.toISOString() ?? null,
+    decidedGameId: lineup.decidedGameId,
+    decidedGameName: decidedGame[0]?.name ?? null,
+    linkedEventId: lineup.linkedEventId,
+    createdBy: creator[0] ?? { id: lineup.createdBy, displayName: 'Unknown' },
+    votingDeadline: lineup.votingDeadline?.toISOString() ?? null,
+    phaseDeadline: lineup.phaseDeadline?.toISOString() ?? null,
+    matchThreshold: lineup.matchThreshold ?? 35,
+    maxVotesPerPlayer: lineup.maxVotesPerPlayer ?? 3,
+    createdAt: lineup.createdAt.toISOString(),
+    updatedAt: lineup.updatedAt.toISOString(),
+  };
+}
+
 /** Map raw query results to the detail response shape. */
 function mapToDetailResponse(
   lineup: typeof schema.communityLineups.$inferSelect,
@@ -80,23 +108,37 @@ function mapToDetailResponse(
 ): LineupDetailResponseDto {
   const voteMap = new Map(voteCounts.map((v) => [v.gameId, v.voteCount]));
   return {
-    id: lineup.id,
-    status: lineup.status,
-    targetDate: lineup.targetDate?.toISOString() ?? null,
-    decidedGameId: lineup.decidedGameId,
-    decidedGameName: decidedGame[0]?.name ?? null,
-    linkedEventId: lineup.linkedEventId,
-    createdBy: creator[0] ?? { id: lineup.createdBy, displayName: 'Unknown' },
-    votingDeadline: lineup.votingDeadline?.toISOString() ?? null,
-    phaseDeadline: lineup.phaseDeadline?.toISOString() ?? null,
-    matchThreshold: lineup.matchThreshold ?? 35,
-    maxVotesPerPlayer: lineup.maxVotesPerPlayer ?? 3,
+    ...mapLineupCore(lineup, creator, decidedGame),
     entries: entries.map((e) => mapEntry(e, voteMap, enrichment)),
     totalVoters: voterCount[0]?.total ?? 0,
     totalMembers: enrichment.totalMembers,
     myVotes,
-    createdAt: lineup.createdAt.toISOString(),
-    updatedAt: lineup.updatedAt.toISOString(),
+    unlinkedSteamCount: enrichment.unlinkedSteamCount,
+    unlinkedSteamMembers: enrichment.unlinkedSteamMembers,
+  };
+}
+
+/** Fetch enrichment data for lineup entries. */
+async function fetchEnrichment(
+  db: Db,
+  gameIds: number[],
+): Promise<EnrichmentMaps> {
+  const [ownerMap, wishlistMap, pricingMap, totalMembers, uc, um] =
+    await Promise.all([
+      countOwnersPerGame(db, gameIds),
+      countWishlistPerGame(db, gameIds),
+      fetchPricingMetadata(db, gameIds),
+      countTotalMembers(db),
+      countUnlinkedSteamMembers(db),
+      findUnlinkedSteamMembers(db),
+    ]);
+  return {
+    ownerMap,
+    wishlistMap,
+    pricingMap,
+    totalMembers,
+    unlinkedSteamCount: uc,
+    unlinkedSteamMembers: um,
   };
 }
 
@@ -121,14 +163,10 @@ export async function buildDetailResponse(
       findUserVotes(db, lineupId, userId),
     ]);
 
-  const gameIds = entries.map((e) => e.gameId);
-  const [ownerMap, wishlistMap, pricingMap, totalMembers] = await Promise.all([
-    countOwnersPerGame(db, gameIds),
-    countWishlistPerGame(db, gameIds),
-    fetchPricingMetadata(db, gameIds),
-    countTotalMembers(db),
-  ]);
-
+  const enrichment = await fetchEnrichment(
+    db,
+    entries.map((e) => e.gameId),
+  );
   return mapToDetailResponse(
     lineup,
     entries,
@@ -136,7 +174,7 @@ export async function buildDetailResponse(
     voterCount,
     creator,
     decidedGame,
-    { ownerMap, wishlistMap, pricingMap, totalMembers },
+    enrichment,
     myVotes,
   );
 }

--- a/api/src/lineups/lineups.module.ts
+++ b/api/src/lineups/lineups.module.ts
@@ -2,8 +2,10 @@ import { Module } from '@nestjs/common';
 import { BullModule } from '@nestjs/bullmq';
 import { LineupsController } from './lineups.controller';
 import { LineupsService } from './lineups.service';
+import { LineupSteamNudgeService } from './lineup-steam-nudge.service';
 import { DrizzleModule } from '../drizzle/drizzle.module';
 import { ActivityLogModule } from '../activity-log/activity-log.module';
+import { NotificationModule } from '../notifications/notification.module';
 import { SettingsModule } from '../settings/settings.module';
 import { LINEUP_PHASE_QUEUE } from './queue/lineup-phase.constants';
 import { LineupPhaseQueueService } from './queue/lineup-phase.queue';
@@ -13,11 +15,17 @@ import { LineupPhaseProcessor } from './queue/lineup-phase.processor';
   imports: [
     DrizzleModule,
     ActivityLogModule,
+    NotificationModule,
     SettingsModule,
     BullModule.registerQueue({ name: LINEUP_PHASE_QUEUE }),
   ],
   controllers: [LineupsController],
-  providers: [LineupsService, LineupPhaseQueueService, LineupPhaseProcessor],
+  providers: [
+    LineupsService,
+    LineupSteamNudgeService,
+    LineupPhaseQueueService,
+    LineupPhaseProcessor,
+  ],
   exports: [LineupsService],
 })
 export class LineupsModule {}

--- a/api/src/lineups/lineups.module.ts
+++ b/api/src/lineups/lineups.module.ts
@@ -26,6 +26,6 @@ import { LineupPhaseProcessor } from './queue/lineup-phase.processor';
     LineupPhaseQueueService,
     LineupPhaseProcessor,
   ],
-  exports: [LineupsService],
+  exports: [LineupsService, LineupSteamNudgeService],
 })
 export class LineupsModule {}

--- a/api/src/lineups/lineups.service.ts
+++ b/api/src/lineups/lineups.service.ts
@@ -24,6 +24,7 @@ import type { LineupStatus } from '../drizzle/schema';
 import { ActivityLogService } from '../activity-log/activity-log.service';
 import { SettingsService } from '../settings/settings.service';
 import { LineupPhaseQueueService } from './queue/lineup-phase.queue';
+import { LineupSteamNudgeService } from './lineup-steam-nudge.service';
 import {
   findActiveLineup,
   findLineupById,
@@ -86,6 +87,7 @@ export class LineupsService {
     private readonly activityLog: ActivityLogService,
     private readonly settings: SettingsService,
     private readonly phaseQueue: LineupPhaseQueueService,
+    private readonly steamNudge: LineupSteamNudgeService,
   ) {}
 
   /** Create a new lineup. Throws 409 if an active lineup already exists. */
@@ -103,6 +105,7 @@ export class LineupsService {
       overrides,
     );
     void this.activityLog.log('lineup', row.id, 'lineup_created', userId);
+    void this.steamNudge.nudgeUnlinkedMembers(row.id);
     await carryOverFromLastDecided(this.db, row.id);
 
     const delayMs = phaseDeadline.getTime() - Date.now();

--- a/api/src/notifications/discord-notification-embed.service.ts
+++ b/api/src/notifications/discord-notification-embed.service.ts
@@ -204,9 +204,7 @@ export class DiscordNotificationEmbedService {
       clientUrl,
     );
     if (primaryButton) buttons.push(primaryButton);
-    buttons.push(
-      ...buildInlineButtons(input.type, input.payload, clientUrl),
-    );
+    buttons.push(...buildInlineButtons(input.type, input.payload, clientUrl));
     const discordButton = this.buildDiscordLinkButton(input);
     if (discordButton) buttons.push(discordButton);
     buttons.push(

--- a/api/src/notifications/discord-notification-embed.service.ts
+++ b/api/src/notifications/discord-notification-embed.service.ts
@@ -15,6 +15,7 @@ import {
   addTypeSpecificFields,
   buildExtraRows,
   buildPrimaryButton,
+  buildInlineButtons,
 } from './notification-embed.helpers';
 
 interface NotificationEmbedInput {
@@ -203,6 +204,9 @@ export class DiscordNotificationEmbedService {
       clientUrl,
     );
     if (primaryButton) buttons.push(primaryButton);
+    buttons.push(
+      ...buildInlineButtons(input.type, input.payload, clientUrl),
+    );
     const discordButton = this.buildDiscordLinkButton(input);
     if (discordButton) buttons.push(discordButton);
     buttons.push(

--- a/api/src/notifications/notification-embed.helpers.ts
+++ b/api/src/notifications/notification-embed.helpers.ts
@@ -296,6 +296,9 @@ export function buildPrimaryButton(
   payload: Record<string, unknown> | undefined,
   clientUrl: string,
 ): ButtonBuilder | null {
+  if (type === 'lineup_steam_nudge') {
+    return buildLineupNudgeButton(payload, clientUrl);
+  }
   const eventId = payload?.eventId != null ? toStr(payload.eventId) : null;
   if (!eventId) return null;
   if (
@@ -314,4 +317,17 @@ export function buildPrimaryButton(
     .setLabel(label)
     .setStyle(ButtonStyle.Link)
     .setURL(`${clientUrl}/events/${eventId}?notif=${notificationId}`);
+}
+
+/** Build the "View Lineup" link button for steam nudge DMs. */
+function buildLineupNudgeButton(
+  payload: Record<string, unknown> | undefined,
+  clientUrl: string,
+): ButtonBuilder | null {
+  const lineupId = payload?.lineupId != null ? toStr(payload.lineupId) : null;
+  if (!lineupId) return null;
+  return new ButtonBuilder()
+    .setLabel('View Lineup')
+    .setStyle(ButtonStyle.Link)
+    .setURL(`${clientUrl}/community-lineup/${lineupId}`);
 }

--- a/api/src/notifications/notification-embed.helpers.ts
+++ b/api/src/notifications/notification-embed.helpers.ts
@@ -188,6 +188,9 @@ export function buildExtraRows(
   payload: Record<string, unknown> | undefined,
   clientUrl: string,
 ): ActionRowBuilder<ButtonBuilder>[] | undefined {
+  if (type === 'lineup_steam_nudge') {
+    return buildSteamNudgeExtraRow(clientUrl);
+  }
   const eventId = payload?.eventId;
   if (eventId == null) return undefined;
   const eid = toStr(eventId);
@@ -317,6 +320,20 @@ export function buildPrimaryButton(
     .setLabel(label)
     .setStyle(ButtonStyle.Link)
     .setURL(`${clientUrl}/events/${eventId}?notif=${notificationId}`);
+}
+
+/** Build "Link Steam" extra row for steam nudge DMs. */
+function buildSteamNudgeExtraRow(
+  clientUrl: string,
+): ActionRowBuilder<ButtonBuilder>[] {
+  return [
+    new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setLabel('Link Steam')
+        .setStyle(ButtonStyle.Link)
+        .setURL(`${clientUrl}/profile/integrations`),
+    ),
+  ];
 }
 
 /** Build the "View Lineup" link button for steam nudge DMs. */

--- a/api/src/notifications/notification-embed.helpers.ts
+++ b/api/src/notifications/notification-embed.helpers.ts
@@ -188,9 +188,6 @@ export function buildExtraRows(
   payload: Record<string, unknown> | undefined,
   clientUrl: string,
 ): ActionRowBuilder<ButtonBuilder>[] | undefined {
-  if (type === 'lineup_steam_nudge') {
-    return buildSteamNudgeExtraRow(clientUrl);
-  }
   const eventId = payload?.eventId;
   if (eventId == null) return undefined;
   const eid = toStr(eventId);
@@ -322,29 +319,30 @@ export function buildPrimaryButton(
     .setURL(`${clientUrl}/events/${eventId}?notif=${notificationId}`);
 }
 
-/** Build "Link Steam" extra row for steam nudge DMs. */
-function buildSteamNudgeExtraRow(
-  clientUrl: string,
-): ActionRowBuilder<ButtonBuilder>[] {
-  return [
-    new ActionRowBuilder<ButtonBuilder>().addComponents(
-      new ButtonBuilder()
-        .setLabel('Link Steam')
-        .setStyle(ButtonStyle.Link)
-        .setURL(`${clientUrl}/profile/integrations`),
-    ),
-  ];
-}
-
-/** Build the "View Lineup" link button for steam nudge DMs. */
+/** Build the "Link Steam" primary button for steam nudge DMs. */
 function buildLineupNudgeButton(
-  payload: Record<string, unknown> | undefined,
+  _payload: Record<string, unknown> | undefined,
   clientUrl: string,
 ): ButtonBuilder | null {
-  const lineupId = payload?.lineupId != null ? toStr(payload.lineupId) : null;
-  if (!lineupId) return null;
   return new ButtonBuilder()
-    .setLabel('View Lineup')
+    .setLabel('Link Steam')
     .setStyle(ButtonStyle.Link)
-    .setURL(`${clientUrl}/community-lineup/${lineupId}`);
+    .setURL(`${clientUrl}/profile/integrations`);
+}
+
+/** Extra buttons to add to the main action row for specific types. */
+export function buildInlineButtons(
+  type: NotificationType,
+  payload: Record<string, unknown> | undefined,
+  clientUrl: string,
+): ButtonBuilder[] {
+  if (type !== 'lineup_steam_nudge') return [];
+  const lineupId = payload?.lineupId != null ? toStr(payload.lineupId) : null;
+  if (!lineupId) return [];
+  return [
+    new ButtonBuilder()
+      .setLabel('View Lineup')
+      .setStyle(ButtonStyle.Link)
+      .setURL(`${clientUrl}/community-lineup/${lineupId}`),
+  ];
 }

--- a/api/src/notifications/notification-embed.helpers.ts
+++ b/api/src/notifications/notification-embed.helpers.ts
@@ -38,6 +38,7 @@ export function getColorForType(type: NotificationType): number {
     missed_event_nudge: EMBED_COLORS.REMINDER,
     role_gap_alert: EMBED_COLORS.REMINDER,
     recruitment_reminder: EMBED_COLORS.ANNOUNCEMENT,
+    lineup_steam_nudge: EMBED_COLORS.ANNOUNCEMENT,
     slot_vacated: EMBED_COLORS.ROSTER_UPDATE,
     member_returned: EMBED_COLORS.ROSTER_UPDATE,
     bench_promoted: EMBED_COLORS.ROSTER_UPDATE,
@@ -64,6 +65,7 @@ export function getEmojiForType(type: NotificationType): string {
     level_up: '⬆️',
     missed_event_nudge: '👋',
     recruitment_reminder: '📢',
+    lineup_steam_nudge: '🔗',
     role_gap_alert: '\u26A0\uFE0F',
   };
   return map[type] ?? '🔔';
@@ -86,6 +88,7 @@ export function getTypeLabel(type: NotificationType): string {
     level_up: 'Level Up',
     missed_event_nudge: 'Missed Event',
     recruitment_reminder: 'Recruitment Reminder',
+    lineup_steam_nudge: 'Steam Link Nudge',
     role_gap_alert: 'Role Gap Alert',
   };
   return map[type] ?? 'Notification';

--- a/api/src/notifications/notification.module.ts
+++ b/api/src/notifications/notification.module.ts
@@ -46,6 +46,7 @@ import { SettingsModule } from '../settings/settings.module';
   ],
   exports: [
     NotificationService,
+    NotificationDedupService,
     RosterNotificationBufferService,
     DiscordNotificationService,
     GameAffinityNotificationService,

--- a/api/src/steam/steam-auth.controller.ts
+++ b/api/src/steam/steam-auth.controller.ts
@@ -266,7 +266,12 @@ export class SteamAuthController {
     if (isPublic) {
       this.steamService.syncLibrary(userId).catch((err: unknown) => {
         this.logger.warn(
-          `Auto-sync after Steam link failed for user ${userId}: ${err instanceof Error ? err.message : 'Unknown error'}`,
+          `Auto-sync library after Steam link failed for user ${userId}: ${err instanceof Error ? err.message : 'Unknown error'}`,
+        );
+      });
+      this.steamWishlistService.syncWishlist(userId).catch((err: unknown) => {
+        this.logger.warn(
+          `Auto-sync wishlist after Steam link failed for user ${userId}: ${err instanceof Error ? err.message : 'Unknown error'}`,
         );
       });
     }

--- a/packages/contract/src/lineup.schema.ts
+++ b/packages/contract/src/lineup.schema.ts
@@ -168,6 +168,8 @@ export const CommonGroundQuerySchema = z.object({
     minOwners: z.coerce.number().int().min(0).max(15).default(2),
     maxPlayers: z.coerce.number().int().positive().optional(),
     genre: z.string().optional(),
+    /** Case-insensitive game name search (ILIKE). */
+    search: z.string().max(100).optional(),
     limit: z.coerce.number().int().min(1).max(50).default(50),
 });
 

--- a/packages/contract/src/lineup.schema.ts
+++ b/packages/contract/src/lineup.schema.ts
@@ -112,6 +112,10 @@ export const LineupDetailResponseSchema = z.object({
     totalMembers: z.number(),
     /** Game IDs the current user has voted for (ROK-936). */
     myVotes: z.array(z.number()),
+    /** Count of members without a linked Steam account (ROK-993). */
+    unlinkedSteamCount: z.number(),
+    /** Members without a linked Steam account (ROK-993, operator-only). */
+    unlinkedSteamMembers: z.array(z.object({ id: z.number(), displayName: z.string() })),
     createdAt: z.string(),
     updatedAt: z.string(),
 });

--- a/web/src/components/lineups/CommonGroundPanel.tsx
+++ b/web/src/components/lineups/CommonGroundPanel.tsx
@@ -198,17 +198,6 @@ function PanelContent({
     );
 }
 
-/** Filter results client-side by name search. */
-function filterBySearch(
-    data: CommonGroundResponseDto | undefined,
-    search: string,
-): CommonGroundResponseDto | undefined {
-    if (!data || !search.trim()) return data;
-    const q = search.toLowerCase();
-    const filtered = data.data.filter((g) => g.gameName.toLowerCase().includes(q));
-    return { ...data, data: filtered };
-}
-
 /** Main Common Ground panel. Pass lineupId when the parent already has it. */
 export function CommonGroundPanel({ lineupId: propLineupId }: { lineupId?: number } = {}): JSX.Element | null {
     const { data: lineup } = useActiveLineup();
@@ -216,9 +205,9 @@ export function CommonGroundPanel({ lineupId: propLineupId }: { lineupId?: numbe
     const [filters, setFilters] = useState<CommonGroundParams>({ minOwners: 0, maxPlayers: 2 });
     const [search, setSearch] = useState('');
     const hasBuilding = propLineupId != null || lineup?.status === 'building';
-    const debouncedFilters = useDebouncedValue(filters, 300);
-    const { data, isLoading, isError, refetch } = useCommonGround(debouncedFilters, hasBuilding);
-    const filtered = useMemo(() => filterBySearch(data, search), [data, search]);
+    const apiParams = useMemo(() => ({ ...filters, search: search.trim() || undefined }), [filters, search]);
+    const debouncedParams = useDebouncedValue(apiParams, 300);
+    const { data, isLoading, isError, refetch } = useCommonGround(debouncedParams, hasBuilding);
     const availableTags = useMemo(() => (data?.data ? extractUniqueTags(data.data) : []), [data]);
     const atCap = (data?.meta.nominatedCount ?? 0) >= (data?.meta.maxNominations ?? 20);
     const { nominatingId, handleNominate } = useNomination(resolvedId);
@@ -229,7 +218,7 @@ export function CommonGroundPanel({ lineupId: propLineupId }: { lineupId?: numbe
         <section className="space-y-3">
             <PanelHeader nominated={data?.meta.nominatedCount ?? 0} max={data?.meta.maxNominations ?? 20} />
             <PanelContent
-                data={filtered} filters={filters} setFilters={setFilters} availableTags={availableTags}
+                data={data} filters={filters} setFilters={setFilters} availableTags={availableTags}
                 isLoading={isLoading} isError={isError} refetch={() => void refetch()}
                 onNominate={handleNominate} nominatingId={nominatingId} atCap={atCap}
                 search={search} onSearchChange={setSearch}

--- a/web/src/components/lineups/CommonGroundPanel.tsx
+++ b/web/src/components/lineups/CommonGroundPanel.tsx
@@ -202,7 +202,7 @@ function PanelContent({
 export function CommonGroundPanel({ lineupId: propLineupId }: { lineupId?: number } = {}): JSX.Element | null {
     const { data: lineup } = useActiveLineup();
     const resolvedId = propLineupId ?? lineup?.id;
-    const [filters, setFilters] = useState<CommonGroundParams>({ minOwners: 0, maxPlayers: 2 });
+    const [filters, setFilters] = useState<CommonGroundParams>({ minOwners: 0 });
     const [search, setSearch] = useState('');
     const hasBuilding = propLineupId != null || lineup?.status === 'building';
     const apiParams = useMemo(() => ({ ...filters, search: search.trim() || undefined }), [filters, search]);

--- a/web/src/components/lineups/LineupDetailHeader.tsx
+++ b/web/src/components/lineups/LineupDetailHeader.tsx
@@ -7,6 +7,7 @@ import { LineupStatusBadge } from './LineupStatusBadge';
 import { PhaseCountdown } from './phase-countdown';
 import { PHASES, PHASE_LABELS } from './lineup-phases';
 import { toast } from '../../lib/toast';
+import { UnlinkedSteamCount } from './UnlinkedSteamCount';
 
 interface Props {
   lineup: LineupDetailResponseDto;
@@ -122,7 +123,14 @@ function PhaseContextInfo({ lineup }: { lineup: LineupDetailResponseDto }): JSX.
   // Total participants = nominators + voters (unique count provided by API)
   const participants = (lineup.totalVoters ?? 0) + (lineup.status === 'building' ? lineup.entries.length : 0);
   if (lineup.status === 'building') {
-    return <span className="text-xs text-dim">{lineup.entries.length}/20 nominated · {participants} participated</span>;
+    return (
+      <span className="text-xs text-dim">
+        {lineup.entries.length}/20 nominated · {participants} participated
+        {lineup.unlinkedSteamCount > 0 && (
+          <> · <UnlinkedSteamCount count={lineup.unlinkedSteamCount} /></>
+        )}
+      </span>
+    );
   }
   if (lineup.status === 'voting') {
     return <span className="text-xs text-dim">{lineup.totalVoters} participated</span>;

--- a/web/src/components/lineups/SteamNudgeBanner.test.tsx
+++ b/web/src/components/lineups/SteamNudgeBanner.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * TDD tests for SteamNudgeBanner (ROK-993).
+ * Validates the dismissible "Link Steam" banner shown to unlinked users
+ * during the building phase of a lineup.
+ *
+ * These tests are written BEFORE the component exists.
+ * They MUST fail until the dev agent builds the component.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../../test/render-helpers';
+import { SteamNudgeBanner } from './SteamNudgeBanner';
+
+// Mock auth hook to control user.steamId and role
+vi.mock('../../hooks/use-auth', () => ({
+  useAuth: vi.fn(() => ({
+    user: { id: 1, role: 'member', username: 'TestUser' },
+  })),
+  isOperatorOrAdmin: vi.fn(() => false),
+}));
+
+// Mock Steam link hook to capture linkSteam calls
+const mockLinkSteam = vi.fn();
+vi.mock('../../hooks/use-steam-link', () => ({
+  useSteamLink: vi.fn(() => ({
+    linkSteam: mockLinkSteam,
+  })),
+}));
+
+import { useAuth } from '../../hooks/use-auth';
+
+const mockUseAuth = vi.mocked(useAuth);
+
+describe('SteamNudgeBanner — visible states', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockLinkSteam.mockReset();
+    mockUseAuth.mockReturnValue({
+      user: { id: 1, role: 'member', username: 'TestUser' } as never,
+    } as never);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('renders when user has no steamId and lineup is building', () => {
+    renderWithProviders(
+      <SteamNudgeBanner
+        lineupId={42}
+        lineupStatus="building"
+        userSteamId={null}
+      />,
+    );
+
+    expect(screen.getByText(/link.*steam/i)).toBeInTheDocument();
+  });
+
+  it('hidden when user has steamId', () => {
+    const { container } = renderWithProviders(
+      <SteamNudgeBanner
+        lineupId={42}
+        lineupStatus="building"
+        userSteamId="76561198000000001"
+      />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('hidden when lineup status is not building', () => {
+    const { container } = renderWithProviders(
+      <SteamNudgeBanner
+        lineupId={42}
+        lineupStatus="voting"
+        userSteamId={null}
+      />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe('SteamNudgeBanner — dismiss behavior', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockLinkSteam.mockReset();
+    mockUseAuth.mockReturnValue({
+      user: { id: 1, role: 'member', username: 'TestUser' } as never,
+    } as never);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('dismiss button hides banner and persists in localStorage', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <SteamNudgeBanner
+        lineupId={42}
+        lineupStatus="building"
+        userSteamId={null}
+      />,
+    );
+
+    const dismissBtn = screen.getByRole('button', { name: /dismiss|close/i });
+    await user.click(dismissBtn);
+
+    expect(screen.queryByText(/link.*steam/i)).not.toBeInTheDocument();
+    expect(
+      localStorage.getItem('raid_ledger_steam_nudge_dismissed_42'),
+    ).toBeTruthy();
+  });
+
+  it('stays hidden when localStorage dismiss key is already set', () => {
+    localStorage.setItem('raid_ledger_steam_nudge_dismissed_42', 'true');
+
+    const { container } = renderWithProviders(
+      <SteamNudgeBanner
+        lineupId={42}
+        lineupStatus="building"
+        userSteamId={null}
+      />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe('SteamNudgeBanner — CTA', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    mockLinkSteam.mockReset();
+    mockUseAuth.mockReturnValue({
+      user: { id: 1, role: 'member', username: 'TestUser' } as never,
+    } as never);
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  it('CTA button calls linkSteam when clicked', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(
+      <SteamNudgeBanner
+        lineupId={42}
+        lineupStatus="building"
+        userSteamId={null}
+      />,
+    );
+
+    const ctaButton = screen.getByRole('button', { name: /link.*steam/i });
+    await user.click(ctaButton);
+
+    expect(mockLinkSteam).toHaveBeenCalled();
+  });
+});

--- a/web/src/components/lineups/SteamNudgeBanner.tsx
+++ b/web/src/components/lineups/SteamNudgeBanner.tsx
@@ -1,0 +1,62 @@
+/**
+ * Dismissible banner prompting users without Steam linked to connect
+ * during the lineup building phase (ROK-993).
+ */
+import { useState } from 'react';
+import { useSteamLink } from '../../hooks/use-steam-link';
+
+interface SteamNudgeBannerProps {
+    lineupId: number;
+    lineupStatus: string;
+    userSteamId: string | null;
+}
+
+const STORAGE_KEY_PREFIX = 'raid_ledger_steam_nudge_dismissed_';
+
+function isDismissed(lineupId: number): boolean {
+    return localStorage.getItem(`${STORAGE_KEY_PREFIX}${lineupId}`) === 'true';
+}
+
+/** Banner action buttons — Link Steam CTA and dismiss. */
+function BannerActions({ onDismiss }: { onDismiss: () => void }) {
+    const { linkSteam } = useSteamLink();
+    return (
+        <div className="ml-4 flex items-center gap-2">
+            <button
+                type="button"
+                onClick={() => linkSteam()}
+                className="rounded bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-700"
+            >
+                Link Steam
+            </button>
+            <button
+                type="button"
+                aria-label="Dismiss"
+                onClick={onDismiss}
+                className="text-blue-500 hover:text-blue-700 dark:text-blue-400"
+            >
+                &times;
+            </button>
+        </div>
+    );
+}
+
+export function SteamNudgeBanner({ lineupId, lineupStatus, userSteamId }: SteamNudgeBannerProps) {
+    const [dismissed, setDismissed] = useState(() => isDismissed(lineupId));
+
+    if (userSteamId || lineupStatus !== 'building' || dismissed) {
+        return null;
+    }
+
+    const handleDismiss = () => {
+        localStorage.setItem(`${STORAGE_KEY_PREFIX}${lineupId}`, 'true');
+        setDismissed(true);
+    };
+
+    return (
+        <div className="flex items-center justify-between rounded-lg border border-blue-300 bg-blue-50 px-4 py-3 text-sm text-blue-800 dark:border-blue-700 dark:bg-blue-900/30 dark:text-blue-200">
+            <p>Connect your account to include your game library in suggestions.</p>
+            <BannerActions onDismiss={handleDismiss} />
+        </div>
+    );
+}

--- a/web/src/components/lineups/UnlinkedSteamCount.test.tsx
+++ b/web/src/components/lineups/UnlinkedSteamCount.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * TDD tests for UnlinkedSteamCount (ROK-993).
+ * Validates operator-visible unlinked member count display
+ * on the lineup detail page during building phase.
+ *
+ * These tests are written BEFORE the component exists.
+ * They MUST fail until the dev agent builds the component.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test/render-helpers';
+import { UnlinkedSteamCount } from './UnlinkedSteamCount';
+
+// Mock auth hook to control user role
+vi.mock('../../hooks/use-auth', () => ({
+  useAuth: vi.fn(() => ({
+    user: { id: 1, role: 'operator', username: 'Admin' },
+  })),
+  isOperatorOrAdmin: vi.fn(() => true),
+}));
+
+import { useAuth, isOperatorOrAdmin } from '../../hooks/use-auth';
+
+const mockUseAuth = vi.mocked(useAuth);
+const mockIsOperatorOrAdmin = vi.mocked(isOperatorOrAdmin);
+
+describe('UnlinkedSteamCount — operator visibility', () => {
+  beforeEach(() => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 1, role: 'operator', username: 'Admin' } as never,
+    } as never);
+    mockIsOperatorOrAdmin.mockReturnValue(true);
+  });
+
+  it('renders count for operator users when count > 0', () => {
+    renderWithProviders(
+      <UnlinkedSteamCount count={5} />,
+    );
+
+    expect(screen.getByText(/5/)).toBeInTheDocument();
+    expect(screen.getByText(/unlinked|without steam/i)).toBeInTheDocument();
+  });
+
+  it('hidden when count is 0', () => {
+    const { container } = renderWithProviders(
+      <UnlinkedSteamCount count={0} />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+});
+
+describe('UnlinkedSteamCount — non-operator visibility', () => {
+  beforeEach(() => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 2, role: 'member', username: 'RegularUser' } as never,
+    } as never);
+    mockIsOperatorOrAdmin.mockReturnValue(false);
+  });
+
+  it('hidden for regular users even when count > 0', () => {
+    const { container } = renderWithProviders(
+      <UnlinkedSteamCount count={5} />,
+    );
+
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/web/src/components/lineups/UnlinkedSteamCount.tsx
+++ b/web/src/components/lineups/UnlinkedSteamCount.tsx
@@ -1,0 +1,26 @@
+/**
+ * Operator-only display of unlinked Steam member count (ROK-993).
+ * Shows an amber text indicator when there are members without Steam linked.
+ */
+import { isOperatorOrAdmin, useAuth } from '../../hooks/use-auth';
+
+interface UnlinkedSteamCountProps {
+    count: number;
+}
+
+export function UnlinkedSteamCount({ count }: UnlinkedSteamCountProps) {
+    const { user } = useAuth();
+
+    if (!isOperatorOrAdmin(user) || count === 0) {
+        return null;
+    }
+
+    return (
+        <span
+            className="text-sm text-amber-600 dark:text-amber-400"
+            title={`${count} member${count === 1 ? '' : 's'} without Steam linked`}
+        >
+            {count} without Steam
+        </span>
+    );
+}

--- a/web/src/hooks/use-auth.ts
+++ b/web/src/hooks/use-auth.ts
@@ -15,6 +15,7 @@ export interface User {
     avatar: string | null;
     customAvatarUrl: string | null;
     role?: UserRole;
+    steamId: string | null;
     onboardingCompletedAt: string | null;
     avatarPreference?: { type: 'custom' | 'discord' | 'character'; characterName?: string } | null;
     resolvedAvatarUrl?: string | null;

--- a/web/src/lib/api/lineups-api.ts
+++ b/web/src/lib/api/lineups-api.ts
@@ -15,6 +15,7 @@ export interface CommonGroundParams {
   minOwners?: number;
   maxPlayers?: number;
   genre?: string;
+  search?: string;
   limit?: number;
 }
 
@@ -31,6 +32,7 @@ export async function getCommonGround(
   if (params.minOwners != null) search.set('minOwners', String(params.minOwners));
   if (params.maxPlayers != null) search.set('maxPlayers', String(params.maxPlayers));
   if (params.genre) search.set('genre', params.genre);
+  if (params.search) search.set('search', params.search);
   if (params.limit != null) search.set('limit', String(params.limit));
 
   const qs = search.toString();

--- a/web/src/pages/lineup-detail-page.tsx
+++ b/web/src/pages/lineup-detail-page.tsx
@@ -12,6 +12,8 @@ import { NominateModal } from '../components/lineups/NominateModal';
 import { PastLineups } from '../components/lineups/PastLineups';
 import { DecidedView } from '../components/lineups/decided/DecidedView';
 import { ActivityTimeline } from '../components/common/ActivityTimeline';
+import { SteamNudgeBanner } from '../components/lineups/SteamNudgeBanner';
+import { useAuth } from '../hooks/use-auth';
 
 function LineupNotFound(): JSX.Element {
   return (
@@ -28,6 +30,7 @@ export function LineupDetailPage(): JSX.Element {
   const { id } = useParams<{ id: string }>();
   const lineupId = id ? parseInt(id, 10) : undefined;
   const { data: lineup, isLoading, error } = useLineupDetail(lineupId);
+  const { user } = useAuth();
   const [modalOpen, setModalOpen] = useState(false);
 
   if (isLoading) return <LineupDetailSkeleton />;
@@ -52,6 +55,12 @@ export function LineupDetailPage(): JSX.Element {
       </div>
 
       <ActivityTimeline entityType="lineup" entityId={lineup.id} collapsible maxVisible={5} />
+
+      {isBuilding && (
+        <div className="mt-3">
+          <SteamNudgeBanner lineupId={lineup.id} lineupStatus={lineup.status} userSteamId={user?.steamId ?? null} />
+        </div>
+      )}
 
       {lineup.status === 'building' && (
         <div className="mt-4">


### PR DESCRIPTION
## Summary
- Dismissible "Link Steam" banner on lineup detail page during building phase for users without Steam linked
- Discord DM nudge with "Link Steam" + "View Lineup" buttons sent to unlinked members when a lineup is created
- Operator-only unlinked member count in lineup header
- Auto-trigger wishlist sync alongside library sync on Steam link
- Server-side search for Common Ground (ILIKE) + exclude bundles/packages

## Linear
ROK-993

## Test plan
- [x] Build passes (contract + api + web)
- [x] TypeScript clean
- [x] Lint clean (errors are pre-existing from ROK-965/989)
- [x] Unit tests pass — 5 API (nudge service) + 9 web (banner + count)
- [ ] Playwright smoke tests (deferred — branch rebased on rok-965)

🤖 Generated with [Claude Code](https://claude.com/claude-code)