### PR TITLE
ROK-1012: increase deadlock retry to 5 attempts with exponential back-off

### DIFF
--- a/api/src/common/testing/integration-helpers.ts
+++ b/api/src/common/testing/integration-helpers.ts
@@ -60,8 +60,8 @@ export async function seedBaseline(
   return { adminUser, adminPassword, adminEmail, game };
 }
 
-const DEADLOCK_MAX_RETRIES = 3;
-const DEADLOCK_DELAY_MS = 50;
+const DEADLOCK_MAX_RETRIES = 5;
+const DEADLOCK_BASE_DELAY_MS = 200;
 
 async function retryOnDeadlock(fn: () => Promise<unknown>): Promise<void> {
   for (let attempt = 1; attempt <= DEADLOCK_MAX_RETRIES; attempt++) {
@@ -72,7 +72,8 @@ async function retryOnDeadlock(fn: () => Promise<unknown>): Promise<void> {
       const isDeadlock =
         err instanceof Error && 'code' in err && err.code === '40P01';
       if (!isDeadlock || attempt === DEADLOCK_MAX_RETRIES) throw err;
-      await new Promise((r) => setTimeout(r, DEADLOCK_DELAY_MS * attempt));
+      const delay = DEADLOCK_BASE_DELAY_MS * 2 ** (attempt - 1);
+      await new Promise((r) => setTimeout(r, delay));
     }
   }
 }


### PR DESCRIPTION
## What

Follow-up to #607. Increases deadlock retry from 3 attempts (50-150ms) to 5 attempts with exponential back-off (200, 400, 800, 1600, 3200ms).

## Why

CI run on main after #607 merged still hit the deadlock — shard 1/3 (`lineups-matches.integration.spec.ts`) exhausted all 3 retries because BullMQ jobs hold locks longer than the 150ms max wait.

## Test plan

- [x] Pre-existing TS errors only (scheduling module — not from this change)
- [x] Change is constants-only (retry count + delay formula)
- [ ] CI integration test shards pass reliably

🤖 Generated with [Claude Code](https://claude.com/claude-code)