### PR TITLE
ROK-1029: fix forwarded event embed gets out of sync with original

### DIFF
--- a/api/src/discord-bot/processors/embed-sync.helpers.ts
+++ b/api/src/discord-bot/processors/embed-sync.helpers.ts
@@ -9,15 +9,18 @@ import { EMBED_STATES, type EmbedState } from '../discord-bot.constants';
 const IMMINENT_THRESHOLD_MS = 2 * 60 * 60 * 1000;
 
 /**
- * Find the tracked Discord message for this event in the given guild.
- * Returns null if no record exists.
+ * Find all tracked Discord messages for this event in the given guild.
+ * Returns an empty array if no records exist.
+ *
+ * Multiple records exist when an event embed has been forwarded or
+ * unfurled into a second channel, creating an additional tracking row.
  */
-export async function findTrackedMessage(
+export async function findTrackedMessages(
   db: PostgresJsDatabase<typeof schema>,
   eventId: number,
   guildId: string,
-): Promise<typeof schema.discordEventMessages.$inferSelect | null> {
-  const [record] = await db
+): Promise<(typeof schema.discordEventMessages.$inferSelect)[]> {
+  return db
     .select()
     .from(schema.discordEventMessages)
     .where(
@@ -25,9 +28,7 @@ export async function findTrackedMessage(
         eq(schema.discordEventMessages.eventId, eventId),
         eq(schema.discordEventMessages.guildId, guildId),
       ),
-    )
-    .limit(1);
-  return record ?? null;
+    );
 }
 
 /**

--- a/api/src/discord-bot/processors/embed-sync.integration.spec.ts
+++ b/api/src/discord-bot/processors/embed-sync.integration.spec.ts
@@ -1,0 +1,168 @@
+/**
+ * Integration tests for embed-sync multi-message tracking (ROK-1029).
+ *
+ * Verifies that findTrackedMessage(s) returns ALL discord_event_messages
+ * rows for an event+guild pair, not just the first one. This is critical
+ * for forwarded/unfurled embeds that create a second tracking row in a
+ * different channel.
+ *
+ * These tests are TDD-first: they WILL FAIL against the current code
+ * because findTrackedMessage() uses LIMIT 1 and returns a single record.
+ * The dev agent must rename the function to findTrackedMessages() and
+ * change it to return an array.
+ */
+import { getTestApp, type TestApp } from '../../common/testing/test-app';
+import { truncateAllTables } from '../../common/testing/integration-helpers';
+import * as schema from '../../drizzle/schema';
+import { findTrackedMessage } from './embed-sync.helpers';
+
+const TEST_GUILD_ID = 'guild-1029';
+const CHANNEL_A = 'channel-a';
+const CHANNEL_B = 'channel-b';
+const MESSAGE_A = 'msg-aaa';
+const MESSAGE_B = 'msg-bbb';
+
+/** Insert an event into the DB and return its id. */
+async function insertEvent(testApp: TestApp): Promise<number> {
+  const now = new Date();
+  const later = new Date(now.getTime() + 3600_000);
+  const [event] = await testApp.db
+    .insert(schema.events)
+    .values({
+      title: 'ROK-1029 Test Event',
+      duration: [now, later],
+      creatorId: testApp.seed.adminUser.id,
+      gameId: testApp.seed.game.id,
+    })
+    .returning();
+  return event.id;
+}
+
+/** Insert a discord_event_messages tracking row. */
+async function insertTrackedMessage(
+  testApp: TestApp,
+  eventId: number,
+  guildId: string,
+  channelId: string,
+  messageId: string,
+) {
+  await testApp.db.insert(schema.discordEventMessages).values({
+    eventId,
+    guildId,
+    channelId,
+    messageId,
+    embedState: 'posted',
+  });
+}
+
+function describeMultiMessageSync() {
+  let testApp: TestApp;
+
+  beforeAll(async () => {
+    testApp = await getTestApp();
+  });
+
+  afterEach(async () => {
+    testApp.seed = await truncateAllTables(testApp.db);
+  });
+
+  describe('AC2: findTrackedMessages returns all records for event+guild', () => {
+    it('returns an array with both records when two channels track the same event', async () => {
+      // Arrange: create event with two tracking rows in different channels
+      const eventId = await insertEvent(testApp);
+      await insertTrackedMessage(testApp, eventId, TEST_GUILD_ID, CHANNEL_A, MESSAGE_A);
+      await insertTrackedMessage(testApp, eventId, TEST_GUILD_ID, CHANNEL_B, MESSAGE_B);
+
+      // Act: call the helper (currently findTrackedMessage, should become findTrackedMessages)
+      const result = await findTrackedMessage(testApp.db, eventId, TEST_GUILD_ID);
+
+      // Assert: must be an array of 2 records
+      // This WILL FAIL because findTrackedMessage returns a single object, not an array
+      expect(Array.isArray(result)).toBe(true);
+      expect((result as unknown[]).length).toBe(2);
+    });
+
+    it('includes both channel IDs in the returned records', async () => {
+      // Arrange
+      const eventId = await insertEvent(testApp);
+      await insertTrackedMessage(testApp, eventId, TEST_GUILD_ID, CHANNEL_A, MESSAGE_A);
+      await insertTrackedMessage(testApp, eventId, TEST_GUILD_ID, CHANNEL_B, MESSAGE_B);
+
+      // Act
+      const result = await findTrackedMessage(testApp.db, eventId, TEST_GUILD_ID);
+
+      // Assert: both channel IDs must be present in the result set
+      // This WILL FAIL because result is a single record, not an array
+      const records = result as unknown as Array<{ channelId: string }>;
+      const channelIds = records.map((r) => r.channelId).sort();
+      expect(channelIds).toEqual([CHANNEL_A, CHANNEL_B]);
+    });
+  });
+
+  describe('AC4: single-channel regression', () => {
+    it('returns an array of 1 record when only one channel tracks the event', async () => {
+      // Arrange: single tracking row
+      const eventId = await insertEvent(testApp);
+      await insertTrackedMessage(testApp, eventId, TEST_GUILD_ID, CHANNEL_A, MESSAGE_A);
+
+      // Act
+      const result = await findTrackedMessage(testApp.db, eventId, TEST_GUILD_ID);
+
+      // Assert: must be an array of 1 record, not a bare object
+      // This WILL FAIL because findTrackedMessage returns a single object
+      expect(Array.isArray(result)).toBe(true);
+      expect((result as unknown[]).length).toBe(1);
+    });
+
+    it('returns an empty array when no tracking rows exist', async () => {
+      // Arrange: event exists but no tracking rows
+      const eventId = await insertEvent(testApp);
+
+      // Act
+      const result = await findTrackedMessage(testApp.db, eventId, TEST_GUILD_ID);
+
+      // Assert: must be an empty array, not null
+      // This WILL FAIL because findTrackedMessage returns null for no records
+      expect(Array.isArray(result)).toBe(true);
+      expect((result as unknown[]).length).toBe(0);
+    });
+  });
+
+  describe('AC1: multi-message sync updates all copies', () => {
+    it('all tracked message IDs are queryable for the same event+guild', async () => {
+      // Arrange: create event with two tracking rows (simulating original + forwarded embed)
+      const eventId = await insertEvent(testApp);
+      await insertTrackedMessage(testApp, eventId, TEST_GUILD_ID, CHANNEL_A, MESSAGE_A);
+      await insertTrackedMessage(testApp, eventId, TEST_GUILD_ID, CHANNEL_B, MESSAGE_B);
+
+      // Act: query all tracked messages
+      const result = await findTrackedMessage(testApp.db, eventId, TEST_GUILD_ID);
+
+      // Assert: the sync processor needs all message IDs to update each embed
+      // This WILL FAIL because findTrackedMessage only returns one record
+      const records = result as unknown as Array<{ messageId: string }>;
+      const messageIds = records.map((r) => r.messageId).sort();
+      expect(messageIds).toEqual([MESSAGE_A, MESSAGE_B]);
+    });
+
+    it('does not return records from a different guild', async () => {
+      // Arrange: two tracking rows in different guilds
+      const eventId = await insertEvent(testApp);
+      await insertTrackedMessage(testApp, eventId, TEST_GUILD_ID, CHANNEL_A, MESSAGE_A);
+      await insertTrackedMessage(testApp, eventId, 'other-guild', CHANNEL_B, MESSAGE_B);
+
+      // Act: query for TEST_GUILD_ID only
+      const result = await findTrackedMessage(testApp.db, eventId, TEST_GUILD_ID);
+
+      // Assert: must return only the record for TEST_GUILD_ID, as an array of 1
+      // This WILL FAIL because findTrackedMessage returns a single object, not an array
+      expect(Array.isArray(result)).toBe(true);
+      const records = result as unknown as Array<{ guildId: string }>;
+      expect(records.length).toBe(1);
+      expect(records[0].guildId).toBe(TEST_GUILD_ID);
+    });
+  });
+}
+
+describe('Embed Sync Multi-Message Tracking (integration)', () =>
+  describeMultiMessageSync());

