### PR TITLE
ROK-1033: fix duplicate scheduling poll embeds posted to same channel

### DIFF
--- a/api/src/lineups/lineup-notification-targets.helpers.ts
+++ b/api/src/lineups/lineup-notification-targets.helpers.ts
@@ -2,7 +2,7 @@
  * Target resolution queries for Community Lineup notifications (ROK-932).
  * Finds Discord-linked members and match members for DM dispatch.
  */
-import { sql } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import * as schema from '../drizzle/schema';
 import type { DiscordMember } from './lineup-notification-dm.helpers';
@@ -20,6 +20,19 @@ export async function findDiscordLinkedMembers(
     FROM users u
     WHERE u.discord_id IS NOT NULL
   `)) as unknown as DiscordMember[];
+}
+
+/** Check if a match already has a poll embed posted (ROK-1033). */
+export async function hasExistingPollEmbed(
+  db: Db,
+  matchId: number,
+): Promise<boolean> {
+  const [row] = await db
+    .select({ embedMessageId: schema.communityLineupMatches.embedMessageId })
+    .from(schema.communityLineupMatches)
+    .where(eq(schema.communityLineupMatches.id, matchId))
+    .limit(1);
+  return !!row?.embedMessageId;
 }
 
 /** Get match members with Discord linked. */

--- a/api/src/lineups/lineup-notification.service.spec.ts
+++ b/api/src/lineups/lineup-notification.service.spec.ts
@@ -633,4 +633,83 @@ describe('LineupNotificationService', () => {
       expect(mockNotificationService.create).not.toHaveBeenCalled();
     });
   });
+
+  // -----------------------------------------------------------------------
+  // ROK-1033: Skip duplicate scheduling channel embed when interactive
+  // poll embed already posted (embedMessageId set on match row)
+  // -----------------------------------------------------------------------
+  describe('ROK-1033: duplicate scheduling embed guard', () => {
+    /**
+     * Helper: stub the Drizzle select chain that the guard will use
+     * to look up embedMessageId on the match row.
+     *
+     * The guard will call db.select().from().where().limit() which
+     * resolves as a thenable returning the provided rows.
+     */
+    function stubMatchLookup(rows: Record<string, unknown>[]) {
+      mockDb.select = jest.fn().mockReturnValue({
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockReturnValue({
+            limit: jest.fn().mockResolvedValue(rows),
+          }),
+        }),
+      });
+    }
+
+    // AC1: embedMessageId already set -> NO channel embed posted
+    it('AC1: skips channel embed when embedMessageId is already set', async () => {
+      stubMatchLookup([
+        { id: MATCH_ID, embedMessageId: 'msg-existing' },
+      ]);
+
+      await service.notifySchedulingOpen(
+        makeMatch({ status: 'scheduling' }),
+      );
+
+      expect(mockBotClient.sendEmbed).not.toHaveBeenCalled();
+    });
+
+    // AC2: embedMessageId already set -> DMs still sent
+    it('AC2: still sends DMs when embedMessageId is already set', async () => {
+      stubMatchLookup([
+        { id: MATCH_ID, embedMessageId: 'msg-existing' },
+      ]);
+      const members = [makeMember(1), makeMember(2)];
+      mockDb.execute.mockResolvedValueOnce(members);
+
+      await service.notifySchedulingOpen(
+        makeMatch({ status: 'scheduling' }),
+      );
+
+      expect(mockNotificationService.create).toHaveBeenCalledTimes(2);
+    });
+
+    // AC3: embedMessageId null (lineup matches) -> channel embed posted
+    it('AC3: posts channel embed when embedMessageId is null', async () => {
+      stubMatchLookup([
+        { id: MATCH_ID, embedMessageId: null },
+      ]);
+
+      await service.notifySchedulingOpen(
+        makeMatch({ status: 'scheduling' }),
+      );
+
+      expect(mockBotClient.sendEmbed).toHaveBeenCalledTimes(1);
+    });
+
+    // AC4: embedMessageId null -> DMs still sent
+    it('AC4: still sends DMs when embedMessageId is null', async () => {
+      stubMatchLookup([
+        { id: MATCH_ID, embedMessageId: null },
+      ]);
+      const members = [makeMember(1), makeMember(2)];
+      mockDb.execute.mockResolvedValueOnce(members);
+
+      await service.notifySchedulingOpen(
+        makeMatch({ status: 'scheduling' }),
+      );
+
+      expect(mockNotificationService.create).toHaveBeenCalledTimes(2);
+    });
+  });
 });

--- a/api/src/lineups/lineup-notification.service.spec.ts
+++ b/api/src/lineups/lineup-notification.service.spec.ts
@@ -17,7 +17,16 @@ import { SettingsService } from '../settings/settings.service';
 // ---------------------------------------------------------------------------
 
 function makeMockDb() {
-  return { execute: jest.fn().mockResolvedValue([]) };
+  return {
+    execute: jest.fn().mockResolvedValue([]),
+    select: jest.fn().mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        where: jest.fn().mockReturnValue({
+          limit: jest.fn().mockResolvedValue([{ embedMessageId: null }]),
+        }),
+      }),
+    }),
+  };
 }
 
 function makeMockNotificationService() {
@@ -658,56 +667,40 @@ describe('LineupNotificationService', () => {
 
     // AC1: embedMessageId already set -> NO channel embed posted
     it('AC1: skips channel embed when embedMessageId is already set', async () => {
-      stubMatchLookup([
-        { id: MATCH_ID, embedMessageId: 'msg-existing' },
-      ]);
+      stubMatchLookup([{ id: MATCH_ID, embedMessageId: 'msg-existing' }]);
 
-      await service.notifySchedulingOpen(
-        makeMatch({ status: 'scheduling' }),
-      );
+      await service.notifySchedulingOpen(makeMatch({ status: 'scheduling' }));
 
       expect(mockBotClient.sendEmbed).not.toHaveBeenCalled();
     });
 
     // AC2: embedMessageId already set -> DMs still sent
     it('AC2: still sends DMs when embedMessageId is already set', async () => {
-      stubMatchLookup([
-        { id: MATCH_ID, embedMessageId: 'msg-existing' },
-      ]);
+      stubMatchLookup([{ id: MATCH_ID, embedMessageId: 'msg-existing' }]);
       const members = [makeMember(1), makeMember(2)];
       mockDb.execute.mockResolvedValueOnce(members);
 
-      await service.notifySchedulingOpen(
-        makeMatch({ status: 'scheduling' }),
-      );
+      await service.notifySchedulingOpen(makeMatch({ status: 'scheduling' }));
 
       expect(mockNotificationService.create).toHaveBeenCalledTimes(2);
     });
 
     // AC3: embedMessageId null (lineup matches) -> channel embed posted
     it('AC3: posts channel embed when embedMessageId is null', async () => {
-      stubMatchLookup([
-        { id: MATCH_ID, embedMessageId: null },
-      ]);
+      stubMatchLookup([{ id: MATCH_ID, embedMessageId: null }]);
 
-      await service.notifySchedulingOpen(
-        makeMatch({ status: 'scheduling' }),
-      );
+      await service.notifySchedulingOpen(makeMatch({ status: 'scheduling' }));
 
       expect(mockBotClient.sendEmbed).toHaveBeenCalledTimes(1);
     });
 
     // AC4: embedMessageId null -> DMs still sent
     it('AC4: still sends DMs when embedMessageId is null', async () => {
-      stubMatchLookup([
-        { id: MATCH_ID, embedMessageId: null },
-      ]);
+      stubMatchLookup([{ id: MATCH_ID, embedMessageId: null }]);
       const members = [makeMember(1), makeMember(2)];
       mockDb.execute.mockResolvedValueOnce(members);
 
-      await service.notifySchedulingOpen(
-        makeMatch({ status: 'scheduling' }),
-      );
+      await service.notifySchedulingOpen(makeMatch({ status: 'scheduling' }));
 
       expect(mockNotificationService.create).toHaveBeenCalledTimes(2);
     });

--- a/api/src/lineups/lineup-notification.service.ts
+++ b/api/src/lineups/lineup-notification.service.ts
@@ -33,6 +33,7 @@ import {
 import {
   findDiscordLinkedMembers,
   findMatchMemberUsers,
+  hasExistingPollEmbed,
 } from './lineup-notification-targets.helpers';
 import { DEDUP_TTL } from './lineup-notification.constants';
 
@@ -286,6 +287,8 @@ export class LineupNotificationService {
 
     const channelId = await resolveLineupChannel(this.settingsService);
     if (!channelId) return;
+
+    if (await hasExistingPollEmbed(this.db, match.id)) return;
 
     const ctx = await this.resolveCtx(match.lineupId, 'decided');
     const { embed, row } = buildSchedulingEmbed(ctx, match.gameName, match.id);


### PR DESCRIPTION
## What
Skip the generic "Scheduling Open" channel embed when the interactive poll embed has already been posted by `SchedulingPollEmbedService`.

## Why
Two independent services both post embeds when a match enters scheduling state — `SchedulingPollEmbedService` (interactive poll with vote tracking) and `LineupNotificationService` (generic announcement). Neither checked for the other's embed, resulting in duplicate channel posts.

## Acceptance criteria
- [x] Only one scheduling embed posted per match per channel
- [x] Interactive poll embed (with vote tracking) takes priority
- [x] Embed updates correctly on timeslot/vote changes (no regression)
- [x] Scheduling DMs still fire regardless of channel embed skip
- [x] No regression for lineup-originated matches (embed still posts when `embedMessageId` is null)

## Test plan
- [x] Unit tests: 4 TDD tests (AC1-AC4) in `lineup-notification.service.spec.ts`
- [x] CI passes (build + lint + type check + 5137 api tests + 2791 web tests + 597 integration tests)
- [x] Operator tested locally
- [x] Code review passed
- [x] Playwright smoke tests passed (321 tests, desktop + mobile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)