### PR TITLE
fix: restore test-chat 120s timeout (ROK-1006)

### DIFF
--- a/api/src/ai/ai-admin.controller.spec.ts
+++ b/api/src/ai/ai-admin.controller.spec.ts
@@ -7,6 +7,7 @@ import { SettingsService } from '../settings/settings.service';
 import { PluginRegistryService } from '../plugins/plugin-host/plugin-registry.service';
 import { Reflector } from '@nestjs/core';
 import type { LlmProvider } from './llm-provider.interface';
+import { AI_DEFAULTS } from './llm.constants';
 
 function createMockProvider(): LlmProvider {
   return {
@@ -313,24 +314,22 @@ describe('ROK-1000: testChat timeout and diagnostics', () => {
     controller = module.get(AiAdminController);
   });
 
-  // --- AC6: Test-chat uses 30s timeout ---
+  // --- AC6: Test-chat uses 120s timeout (ROK-1006: cold-start on CPU-only NAS) ---
 
-  it('AC6: calls llmService.chat with 30_000ms timeout, not 120_000ms', async () => {
+  it('AC6: calls llmService.chat with maxTimeoutMs for cold-start tolerance', async () => {
     await controller.testChat();
 
     expect(mockLlmService.chat).toHaveBeenCalledWith(
       expect.any(Object),
-      expect.objectContaining({ timeoutMs: 30_000 }),
+      expect.objectContaining({ timeoutMs: AI_DEFAULTS.maxTimeoutMs }),
     );
   });
 
-  it('AC6: timeout is exactly 30_000 (not AI_DEFAULTS.maxTimeoutMs)', async () => {
+  it('AC6: timeout is AI_DEFAULTS.maxTimeoutMs (120_000)', async () => {
     await controller.testChat();
 
     const context = mockLlmService.chat.mock.calls[0][1];
-    expect(context.timeoutMs).toBe(30_000);
-    // Verify it's NOT 120_000 (the old value)
-    expect(context.timeoutMs).not.toBe(120_000);
+    expect(context.timeoutMs).toBe(AI_DEFAULTS.maxTimeoutMs);
   });
 
   // --- AC7: Timeout error includes provider, model, and elapsed time ---

--- a/api/src/ai/ai-admin.controller.ts
+++ b/api/src/ai/ai-admin.controller.ts
@@ -9,7 +9,7 @@ import { LlmService } from './llm.service';
 import { LlmProviderRegistry } from './llm-provider-registry';
 import { AiRequestLogService } from './ai-request-log.service';
 import { SettingsService } from '../settings/settings.service';
-import { AI_SETTING_KEYS } from './llm.constants';
+import { AI_DEFAULTS, AI_SETTING_KEYS } from './llm.constants';
 import { buildStatusResponse, buildUsageResponse } from './ai-admin.helpers';
 import type {
   AiStatusDto,
@@ -115,7 +115,11 @@ export class AiAdminController {
     try {
       const result = await this.llmService.chat(
         { messages: [{ role: 'user', content: 'Say hello in one sentence.' }] },
-        { feature: 'admin-test', maxResponseLength: 200, timeoutMs: 30_000 },
+        {
+          feature: 'admin-test',
+          maxResponseLength: 200,
+          timeoutMs: AI_DEFAULTS.maxTimeoutMs,
+        },
       );
       this.logger.log(`test-chat ok | latency=${result.latencyMs}ms`);
       return {


### PR DESCRIPTION
## What
Restore the test-chat timeout to `AI_DEFAULTS.maxTimeoutMs` (120s) — the fix from PR #583 was overwritten by the ROK-1000 merge which re-hardcoded it to 30s.

## Why
CPU-only Ollama on the NAS needs ~120s for cold-start model loading + inference. The 30s timeout causes every first test-chat attempt to fail.

## Changes
- `ai-admin.controller.ts` — import `AI_DEFAULTS`, use `AI_DEFAULTS.maxTimeoutMs` instead of `30_000`
- `ai-admin.controller.spec.ts` — update AC6 tests to expect `maxTimeoutMs` (120s)

## Test plan
- [x] API typecheck clean
- [x] 367 API test suites pass (5065 tests)
- [x] 0 lint errors
- [ ] Verify test-chat works on NAS after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)