--- a/api/src/discord-bot/processors/embed-sync.integration.spec.ts
+++ b/api/src/discord-bot/processors/embed-sync.integration.spec.ts
@@ -14,7 +14,7 @@
 import { getTestApp, type TestApp } from '../../common/testing/test-app';
 import { truncateAllTables } from '../../common/testing/integration-helpers';
 import * as schema from '../../drizzle/schema';
-import { findTrackedMessage } from './embed-sync.helpers';
+import { findTrackedMessages } from './embed-sync.helpers';
 
 const TEST_GUILD_ID = 'guild-1029';
 const CHANNEL_A = 'channel-a';
@@ -70,11 +70,27 @@ function describeMultiMessageSync() {
     it('returns an array with both records when two channels track the same event', async () => {
       // Arrange: create event with two tracking rows in different channels
       const eventId = await insertEvent(testApp);
-      await insertTrackedMessage(testApp, eventId, TEST_GUILD_ID, CHANNEL_A, MESSAGE_A);
-      await insertTrackedMessage(testApp, eventId, TEST_GUILD_ID, CHANNEL_B, MESSAGE_B);
+      await insertTrackedMessage(
+        testApp,
+        eventId,
+        TEST_GUILD_ID,
+        CHANNEL_A,
+        MESSAGE_A,
+      );
+      await insertTrackedMessage(
+        testApp,
+        eventId,
+        TEST_GUILD_ID,
+        CHANNEL_B,
+        MESSAGE_B,
+      );
 
       // Act: call the helper (currently findTrackedMessage, should become findTrackedMessages)
-      const result = await findTrackedMessage(testApp.db, eventId, TEST_GUILD_ID);
+      const result = await findTrackedMessages(
+        testApp.db,
+        eventId,
+        TEST_GUILD_ID,
+      );
 
       // Assert: must be an array of 2 records
       // This WILL FAIL because findTrackedMessage returns a single object, not an array
@@ -85,11 +101,27 @@ function describeMultiMessageSync() {
     it('includes both channel IDs in the returned records', async () => {
       // Arrange
       const eventId = await insertEvent(testApp);
-      await insertTrackedMessage(testApp, eventId, TEST_GUILD_ID, CHANNEL_A, MESSAGE_A);
-      await insertTrackedMessage(testApp, eventId, TEST_GUILD_ID, CHANNEL_B, MESSAGE_B);
+      await insertTrackedMessage(
+        testApp,
+        eventId,
+        TEST_GUILD_ID,
+        CHANNEL_A,
+        MESSAGE_A,
+      );
+      await insertTrackedMessage(
+        testApp,
+        eventId,
+        TEST_GUILD_ID,
+        CHANNEL_B,
+        MESSAGE_B,
+      );
 
       // Act
-      const result = await findTrackedMessage(testApp.db, eventId, TEST_GUILD_ID);
+      const result = await findTrackedMessages(
+        testApp.db,
+        eventId,
+        TEST_GUILD_ID,
+      );
 
       // Assert: both channel IDs must be present in the result set
       // This WILL FAIL because result is a single record, not an array
@@ -103,10 +135,20 @@ function describeMultiMessageSync() {
     it('returns an array of 1 record when only one channel tracks the event', async () => {
       // Arrange: single tracking row
       const eventId = await insertEvent(testApp);
-      await insertTrackedMessage(testApp, eventId, TEST_GUILD_ID, CHANNEL_A, MESSAGE_A);
+      await insertTrackedMessage(
+        testApp,
+        eventId,
+        TEST_GUILD_ID,
+        CHANNEL_A,
+        MESSAGE_A,
+      );
 
       // Act
-      const result = await findTrackedMessage(testApp.db, eventId, TEST_GUILD_ID);
+      const result = await findTrackedMessages(
+        testApp.db,
+        eventId,
+        TEST_GUILD_ID,
+      );
 
       // Assert: must be an array of 1 record, not a bare object
       // This WILL FAIL because findTrackedMessage returns a single object
@@ -119,7 +161,11 @@ function describeMultiMessageSync() {
       const eventId = await insertEvent(testApp);
 
       // Act
-      const result = await findTrackedMessage(testApp.db, eventId, TEST_GUILD_ID);
+      const result = await findTrackedMessages(
+        testApp.db,
+        eventId,
+        TEST_GUILD_ID,
+      );
 
       // Assert: must be an empty array, not null
       // This WILL FAIL because findTrackedMessage returns null for no records
@@ -132,11 +178,27 @@ function describeMultiMessageSync() {
     it('all tracked message IDs are queryable for the same event+guild', async () => {
       // Arrange: create event with two tracking rows (simulating original + forwarded embed)
       const eventId = await insertEvent(testApp);
-      await insertTrackedMessage(testApp, eventId, TEST_GUILD_ID, CHANNEL_A, MESSAGE_A);
-      await insertTrackedMessage(testApp, eventId, TEST_GUILD_ID, CHANNEL_B, MESSAGE_B);
+      await insertTrackedMessage(
+        testApp,
+        eventId,
+        TEST_GUILD_ID,
+        CHANNEL_A,
+        MESSAGE_A,
+      );
+      await insertTrackedMessage(
+        testApp,
+        eventId,
+        TEST_GUILD_ID,
+        CHANNEL_B,
+        MESSAGE_B,
+      );
 
       // Act: query all tracked messages
-      const result = await findTrackedMessage(testApp.db, eventId, TEST_GUILD_ID);
+      const result = await findTrackedMessages(
+        testApp.db,
+        eventId,
+        TEST_GUILD_ID,
+      );
 
       // Assert: the sync processor needs all message IDs to update each embed
       // This WILL FAIL because findTrackedMessage only returns one record
@@ -148,11 +210,27 @@ function describeMultiMessageSync() {
     it('does not return records from a different guild', async () => {
       // Arrange: two tracking rows in different guilds
       const eventId = await insertEvent(testApp);
-      await insertTrackedMessage(testApp, eventId, TEST_GUILD_ID, CHANNEL_A, MESSAGE_A);
-      await insertTrackedMessage(testApp, eventId, 'other-guild', CHANNEL_B, MESSAGE_B);
+      await insertTrackedMessage(
+        testApp,
+        eventId,
+        TEST_GUILD_ID,
+        CHANNEL_A,
+        MESSAGE_A,
+      );
+      await insertTrackedMessage(
+        testApp,
+        eventId,
+        'other-guild',
+        CHANNEL_B,
+        MESSAGE_B,
+      );
 
       // Act: query for TEST_GUILD_ID only
-      const result = await findTrackedMessage(testApp.db, eventId, TEST_GUILD_ID);
+      const result = await findTrackedMessages(
+        testApp.db,
+        eventId,
+        TEST_GUILD_ID,
+      );
 
       // Assert: must return only the record for TEST_GUILD_ID, as an array of 1
       // This WILL FAIL because findTrackedMessage returns a single object, not an array

--- a/api/src/discord-bot/processors/embed-sync.processor.ts
+++ b/api/src/discord-bot/processors/embed-sync.processor.ts
@@ -22,7 +22,7 @@ import {
   type EmbedSyncJobData,
 } from '../queues/embed-sync.queue';
 import {
-  findTrackedMessage,
+  findTrackedMessages,
   buildEventData,
   computeEmbedState,
 } from './embed-sync.helpers';
@@ -68,9 +68,11 @@ export class EmbedSyncProcessor extends WorkerHost implements OnModuleInit {
     const guildId = this.requireConnection();
     if (!guildId) return;
 
-    const record = await findTrackedMessage(this.db, eventId, guildId);
-    if (!record) return;
-    if (record.embedState === EMBED_STATES.CANCELLED) return;
+    const records = await findTrackedMessages(this.db, eventId, guildId);
+    const active = records.filter(
+      (r) => r.embedState !== EMBED_STATES.CANCELLED,
+    );
+    if (active.length === 0) return;
 
     const event = await this.fetchEvent(eventId);
     if (!event || event.cancelledAt) return;
@@ -81,7 +83,17 @@ export class EmbedSyncProcessor extends WorkerHost implements OnModuleInit {
       this.channelResolver,
     );
     const newState = computeEmbedState(event, eventData);
-    await this.editAndSync(record, eventData, newState, eventId, reason, start);
+    const context = await this.buildContext();
+
+    await this.syncAllMessages(active, eventData, newState, context, eventId);
+    this.logAndTriggerSideEffects(
+      active,
+      newState,
+      eventId,
+      eventData,
+      reason,
+      start,
+    );
   }
 
   /** Validate bot connection, return guildId or null. */
@@ -112,32 +124,82 @@ export class EmbedSyncProcessor extends WorkerHost implements OnModuleInit {
     return event ?? null;
   }
 
-  /** Build embed, edit Discord message, update state, trigger side effects. */
-  private async editAndSync(
-    record: typeof schema.discordEventMessages.$inferSelect,
+  /** Sync all tracked messages, catching errors per-message. */
+  private async syncAllMessages(
+    records: (typeof schema.discordEventMessages.$inferSelect)[],
     eventData: EmbedEventData,
     newState: EmbedState,
+    context: EmbedContext,
     eventId: number,
-    reason: string,
-    perfStart: number,
   ): Promise<void> {
-    const previousState = record.embedState as EmbedState;
-    const context = await this.buildContext();
     const { embed, row, content } = this.embedFactory.buildEventUpdate(
       eventData,
       context,
       newState,
     );
-    await this.clientService.editEmbed(
-      record.channelId,
-      record.messageId,
-      embed,
-      row,
-      content,
+    for (const record of records) {
+      await this.syncSingleMessage(
+        record,
+        embed,
+        row,
+        content,
+        newState,
+        eventId,
+      );
+    }
+  }
+
+  /** Edit a single Discord message, persist state, and clean up bumps. */
+  private async syncSingleMessage(
+    record: typeof schema.discordEventMessages.$inferSelect,
+    embed: ReturnType<DiscordEmbedFactory['buildEventUpdate']>['embed'],
+    row: ReturnType<DiscordEmbedFactory['buildEventUpdate']>['row'],
+    content: ReturnType<DiscordEmbedFactory['buildEventUpdate']>['content'],
+    newState: EmbedState,
+    eventId: number,
+  ): Promise<void> {
+    try {
+      await this.clientService.editEmbed(
+        record.channelId,
+        record.messageId,
+        embed,
+        row,
+        content,
+      );
+      await this.persistState(record.id, newState);
+      await this.maybeDeleteBumpMessage(record, newState, eventId);
+    } catch (err) {
+      this.logger.warn(
+        `Failed to sync embed in channel ${record.channelId} ` +
+          `for event ${eventId}: ${err instanceof Error ? err.message : 'Unknown'}`,
+      );
+    }
+  }
+
+  /** Log state transitions and trigger side effects ONCE for all messages. */
+  private logAndTriggerSideEffects(
+    records: (typeof schema.discordEventMessages.$inferSelect)[],
+    newState: EmbedState,
+    eventId: number,
+    eventData: EmbedEventData,
+    reason: string,
+    perfStart: number,
+  ): void {
+    const previousState = records[0]?.embedState as EmbedState | undefined;
+    if (previousState && newState !== previousState) {
+      this.logger.log(
+        `Embed state transition for event ${eventId}: ${previousState} -> ${newState}`,
+      );
+    }
+    this.logger.log(
+      `Synced embed for event ${eventId} (state: ${newState}, reason: ${reason})`,
     );
-    await this.persistState(record.id, newState);
-    await this.maybeDeleteBumpMessage(record, newState, eventId);
-    this.logTransition(previousState, newState, eventId, reason, perfStart);
+    if (perfStart) {
+      perfLog('QUEUE', 'embed-sync', performance.now() - perfStart, {
+        eventId,
+        reason,
+      });
+    }
     this.triggerSideEffects(newState, eventId, eventData);
   }
 
@@ -173,30 +235,6 @@ export class EmbedSyncProcessor extends WorkerHost implements OnModuleInit {
       this.logger.warn(
         `Failed to delete bump message for event ${eventId}: ${err instanceof Error ? err.message : 'Unknown'}`,
       );
-    }
-  }
-
-  /** Log state transition and performance data. */
-  private logTransition(
-    prev: EmbedState,
-    next: EmbedState,
-    eventId: number,
-    reason: string,
-    perfStart: number,
-  ): void {
-    if (next !== prev) {
-      this.logger.log(
-        `Embed state transition for event ${eventId}: ${prev} -> ${next}`,
-      );
-    }
-    this.logger.log(
-      `Synced embed for event ${eventId} (state: ${next}, reason: ${reason})`,
-    );
-    if (perfStart) {
-      perfLog('QUEUE', 'embed-sync', performance.now() - perfStart, {
-        eventId,
-        reason,
-      });
     }
   }
 


### PR DESCRIPTION
## Summary
- Fix `findTrackedMessage()` → `findTrackedMessages()`: removed `LIMIT 1`, returns all `discord_event_messages` rows for an event+guild so forwarded/unfurled embed copies all receive sync updates
- Processor now iterates over all tracked messages with per-message try-catch (one failed edit doesn't block others), side effects fire once after loop
- Added 6 integration tests covering multi-message and single-message scenarios

## Linear
ROK-1029

## Test plan
- [x] Integration tests: 6 new tests (multi-message returns, single-message regression, guild scoping)
- [x] Full CI passes: build + lint + typecheck + 5133 api tests + 2791 web tests + 603 integration tests
- [x] Code review passed (no critical issues)
- [x] 4-agent validation: code verifier (ACCURATE), logic reviewer (SOUND), completeness auditor (MOSTLY COMPLETE), risk assessor (MODERATE RISK — all acceptable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)