### PR TITLE
ROK-1025: fix activity-log race condition — await instead of void

### DIFF
--- a/api/src/activity-log/activity-log.service.ts
+++ b/api/src/activity-log/activity-log.service.ts
@@ -38,7 +38,7 @@ export class ActivityLogService {
     private readonly db: PostgresJsDatabase<typeof schema>,
   ) {}
 
-  /** Record an activity log entry. Fire-and-forget safe. */
+  /** Record an activity log entry. All callers should await this. */
   async log(
     entityType: ActivityEntityTypeDto,
     entityId: number,

--- a/api/src/events/events.service.ts
+++ b/api/src/events/events.service.ts
@@ -110,7 +110,7 @@ export class EventsService {
       endTime,
       creatorId,
     );
-    void this.activityLog.log('event', result.id, 'event_created', creatorId, {
+    await this.activityLog.log('event', result.id, 'event_created', creatorId, {
       title: dto.title,
     });
     return result;
@@ -204,7 +204,7 @@ export class EventsService {
       isAdmin,
       dto,
     );
-    void this.activityLog.log('event', eventId, 'event_cancelled', userId, {
+    await this.activityLog.log('event', eventId, 'event_cancelled', userId, {
       reason: dto.reason ?? null,
     });
     return this.postMutate(
@@ -256,7 +256,7 @@ export class EventsService {
       isAdmin,
       dto,
     );
-    void this.activityLog.log('event', eventId, 'event_rescheduled', userId, {
+    await this.activityLog.log('event', eventId, 'event_rescheduled', userId, {
       oldStart: eventBefore.startTime,
       newStart: dto.startTime,
     });

--- a/api/src/events/signups.service.ts
+++ b/api/src/events/signups.service.ts
@@ -97,7 +97,7 @@ export class SignupsService {
       action: 'signup_created',
     });
     this.rosterNotificationBuffer.bufferJoin(eventId, userId);
-    void this.activityLog.log('event', eventId, 'signup_added', userId, {
+    await this.activityLog.log('event', eventId, 'signup_added', userId, {
       role: dto?.slotRole ?? dto?.preferredRoles?.[0] ?? null,
     });
     const character = dto?.characterId
@@ -247,7 +247,7 @@ export class SignupsService {
 
   async cancel(eventId: number, userId: number): Promise<void> {
     await this.rosterService.cancel(eventId, userId);
-    void this.activityLog.log('event', eventId, 'signup_cancelled', userId);
+    await this.activityLog.log('event', eventId, 'signup_cancelled', userId);
   }
 
   async selfUnassign(

--- a/api/src/lineups/lineups-activity.helpers.ts
+++ b/api/src/lineups/lineups-activity.helpers.ts
@@ -15,12 +15,12 @@ export async function logTransition(
   dto: UpdateLineupStatusDto,
 ): Promise<void> {
   if (dto.status === 'voting') {
-    void activityLog.log('lineup', id, 'voting_started', null, {
+    await activityLog.log('lineup', id, 'voting_started', null, {
       votingDeadline: dto.votingDeadline ?? null,
     });
   } else if (dto.status === 'decided' && dto.decidedGameId) {
     const [game] = await findGameName(db, dto.decidedGameId);
-    void activityLog.log('lineup', id, 'lineup_decided', null, {
+    await activityLog.log('lineup', id, 'lineup_decided', null, {
       gameId: dto.decidedGameId,
       gameName: game?.name ?? 'Unknown',
     });
@@ -36,7 +36,7 @@ export async function logNomination(
   userId: number,
 ): Promise<void> {
   const [game] = await findGameName(db, dto.gameId);
-  void activityLog.log('lineup', lineupId, 'game_nominated', userId, {
+  await activityLog.log('lineup', lineupId, 'game_nominated', userId, {
     gameId: dto.gameId,
     gameName: game?.name ?? 'Unknown',
     note: dto.note ?? null,

--- a/api/src/lineups/lineups.service.remove.spec.ts
+++ b/api/src/lineups/lineups.service.remove.spec.ts
@@ -125,7 +125,7 @@ describe('LineupsService.removeNomination', () => {
         ),
     };
 
-    mockActivityLog = { log: jest.fn() };
+    mockActivityLog = { log: jest.fn().mockResolvedValue(undefined) };
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [

--- a/api/src/lineups/lineups.service.spec.ts
+++ b/api/src/lineups/lineups.service.spec.ts
@@ -169,7 +169,7 @@ function describeLineupsService() {
       providers: [
         LineupsService,
         { provide: DrizzleAsyncProvider, useValue: mockDb },
-        { provide: ActivityLogService, useValue: { log: jest.fn() } },
+        { provide: ActivityLogService, useValue: { log: jest.fn().mockResolvedValue(undefined) } },
         {
           provide: SettingsService,
           useValue: { get: jest.fn().mockResolvedValue(null) },

--- a/api/src/lineups/lineups.service.ts
+++ b/api/src/lineups/lineups.service.ts
@@ -109,7 +109,7 @@ export class LineupsService {
       phaseDeadline,
       overrides,
     );
-    void this.activityLog.log('lineup', row.id, 'lineup_created', userId);
+    await this.activityLog.log('lineup', row.id, 'lineup_created', userId);
     void this.steamNudge.nudgeUnlinkedMembers(row.id);
     await carryOverFromLastDecided(this.db, row.id);
 
@@ -157,7 +157,7 @@ export class LineupsService {
       gameId,
       lineup.maxVotesPerPlayer ?? 3,
     );
-    void this.activityLog.log('lineup', lineupId, 'vote_cast', userId, {
+    await this.activityLog.log('lineup', lineupId, 'vote_cast', userId, {
       gameId,
       action,
     });
@@ -264,7 +264,7 @@ export class LineupsService {
     const entry = await findEntry(this.db, lineupId, gameId);
     validateRemoval(entry, caller);
     await deleteEntry(this.db, lineupId, gameId);
-    void this.activityLog.log(
+    await this.activityLog.log(
       'lineup',
       lineupId,
       'nomination_removed',


### PR DESCRIPTION
## What
All `activityLog.log()` calls across the codebase used `void` (fire-and-forget), creating a race condition where integration tests could query the activity timeline before the DB insert completed. Changed all 11 `void` → `await` calls and aligned test mocks.

## Why
`activity-log.integration.spec.ts:184` intermittently fails because `signup_added` isn't written before the GET query runs. The `void` pattern discards the promise from a direct DB insert — sub-ms latency, no reason not to await.

Resolves [ROK-1025](https://linear.app/roknua-projects/issue/ROK-1025)

## Acceptance criteria
- [ ] `activity-log.integration.spec.ts` passes reliably (no flake on `signup_added`)
- [ ] Zero remaining `void activityLog.log()` calls in services/helpers
- [ ] All 5133 API unit tests pass
- [ ] No `void` → `await` change affects response latency (single-row inserts)

## Test plan
- Ran activity-log integration test 5x consecutively — 9/9 pass each run
- Full API test suite: 373 suites, 5133 tests pass
- TypeScript + lint clean
- Build passes all workspaces

### Files changed
| File | Changes |
|------|---------|
| `api/src/activity-log/activity-log.service.ts` | Updated JSDoc |
| `api/src/events/events.service.ts` | 3× `void` → `await` |
| `api/src/events/signups.service.ts` | 2× `void` → `await` |
| `api/src/lineups/lineups.service.ts` | 3× `void` → `await` |
| `api/src/lineups/lineups-activity.helpers.ts` | 3× `void` → `await` |
| `api/src/lineups/lineups.service.spec.ts` | Mock → `mockResolvedValue(undefined)` |
| `api/src/lineups/lineups.service.remove.spec.ts` | Mock → `mockResolvedValue(undefined)` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)