### PR TITLE
ROK-1034: fix: original event remains visible after rescheduling to scheduling poll

### DIFF
--- a/api/src/discord-bot/discord-bot.constants.ts
+++ b/api/src/discord-bot/discord-bot.constants.ts
@@ -58,6 +58,7 @@ export const EMBED_STATES = {
   LIVE: 'live',
   COMPLETED: 'completed',
   CANCELLED: 'cancelled',
+  RESCHEDULING: 'rescheduling',
 } as const;
 
 export type EmbedState = (typeof EMBED_STATES)[keyof typeof EMBED_STATES];

--- a/api/src/discord-bot/services/discord-embed.factory.ts
+++ b/api/src/discord-bot/services/discord-embed.factory.ts
@@ -233,6 +233,20 @@ export class DiscordEmbedFactory {
     };
   }
 
+  /** Build a rescheduling embed (amber, "RESCHEDULING" badge, ROK-1034). */
+  buildEventRescheduling(
+    event: EmbedEventData,
+    context: EmbedContext,
+  ): EmbedResult {
+    const embed = new EmbedBuilder()
+      .setColor(EMBED_COLORS.REMINDER)
+      .setTitle(`${event.title} — RESCHEDULING`)
+      .setDescription('This event is being rescheduled via a scheduling poll.')
+      .setFooter({ text: context.communityName || 'Raid Ledger' })
+      .setTimestamp();
+    return { embed };
+  }
+
   /** Build a scheduling poll embed for a Discord channel (ROK-1014). */
   buildSchedulingPollEmbed(
     data: SchedulingPollEmbedData,

--- a/api/src/drizzle/migrations/0119_vengeful_king_cobra.sql
+++ b/api/src/drizzle/migrations/0119_vengeful_king_cobra.sql
@@ -1,0 +1,7 @@
+ALTER TABLE "events" ADD COLUMN "rescheduling_poll_id" integer;--> statement-breakpoint
+ALTER TABLE "events" ADD CONSTRAINT "events_rescheduling_poll_id_community_lineup_matches_id_fk"
+  FOREIGN KEY ("rescheduling_poll_id") REFERENCES "community_lineup_matches"("id")
+  ON DELETE SET NULL;--> statement-breakpoint
+CREATE INDEX "idx_events_rescheduling_poll_id"
+  ON "events" ("rescheduling_poll_id")
+  WHERE rescheduling_poll_id IS NOT NULL;

--- a/api/src/drizzle/migrations/meta/0119_snapshot.json
+++ b/api/src/drizzle/migrations/meta/0119_snapshot.json
@@ -1,0 +1,6424 @@
+{
+  "id": "0652cbfc-666f-4b37-836e-244db74db491",
+  "prevId": "191d492d-11fe-41be-bdbb-ff40a9422061",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_id": {
+          "name": "steam_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_avatar_url": {
+          "name": "custom_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_time_confirmed_at": {
+          "name": "game_time_confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_discord_id_unique": {
+          "name": "users_discord_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_id"
+          ]
+        },
+        "users_steam_id_unique": {
+          "name": "users_steam_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "steam_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "display_name_length": {
+          "name": "display_name_length",
+          "value": "\"users\".\"display_name\" IS NULL OR (LENGTH(\"users\".\"display_name\") >= 2 AND LENGTH(\"users\".\"display_name\") <= 30)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "tsrange",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_config": {
+          "name": "slot_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_attendees": {
+          "name": "max_attendees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_unbench": {
+          "name": "auto_unbench",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "recurrence_group_id": {
+          "name": "recurrence_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_rule": {
+          "name": "recurrence_rule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_instances": {
+          "name": "content_instances",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_15min": {
+          "name": "reminder_15min",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_1hour": {
+          "name": "reminder_1hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_24hour": {
+          "name": "reminder_24hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_ad_hoc": {
+          "name": "is_ad_hoc",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ad_hoc_status": {
+          "name": "ad_hoc_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_binding_id": {
+          "name": "channel_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_scheduled_event_id": {
+          "name": "discord_scheduled_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extended_until": {
+          "name": "extended_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_channel_override": {
+          "name": "notification_channel_override",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rescheduling_poll_id": {
+          "name": "rescheduling_poll_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_events_creator_id": {
+          "name": "idx_events_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_game_id": {
+          "name": "idx_events_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_ad_hoc_binding": {
+          "name": "idx_events_ad_hoc_binding",
+          "columns": [
+            {
+              "expression": "channel_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_ad_hoc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_recurrence_group_id": {
+          "name": "idx_events_recurrence_group_id",
+          "columns": [
+            {
+              "expression": "recurrence_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_cancelled_at": {
+          "name": "idx_events_cancelled_at",
+          "columns": [
+            {
+              "expression": "cancelled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_discord_scheduled_event_id": {
+          "name": "idx_events_discord_scheduled_event_id",
+          "columns": [
+            {
+              "expression": "discord_scheduled_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_game_id_games_id_fk": {
+          "name": "events_game_id_games_id_fk",
+          "tableFrom": "events",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_creator_id_users_id_fk": {
+          "name": "events_creator_id_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_channel_binding_id_channel_bindings_id_fk": {
+          "name": "events_channel_binding_id_channel_bindings_id_fk",
+          "tableFrom": "events",
+          "tableTo": "channel_bindings",
+          "columnsFrom": [
+            "channel_binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_types": {
+      "name": "event_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_player_cap": {
+          "name": "default_player_cap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_duration_minutes": {
+          "name": "default_duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_composition": {
+          "name": "requires_composition",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_event_types_game_id": {
+          "name": "idx_event_types_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_types_game_id_games_id_fk": {
+          "name": "event_types_game_id_games_id_fk",
+          "tableFrom": "event_types",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_types_game_slug_unique": {
+          "name": "event_types_game_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "game_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "igdb_id": {
+          "name": "igdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregated_rating": {
+          "name": "aggregated_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "popularity": {
+          "name": "popularity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_modes": {
+          "name": "game_modes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "themes": {
+          "name": "themes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "platforms": {
+          "name": "platforms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "screenshots": {
+          "name": "screenshots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "videos": {
+          "name": "videos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "first_release_date": {
+          "name": "first_release_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_count": {
+          "name": "player_count",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitch_game_id": {
+          "name": "twitch_game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_app_id": {
+          "name": "steam_app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crossplay": {
+          "name": "crossplay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color_hex": {
+          "name": "color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_roles": {
+          "name": "has_roles",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_specs": {
+          "name": "has_specs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "itad_game_id": {
+          "name": "itad_game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_boxart_url": {
+          "name": "itad_boxart_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_tags": {
+          "name": "itad_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "max_characters_per_user": {
+          "name": "max_characters_per_user",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "api_namespace_prefix": {
+          "name": "api_namespace_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_current_price": {
+          "name": "itad_current_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_current_cut": {
+          "name": "itad_current_cut",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_current_shop": {
+          "name": "itad_current_shop",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_current_url": {
+          "name": "itad_current_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_lowest_price": {
+          "name": "itad_lowest_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_lowest_cut": {
+          "name": "itad_lowest_cut",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_price_updated_at": {
+          "name": "itad_price_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "early_access": {
+          "name": "early_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "igdb_enrichment_status": {
+          "name": "igdb_enrichment_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "igdb_enrichment_retry_count": {
+          "name": "igdb_enrichment_retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "games_igdb_id_unique": {
+          "name": "games_igdb_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "igdb_id"
+          ]
+        },
+        "games_slug_unique": {
+          "name": "games_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "games_itad_game_id_unique": {
+          "name": "games_itad_game_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "itad_game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_signups": {
+      "name": "event_signups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_avatar_hash": {
+          "name": "discord_avatar_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation_status": {
+          "name": "confirmation_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'signed_up'"
+        },
+        "preferred_roles": {
+          "name": "preferred_roles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attendance_status": {
+          "name": "attendance_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attendance_recorded_at": {
+          "name": "attendance_recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roached_out_at": {
+          "name": "roached_out_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_up_at": {
+          "name": "signed_up_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_event_signups_event_id": {
+          "name": "idx_event_signups_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_signups_discord_user_id": {
+          "name": "idx_event_signups_discord_user_id",
+          "columns": [
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_signups_user_id": {
+          "name": "idx_event_signups_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_signups_event_id_status": {
+          "name": "idx_event_signups_event_id_status",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_signups_event_id_events_id_fk": {
+          "name": "event_signups_event_id_events_id_fk",
+          "tableFrom": "event_signups",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_signups_user_id_users_id_fk": {
+          "name": "event_signups_user_id_users_id_fk",
+          "tableFrom": "event_signups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_signups_character_id_characters_id_fk": {
+          "name": "event_signups_character_id_characters_id_fk",
+          "tableFrom": "event_signups",
+          "tableTo": "characters",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_user": {
+          "name": "unique_event_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id"
+          ]
+        },
+        "unique_event_discord_user": {
+          "name": "unique_event_discord_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "discord_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_or_discord": {
+          "name": "user_or_discord",
+          "value": "\"event_signups\".\"user_id\" IS NOT NULL OR \"event_signups\".\"discord_user_id\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.characters": {
+      "name": "characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "realm": {
+          "name": "realm",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class": {
+          "name": "class",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_override": {
+          "name": "role_override",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_main": {
+          "name": "is_main",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "item_level": {
+          "name": "item_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "render_url": {
+          "name": "render_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "race": {
+          "name": "race",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faction": {
+          "name": "faction",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_url": {
+          "name": "profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_variant": {
+          "name": "game_variant",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "equipment": {
+          "name": "equipment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "talents": {
+          "name": "talents",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_one_main_per_game": {
+          "name": "idx_one_main_per_game",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"characters\".\"is_main\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_characters_user_id": {
+          "name": "idx_characters_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_characters_user_id_name": {
+          "name": "idx_characters_user_id_name",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "characters_user_id_users_id_fk": {
+          "name": "characters_user_id_users_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "characters_game_id_games_id_fk": {
+          "name": "characters_game_id_games_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_game_character": {
+          "name": "unique_user_game_character",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id",
+            "name",
+            "realm"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.local_credentials": {
+      "name": "local_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "local_credentials_user_id_users_id_fk": {
+          "name": "local_credentials_user_id_users_id_fk",
+          "tableFrom": "local_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "local_credentials_email_unique": {
+          "name": "local_credentials_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.availability": {
+      "name": "availability",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_range": {
+          "name": "time_range",
+          "type": "tsrange",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_availability_user_id": {
+          "name": "idx_availability_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "availability_user_id_users_id_fk": {
+          "name": "availability_user_id_users_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "availability_game_id_games_id_fk": {
+          "name": "availability_game_id_games_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "availability_source_event_id_events_id_fk": {
+          "name": "availability_source_event_id_events_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "events",
+          "columnsFrom": [
+            "source_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roster_assignments": {
+      "name": "roster_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signup_id": {
+          "name": "signup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "is_override": {
+          "name": "is_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_roster_assignments_event_id": {
+          "name": "idx_roster_assignments_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_roster_assignments_signup_id": {
+          "name": "idx_roster_assignments_signup_id",
+          "columns": [
+            {
+              "expression": "signup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roster_assignments_event_id_events_id_fk": {
+          "name": "roster_assignments_event_id_events_id_fk",
+          "tableFrom": "roster_assignments",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "roster_assignments_signup_id_event_signups_id_fk": {
+          "name": "roster_assignments_signup_id_event_signups_id_fk",
+          "tableFrom": "roster_assignments",
+          "tableTo": "event_signups",
+          "columnsFrom": [
+            "signup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_signup": {
+          "name": "unique_event_signup",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "signup_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_settings_key_unique": {
+          "name": "app_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_expires_at": {
+          "name": "idx_notifications_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_preferences": {
+      "name": "user_notification_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_prefs": {
+          "name": "channel_prefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"slot_vacated\":{\"inApp\":true,\"push\":true,\"discord\":true},\"event_reminder\":{\"inApp\":true,\"push\":true,\"discord\":true},\"new_event\":{\"inApp\":true,\"push\":true,\"discord\":true},\"subscribed_game\":{\"inApp\":true,\"push\":true,\"discord\":true},\"achievement_unlocked\":{\"inApp\":true,\"push\":false,\"discord\":false},\"level_up\":{\"inApp\":true,\"push\":false,\"discord\":false},\"missed_event_nudge\":{\"inApp\":true,\"push\":true,\"discord\":true},\"event_rescheduled\":{\"inApp\":true,\"push\":true,\"discord\":true},\"bench_promoted\":{\"inApp\":true,\"push\":true,\"discord\":true},\"event_cancelled\":{\"inApp\":true,\"push\":true,\"discord\":true},\"roster_reassigned\":{\"inApp\":true,\"push\":true,\"discord\":true},\"tentative_displaced\":{\"inApp\":true,\"push\":true,\"discord\":true},\"member_returned\":{\"inApp\":true,\"push\":true,\"discord\":true},\"recruitment_reminder\":{\"inApp\":true,\"push\":true,\"discord\":true},\"role_gap_alert\":{\"inApp\":true,\"push\":true,\"discord\":true},\"lineup_steam_nudge\":{\"inApp\":true,\"push\":false,\"discord\":true},\"community_lineup\":{\"inApp\":true,\"push\":true,\"discord\":true},\"system\":{\"inApp\":true,\"push\":false,\"discord\":false}}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_preferences_user_id_users_id_fk": {
+          "name": "user_notification_preferences_user_id_users_id_fk",
+          "tableFrom": "user_notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_preference_key": {
+          "name": "unique_user_preference_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_time_templates": {
+      "name": "game_time_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_hour": {
+          "name": "start_hour",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_time_templates_user_id_idx": {
+          "name": "game_time_templates_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_time_templates_user_id_users_id_fk": {
+          "name": "game_time_templates_user_id_users_id_fk",
+          "tableFrom": "game_time_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_game_time_slot": {
+          "name": "unique_user_game_time_slot",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "day_of_week",
+            "start_hour"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_time_absences": {
+      "name": "game_time_absences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_time_absences_user_id_idx": {
+          "name": "game_time_absences_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_time_absences_user_id_users_id_fk": {
+          "name": "game_time_absences_user_id_users_id_fk",
+          "tableFrom": "game_time_absences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_time_overrides": {
+      "name": "game_time_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hour": {
+          "name": "hour",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_time_overrides_user_id_idx": {
+          "name": "game_time_overrides_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_time_overrides_user_id_users_id_fk": {
+          "name": "game_time_overrides_user_id_users_id_fk",
+          "tableFrom": "game_time_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_override_date_hour": {
+          "name": "unique_user_override_date_hour",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "date",
+            "hour"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_interests": {
+      "name": "game_interests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "playtime_forever": {
+          "name": "playtime_forever",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playtime_2weeks": {
+          "name": "playtime_2weeks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_game_interests_game_id": {
+          "name": "idx_game_interests_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_interests_user_id_users_id_fk": {
+          "name": "game_interests_user_id_users_id_fk",
+          "tableFrom": "game_interests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_interests_game_id_games_id_fk": {
+          "name": "game_interests_game_id_games_id_fk",
+          "tableFrom": "game_interests",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_user_game_interest_source": {
+          "name": "uq_user_game_interest_source",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id",
+            "source"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_reminders_sent": {
+      "name": "event_reminders_sent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reminder_type": {
+          "name": "reminder_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_reminders_sent_event_id_events_id_fk": {
+          "name": "event_reminders_sent_event_id_events_id_fk",
+          "tableFrom": "event_reminders_sent",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_reminders_sent_user_id_users_id_fk": {
+          "name": "event_reminders_sent_user_id_users_id_fk",
+          "tableFrom": "event_reminders_sent",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_user_reminder": {
+          "name": "unique_event_user_reminder",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id",
+            "reminder_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_templates": {
+      "name": "event_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_templates_user_id_users_id_fk": {
+          "name": "event_templates_user_id_users_id_fk",
+          "tableFrom": "event_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plugins": {
+      "name": "plugins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config_json": {
+          "name": "config_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plugins_slug_unique": {
+          "name": "plugins_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_user_id_users_id_fk": {
+          "name": "feedback_user_id_users_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pug_slots": {
+      "name": "pug_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_avatar_hash": {
+          "name": "discord_avatar_hash",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class": {
+          "name": "class",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "server_invite_url": {
+          "name": "server_invite_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_event_pug": {
+          "name": "unique_event_pug",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pug_slots\".\"discord_username\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_invite_code": {
+          "name": "unique_invite_code",
+          "columns": [
+            {
+              "expression": "invite_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pug_slots\".\"invite_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pug_slots_event_id_events_id_fk": {
+          "name": "pug_slots_event_id_events_id_fk",
+          "tableFrom": "pug_slots",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pug_slots_claimed_by_user_id_users_id_fk": {
+          "name": "pug_slots_claimed_by_user_id_users_id_fk",
+          "tableFrom": "pug_slots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "claimed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pug_slots_created_by_users_id_fk": {
+          "name": "pug_slots_created_by_users_id_fk",
+          "tableFrom": "pug_slots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cron_jobs": {
+      "name": "cron_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_slug": {
+          "name": "plugin_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Other'"
+        },
+        "paused": {
+          "name": "paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cron_jobs_name_unique": {
+          "name": "cron_jobs_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cron_job_executions": {
+      "name": "cron_job_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cron_job_id": {
+          "name": "cron_job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cron_job_executions_job_started_idx": {
+          "name": "cron_job_executions_job_started_idx",
+          "columns": [
+            {
+              "expression": "cron_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cron_job_executions_cron_job_id_cron_jobs_id_fk": {
+          "name": "cron_job_executions_cron_job_id_cron_jobs_id_fk",
+          "tableFrom": "cron_job_executions",
+          "tableTo": "cron_jobs",
+          "columnsFrom": [
+            "cron_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_event_messages": {
+      "name": "discord_event_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embed_state": {
+          "name": "embed_state",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'posted'"
+        },
+        "bump_message_id": {
+          "name": "bump_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_discord_event_messages_event": {
+          "name": "idx_discord_event_messages_event",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_discord_event_messages_message": {
+          "name": "idx_discord_event_messages_message",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_event_messages_event_id_events_id_fk": {
+          "name": "discord_event_messages_event_id_events_id_fk",
+          "tableFrom": "discord_event_messages",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_channel_message": {
+          "name": "unique_event_channel_message",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "channel_id",
+            "message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_bindings": {
+      "name": "channel_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding_purpose": {
+          "name": "binding_purpose",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_group_id": {
+          "name": "recurrence_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_bindings_guild_channel_series_unique": {
+          "name": "channel_bindings_guild_channel_series_unique",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurrence_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_bindings_guild": {
+          "name": "idx_channel_bindings_guild",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_bindings_game": {
+          "name": "idx_channel_bindings_game",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_bindings_recurrence_group": {
+          "name": "idx_channel_bindings_recurrence_group",
+          "columns": [
+            {
+              "expression": "recurrence_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_bindings_game_id_games_id_fk": {
+          "name": "channel_bindings_game_id_games_id_fk",
+          "tableFrom": "channel_bindings",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_event_reminders_sent": {
+      "name": "post_event_reminders_sent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pug_slot_id": {
+          "name": "pug_slot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_event_reminders_sent_event_id_events_id_fk": {
+          "name": "post_event_reminders_sent_event_id_events_id_fk",
+          "tableFrom": "post_event_reminders_sent",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_event_reminders_sent_pug_slot_id_pug_slots_id_fk": {
+          "name": "post_event_reminders_sent_pug_slot_id_pug_slots_id_fk",
+          "tableFrom": "post_event_reminders_sent",
+          "tableTo": "pug_slots",
+          "columnsFrom": [
+            "pug_slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_post_event_pug_reminder": {
+          "name": "unique_post_event_pug_reminder",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "pug_slot_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_plans": {
+      "name": "event_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slot_config": {
+          "name": "slot_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_attendees": {
+          "name": "max_attendees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_unbench": {
+          "name": "auto_unbench",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_options": {
+          "name": "poll_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_duration_hours": {
+          "name": "poll_duration_hours",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_mode": {
+          "name": "poll_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "poll_round": {
+          "name": "poll_round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "poll_channel_id": {
+          "name": "poll_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_message_id": {
+          "name": "poll_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "winning_option": {
+          "name": "winning_option",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_event_id": {
+          "name": "created_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_instances": {
+          "name": "content_instances",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_15min": {
+          "name": "reminder_15min",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_1hour": {
+          "name": "reminder_1hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_24hour": {
+          "name": "reminder_24hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "poll_started_at": {
+          "name": "poll_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_ends_at": {
+          "name": "poll_ends_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_event_plans_creator_id": {
+          "name": "idx_event_plans_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_plans_status": {
+          "name": "idx_event_plans_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_plans_creator_id_users_id_fk": {
+          "name": "event_plans_creator_id_users_id_fk",
+          "tableFrom": "event_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_plans_game_id_games_id_fk": {
+          "name": "event_plans_game_id_games_id_fk",
+          "tableFrom": "event_plans",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "event_plans_created_event_id_events_id_fk": {
+          "name": "event_plans_created_event_id_events_id_fk",
+          "tableFrom": "event_plans",
+          "tableTo": "events",
+          "columnsFrom": [
+            "created_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_dungeon_quests": {
+      "name": "wow_classic_dungeon_quests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dungeon_instance_id": {
+          "name": "dungeon_instance_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quest_level": {
+          "name": "quest_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_level": {
+          "name": "required_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expansion": {
+          "name": "expansion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quest_giver_npc": {
+          "name": "quest_giver_npc",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quest_giver_zone": {
+          "name": "quest_giver_zone",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_quest_id": {
+          "name": "prev_quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_quest_id": {
+          "name": "next_quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewards_json": {
+          "name": "rewards_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objectives": {
+          "name": "objectives",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_restriction": {
+          "name": "class_restriction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "race_restriction": {
+          "name": "race_restriction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_inside_dungeon": {
+          "name": "starts_inside_dungeon",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sharable": {
+          "name": "sharable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reward_xp": {
+          "name": "reward_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_gold": {
+          "name": "reward_gold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_type": {
+          "name": "reward_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wow_classic_dungeon_quests_quest_id_unique": {
+          "name": "wow_classic_dungeon_quests_quest_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "quest_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_boss_loot": {
+      "name": "wow_classic_boss_loot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "boss_id": {
+          "name": "boss_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot": {
+          "name": "slot",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality": {
+          "name": "quality",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_level": {
+          "name": "item_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drop_rate": {
+          "name": "drop_rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expansion": {
+          "name": "expansion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_restrictions": {
+          "name": "class_restrictions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_subclass": {
+          "name": "item_subclass",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wow_classic_boss_loot_boss_id_wow_classic_bosses_id_fk": {
+          "name": "wow_classic_boss_loot_boss_id_wow_classic_bosses_id_fk",
+          "tableFrom": "wow_classic_boss_loot",
+          "tableTo": "wow_classic_bosses",
+          "columnsFrom": [
+            "boss_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_loot_boss_item_expansion": {
+          "name": "uq_loot_boss_item_expansion",
+          "nullsNotDistinct": false,
+          "columns": [
+            "boss_id",
+            "item_id",
+            "expansion"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_bosses": {
+      "name": "wow_classic_bosses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expansion": {
+          "name": "expansion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sod_modified": {
+          "name": "sod_modified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_boss_instance_name_expansion": {
+          "name": "uq_boss_instance_name_expansion",
+          "nullsNotDistinct": false,
+          "columns": [
+            "instance_id",
+            "name",
+            "expansion"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_quest_progress": {
+      "name": "wow_classic_quest_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picked_up": {
+          "name": "picked_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wow_classic_quest_progress_event_id_events_id_fk": {
+          "name": "wow_classic_quest_progress_event_id_events_id_fk",
+          "tableFrom": "wow_classic_quest_progress",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wow_classic_quest_progress_user_id_users_id_fk": {
+          "name": "wow_classic_quest_progress_user_id_users_id_fk",
+          "tableFrom": "wow_classic_quest_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_quest_progress_event_user_quest": {
+          "name": "uq_quest_progress_event_user_quest",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id",
+            "quest_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_activity_sessions": {
+      "name": "game_activity_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_activity_name": {
+          "name": "discord_activity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "game_activity_sessions_user_game_started_idx": {
+          "name": "game_activity_sessions_user_game_started_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "game_activity_sessions_game_started_idx": {
+          "name": "game_activity_sessions_game_started_idx",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_activity_sessions_user_id_users_id_fk": {
+          "name": "game_activity_sessions_user_id_users_id_fk",
+          "tableFrom": "game_activity_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_activity_sessions_game_id_games_id_fk": {
+          "name": "game_activity_sessions_game_id_games_id_fk",
+          "tableFrom": "game_activity_sessions",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_activity_rollups": {
+      "name": "game_activity_rollups",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period": {
+          "name": "period",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_seconds": {
+          "name": "total_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "game_activity_rollups_game_period_start_idx": {
+          "name": "game_activity_rollups_game_period_start_idx",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_activity_rollups_user_id_users_id_fk": {
+          "name": "game_activity_rollups_user_id_users_id_fk",
+          "tableFrom": "game_activity_rollups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_activity_rollups_game_id_games_id_fk": {
+          "name": "game_activity_rollups_game_id_games_id_fk",
+          "tableFrom": "game_activity_rollups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "game_activity_rollups_user_game_period_unique": {
+          "name": "game_activity_rollups_user_game_period_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id",
+            "period",
+            "period_start"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_game_mappings": {
+      "name": "discord_game_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "discord_activity_name": {
+          "name": "discord_activity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "discord_game_mappings_game_id_games_id_fk": {
+          "name": "discord_game_mappings_game_id_games_id_fk",
+          "tableFrom": "discord_game_mappings",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_game_mappings_discord_activity_name_unique": {
+          "name": "discord_game_mappings_discord_activity_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_activity_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ad_hoc_participants": {
+      "name": "ad_hoc_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_avatar_hash": {
+          "name": "discord_avatar_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_duration_seconds": {
+          "name": "total_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "ad_hoc_participants_event_discord_user_unique": {
+          "name": "ad_hoc_participants_event_discord_user_unique",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ad_hoc_participants_event": {
+          "name": "idx_ad_hoc_participants_event",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ad_hoc_participants_user": {
+          "name": "idx_ad_hoc_participants_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ad_hoc_participants_event_id_events_id_fk": {
+          "name": "ad_hoc_participants_event_id_events_id_fk",
+          "tableFrom": "ad_hoc_participants",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ad_hoc_participants_user_id_users_id_fk": {
+          "name": "ad_hoc_participants_user_id_users_id_fk",
+          "tableFrom": "ad_hoc_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_interest_suppressions": {
+      "name": "game_interest_suppressions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suppressed_at": {
+          "name": "suppressed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_interest_suppressions_user_id_users_id_fk": {
+          "name": "game_interest_suppressions_user_id_users_id_fk",
+          "tableFrom": "game_interest_suppressions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_interest_suppressions_game_id_games_id_fk": {
+          "name": "game_interest_suppressions_game_id_games_id_fk",
+          "tableFrom": "game_interest_suppressions",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_user_game_suppression": {
+          "name": "uq_user_game_suppression",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_voice_sessions": {
+      "name": "event_voice_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_join_at": {
+          "name": "first_join_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_leave_at": {
+          "name": "last_leave_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_duration_sec": {
+          "name": "total_duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "segments": {
+          "name": "segments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "event_voice_sessions_event_discord_user_unique": {
+          "name": "event_voice_sessions_event_discord_user_unique",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_voice_sessions_event": {
+          "name": "idx_event_voice_sessions_event",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_voice_sessions_event_id_events_id_fk": {
+          "name": "event_voice_sessions_event_id_events_id_fk",
+          "tableFrom": "event_voice_sessions",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_voice_sessions_user_id_users_id_fk": {
+          "name": "event_voice_sessions_user_id_users_id_fk",
+          "tableFrom": "event_voice_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrichments": {
+      "name": "enrichments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enricher_key": {
+          "name": "enricher_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_enrichments_entity": {
+          "name": "idx_enrichments_entity",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_entity_enricher": {
+          "name": "unique_entity_enricher",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "enricher_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_request_logs": {
+      "name": "ai_request_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "feature": {
+          "name": "feature",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ai_request_logs_created_at": {
+          "name": "idx_ai_request_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_request_logs_feature_created_at": {
+          "name": "idx_ai_request_logs_feature_created_at",
+          "columns": [
+            {
+              "expression": "feature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_request_logs_user_id_users_id_fk": {
+          "name": "ai_request_logs_user_id_users_id_fk",
+          "tableFrom": "ai_request_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_entries": {
+      "name": "community_lineup_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nominated_by": {
+          "name": "nominated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carried_over_from": {
+          "name": "carried_over_from",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_entries_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_entries_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_entries",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_entries_game_id_games_id_fk": {
+          "name": "community_lineup_entries_game_id_games_id_fk",
+          "tableFrom": "community_lineup_entries",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_entries_nominated_by_users_id_fk": {
+          "name": "community_lineup_entries_nominated_by_users_id_fk",
+          "tableFrom": "community_lineup_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "nominated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_entries_carried_over_from_community_lineups_id_fk": {
+          "name": "community_lineup_entries_carried_over_from_community_lineups_id_fk",
+          "tableFrom": "community_lineup_entries",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "carried_over_from"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lineup_entry_game": {
+          "name": "uq_lineup_entry_game",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineup_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_votes": {
+      "name": "community_lineup_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_votes_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_votes_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_votes",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_votes_user_id_users_id_fk": {
+          "name": "community_lineup_votes_user_id_users_id_fk",
+          "tableFrom": "community_lineup_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_votes_game_id_games_id_fk": {
+          "name": "community_lineup_votes_game_id_games_id_fk",
+          "tableFrom": "community_lineup_votes",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lineup_vote_user_game": {
+          "name": "uq_lineup_vote_user_game",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineup_id",
+            "user_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineups": {
+      "name": "community_lineups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'building'"
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_game_id": {
+          "name": "decided_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_event_id": {
+          "name": "linked_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voting_deadline": {
+          "name": "voting_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase_deadline": {
+          "name": "phase_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase_duration_override": {
+          "name": "phase_duration_override",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_threshold": {
+          "name": "match_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 35
+        },
+        "max_votes_per_player": {
+          "name": "max_votes_per_player",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "default_tiebreaker_mode": {
+          "name": "default_tiebreaker_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_tiebreaker_id": {
+          "name": "active_tiebreaker_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineups_decided_game_id_games_id_fk": {
+          "name": "community_lineups_decided_game_id_games_id_fk",
+          "tableFrom": "community_lineups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "decided_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_lineups_linked_event_id_events_id_fk": {
+          "name": "community_lineups_linked_event_id_events_id_fk",
+          "tableFrom": "community_lineups",
+          "tableTo": "events",
+          "columnsFrom": [
+            "linked_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_lineups_created_by_users_id_fk": {
+          "name": "community_lineups_created_by_users_id_fk",
+          "tableFrom": "community_lineups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_tiebreaker_bracket_matchups": {
+      "name": "community_lineup_tiebreaker_bracket_matchups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tiebreaker_id": {
+          "name": "tiebreaker_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_a_id": {
+          "name": "game_a_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_b_id": {
+          "name": "game_b_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "winner_game_id": {
+          "name": "winner_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bye": {
+          "name": "is_bye",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_tiebreaker_bracket_matchups_tiebreaker_id_community_lineup_tiebreakers_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_matchups_tiebreaker_id_community_lineup_tiebreakers_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_matchups",
+          "tableTo": "community_lineup_tiebreakers",
+          "columnsFrom": [
+            "tiebreaker_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_matchups_game_a_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_matchups_game_a_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_matchups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_matchups_game_b_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_matchups_game_b_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_matchups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_matchups_winner_game_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_matchups_winner_game_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_matchups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "winner_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_tiebreaker_matchup_round_pos": {
+          "name": "uq_tiebreaker_matchup_round_pos",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tiebreaker_id",
+            "round",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_tiebreaker_bracket_votes": {
+      "name": "community_lineup_tiebreaker_bracket_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "matchup_id": {
+          "name": "matchup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_tiebreaker_bracket_votes_matchup_id_community_lineup_tiebreaker_bracket_matchups_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_votes_matchup_id_community_lineup_tiebreaker_bracket_matchups_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_votes",
+          "tableTo": "community_lineup_tiebreaker_bracket_matchups",
+          "columnsFrom": [
+            "matchup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_votes_user_id_users_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_votes_user_id_users_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_votes_game_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_votes_game_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_votes",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_tiebreaker_bracket_vote": {
+          "name": "uq_tiebreaker_bracket_vote",
+          "nullsNotDistinct": false,
+          "columns": [
+            "matchup_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_tiebreaker_vetoes": {
+      "name": "community_lineup_tiebreaker_vetoes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tiebreaker_id": {
+          "name": "tiebreaker_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revealed": {
+          "name": "revealed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_tiebreaker_vetoes_tiebreaker_id_community_lineup_tiebreakers_id_fk": {
+          "name": "community_lineup_tiebreaker_vetoes_tiebreaker_id_community_lineup_tiebreakers_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_vetoes",
+          "tableTo": "community_lineup_tiebreakers",
+          "columnsFrom": [
+            "tiebreaker_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_vetoes_user_id_users_id_fk": {
+          "name": "community_lineup_tiebreaker_vetoes_user_id_users_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_vetoes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_vetoes_game_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_vetoes_game_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_vetoes",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_tiebreaker_veto_user": {
+          "name": "uq_tiebreaker_veto_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tiebreaker_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_tiebreakers": {
+      "name": "community_lineup_tiebreakers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "tied_game_ids": {
+          "name": "tied_game_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_vote_count": {
+          "name": "original_vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "winner_game_id": {
+          "name": "winner_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round_deadline": {
+          "name": "round_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_tiebreakers_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_tiebreakers_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_tiebreakers",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreakers_winner_game_id_games_id_fk": {
+          "name": "community_lineup_tiebreakers_winner_game_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreakers",
+          "tableTo": "games",
+          "columnsFrom": [
+            "winner_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_match_members": {
+      "name": "community_lineup_match_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_match_members_match_id_community_lineup_matches_id_fk": {
+          "name": "community_lineup_match_members_match_id_community_lineup_matches_id_fk",
+          "tableFrom": "community_lineup_match_members",
+          "tableTo": "community_lineup_matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_match_members_user_id_users_id_fk": {
+          "name": "community_lineup_match_members_user_id_users_id_fk",
+          "tableFrom": "community_lineup_match_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_match_member_user": {
+          "name": "uq_match_member_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_matches": {
+      "name": "community_lineup_matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'suggested'"
+        },
+        "threshold_met": {
+          "name": "threshold_met",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "vote_percentage": {
+          "name": "vote_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fit_type": {
+          "name": "fit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_event_id": {
+          "name": "linked_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_message_id": {
+          "name": "embed_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_channel_id": {
+          "name": "embed_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_vote_threshold": {
+          "name": "min_vote_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threshold_notified_at": {
+          "name": "threshold_notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_matches_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_matches_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_matches",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_matches_game_id_games_id_fk": {
+          "name": "community_lineup_matches_game_id_games_id_fk",
+          "tableFrom": "community_lineup_matches",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_matches_linked_event_id_events_id_fk": {
+          "name": "community_lineup_matches_linked_event_id_events_id_fk",
+          "tableFrom": "community_lineup_matches",
+          "tableTo": "events",
+          "columnsFrom": [
+            "linked_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lineup_match_game": {
+          "name": "uq_lineup_match_game",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineup_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_schedule_slots": {
+      "name": "community_lineup_schedule_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_time": {
+          "name": "proposed_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overlap_score": {
+          "name": "overlap_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_by": {
+          "name": "suggested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_schedule_slots_match_id_community_lineup_matches_id_fk": {
+          "name": "community_lineup_schedule_slots_match_id_community_lineup_matches_id_fk",
+          "tableFrom": "community_lineup_schedule_slots",
+          "tableTo": "community_lineup_matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_schedule_votes": {
+      "name": "community_lineup_schedule_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slot_id": {
+          "name": "slot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_schedule_votes_slot_id_community_lineup_schedule_slots_id_fk": {
+          "name": "community_lineup_schedule_votes_slot_id_community_lineup_schedule_slots_id_fk",
+          "tableFrom": "community_lineup_schedule_votes",
+          "tableTo": "community_lineup_schedule_slots",
+          "columnsFrom": [
+            "slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_schedule_votes_user_id_users_id_fk": {
+          "name": "community_lineup_schedule_votes_user_id_users_id_fk",
+          "tableFrom": "community_lineup_schedule_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_schedule_vote_user": {
+          "name": "uq_schedule_vote_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slot_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_activity_log_entity": {
+          "name": "idx_activity_log_entity",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_actor_id_users_id_fk": {
+          "name": "activity_log_actor_id_users_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_dedup": {
+      "name": "notification_dedup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_notification_dedup_key": {
+          "name": "uq_notification_dedup_key",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_dedup_expires_at": {
+          "name": "idx_notification_dedup_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consumed_intent_tokens": {
+      "name": "consumed_intent_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_consumed_intent_tokens_consumed_at": {
+          "name": "idx_consumed_intent_tokens_consumed_at",
+          "columns": [
+            {
+              "expression": "consumed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "consumed_intent_tokens_token_hash_unique": {
+          "name": "consumed_intent_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/src/drizzle/migrations/meta/_journal.json
+++ b/api/src/drizzle/migrations/meta/_journal.json
@@ -834,6 +834,13 @@
       "when": 1775949215716,
       "tag": "0118_add_poll_source_to_game_interests",
       "breakpoints": true
+    },
+    {
+      "idx": 119,
+      "version": "7",
+      "when": 1775949315716,
+      "tag": "0119_vengeful_king_cobra",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/drizzle/schema/events.ts
+++ b/api/src/drizzle/schema/events.ts
@@ -98,6 +98,10 @@ export const events = pgTable(
     notificationChannelOverride: varchar('notification_channel_override', {
       length: 255,
     }),
+    /** ROK-1034: FK to community_lineup_matches.id when event is being rescheduled
+     *  via a scheduling poll. Non-null hides the event from calendars/queries.
+     *  Not using .references() to avoid circular import with community-lineup-matches. */
+    reschedulingPollId: integer('rescheduling_poll_id'),
     /** Soft-cancel timestamp. Non-null means the event is cancelled (ROK-374). */
     cancelledAt: timestamp('cancelled_at'),
     /** Optional reason provided when the event was cancelled (ROK-374). */

--- a/api/src/events/event-dashboard-queries.helpers.ts
+++ b/api/src/events/event-dashboard-queries.helpers.ts
@@ -40,6 +40,7 @@ function buildDashboardConditions(
   const conds: ReturnType<typeof gte>[] = [
     gte(sql`upper(${schema.events.duration})`, sql`${now}::timestamp`),
     sql`${schema.events.cancelledAt} IS NULL`,
+    sql`${schema.events.reschedulingPollId} IS NULL`,
   ];
   if (!isAdmin) conds.push(eq(schema.events.creatorId, userId));
   return conds;
@@ -132,6 +133,7 @@ async function fetchAttendanceRows(
   const conds: ReturnType<typeof gte>[] = [
     lte(sql`upper(${schema.events.duration})`, sql`${now}::timestamp`),
     sql`${schema.events.cancelledAt} IS NULL`,
+    sql`${schema.events.reschedulingPollId} IS NULL`,
   ];
   if (!isAdmin) conds.push(eq(schema.events.creatorId, userId));
   return db

--- a/api/src/events/event-query-filters.helpers.ts
+++ b/api/src/events/event-query-filters.helpers.ts
@@ -80,6 +80,7 @@ export function buildFilterConditions(
   if (query.includeCancelled !== 'true') {
     conditions.push(sql`${schema.events.cancelledAt} IS NULL`);
   }
+  conditions.push(sql`${schema.events.reschedulingPollId} IS NULL`);
   addUpcomingCondition(conditions, query.upcoming);
   addDateRangeConditions(conditions, query);
   addEntityConditions(conditions, query, authenticatedUserId);

--- a/api/src/events/event-query.helpers.ts
+++ b/api/src/events/event-query.helpers.ts
@@ -210,6 +210,7 @@ function buildUpcomingUserConditions(
     inArray(schema.events.id, signedUpEventIds),
     gte(sql`lower(${schema.events.duration})`, sql`${now}::timestamp`),
     sql`${schema.events.cancelledAt} IS NULL`,
+    sql`${schema.events.reschedulingPollId} IS NULL`,
   ];
 }
 

--- a/api/src/events/event-response-map.helpers.ts
+++ b/api/src/events/event-response-map.helpers.ts
@@ -71,6 +71,7 @@ function mapEventFields(
     channelBindingId: event.channelBindingId ?? null,
     notificationChannelOverride: event.notificationChannelOverride ?? null,
     extendedUntil: event.extendedUntil?.toISOString() ?? null,
+    reschedulingPollId: event.reschedulingPollId ?? null,
     createdAt: event.createdAt.toISOString(),
     updatedAt: event.updatedAt.toISOString(),
   };

--- a/api/src/events/signups-cancel.helpers.ts
+++ b/api/src/events/signups-cancel.helpers.ts
@@ -38,6 +38,11 @@ export function assertEventAcceptingSignups(
       'This event has been cancelled and is no longer accepting signups.',
     );
   }
+  if (event.reschedulingPollId) {
+    throw new ConflictException(
+      'This event is being rescheduled via a scheduling poll and is no longer accepting signups.',
+    );
+  }
   if (event.adHocStatus === 'ended') {
     throw new ConflictException(
       'This event has ended and is no longer accepting signups.',

--- a/api/src/lineups/lineups-lifecycle.helpers.ts
+++ b/api/src/lineups/lineups-lifecycle.helpers.ts
@@ -8,6 +8,7 @@ import {
   type Logger,
 } from '@nestjs/common';
 import { eq } from 'drizzle-orm';
+import { clearLinkedEventsByLineup } from './standalone-poll/standalone-poll-query.helpers';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type {
   CreateLineupDto,
@@ -84,6 +85,9 @@ export async function applyStatusUpdate(
       nextPhase,
       phaseDeadline.getTime() - Date.now(),
     );
+  }
+  if (dto.status === 'archived') {
+    await clearLinkedEventsByLineup(db, id);
   }
 }
 

--- a/api/src/lineups/lineups.service.spec.ts
+++ b/api/src/lineups/lineups.service.spec.ts
@@ -22,6 +22,11 @@ jest.mock('./lineups-carryover.helpers', () => ({
   carryOverFromLastDecided: jest.fn().mockResolvedValue(undefined),
 }));
 
+// Mock standalone-poll query helper to avoid DB queries (ROK-1034)
+jest.mock('./standalone-poll/standalone-poll-query.helpers', () => ({
+  clearLinkedEventsByLineup: jest.fn().mockResolvedValue(undefined),
+}));
+
 // Mock notification hooks to avoid extra DB queries (ROK-932)
 jest.mock('./lineups-notify-hooks.helpers', () => ({
   fireLineupCreated: jest.fn(),

--- a/api/src/lineups/standalone-poll/standalone-poll-notification.service.ts
+++ b/api/src/lineups/standalone-poll/standalone-poll-notification.service.ts
@@ -1,10 +1,11 @@
 /**
- * Notification service for standalone scheduling polls (ROK-977).
+ * Notification service for standalone scheduling polls (ROK-977 / ROK-1034).
  * Sends DMs + channel embeds to game-interested users.
  *
- * Uses community_lineup notification type (not subscribed_game)
- * for consistency with existing lineup notifications. Distinguished
- * via payload.subtype = 'standalone_scheduling_poll'.
+ * When a poll is linked to an event (rescheduling), roster members receive
+ * a reschedule-specific notification while interest-only users receive the
+ * generic poll notification. Dedup ensures roster members do not also get
+ * the generic notification.
  */
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { sql } from 'drizzle-orm';
@@ -12,6 +13,16 @@ import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { DrizzleAsyncProvider } from '../../drizzle/drizzle.module';
 import * as schema from '../../drizzle/schema';
 import { NotificationService } from '../../notifications/notification.service';
+
+/** Notification payload for standalone scheduling polls. */
+interface PollNotifPayload {
+  subtype: string;
+  lineupId: number;
+  matchId: number;
+  gameName: string;
+  creatorName: string;
+  gameCoverUrl?: string;
+}
 
 @Injectable()
 export class StandalonePollNotificationService {
@@ -25,6 +36,8 @@ export class StandalonePollNotificationService {
 
   /**
    * Notify game-interested users about a new scheduling poll.
+   * When linkedEventId is provided, roster members get a reschedule
+   * notification while interest-only users get the generic one.
    * Fire-and-forget — errors are logged, never thrown.
    */
   async notifyInterestedUsers(
@@ -34,18 +47,25 @@ export class StandalonePollNotificationService {
     matchId: number,
     creatorId: number,
     gameCoverUrl?: string | null,
+    linkedEventId?: number,
   ): Promise<void> {
     try {
-      const recipientIds = await this.findRecipients(gameId, creatorId);
-      if (recipientIds.length === 0) return;
+      const allRecipientIds = await this.findRecipients(gameId, creatorId);
+      if (allRecipientIds.length === 0) return;
       const creatorName = await this.getCreatorName(creatorId);
-      await this.dispatchNotifications(
-        recipientIds,
-        gameName,
+      const basePayload = this.buildBasePayload(
         lineupId,
         matchId,
+        gameName,
         creatorName,
         gameCoverUrl,
+      );
+      await this.splitAndDispatch(
+        allRecipientIds,
+        gameName,
+        basePayload,
+        creatorName,
+        linkedEventId,
       );
     } catch (error) {
       this.logger.error(
@@ -112,6 +132,18 @@ export class StandalonePollNotificationService {
     return rows.map((r) => r.id);
   }
 
+  /** Find roster members for a linked event. */
+  private async findRosterMembers(eventId: number): Promise<number[]> {
+    const rows = await this.db.execute<{ userId: number }>(sql`
+      SELECT es.user_id AS "userId"
+      FROM event_signups es
+      WHERE es.event_id = ${eventId}
+        AND es.status IN ('signed_up', 'tentative')
+        AND es.user_id IS NOT NULL
+    `);
+    return rows.map((r) => r.userId);
+  }
+
   /** Look up the creator's display name or username. */
   private async getCreatorName(creatorId: number): Promise<string> {
     const rows = await this.db.execute<{
@@ -125,14 +157,78 @@ export class StandalonePollNotificationService {
     return row?.displayName || row?.username || 'Someone';
   }
 
-  /** Dispatch community_lineup notifications to recipients. */
-  private async dispatchNotifications(
-    recipientIds: number[],
-    gameName: string,
+  /** Build base notification payload. */
+  private buildBasePayload(
     lineupId: number,
     matchId: number,
+    gameName: string,
     creatorName: string,
     gameCoverUrl?: string | null,
+  ): PollNotifPayload {
+    return {
+      subtype: 'standalone_scheduling_poll',
+      lineupId,
+      matchId,
+      gameName,
+      creatorName,
+      ...(gameCoverUrl ? { gameCoverUrl } : {}),
+    };
+  }
+
+  /** Split recipients and dispatch appropriate notifications. */
+  private async splitAndDispatch(
+    allRecipientIds: number[],
+    gameName: string,
+    basePayload: PollNotifPayload,
+    creatorName: string,
+    linkedEventId?: number,
+  ): Promise<void> {
+    if (!linkedEventId) {
+      await this.dispatchGeneric(
+        allRecipientIds,
+        gameName,
+        basePayload,
+        creatorName,
+      );
+      return;
+    }
+    const rosterIds = await this.findRosterMembers(linkedEventId);
+    const rosterSet = new Set(rosterIds);
+    const rosterRecipients = allRecipientIds.filter((id) => rosterSet.has(id));
+    const genericRecipients = allRecipientIds.filter(
+      (id) => !rosterSet.has(id),
+    );
+
+    const promises: Promise<void>[] = [];
+    if (rosterRecipients.length > 0) {
+      promises.push(
+        this.dispatchReschedule(
+          rosterRecipients,
+          gameName,
+          basePayload,
+          creatorName,
+        ),
+      );
+    }
+    if (genericRecipients.length > 0) {
+      promises.push(
+        this.dispatchGeneric(
+          genericRecipients,
+          gameName,
+          basePayload,
+          creatorName,
+        ),
+      );
+    }
+    await Promise.all(promises);
+  }
+
+  /** Dispatch generic poll notifications. */
+  private async dispatchGeneric(
+    recipientIds: number[],
+    gameName: string,
+    basePayload: PollNotifPayload,
+    creatorName: string,
   ): Promise<void> {
     const results = await Promise.allSettled(
       recipientIds.map((userId) =>
@@ -141,20 +237,54 @@ export class StandalonePollNotificationService {
           type: 'community_lineup',
           title: `Scheduling poll for ${gameName}`,
           message: `${creatorName} started a poll — set your availability so the group can find the best time to play.`,
-          payload: {
-            subtype: 'standalone_scheduling_poll',
-            lineupId,
-            matchId,
-            gameName,
-            creatorName,
-            ...(gameCoverUrl ? { gameCoverUrl } : {}),
-          },
+          payload: { ...basePayload, subtype: 'standalone_scheduling_poll' },
         }),
       ),
     );
+    this.logResults(
+      results,
+      recipientIds.length,
+      basePayload.matchId,
+      'generic',
+    );
+  }
+
+  /** Dispatch reschedule-specific notifications to roster members. */
+  private async dispatchReschedule(
+    recipientIds: number[],
+    gameName: string,
+    basePayload: PollNotifPayload,
+    creatorName: string,
+  ): Promise<void> {
+    const results = await Promise.allSettled(
+      recipientIds.map((userId) =>
+        this.notificationService.create({
+          userId,
+          type: 'community_lineup',
+          title: `Event being rescheduled — ${gameName}`,
+          message: `${creatorName} started a rescheduling poll — vote on a new time.`,
+          payload: { ...basePayload, subtype: 'event_rescheduling' },
+        }),
+      ),
+    );
+    this.logResults(
+      results,
+      recipientIds.length,
+      basePayload.matchId,
+      'reschedule',
+    );
+  }
+
+  /** Log dispatch results. */
+  private logResults(
+    results: PromiseSettledResult<unknown>[],
+    total: number,
+    matchId: number,
+    kind: string,
+  ): void {
     const sent = results.filter((r) => r.status === 'fulfilled').length;
     this.logger.log(
-      `Standalone poll notifications: ${sent}/${recipientIds.length} sent (match ${matchId})`,
+      `Standalone poll ${kind} notifications: ${sent}/${total} sent (match ${matchId})`,
     );
   }
 }

--- a/api/src/lineups/standalone-poll/standalone-poll-notification.service.ts
+++ b/api/src/lineups/standalone-poll/standalone-poll-notification.service.ts
@@ -144,6 +144,18 @@ export class StandalonePollNotificationService {
     return rows.map((r) => r.userId);
   }
 
+  /** Fetch the start time of a linked event. */
+  private async findEventStartTime(
+    eventId: number,
+  ): Promise<Date | undefined> {
+    const rows = await this.db.execute<{ startTime: string }>(sql`
+      SELECT lower(duration)::text AS "startTime"
+      FROM events WHERE id = ${eventId} LIMIT 1
+    `);
+    const raw = rows[0]?.startTime;
+    return raw ? new Date(raw.endsWith('Z') ? raw : raw + 'Z') : undefined;
+  }
+
   /** Look up the creator's display name or username. */
   private async getCreatorName(creatorId: number): Promise<string> {
     const rows = await this.db.execute<{
@@ -192,7 +204,10 @@ export class StandalonePollNotificationService {
       );
       return;
     }
-    const rosterIds = await this.findRosterMembers(linkedEventId);
+    const [rosterIds, eventStartTime] = await Promise.all([
+      this.findRosterMembers(linkedEventId),
+      this.findEventStartTime(linkedEventId),
+    ]);
     const rosterSet = new Set(rosterIds);
     const rosterRecipients = allRecipientIds.filter((id) => rosterSet.has(id));
     const genericRecipients = allRecipientIds.filter(
@@ -207,6 +222,7 @@ export class StandalonePollNotificationService {
           gameName,
           basePayload,
           creatorName,
+          eventStartTime,
         ),
       );
     }
@@ -255,14 +271,18 @@ export class StandalonePollNotificationService {
     gameName: string,
     basePayload: PollNotifPayload,
     creatorName: string,
+    eventStartTime?: Date,
   ): Promise<void> {
+    const timeStr = eventStartTime
+      ? ` (<t:${Math.floor(eventStartTime.getTime() / 1000)}:f>)`
+      : '';
     const results = await Promise.allSettled(
       recipientIds.map((userId) =>
         this.notificationService.create({
           userId,
           type: 'community_lineup',
           title: `Event being rescheduled — ${gameName}`,
-          message: `${creatorName} started a rescheduling poll — vote on a new time.`,
+          message: `The event you signed up for${timeStr} is being rescheduled — vote now to pick the next date.`,
           payload: { ...basePayload, subtype: 'event_rescheduling' },
         }),
       ),

--- a/api/src/lineups/standalone-poll/standalone-poll-notification.service.ts
+++ b/api/src/lineups/standalone-poll/standalone-poll-notification.service.ts
@@ -145,9 +145,7 @@ export class StandalonePollNotificationService {
   }
 
   /** Fetch the start time of a linked event. */
-  private async findEventStartTime(
-    eventId: number,
-  ): Promise<Date | undefined> {
+  private async findEventStartTime(eventId: number): Promise<Date | undefined> {
     const rows = await this.db.execute<{ startTime: string }>(sql`
       SELECT lower(duration)::text AS "startTime"
       FROM events WHERE id = ${eventId} LIMIT 1

--- a/api/src/lineups/standalone-poll/standalone-poll-query.helpers.ts
+++ b/api/src/lineups/standalone-poll/standalone-poll-query.helpers.ts
@@ -113,16 +113,55 @@ export async function insertMatchMembers(
   );
 }
 
-/** Complete a standalone poll: set match to 'scheduled' and archive the lineup.
- *  Only acts on matches whose parent lineup is marked standalone. */
+/**
+ * Atomically stamp reschedulingPollId on an event.
+ * Guard: only stamps if reschedulingPollId IS NULL AND cancelledAt IS NULL.
+ * Returns true if stamped, false if event is already rescheduling or cancelled.
+ */
+export async function stampReschedulingPollId(
+  db: Db,
+  eventId: number,
+  matchId: number,
+): Promise<boolean> {
+  const result = await db
+    .update(schema.events)
+    .set({ reschedulingPollId: matchId })
+    .where(
+      and(
+        eq(schema.events.id, eventId),
+        sql`${schema.events.reschedulingPollId} IS NULL`,
+        sql`${schema.events.cancelledAt} IS NULL`,
+      ),
+    )
+    .returning({ id: schema.events.id });
+  return result.length > 0;
+}
+
+/**
+ * Clear reschedulingPollId on an event (used on poll expiry).
+ * Does NOT cancel the event — just removes the linkage.
+ */
+export async function clearReschedulingPollId(
+  db: Db,
+  eventId: number,
+): Promise<void> {
+  await db
+    .update(schema.events)
+    .set({ reschedulingPollId: null })
+    .where(eq(schema.events.id, eventId));
+}
+
+/** Complete a standalone poll: set match to 'scheduled', archive the lineup,
+ *  and cancel any linked event. Returns linkedEventId if one was cancelled. */
 export async function completeStandalonePoll(
   db: Db,
   matchId: number,
-): Promise<boolean> {
+): Promise<{ ok: boolean; linkedEventId?: number }> {
   const [match] = await db
     .select({
       id: schema.communityLineupMatches.id,
       lineupId: schema.communityLineupMatches.lineupId,
+      linkedEventId: schema.communityLineupMatches.linkedEventId,
     })
     .from(schema.communityLineupMatches)
     .innerJoin(
@@ -136,7 +175,7 @@ export async function completeStandalonePoll(
       ),
     )
     .limit(1);
-  if (!match) return false;
+  if (!match) return { ok: false };
 
   await db.transaction(async (tx) => {
     await tx
@@ -147,8 +186,23 @@ export async function completeStandalonePoll(
       .update(schema.communityLineups)
       .set({ status: 'archived' })
       .where(eq(schema.communityLineups.id, match.lineupId));
+    if (match.linkedEventId) {
+      await cancelLinkedEvent(tx as unknown as Db, match.linkedEventId);
+    }
   });
-  return true;
+  return { ok: true, linkedEventId: match.linkedEventId ?? undefined };
+}
+
+/** Cancel a linked event and clear its reschedulingPollId. */
+async function cancelLinkedEvent(db: Db, eventId: number): Promise<void> {
+  await db
+    .update(schema.events)
+    .set({
+      cancelledAt: new Date(),
+      cancellationReason: 'Rescheduled via scheduling poll',
+      reschedulingPollId: null,
+    })
+    .where(eq(schema.events.id, eventId));
 }
 
 /** Find all active standalone polls (scheduling matches in standalone lineups). */
@@ -184,6 +238,26 @@ export async function findActiveStandalonePolls(db: Db): Promise<
     ORDER BY m.created_at DESC
   `);
   return [...rows];
+}
+
+/**
+ * Clear reschedulingPollId on all events linked to matches
+ * in the given lineup (used on poll expiry / archive).
+ */
+export async function clearLinkedEventsByLineup(
+  db: Db,
+  lineupId: number,
+): Promise<void> {
+  const matches = await db
+    .select({ linkedEventId: schema.communityLineupMatches.linkedEventId })
+    .from(schema.communityLineupMatches)
+    .where(eq(schema.communityLineupMatches.lineupId, lineupId));
+
+  for (const m of matches) {
+    if (m.linkedEventId) {
+      await clearReschedulingPollId(db, m.linkedEventId);
+    }
+  }
 }
 
 /** Count members for a given match. */

--- a/api/src/lineups/standalone-poll/standalone-poll.integration.spec.ts
+++ b/api/src/lineups/standalone-poll/standalone-poll.integration.spec.ts
@@ -471,9 +471,7 @@ function describeEventsExclusion() {
     expect(res.status).toBe(200);
 
     // Response shape is { data: [...], meta: {...} }
-    const eventIds = (res.body.data as Array<{ id: number }>).map(
-      (e) => e.id,
-    );
+    const eventIds = (res.body.data as Array<{ id: number }>).map((e) => e.id);
 
     // The event being rescheduled should be hidden
     expect(eventIds).not.toContain(event.id);

--- a/api/src/lineups/standalone-poll/standalone-poll.integration.spec.ts
+++ b/api/src/lineups/standalone-poll/standalone-poll.integration.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Standalone Scheduling Poll Integration Tests (ROK-977)
+ * Standalone Scheduling Poll Integration Tests (ROK-977 + ROK-1034)
  *
  * Verifies the POST /scheduling-polls endpoint against a real PostgreSQL
  * database. This endpoint creates a "standalone" scheduling poll that skips
@@ -10,13 +10,24 @@
  *   - A community_lineup_match in "scheduling" status
  *   - community_lineup_match_members for provided userIds
  *
- * Acceptance Criteria covered:
+ * ROK-977 Acceptance Criteria:
  *   AC1: POST with valid gameId creates lineup (decided) + match (scheduling)
  *   AC2: Match members inserted for provided memberUserIds
  *   AC3: Phase timer scheduled when durationHours provided
  *   AC4: 404 when gameId doesn't exist
  *   AC5: 404 when linkedEventId doesn't exist
  *   AC6: Any authenticated user can create (no operator role required)
+ *
+ * ROK-1034 Acceptance Criteria (rescheduling poll linkage):
+ *   AC1: POST with linkedEventId sets rescheduling_poll_id on the event
+ *   AC2: GET /events excludes events with rescheduling_poll_id IS NOT NULL
+ *   AC3: POST /events/:id/signup on rescheduling event returns 409
+ *   AC4: POST /scheduling-polls on event already being rescheduled returns 409
+ *   AC5: Poll completion cancels linked event, clears rescheduling_poll_id
+ *   AC6: Poll expiry clears rescheduling_poll_id, event reappears
+ *   AC7: Roster members receive reschedule-specific DM
+ *   AC8: Game-interest-only users receive generic poll DM
+ *   AC9: Roster member who also hearted game receives ONLY reschedule DM (dedup)
  */
 import { getTestApp, type TestApp } from '../../common/testing/test-app';
 import {
@@ -24,6 +35,7 @@ import {
   loginAsAdmin,
 } from '../../common/testing/integration-helpers';
 import * as schema from '../../drizzle/schema';
+import { eq } from 'drizzle-orm';
 
 // ── Shared state ──────────────────────────────────────────────
 let testApp: TestApp;
@@ -89,7 +101,23 @@ function postSchedulingPoll(token: string, body: Record<string, unknown>) {
     .send(body);
 }
 
-// ── AC1: POST with valid gameId creates lineup + match ───────
+async function addSignup(eventId: number, userId: number) {
+  const [signup] = await testApp.db
+    .insert(schema.eventSignups)
+    .values({ eventId, userId, status: 'signed_up' })
+    .returning();
+  return signup;
+}
+
+async function addGameInterest(userId: number, gameId: number) {
+  await testApp.db.insert(schema.gameInterests).values({
+    userId,
+    gameId,
+    source: 'manual',
+  });
+}
+
+// ── ROK-977 AC1: POST with valid gameId creates lineup + match ───────
 
 function describeCreatePoll() {
   it('should create a lineup in decided status and match in scheduling status', async () => {
@@ -163,7 +191,7 @@ function describeCreatePoll() {
 }
 describe('POST /scheduling-polls — create poll', describeCreatePoll);
 
-// ── AC2: Match members inserted for provided memberUserIds ───
+// ── ROK-977 AC2: Match members inserted for provided memberUserIds ───
 
 function describeMembers() {
   it('should insert match members for provided memberUserIds', async () => {
@@ -220,7 +248,7 @@ function describeMembers() {
 }
 describe('POST /scheduling-polls — match members', describeMembers);
 
-// ── AC3: Phase timer scheduled when durationHours provided ───
+// ── ROK-977 AC3: Phase timer scheduled when durationHours provided ───
 
 function describePhaseDuration() {
   it('should set phase deadline when durationHours is provided', async () => {
@@ -269,7 +297,7 @@ function describePhaseDuration() {
 }
 describe('POST /scheduling-polls — phase duration', describePhaseDuration);
 
-// ── AC4: 404 when gameId doesn't exist ───────────────────────
+// ── ROK-977 AC4: 404 when gameId doesn't exist ───────────────────────
 
 function describeInvalidGame() {
   it('should return 404 when gameId does not exist', async () => {
@@ -283,7 +311,7 @@ function describeInvalidGame() {
 }
 describe('POST /scheduling-polls — invalid gameId', describeInvalidGame);
 
-// ── AC5: 404 when linkedEventId doesn't exist ────────────────
+// ── ROK-977 AC5: 404 when linkedEventId doesn't exist ────────────────
 
 function describeLinkedEvent() {
   it('should return 404 when linkedEventId does not exist', async () => {
@@ -319,7 +347,7 @@ function describeLinkedEvent() {
 }
 describe('POST /scheduling-polls — linkedEventId', describeLinkedEvent);
 
-// ── AC6: Any authenticated user can create ───────────────────
+// ── ROK-977 AC6: Any authenticated user can create ───────────────────
 
 function describeAuth() {
   it('should return 401 without authentication', async () => {
@@ -353,3 +381,369 @@ function describeAuth() {
   });
 }
 describe('POST /scheduling-polls — authentication', describeAuth);
+
+// =====================================================================
+// ROK-1034: Rescheduling poll event linkage
+// =====================================================================
+//
+// All tests below MUST FAIL because the implementation does not exist yet:
+// - rescheduling_poll_id column does not exist on the events table
+// - StandalonePollService.create() does not set reschedulingPollId on events
+// - completeStandalonePoll() does not cancel the linked event
+// - Signup guard does not check reschedulingPollId
+// - Notification splitting does not exist
+// =====================================================================
+
+// ── ROK-1034 AC1: POST with linkedEventId sets rescheduling_poll_id ──
+
+function describeReschedulingPollId() {
+  it('should set rescheduling_poll_id on the event when creating poll with linkedEventId', async () => {
+    const event = await createEvent('Reschedule Me', testApp.seed.game.id);
+
+    const res = await postSchedulingPoll(adminToken, {
+      gameId: testApp.seed.game.id,
+      linkedEventId: event.id,
+    });
+
+    expect(res.status).toBe(201);
+
+    // Read the event back from DB and verify reschedulingPollId is set
+    const matchId = res.body.id as number;
+    const [updatedEvent] = await testApp.db
+      .select()
+      .from(schema.events)
+      .where(eq(schema.events.id, event.id));
+
+    // This will fail because the column does not exist yet
+    expect((updatedEvent as Record<string, unknown>).reschedulingPollId).toBe(
+      matchId,
+    );
+  });
+
+  it('should NOT set rescheduling_poll_id when linkedEventId is omitted', async () => {
+    const event = await createEvent('Not Linked', testApp.seed.game.id);
+
+    const res = await postSchedulingPoll(adminToken, {
+      gameId: testApp.seed.game.id,
+    });
+
+    expect(res.status).toBe(201);
+
+    // The event should have reschedulingPollId as null (column exists but unset)
+    const [updatedEvent] = await testApp.db
+      .select()
+      .from(schema.events)
+      .where(eq(schema.events.id, event.id));
+
+    // Will fail until the column is added — then should be null
+    expect(updatedEvent).toHaveProperty('reschedulingPollId');
+    expect(
+      (updatedEvent as Record<string, unknown>).reschedulingPollId,
+    ).toBeNull();
+  });
+}
+describe(
+  'ROK-1034 AC1 — rescheduling_poll_id linkage',
+  describeReschedulingPollId,
+);
+
+// ── ROK-1034 AC2: GET /events excludes events being rescheduled ──────
+
+function describeEventsExclusion() {
+  it('should exclude events with rescheduling_poll_id from GET /events', async () => {
+    const event = await createEvent('Hidden Event', testApp.seed.game.id);
+    const visibleEvent = await createEvent(
+      'Visible Event',
+      testApp.seed.game.id,
+    );
+
+    // Create poll linked to the first event (sets rescheduling_poll_id)
+    await postSchedulingPoll(adminToken, {
+      gameId: testApp.seed.game.id,
+      linkedEventId: event.id,
+    });
+
+    // GET /events should only return the visible event
+    const res = await testApp.request
+      .get('/events')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+
+    // Response shape is { data: [...], meta: {...} }
+    const eventIds = (res.body.data as Array<{ id: number }>).map(
+      (e) => e.id,
+    );
+
+    // The event being rescheduled should be hidden
+    expect(eventIds).not.toContain(event.id);
+    // The normal event should still appear
+    expect(eventIds).toContain(visibleEvent.id);
+  });
+}
+describe(
+  'ROK-1034 AC2 — events query excludes rescheduling events',
+  describeEventsExclusion,
+);
+
+// ── ROK-1034 AC3: POST /events/:id/signup on rescheduling event → 409
+
+function describeSignupBlock() {
+  it('should return 409 when signing up for an event being rescheduled', async () => {
+    const event = await createEvent('Blocked Signup', testApp.seed.game.id);
+
+    // Create a poll linked to this event
+    await postSchedulingPoll(adminToken, {
+      gameId: testApp.seed.game.id,
+      linkedEventId: event.id,
+    });
+
+    // Attempt to sign up — should be blocked with 409 Conflict
+    const member = await loginAsMember('blocked-signup-user');
+    const signupRes = await testApp.request
+      .post(`/events/${event.id}/signup`)
+      .set('Authorization', `Bearer ${member.token}`)
+      .send({});
+
+    expect(signupRes.status).toBe(409);
+  });
+}
+describe(
+  'ROK-1034 AC3 — signup blocked during rescheduling',
+  describeSignupBlock,
+);
+
+// ── ROK-1034 AC4: POST /scheduling-polls on already-rescheduling event → 409
+
+function describeDuplicateReschedulingPoll() {
+  it('should return 409 when creating a second poll for an event already being rescheduled', async () => {
+    const event = await createEvent('Already Polling', testApp.seed.game.id);
+
+    // First poll succeeds
+    const firstRes = await postSchedulingPoll(adminToken, {
+      gameId: testApp.seed.game.id,
+      linkedEventId: event.id,
+    });
+    expect(firstRes.status).toBe(201);
+
+    // Second poll for the same event should be rejected
+    const secondRes = await postSchedulingPoll(adminToken, {
+      gameId: testApp.seed.game.id,
+      linkedEventId: event.id,
+    });
+    expect(secondRes.status).toBe(409);
+  });
+}
+describe(
+  'ROK-1034 AC4 — duplicate rescheduling poll rejected',
+  describeDuplicateReschedulingPoll,
+);
+
+// ── ROK-1034 AC5: Poll completion cancels linked event ───────────────
+
+function describePollCompletion() {
+  it('should cancel linked event and clear rescheduling_poll_id when poll is completed', async () => {
+    const event = await createEvent('Complete Me', testApp.seed.game.id);
+
+    const pollRes = await postSchedulingPoll(adminToken, {
+      gameId: testApp.seed.game.id,
+      linkedEventId: event.id,
+    });
+    expect(pollRes.status).toBe(201);
+
+    const matchId = pollRes.body.id as number;
+
+    // Complete the poll
+    const completeRes = await testApp.request
+      .post(`/scheduling-polls/${matchId}/complete`)
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(completeRes.status).toBe(200);
+
+    // Verify: original event should now have cancelledAt set
+    const [updatedEvent] = await testApp.db
+      .select()
+      .from(schema.events)
+      .where(eq(schema.events.id, event.id));
+
+    expect(updatedEvent.cancelledAt).not.toBeNull();
+
+    // Verify: rescheduling_poll_id should be cleared
+    expect(
+      (updatedEvent as Record<string, unknown>).reschedulingPollId,
+    ).toBeNull();
+  });
+}
+describe(
+  'ROK-1034 AC5 — poll completion cancels linked event',
+  describePollCompletion,
+);
+
+// ── ROK-1034 AC6: Poll expiry restores event ────────────────────────
+
+function describePollExpiry() {
+  it('should clear rescheduling_poll_id when poll auto-archives (expires)', async () => {
+    const event = await createEvent('Expire Poll', testApp.seed.game.id);
+
+    const pollRes = await postSchedulingPoll(adminToken, {
+      gameId: testApp.seed.game.id,
+      linkedEventId: event.id,
+      durationHours: 1, // short duration for test
+    });
+    expect(pollRes.status).toBe(201);
+
+    const lineupId = pollRes.body.lineupId as number;
+
+    // Force-archive the lineup via the admin status endpoint
+    // (mimics what LineupPhaseProcessor does when the phase timer fires).
+    // The auto-archive handler should detect the linked event and clear
+    // its rescheduling_poll_id without cancelling it.
+    await testApp.request
+      .patch(`/lineups/${lineupId}/status`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ status: 'archived' });
+
+    // After archival, the event's rescheduling_poll_id should be cleared
+    const [updatedEvent] = await testApp.db
+      .select()
+      .from(schema.events)
+      .where(eq(schema.events.id, event.id));
+
+    // Event should NOT be cancelled (poll expired, not completed)
+    expect(updatedEvent.cancelledAt).toBeNull();
+
+    // rescheduling_poll_id should be cleared so event reappears
+    expect(updatedEvent).toHaveProperty('reschedulingPollId');
+    expect(
+      (updatedEvent as Record<string, unknown>).reschedulingPollId,
+    ).toBeNull();
+  });
+}
+describe(
+  'ROK-1034 AC6 — poll expiry restores event visibility',
+  describePollExpiry,
+);
+
+// ── ROK-1034 AC7: Roster members receive reschedule-specific DM ─────
+
+function describeRosterNotifications() {
+  it('should send reschedule-specific notification to roster members', async () => {
+    const rosterMember = await loginAsMember('roster-notif');
+    const event = await createEvent('Roster DM', testApp.seed.game.id);
+
+    // Add roster member as signup on the event
+    await addSignup(event.id, rosterMember.userId);
+
+    // Create poll linked to the event
+    await postSchedulingPoll(adminToken, {
+      gameId: testApp.seed.game.id,
+      linkedEventId: event.id,
+    });
+
+    // Allow fire-and-forget notifications to complete
+    await new Promise((r) => setTimeout(r, 500));
+
+    // Check notification for roster member — should have reschedule subtype
+    const notifications = await testApp.db
+      .select()
+      .from(schema.notifications)
+      .where(eq(schema.notifications.userId, rosterMember.userId));
+
+    const rescheduleNotif = notifications.find((n) => {
+      const payload = n.payload as Record<string, unknown> | null;
+      return payload?.subtype === 'event_rescheduling';
+    });
+
+    expect(rescheduleNotif).toBeDefined();
+    expect(rescheduleNotif!.title).toMatch(/reschedul/i);
+  });
+}
+describe(
+  'ROK-1034 AC7 — roster members get reschedule DM',
+  describeRosterNotifications,
+);
+
+// ── ROK-1034 AC8: Game-interest-only users get generic DM ───────────
+
+function describeInterestOnlyNotifications() {
+  it('should send generic poll notification (not reschedule) to game-interest-only users', async () => {
+    const interestUser = await loginAsMember('interest-notif');
+    const event = await createEvent('Interest DM', testApp.seed.game.id);
+
+    // User has game interest but is NOT signed up for the event
+    await addGameInterest(interestUser.userId, testApp.seed.game.id);
+
+    // Create poll linked to the event
+    await postSchedulingPoll(adminToken, {
+      gameId: testApp.seed.game.id,
+      linkedEventId: event.id,
+    });
+
+    // Allow fire-and-forget notifications to complete
+    await new Promise((r) => setTimeout(r, 500));
+
+    // Check notification for interest-only user — should have generic subtype
+    const userNotifs = await testApp.db
+      .select()
+      .from(schema.notifications)
+      .where(eq(schema.notifications.userId, interestUser.userId));
+
+    expect(userNotifs.length).toBeGreaterThanOrEqual(1);
+
+    // Should receive ONLY generic notifications (not reschedule)
+    for (const n of userNotifs) {
+      const payload = n.payload as Record<string, unknown> | null;
+      expect(payload?.subtype).not.toBe('event_rescheduling');
+    }
+
+    // At least one should be the standard scheduling poll notification
+    const genericNotif = userNotifs.find((n) => {
+      const payload = n.payload as Record<string, unknown> | null;
+      return payload?.subtype === 'standalone_scheduling_poll';
+    });
+    expect(genericNotif).toBeDefined();
+  });
+}
+describe(
+  'ROK-1034 AC8 — interest-only users get generic DM',
+  describeInterestOnlyNotifications,
+);
+
+// ── ROK-1034 AC9: Roster + interest user gets ONLY reschedule DM ────
+
+function describeNotificationDedup() {
+  it('should send ONLY reschedule DM to user who is both roster member and game-interested', async () => {
+    const dualUser = await loginAsMember('dual-notif');
+    const event = await createEvent('Dedup DM', testApp.seed.game.id);
+
+    // User is both signed up for the event AND has game interest
+    await addSignup(event.id, dualUser.userId);
+    await addGameInterest(dualUser.userId, testApp.seed.game.id);
+
+    // Create poll linked to the event
+    await postSchedulingPoll(adminToken, {
+      gameId: testApp.seed.game.id,
+      linkedEventId: event.id,
+    });
+
+    // Allow fire-and-forget notifications to complete
+    await new Promise((r) => setTimeout(r, 500));
+
+    // Check notifications for dual user — should have exactly 1
+    const notifications = await testApp.db
+      .select()
+      .from(schema.notifications)
+      .where(eq(schema.notifications.userId, dualUser.userId));
+
+    // Dedup: should receive exactly ONE notification, not two
+    expect(notifications).toHaveLength(1);
+
+    // And it should be the reschedule-specific one (higher priority)
+    const payload = notifications[0].payload as Record<string, unknown> | null;
+    expect(payload?.subtype).toBe('event_rescheduling');
+  });
+}
+describe(
+  'ROK-1034 AC9 — notification dedup for dual roster+interest users',
+  describeNotificationDedup,
+);

--- a/api/src/lineups/standalone-poll/standalone-poll.service.ts
+++ b/api/src/lineups/standalone-poll/standalone-poll.service.ts
@@ -3,7 +3,13 @@
  * Creates a minimal lineup (decided) + match (scheduling) behind the scenes,
  * exposing a simplified API that skips the full lineup flow.
  */
-import { Inject, Injectable, Logger, NotFoundException } from '@nestjs/common';
+import {
+  Inject,
+  Injectable,
+  Logger,
+  NotFoundException,
+  ConflictException,
+} from '@nestjs/common';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type { SchedulingPollResponseDto } from '@raid-ledger/contract';
 import { eq } from 'drizzle-orm';
@@ -22,6 +28,7 @@ import {
   countMatchMembers,
   findActiveStandalonePolls,
   completeStandalonePoll,
+  stampReschedulingPollId,
 } from './standalone-poll-query.helpers';
 import {
   findScheduleSlots,
@@ -71,8 +78,8 @@ export class StandalonePollService {
     startTime?: string,
     creatorId?: number,
   ): Promise<boolean> {
-    const ok = await completeStandalonePoll(this.db, matchId);
-    if (ok && eventId) {
+    const result = await completeStandalonePoll(this.db, matchId);
+    if (result.ok && eventId) {
       this.fireAutoSignup(matchId, eventId, startTime, creatorId).catch(
         (err) => {
           const msg = err instanceof Error ? err.message : String(err);
@@ -80,7 +87,7 @@ export class StandalonePollService {
         },
       );
     }
-    return ok;
+    return result.ok;
   }
 
   /** Fire-and-forget auto-signup + auto-heart for poll voters (ROK-1031). */
@@ -189,11 +196,20 @@ export class StandalonePollService {
       input.linkedEventId,
       input.minVoteThreshold,
     );
+    if (input.linkedEventId) {
+      await this.linkEventToPoll(input.linkedEventId, match.id);
+    }
     await this.addMembers(match.id, userId, input.memberUserIds);
     if (phaseDeadline) {
       await this.scheduleArchive(lineup.id, phaseDeadline);
     }
-    this.fireNotifications(game, lineup.id, match.id, userId);
+    this.fireNotifications(
+      game,
+      lineup.id,
+      match.id,
+      userId,
+      input.linkedEventId,
+    );
     this.schedulingPollEmbed.firePostInitialEmbed(
       { id: match.id, gameId: input.gameId },
       lineup.id,
@@ -246,12 +262,26 @@ export class StandalonePollService {
     await this.phaseQueue.scheduleTransition(lineupId, 'archived', delayMs);
   }
 
+  /** Atomically set reschedulingPollId on the linked event. */
+  private async linkEventToPoll(
+    eventId: number,
+    matchId: number,
+  ): Promise<void> {
+    const stamped = await stampReschedulingPollId(this.db, eventId, matchId);
+    if (!stamped) {
+      throw new ConflictException(
+        'Event is already being rescheduled or has been cancelled.',
+      );
+    }
+  }
+
   /** Fire-and-forget: notify game-interested users. */
   private fireNotifications(
     game: { id: number; name: string; coverUrl: string | null },
     lineupId: number,
     matchId: number,
     creatorId: number,
+    linkedEventId?: number,
   ): void {
     void this.notifications.notifyInterestedUsers(
       game.id,
@@ -260,6 +290,7 @@ export class StandalonePollService {
       matchId,
       creatorId,
       game.coverUrl,
+      linkedEventId,
     );
   }
 

--- a/api/src/notifications/notification-embed.buttons.ts
+++ b/api/src/notifications/notification-embed.buttons.ts
@@ -163,8 +163,9 @@ function buildLineupButton(
       .setURL(`${clientUrl}/events/${eventId}`);
   }
   if (matchId && lineupId) {
+    const isReschedule = sub === 'event_rescheduling';
     return new ButtonBuilder()
-      .setLabel('Vote on a Time')
+      .setLabel(isReschedule ? 'Vote Now' : 'Vote on a Time')
       .setStyle(ButtonStyle.Link)
       .setURL(`${clientUrl}/community-lineup/${lineupId}/schedule/${matchId}`);
   }

--- a/api/src/notifications/post-event-reminder.service.ts
+++ b/api/src/notifications/post-event-reminder.service.ts
@@ -93,7 +93,7 @@ export class PostEventReminderService {
       JOIN events e ON e.id = ps.event_id
       LEFT JOIN users u ON u.id = ps.claimed_by_user_id
       WHERE upper(e.duration) BETWEEN (now() - interval '16 minutes') AND (now() - interval '14 minutes')
-        AND ps.status IN ('accepted', 'claimed') AND e.cancelled_at IS NULL
+        AND ps.status IN ('accepted', 'claimed') AND e.cancelled_at IS NULL AND e.rescheduling_poll_id IS NULL
         AND (u.onboarding_completed_at IS NULL OR ps.claimed_by_user_id IS NULL)
         AND ps.id NOT IN (SELECT pug_slot_id FROM post_event_reminders_sent)
     `);

--- a/api/src/notifications/recruitment-reminder.helpers.ts
+++ b/api/src/notifications/recruitment-reminder.helpers.ts
@@ -72,6 +72,7 @@ export async function findEligibleEvents(
     INNER JOIN games g ON g.id = e.game_id
     INNER JOIN discord_event_messages dem ON dem.event_id = e.id
     WHERE e.cancelled_at IS NULL
+      AND e.rescheduling_poll_id IS NULL
       AND lower(e.duration) >= ${now.toISOString()}::timestamptz
       AND lower(e.duration) <= ${in48h.toISOString()}::timestamptz
       AND dem.embed_state != 'full' AND e.game_id IS NOT NULL

--- a/packages/contract/src/events.schema.ts
+++ b/packages/contract/src/events.schema.ts
@@ -162,6 +162,8 @@ export const EventResponseSchema = z.object({
     extendedUntil: z.string().datetime().nullable().optional(),
     /** ROK-1031: Events that conflict with this event for the authenticated user. */
     myConflicts: z.array(ConflictingEventSchema).optional(),
+    /** ROK-1034: FK to scheduling poll match ID when event is being rescheduled */
+    reschedulingPollId: z.number().nullable().optional(),
     createdAt: z.string().datetime(),
     updatedAt: z.string().datetime(),
 });

--- a/web/src/components/calendar/CalendarView.tsx
+++ b/web/src/components/calendar/CalendarView.tsx
@@ -88,6 +88,7 @@ function useCalendarEvents(eventsData: ReturnType<typeof useEvents>['data'], sel
         return eventsData.data
             .filter((event) => {
                 if (event.cancelledAt) return false;
+                if (event.reschedulingPollId) return false;
                 if (selectedGames === undefined) return true;
                 return event.game?.slug && selectedGames.has(event.game.slug);
             })

--- a/web/src/components/events/cancel-event-modal.tsx
+++ b/web/src/components/events/cancel-event-modal.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { toast } from '../../lib/toast';
 import { Modal } from '../ui/modal';
 import { useCancelEvent } from '../../hooks/use-events';
-import { useConvertEventToPlan } from '../../hooks/use-event-plans';
+import { useCreateSchedulingPoll } from '../../hooks/use-standalone-poll';
 
 interface CancelEventModalProps {
     isOpen: boolean;
@@ -11,14 +11,15 @@ interface CancelEventModalProps {
     eventId: number;
     eventTitle: string;
     signupCount: number;
+    gameId?: number;
     /** ROK-536: Pre-populate reason from deep-link query param. */
     initialReason?: string;
 }
 
-function useCancelHandlers({ eventId, eventTitle, onClose }: { eventId: number; eventTitle: string; onClose: () => void }) {
+function useCancelHandlers({ eventId, eventTitle, gameId, onClose }: { eventId: number; eventTitle: string; gameId?: number; onClose: () => void }) {
     const [reason, setReason] = useState('');
     const cancelEvent = useCancelEvent(eventId);
-    const convertToPlan = useConvertEventToPlan();
+    const createPoll = useCreateSchedulingPoll();
     const navigate = useNavigate();
 
     const handleClose = () => { setReason(''); onClose(); };
@@ -33,14 +34,16 @@ function useCancelHandlers({ eventId, eventTitle, onClose }: { eventId: number; 
         }
     };
 
-    const handleConvertToPlan = async () => {
+    const handleConvertToPoll = async () => {
+        if (!gameId) return;
         try {
-            await convertToPlan.mutateAsync({ eventId, options: { cancelOriginal: true } });
-            setReason(''); onClose(); navigate('/events?tab=plans');
+            const poll = await createPoll.mutateAsync({ gameId, linkedEventId: eventId, durationHours: 72 });
+            setReason(''); onClose();
+            navigate(`/community-lineup/${poll.lineupId}/schedule/${poll.id}`);
         } catch { /* Error toast handled by mutation */ }
     };
 
-    return { reason, setReason, cancelEvent, convertToPlan, handleClose, handleConfirm, handleConvertToPlan };
+    return { reason, setReason, cancelEvent, createPoll, handleClose, handleConfirm, handleConvertToPoll, canConvert: !!gameId };
 }
 
 function ReasonInput({ reason, onChange }: { reason: string; onChange: (v: string) => void }) {
@@ -68,8 +71,8 @@ function ActionButtons({ onClose, onConfirm, cancelPending, convertPending }: {
     );
 }
 
-function ConvertToPlanSection({ onConvert, isPending, cancelPending }: {
-    onConvert: () => void; isPending: boolean; cancelPending: boolean;
+function ConvertToPollSection({ onConvert, isPending, cancelPending, disabled }: {
+    onConvert: () => void; isPending: boolean; cancelPending: boolean; disabled: boolean;
 }) {
     return (
         <>
@@ -78,11 +81,11 @@ function ConvertToPlanSection({ onConvert, isPending, cancelPending }: {
                 <span className="text-xs text-muted">or</span>
                 <div className="flex-1 border-t border-edge" />
             </div>
-            <button onClick={onConvert} disabled={isPending || cancelPending}
+            <button onClick={onConvert} disabled={isPending || cancelPending || disabled}
                 className="w-full rounded-lg bg-violet-600 hover:bg-violet-500 disabled:opacity-50 disabled:cursor-not-allowed px-4 py-2.5 text-sm font-medium text-white transition-colors">
-                {isPending ? 'Converting...' : 'Convert to Plan'}
+                {isPending ? 'Creating poll...' : 'Convert to Poll'}
             </button>
-            <p className="text-xs text-muted text-center -mt-1">Post a Discord poll so your community can vote on a new time</p>
+            <p className="text-xs text-muted text-center -mt-1">Don't cancel — let your community vote on a new time instead</p>
         </>
     );
 }
@@ -90,8 +93,8 @@ function ConvertToPlanSection({ onConvert, isPending, cancelPending }: {
 /**
  * Confirmation modal for cancelling an event (ROK-374).
  */
-export function CancelEventModal({ isOpen, onClose, eventId, eventTitle, signupCount, initialReason }: CancelEventModalProps) {
-    const h = useCancelHandlers({ eventId, eventTitle, onClose });
+export function CancelEventModal({ isOpen, onClose, eventId, eventTitle, signupCount, gameId, initialReason }: CancelEventModalProps) {
+    const h = useCancelHandlers({ eventId, eventTitle, gameId, onClose });
 
     // Initialize reason from prop
     if (initialReason && !h.reason) h.setReason(initialReason);
@@ -109,9 +112,9 @@ export function CancelEventModal({ isOpen, onClose, eventId, eventTitle, signupC
                 )}
                 <ReasonInput reason={h.reason} onChange={h.setReason} />
                 <ActionButtons onClose={h.handleClose} onConfirm={h.handleConfirm}
-                    cancelPending={h.cancelEvent.isPending} convertPending={h.convertToPlan.isPending} />
-                <ConvertToPlanSection onConvert={h.handleConvertToPlan}
-                    isPending={h.convertToPlan.isPending} cancelPending={h.cancelEvent.isPending} />
+                    cancelPending={h.cancelEvent.isPending} convertPending={h.createPoll.isPending} />
+                <ConvertToPollSection onConvert={h.handleConvertToPoll}
+                    isPending={h.createPoll.isPending} cancelPending={h.cancelEvent.isPending} disabled={!h.canConvert} />
             </div>
         </Modal>
     );

--- a/web/src/hooks/use-standalone-poll.ts
+++ b/web/src/hooks/use-standalone-poll.ts
@@ -29,6 +29,7 @@ export function useCreateSchedulingPoll() {
       void queryClient.invalidateQueries({ queryKey: ['scheduling-banner'] });
       void queryClient.invalidateQueries({ queryKey: ['standalone-polls'] });
       void queryClient.invalidateQueries({ queryKey: ['lineups'] });
+      void queryClient.invalidateQueries({ queryKey: ['events'] });
     },
     onError: (error: Error) => {
       toast.error(error.message || 'Failed to create scheduling poll');

--- a/web/src/pages/event-detail-page.tsx
+++ b/web/src/pages/event-detail-page.tsx
@@ -141,7 +141,7 @@ function EventDetailModals({ event, eventId, derived, handlers, showCancelModal,
             <ConfirmModalSection show={handlers.showConfirmModal} onClose={handlers.closeConfirmModal} onConfirm={handlers.handleSelectionConfirm} onSkip={handlers.handleSelectionSkip}
                 isConfirming={handlers.signup.isPending} gameId={derived.gameRegistryEntry?.id ?? event.game?.id ?? undefined} gameName={event.game?.name ?? undefined}
                 hasRoles={derived.gameRegistryEntry?.hasRoles ?? true} gameSlug={event.game?.slug ?? undefined} preSelectedRole={handlers.preSelectedRole} eventId={eventId} />
-            <CancelModalSection show={showCancelModal || (canDeepLink && deepLinkAction === 'cancel')} eventId={eventId} eventTitle={event.title} signupCount={event.signupCount} initialReason={deepLinkReason ?? undefined}
+            <CancelModalSection show={showCancelModal || (canDeepLink && deepLinkAction === 'cancel')} eventId={eventId} eventTitle={event.title} signupCount={event.signupCount} gameId={event.game?.id} initialReason={deepLinkReason ?? undefined}
                 onClose={() => { setShowCancelModal(false); clearDeepLink(); }} />
             <RescheduleModalSection show={showRescheduleModal || (canDeepLink && deepLinkAction === 'reschedule')} eventId={eventId} currentStartTime={event.startTime} currentEndTime={event.endTime}
                 eventTitle={event.title} gameId={event.game?.id} gameSlug={event.game?.slug} gameName={event.game?.name} coverUrl={event.game?.coverUrl} description={event.description}
@@ -150,7 +150,15 @@ function EventDetailModals({ event, eventId, derived, handlers, showCancelModal,
             <RemoveConfirmModal removeConfirm={handlers.removeConfirm} onClose={() => handlers.setRemoveConfirm(null)} onConfirm={handlers.handleConfirmRemoveFromEvent} isPending={handlers.adminRemoveUser.isPending} />
             <InviteModalSection show={showInviteModal} onClose={() => setShowInviteModal(false)} eventId={eventId} pugs={handlers.pugs} roster={roster} isMMOGame={derived.isMMOGame} />
             <SeriesScopeModalSection show={seriesAction !== null} action={seriesAction ?? 'edit'} eventId={eventId}
-                onClose={() => setSeriesAction(null)} onSeriesConfirm={handlers.handleSeriesConfirm} isPending={handlers.isSeriesPending} />
+                onClose={() => setSeriesAction(null)} isPending={handlers.isSeriesPending}
+                onSeriesConfirm={(action, scope) => {
+                    if (action === 'cancel' && scope === 'this') {
+                        setSeriesAction(null);
+                        setShowCancelModal(true);
+                        return;
+                    }
+                    handlers.handleSeriesConfirm(action, scope);
+                }} />
         </>
     );
 }

--- a/web/src/pages/event-detail/EventDetailModals.tsx
+++ b/web/src/pages/event-detail/EventDetailModals.tsx
@@ -62,6 +62,7 @@ interface CancelModalProps {
     eventId: number;
     eventTitle: string;
     signupCount: number;
+    gameId?: number;
     initialReason?: string;
 }
 
@@ -76,6 +77,7 @@ export function CancelModalSection(props: CancelModalProps): JSX.Element | null 
                 eventId={props.eventId}
                 eventTitle={props.eventTitle}
                 signupCount={props.signupCount}
+                gameId={props.gameId}
                 initialReason={props.initialReason}
             />
         </Suspense>


### PR DESCRIPTION
## Summary
- Hide events from calendar when rescheduled to a scheduling poll (`reschedulingPollId` column + query filters)
- Split DM notifications: roster members get reschedule-specific DM with original event time + "Vote Now" button; game-interest users get generic poll DM
- Cancel modal rewired from "Convert to Plan" → "Convert to Poll" (creates scheduling poll), series cancel "This event only" chains to confirmation modal
- Poll completion cancels linked event; poll expiry restores it

## Linear
ROK-1034

## Test plan
- [x] `validate-ci.sh --full` passes (build, typecheck, lint, tests+coverage, integration)
- [x] Migration validation passes (0119_vengeful_king_cobra)
- [x] Operator tested locally — all 7 ACs confirmed
- [x] Code review passed (no blocking issues)
- [x] Smoke tests passed (5133 API + 2791 web tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)