### PR TITLE
fix: test-chat uses 120s timeout for CPU-only Ollama on NAS

### DIFF
--- a/api/src/ai/ai-admin.controller.ts
+++ b/api/src/ai/ai-admin.controller.ts
@@ -9,7 +9,7 @@ import { LlmService } from './llm.service';
 import { LlmProviderRegistry } from './llm-provider-registry';
 import { AiRequestLogService } from './ai-request-log.service';
 import { SettingsService } from '../settings/settings.service';
-import { AI_SETTING_KEYS } from './llm.constants';
+import { AI_DEFAULTS, AI_SETTING_KEYS } from './llm.constants';
 import { buildStatusResponse, buildUsageResponse } from './ai-admin.helpers';
 import type {
   AiStatusDto,
@@ -114,7 +114,7 @@ export class AiAdminController {
     try {
       const result = await this.llmService.chat(
         { messages: [{ role: 'user', content: 'Say hello in one sentence.' }] },
-        { feature: 'admin-test', maxResponseLength: 200 },
+        { feature: 'admin-test', maxResponseLength: 200, timeoutMs: AI_DEFAULTS.maxTimeoutMs },
       );
       return {
         success: true,

--- a/api/src/ai/llm-provider.interface.ts
+++ b/api/src/ai/llm-provider.interface.ts
@@ -79,6 +79,8 @@ export interface LlmRequestContext {
   feature: string;
   userId?: number;
   maxResponseLength?: number;
+  /** Override the default timeout for this request (e.g. admin test-chat). */
+  timeoutMs?: number;
 }
 
 /** Provider-agnostic interface for LLM backends. */

--- a/api/src/ai/llm.service.ts
+++ b/api/src/ai/llm.service.ts
@@ -59,7 +59,7 @@ export class LlmService {
       try {
         const response = await executeWithTimeout(
           () => provider.chat(prepared),
-          AI_DEFAULTS.timeoutMs,
+          context.timeoutMs ?? AI_DEFAULTS.timeoutMs,
         );
         this.circuitBreaker.recordSuccess();
         const sanitized = this.sanitizeChatResponse(response, context);

--- a/api/src/ai/providers/ollama.provider.ts
+++ b/api/src/ai/providers/ollama.provider.ts
@@ -82,7 +82,7 @@ export class OllamaProvider implements LlmProvider {
         stream: false,
         options: { num_predict: options.maxTokens },
       }),
-      timeoutMs: AI_DEFAULTS.timeoutMs,
+      timeoutMs: AI_DEFAULTS.maxTimeoutMs,
     });
     return mapOllamaChatResponse(raw, Date.now() - start);
   }
@@ -101,7 +101,7 @@ export class OllamaProvider implements LlmProvider {
         stream: false,
         options: { num_predict: options.maxTokens },
       }),
-      timeoutMs: AI_DEFAULTS.timeoutMs,
+      timeoutMs: AI_DEFAULTS.maxTimeoutMs,
     });
     return mapOllamaGenerateResponse(raw, Date.now() - start);
   }


### PR DESCRIPTION
## Summary
- Add optional `timeoutMs` to `LlmRequestContext` so callers can override the default
- Test-chat endpoint uses `maxTimeoutMs` (120s) since it's a one-shot admin action
- Ollama provider fetch uses `maxTimeoutMs` as safety net (service layer controls real timeout)
- Normal chat requests keep the 60s default via `AI_DEFAULTS.timeoutMs`
- Root cause: CPU-only Ollama on Synology NAS needs >60s for first inference (cold model load)

## Test plan
- [x] Build passes (contract + api)
- [x] TypeScript clean
- [x] Lint clean (0 errors)
- [x] Unit tests pass (4985 passed)
- [ ] Playwright skipped (API-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)