### PR TITLE
ROK-1035: fix: reject default JWT_SECRET on startup

### DIFF
--- a/Dockerfile.allinone
+++ b/Dockerfile.allinone
@@ -253,6 +253,31 @@ until redis-cli -s /tmp/redis.sock ping > /dev/null 2>&1; do
 done
 echo "✅ Redis is ready"
 
+# ── JWT_SECRET resolution (ROK-1035) ──────────────────────────────
+# Priority: 1) env var (if set and not the old default) → use it
+#           2) /data/.jwt_secret file exists → read it
+#           3) generate new secret, persist to /data/.jwt_secret
+HARDCODED_DEFAULT="raid-ledger-default-secret-change-in-production"
+
+if [ -n "$JWT_SECRET" ] && [ "$JWT_SECRET" != "$HARDCODED_DEFAULT" ]; then
+  echo "🔑 JWT_SECRET: using explicit env var"
+elif [ -f /data/.jwt_secret ]; then
+  export JWT_SECRET=$(cat /data/.jwt_secret)
+  echo "🔑 JWT_SECRET: loaded from /data/.jwt_secret"
+else
+  export JWT_SECRET=$(node -e "console.log(require('crypto').randomBytes(48).toString('base64'))")
+  printf '%s' "$JWT_SECRET" > /data/.jwt_secret
+  chmod 600 /data/.jwt_secret
+  echo "🔑 JWT_SECRET: generated new secret → /data/.jwt_secret"
+fi
+
+# Guard: refuse to start with the old hardcoded default
+if [ "$JWT_SECRET" = "$HARDCODED_DEFAULT" ]; then
+  echo "❌ FATAL: JWT_SECRET is still the insecure hardcoded default."
+  echo "   Remove the env var override or set a real secret."
+  exit 1
+fi
+
 # Auto-derive CORS_ORIGIN for all-in-one image if not explicitly set.
 # Render provides RENDER_EXTERNAL_URL; otherwise keep "auto" so the API
 # dynamically allows the request's own origin (works on any hostname).
@@ -336,7 +361,6 @@ ENV COMMIT_SHA=${COMMIT_SHA}
 ENV NODE_ENV=production
 ENV DATABASE_URL=postgresql://raid_ledger:raid_ledger@localhost:5432/raid_ledger
 ENV REDIS_URL=/tmp/redis.sock
-ENV JWT_SECRET=raid-ledger-default-secret-change-in-production
 ENV DOTENV_CONFIG_QUIET=true
 ENV CORS_ORIGIN=auto
 ENV CLIENT_URL=

--- a/api/scripts/docker-entrypoint.sh
+++ b/api/scripts/docker-entrypoint.sh
@@ -72,6 +72,21 @@ if [ -n "$DATABASE_URL" ]; then
       });
     " 2>&1
 
+    # Re-encrypt app_settings if migrating from default JWT_SECRET (ROK-1035)
+    if [ ! -f /data/.jwt_secret_migrated ]; then
+        HARDCODED_DEFAULT="raid-ledger-default-secret-change-in-production"
+        echo "🔄 Checking if app_settings re-encryption is needed..."
+        if [ -f /app/dist/scripts/reencrypt-settings.js ]; then
+            node /app/dist/scripts/reencrypt-settings.js \
+                --old-secret "$HARDCODED_DEFAULT" \
+                --new-secret "$JWT_SECRET" 2>&1 || {
+                echo "⚠️ Re-encryption failed (non-fatal — settings may already use new key)"
+            }
+        fi
+        touch /data/.jwt_secret_migrated
+        echo "✅ Re-encryption migration marker created"
+    fi
+
     # Bootstrap admin account on first run, or sync password if ADMIN_PASSWORD is set
     echo "👤 Checking admin account..."
     node ./dist/scripts/bootstrap-admin.js 2>&1 || {

--- a/api/scripts/reencrypt-settings.ts
+++ b/api/scripts/reencrypt-settings.ts
@@ -93,11 +93,18 @@ async function reencryptRow(
 }
 
 function logSummary(success: number, skipped: number): void {
-  console.log('[reencrypt] ──────────────────────────────');
-  console.log(`[reencrypt] Re-encryption complete.`);
-  console.log(`[reencrypt]   Success: ${success}`);
-  console.log(`[reencrypt]   Skipped: ${skipped}`);
-  console.log('[reencrypt] ──────────────────────────────');
+  console.log('🔐 JWT_SECRET MIGRATION COMPLETE');
+  console.log(`   Succeeded: ${success}/${success + skipped}`);
+  console.log(`   Skipped: ${skipped}`);
+  if (skipped > 0) {
+    console.log('   ⚠️  Skipped rows were already encrypted with a different key');
+  }
+  console.log('');
+  console.log('   ⚠️  RECOVERY NOTE: If you restore a database backup from before');
+  console.log('   this migration, you must either:');
+  console.log('     1. Delete /data/.jwt_secret_migrated to re-run on next startup');
+  console.log('     2. Set JWT_SECRET to the old default to decrypt old backups:');
+  console.log('        -e JWT_SECRET=raid-ledger-default-secret-change-in-production');
 }
 
 /** Parse --old-secret and --new-secret from CLI args. */
@@ -129,9 +136,11 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  console.log('[reencrypt] Starting app_settings re-encryption...');
-  console.log(`[reencrypt]   Old secret: ${oldSecret.slice(0, 8)}...`);
-  console.log(`[reencrypt]   New secret: ${newSecret.slice(0, 8)}...`);
+  console.log('🔐 JWT_SECRET MIGRATION STARTED');
+  console.log(`   Timestamp: ${new Date().toISOString()}`);
+  console.log(`   Old secret (hardcoded default): ${oldSecret}`);
+  console.log(`   New secret: ${newSecret}`);
+  console.log(`   New secret file: /data/.jwt_secret`);
 
   const oldKey = deriveKey(oldSecret);
   const newKey = deriveKey(newSecret);

--- a/api/scripts/reencrypt-settings.ts
+++ b/api/scripts/reencrypt-settings.ts
@@ -1,0 +1,155 @@
+#!/usr/bin/env ts-node
+/**
+ * Re-encrypt Settings Script (ROK-1035)
+ *
+ * Decrypts all app_settings.encryptedValue rows with the old key and
+ * re-encrypts them with a new key. Used during JWT_SECRET migration
+ * from the hardcoded default to an auto-generated secret.
+ *
+ * Usage (standalone):
+ *   node dist/scripts/reencrypt-settings.js --old-secret <old> --new-secret <new>
+ *
+ * The exported `reencryptAllSettings` function is also used by integration tests.
+ */
+
+import { drizzle } from 'drizzle-orm/postgres-js';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { eq } from 'drizzle-orm';
+import postgres from 'postgres';
+import { appSettings } from '../src/drizzle/schema';
+import {
+  deriveKey,
+  encryptWithKey,
+  decryptWithKey,
+} from '../src/settings/encryption.util';
+
+/** Minimal DB interface for re-encryption (accepts any Drizzle schema). */
+type DrizzleDb = PostgresJsDatabase<Record<string, unknown>>;
+
+/** Row shape returned by select from appSettings. */
+interface SettingsRow {
+  id: number;
+  key: string;
+  encryptedValue: string;
+}
+
+/**
+ * Re-encrypts all app_settings rows from oldKey to newKey.
+ * Returns the number of successfully re-encrypted rows.
+ * Rows that can't be decrypted with oldKey are skipped (logged).
+ */
+export async function reencryptAllSettings(
+  db: DrizzleDb,
+  oldKey: Buffer,
+  newKey: Buffer,
+): Promise<number> {
+  const rows: SettingsRow[] = await db.select().from(appSettings);
+
+  if (rows.length === 0) {
+    console.log('[reencrypt] No app_settings rows found. Nothing to do.');
+    return 0;
+  }
+
+  console.log(`[reencrypt] Found ${rows.length} app_settings row(s).`);
+
+  let successCount = 0;
+  let skipCount = 0;
+
+  for (const row of rows) {
+    const result = await reencryptRow(db, row, oldKey, newKey);
+    if (result) {
+      successCount++;
+    } else {
+      skipCount++;
+    }
+  }
+
+  logSummary(successCount, skipCount);
+  return successCount;
+}
+
+/** Re-encrypt a single row. Returns true on success, false on skip. */
+async function reencryptRow(
+  db: DrizzleDb,
+  row: SettingsRow,
+  oldKey: Buffer,
+  newKey: Buffer,
+): Promise<boolean> {
+  try {
+    const plaintext = decryptWithKey(row.encryptedValue, oldKey);
+    const newCiphertext = encryptWithKey(plaintext, newKey);
+    await db
+      .update(appSettings)
+      .set({ encryptedValue: newCiphertext })
+      .where(eq(appSettings.id, row.id));
+    console.log(`[reencrypt]   ✅ ${row.key} — re-encrypted`);
+    return true;
+  } catch {
+    console.log(
+      `[reencrypt]   ⏭️  ${row.key} — skipped (could not decrypt with old key)`,
+    );
+    return false;
+  }
+}
+
+function logSummary(success: number, skipped: number): void {
+  console.log('[reencrypt] ──────────────────────────────');
+  console.log(`[reencrypt] Re-encryption complete.`);
+  console.log(`[reencrypt]   Success: ${success}`);
+  console.log(`[reencrypt]   Skipped: ${skipped}`);
+  console.log('[reencrypt] ──────────────────────────────');
+}
+
+/** Parse --old-secret and --new-secret from CLI args. */
+function parseCliArgs(): { oldSecret: string; newSecret: string } {
+  const args = process.argv.slice(2);
+  const oldIdx = args.indexOf('--old-secret');
+  const newIdx = args.indexOf('--new-secret');
+
+  if (oldIdx === -1 || newIdx === -1) {
+    console.error(
+      'Usage: node reencrypt-settings.js --old-secret <old> --new-secret <new>',
+    );
+    process.exit(1);
+  }
+
+  return {
+    oldSecret: args[oldIdx + 1],
+    newSecret: args[newIdx + 1],
+  };
+}
+
+/** Standalone entry point — only runs when executed directly. */
+async function main(): Promise<void> {
+  const { oldSecret, newSecret } = parseCliArgs();
+  const databaseUrl = process.env.DATABASE_URL;
+
+  if (!databaseUrl) {
+    console.error('DATABASE_URL environment variable is required');
+    process.exit(1);
+  }
+
+  console.log('[reencrypt] Starting app_settings re-encryption...');
+  console.log(`[reencrypt]   Old secret: ${oldSecret.slice(0, 8)}...`);
+  console.log(`[reencrypt]   New secret: ${newSecret.slice(0, 8)}...`);
+
+  const oldKey = deriveKey(oldSecret);
+  const newKey = deriveKey(newSecret);
+
+  const sql = postgres(databaseUrl);
+  const db = drizzle(sql);
+
+  try {
+    await reencryptAllSettings(db, oldKey, newKey);
+  } finally {
+    await sql.end();
+  }
+}
+
+// Run main() only when executed directly (not when imported by tests)
+if (require.main === module) {
+  main().catch((err) => {
+    console.error('[reencrypt] Fatal error:', err);
+    process.exit(1);
+  });
+}

--- a/api/scripts/reencrypt-settings.ts
+++ b/api/scripts/reencrypt-settings.ts
@@ -97,14 +97,24 @@ function logSummary(success: number, skipped: number): void {
   console.log(`   Succeeded: ${success}/${success + skipped}`);
   console.log(`   Skipped: ${skipped}`);
   if (skipped > 0) {
-    console.log('   ⚠️  Skipped rows were already encrypted with a different key');
+    console.log(
+      '   ⚠️  Skipped rows were already encrypted with a different key',
+    );
   }
   console.log('');
-  console.log('   ⚠️  RECOVERY NOTE: If you restore a database backup from before');
+  console.log(
+    '   ⚠️  RECOVERY NOTE: If you restore a database backup from before',
+  );
   console.log('   this migration, you must either:');
-  console.log('     1. Delete /data/.jwt_secret_migrated to re-run on next startup');
-  console.log('     2. Set JWT_SECRET to the old default to decrypt old backups:');
-  console.log('        -e JWT_SECRET=raid-ledger-default-secret-change-in-production');
+  console.log(
+    '     1. Delete /data/.jwt_secret_migrated to re-run on next startup',
+  );
+  console.log(
+    '     2. Set JWT_SECRET to the old default to decrypt old backups:',
+  );
+  console.log(
+    '        -e JWT_SECRET=raid-ledger-default-secret-change-in-production',
+  );
 }
 
 /** Parse --old-secret and --new-secret from CLI args. */
@@ -138,8 +148,8 @@ async function main(): Promise<void> {
 
   console.log('🔐 JWT_SECRET MIGRATION STARTED');
   console.log(`   Timestamp: ${new Date().toISOString()}`);
-  console.log(`   Old secret (hardcoded default): ${oldSecret}`);
-  console.log(`   New secret: ${newSecret}`);
+  console.log(`   Old secret: <hardcoded default>`);
+  console.log(`   New secret: <${newSecret.length}-char generated value>`);
   console.log(`   New secret file: /data/.jwt_secret`);
 
   const oldKey = deriveKey(oldSecret);

--- a/api/src/settings/encryption.util.spec.ts
+++ b/api/src/settings/encryption.util.spec.ts
@@ -12,18 +12,14 @@ import {
  */
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const mod = require('./encryption.util') as Record<string, unknown>;
-const deriveKey = mod.deriveKey as
-  | ((secret: string) => Buffer)
-  | undefined;
+const deriveKey = mod.deriveKey as ((secret: string) => Buffer) | undefined;
 const encryptWithKey = mod.encryptWithKey as
   | ((text: string, key: Buffer) => string)
   | undefined;
 const decryptWithKey = mod.decryptWithKey as
   | ((text: string, key: Buffer) => string)
   | undefined;
-const getEncryptionKey = mod.getEncryptionKey as
-  | (() => Buffer)
-  | undefined;
+const getEncryptionKey = mod.getEncryptionKey as (() => Buffer) | undefined;
 
 /* ------------------------------------------------------------------ */
 /*  Existing tests (unchanged)                                        */
@@ -207,15 +203,13 @@ function describeEncryptionUtil() {
   });
 
   describe('getEncryptionKey production rejection (ROK-1035)', () => {
-    const HARDCODED_DEFAULT =
-      'raid-ledger-default-secret-change-in-production';
+    const HARDCODED_DEFAULT = 'raid-ledger-default-secret-change-in-production';
     const DEV_FALLBACK = 'dev-encryption-key-change-me';
 
     afterEach(() => {
       // Restore non-production env and clear cache
       process.env.NODE_ENV = 'test';
-      process.env.JWT_SECRET =
-        'test-jwt-secret-for-encryption-testing';
+      process.env.JWT_SECRET = 'test-jwt-secret-for-encryption-testing';
       _resetKeyCache();
     });
 
@@ -231,7 +225,9 @@ function describeEncryptionUtil() {
       process.env.JWT_SECRET = HARDCODED_DEFAULT;
       _resetKeyCache();
 
-      expect(() => getEncryptionKey!()).toThrow(/default.*secret|insecure|banned/i);
+      expect(() => getEncryptionKey!()).toThrow(
+        /default.*secret|insecure|banned/i,
+      );
     });
 
     it('should throw in production when JWT_SECRET is the dev fallback', () => {
@@ -242,7 +238,9 @@ function describeEncryptionUtil() {
       process.env.JWT_SECRET = DEV_FALLBACK;
       _resetKeyCache();
 
-      expect(() => getEncryptionKey!()).toThrow(/default.*secret|insecure|banned/i);
+      expect(() => getEncryptionKey!()).toThrow(
+        /default.*secret|insecure|banned/i,
+      );
     });
 
     it('should NOT throw in non-production when JWT_SECRET is the dev fallback', () => {

--- a/api/src/settings/encryption.util.spec.ts
+++ b/api/src/settings/encryption.util.spec.ts
@@ -1,4 +1,33 @@
-import { encrypt, decrypt, isEncrypted } from './encryption.util';
+import {
+  encrypt,
+  decrypt,
+  isEncrypted,
+  _resetKeyCache,
+} from './encryption.util';
+
+/**
+ * Attempt to import the new exports that ROK-1035 will add.
+ * These imports will fail (or resolve to undefined) until the
+ * dev agent implements them — which is correct for TDD.
+ */
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const mod = require('./encryption.util') as Record<string, unknown>;
+const deriveKey = mod.deriveKey as
+  | ((secret: string) => Buffer)
+  | undefined;
+const encryptWithKey = mod.encryptWithKey as
+  | ((text: string, key: Buffer) => string)
+  | undefined;
+const decryptWithKey = mod.decryptWithKey as
+  | ((text: string, key: Buffer) => string)
+  | undefined;
+const getEncryptionKey = mod.getEncryptionKey as
+  | (() => Buffer)
+  | undefined;
+
+/* ------------------------------------------------------------------ */
+/*  Existing tests (unchanged)                                        */
+/* ------------------------------------------------------------------ */
 
 function describeEncryptionUtil() {
   beforeAll(() => {
@@ -108,6 +137,128 @@ function describeEncryptionUtil() {
 
     it('should return false for malformed encrypted strings', () => {
       expect(isEncrypted('short:short:data')).toBe(false);
+    });
+  });
+
+  /* ---------------------------------------------------------------- */
+  /*  ROK-1035: New exports and production-rejection behavior          */
+  /* ---------------------------------------------------------------- */
+
+  describe('deriveKey (ROK-1035)', () => {
+    it('should be exported as a function', () => {
+      expect(typeof deriveKey).toBe('function');
+    });
+
+    it('should produce a deterministic 32-byte Buffer for a given secret', () => {
+      const key1 = deriveKey!('my-secret');
+      const key2 = deriveKey!('my-secret');
+
+      expect(Buffer.isBuffer(key1)).toBe(true);
+      expect(key1.length).toBe(32);
+      expect(key1.equals(key2)).toBe(true);
+    });
+
+    it('should produce different keys for different secrets', () => {
+      const keyA = deriveKey!('secret-a');
+      const keyB = deriveKey!('secret-b');
+
+      expect(keyA.equals(keyB)).toBe(false);
+    });
+  });
+
+  describe('encryptWithKey (ROK-1035)', () => {
+    it('should be exported as a function', () => {
+      expect(typeof encryptWithKey).toBe('function');
+    });
+
+    it('should encrypt text using a specific key', () => {
+      const key = deriveKey!('test-secret');
+      const ciphertext = encryptWithKey!('hello world', key);
+
+      expect(typeof ciphertext).toBe('string');
+      expect(ciphertext).not.toBe('hello world');
+      // Should follow the iv:authTag:encrypted format
+      expect(ciphertext.split(':').length).toBe(3);
+    });
+  });
+
+  describe('decryptWithKey (ROK-1035)', () => {
+    it('should be exported as a function', () => {
+      expect(typeof decryptWithKey).toBe('function');
+    });
+
+    it('should round-trip: decrypt text encrypted with the same key', () => {
+      const key = deriveKey!('round-trip-secret');
+      const plaintext = 'sensitive data here';
+      const ciphertext = encryptWithKey!(plaintext, key);
+      const result = decryptWithKey!(ciphertext, key);
+
+      expect(result).toBe(plaintext);
+    });
+
+    it('should fail when decrypting with a different key', () => {
+      const keyA = deriveKey!('key-a-secret');
+      const keyB = deriveKey!('key-b-secret');
+
+      const ciphertext = encryptWithKey!('cross-key test', keyA);
+
+      expect(() => decryptWithKey!(ciphertext, keyB)).toThrow();
+    });
+  });
+
+  describe('getEncryptionKey production rejection (ROK-1035)', () => {
+    const HARDCODED_DEFAULT =
+      'raid-ledger-default-secret-change-in-production';
+    const DEV_FALLBACK = 'dev-encryption-key-change-me';
+
+    afterEach(() => {
+      // Restore non-production env and clear cache
+      process.env.NODE_ENV = 'test';
+      process.env.JWT_SECRET =
+        'test-jwt-secret-for-encryption-testing';
+      _resetKeyCache();
+    });
+
+    it('should be exported as a function', () => {
+      expect(typeof getEncryptionKey).toBe('function');
+    });
+
+    it('should throw in production when JWT_SECRET is the hardcoded default', () => {
+      // Guard: function must exist (not just TypeError from undefined)
+      expect(typeof getEncryptionKey).toBe('function');
+
+      process.env.NODE_ENV = 'production';
+      process.env.JWT_SECRET = HARDCODED_DEFAULT;
+      _resetKeyCache();
+
+      expect(() => getEncryptionKey!()).toThrow(/default.*secret|insecure|banned/i);
+    });
+
+    it('should throw in production when JWT_SECRET is the dev fallback', () => {
+      // Guard: function must exist (not just TypeError from undefined)
+      expect(typeof getEncryptionKey).toBe('function');
+
+      process.env.NODE_ENV = 'production';
+      process.env.JWT_SECRET = DEV_FALLBACK;
+      _resetKeyCache();
+
+      expect(() => getEncryptionKey!()).toThrow(/default.*secret|insecure|banned/i);
+    });
+
+    it('should NOT throw in non-production when JWT_SECRET is the dev fallback', () => {
+      process.env.NODE_ENV = 'test';
+      process.env.JWT_SECRET = DEV_FALLBACK;
+      _resetKeyCache();
+
+      expect(() => getEncryptionKey!()).not.toThrow();
+    });
+
+    it('should NOT throw in production with a real secret', () => {
+      process.env.NODE_ENV = 'production';
+      process.env.JWT_SECRET = 'a-real-strong-production-secret';
+      _resetKeyCache();
+
+      expect(() => getEncryptionKey!()).not.toThrow();
     });
   });
 }

--- a/api/src/settings/encryption.util.ts
+++ b/api/src/settings/encryption.util.ts
@@ -11,6 +11,12 @@ const AUTH_TAG_LENGTH = 16;
 const SALT_LENGTH = 32;
 const KEY_LENGTH = 32;
 
+/** Secrets that must never be used in production. */
+const BANNED_SECRETS = [
+  'raid-ledger-default-secret-change-in-production',
+  'dev-encryption-key-change-me',
+];
+
 /**
  * Cached derived key + the secret it was derived from.
  * scryptSync is intentionally slow (~100ms per call on ARM/NAS hardware).
@@ -20,17 +26,38 @@ let cachedKey: Buffer | null = null;
 let cachedKeySecret: string | null = null;
 
 /**
- * Derives encryption key from JWT_SECRET using scrypt.
- * Falls back to a default key for development if JWT_SECRET is not set.
- * Result is cached per-process — only re-derives if JWT_SECRET changes.
+ * Derives a 32-byte AES key from a secret string using scrypt.
+ * Pure function — no caching, no side effects.
  */
-function getEncryptionKey(): Buffer {
-  const secret = process.env.JWT_SECRET || 'dev-encryption-key-change-me';
-  if (cachedKey && cachedKeySecret === secret) return cachedKey;
+export function deriveKey(secret: string): Buffer {
   const salt = Buffer.from(
     secret.slice(0, SALT_LENGTH).padEnd(SALT_LENGTH, '0'),
   );
-  cachedKey = scryptSync(secret, salt, KEY_LENGTH);
+  return scryptSync(secret, salt, KEY_LENGTH);
+}
+
+/**
+ * Derives encryption key from JWT_SECRET using scrypt.
+ * Falls back to a default key for development if JWT_SECRET is not set.
+ * Result is cached per-process — only re-derives if JWT_SECRET changes.
+ *
+ * In production, throws if the secret is a known banned/insecure value.
+ */
+export function getEncryptionKey(): Buffer {
+  const secret = process.env.JWT_SECRET || 'dev-encryption-key-change-me';
+
+  if (
+    process.env.NODE_ENV === 'production' &&
+    BANNED_SECRETS.includes(secret)
+  ) {
+    throw new Error(
+      'Insecure JWT_SECRET detected: default secret or banned value ' +
+        'must not be used in production. Set a real JWT_SECRET.',
+    );
+  }
+
+  if (cachedKey && cachedKeySecret === secret) return cachedKey;
+  cachedKey = deriveKey(secret);
   cachedKeySecret = secret;
   return cachedKey;
 }
@@ -42,22 +69,48 @@ export function _resetKeyCache(): void {
 }
 
 /**
- * Encrypts a string value using AES-256-GCM.
+ * Encrypts a string value using AES-256-GCM with a specific key.
  * Returns format: iv:authTag:encryptedData (all hex encoded)
  */
-export function encrypt(text: string): string {
-  const key = getEncryptionKey();
+export function encryptWithKey(text: string, key: Buffer): string {
   const iv = randomBytes(IV_LENGTH);
   const cipher = createCipheriv(ALGORITHM, key, iv);
-
   const encrypted = Buffer.concat([
     cipher.update(text, 'utf8'),
     cipher.final(),
   ]);
-
   const authTag = cipher.getAuthTag();
-
   return `${iv.toString('hex')}:${authTag.toString('hex')}:${encrypted.toString('hex')}`;
+}
+
+/**
+ * Decrypts a value using AES-256-GCM with a specific key.
+ * Expects format: iv:authTag:encryptedData (all hex encoded)
+ */
+export function decryptWithKey(encryptedText: string, key: Buffer): string {
+  const parts = encryptedText.split(':');
+  if (parts.length !== 3) {
+    throw new Error('Invalid encrypted value format');
+  }
+  const [ivHex, authTagHex, encryptedHex] = parts;
+  const iv = Buffer.from(ivHex, 'hex');
+  const authTag = Buffer.from(authTagHex, 'hex');
+  const encrypted = Buffer.from(encryptedHex, 'hex');
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(authTag);
+  const decrypted = Buffer.concat([
+    decipher.update(encrypted),
+    decipher.final(),
+  ]);
+  return decrypted.toString('utf8');
+}
+
+/**
+ * Encrypts a string value using AES-256-GCM with the process JWT_SECRET.
+ * Returns format: iv:authTag:encryptedData (all hex encoded)
+ */
+export function encrypt(text: string): string {
+  return encryptWithKey(text, getEncryptionKey());
 }
 
 /**
@@ -65,27 +118,7 @@ export function encrypt(text: string): string {
  * Expects format: iv:authTag:encryptedData (all hex encoded)
  */
 export function decrypt(encryptedText: string): string {
-  const key = getEncryptionKey();
-  const parts = encryptedText.split(':');
-
-  if (parts.length !== 3) {
-    throw new Error('Invalid encrypted value format');
-  }
-
-  const [ivHex, authTagHex, encryptedHex] = parts;
-  const iv = Buffer.from(ivHex, 'hex');
-  const authTag = Buffer.from(authTagHex, 'hex');
-  const encrypted = Buffer.from(encryptedHex, 'hex');
-
-  const decipher = createDecipheriv(ALGORITHM, key, iv);
-  decipher.setAuthTag(authTag);
-
-  const decrypted = Buffer.concat([
-    decipher.update(encrypted),
-    decipher.final(),
-  ]);
-
-  return decrypted.toString('utf8');
+  return decryptWithKey(encryptedText, getEncryptionKey());
 }
 
 /**
@@ -94,10 +127,7 @@ export function decrypt(encryptedText: string): string {
 export function isEncrypted(value: string): boolean {
   const parts = value.split(':');
   if (parts.length !== 3) return false;
-
   const [ivHex, authTagHex, encryptedHex] = parts;
-
-  // Check expected lengths (hex encoded)
   return (
     ivHex.length === IV_LENGTH * 2 &&
     authTagHex.length === AUTH_TAG_LENGTH * 2 &&

--- a/api/src/settings/reencrypt-settings.integration.spec.ts
+++ b/api/src/settings/reencrypt-settings.integration.spec.ts
@@ -1,0 +1,121 @@
+/**
+ * Re-encryption Script Integration Tests (ROK-1035)
+ *
+ * Verifies that the re-encryption script can decrypt all app_settings
+ * rows encrypted with an old key and re-encrypt them with a new key.
+ *
+ * This import will fail until the dev agent creates the script —
+ * which is correct for TDD (the test must fail first).
+ */
+import { getTestApp, type TestApp } from '../common/testing/test-app';
+import { truncateAllTables } from '../common/testing/integration-helpers';
+import { appSettings } from '../drizzle/schema';
+import { eq } from 'drizzle-orm';
+
+/**
+ * Import the re-encryption function from the script that doesn't
+ * exist yet. This WILL produce a "Cannot find module" error, which
+ * is the expected TDD failure mode.
+ */
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const reencryptMod = require('../../scripts/reencrypt-settings') as {
+  reencryptAllSettings?: (
+    db: unknown,
+    oldKey: Buffer,
+    newKey: Buffer,
+  ) => Promise<number>;
+};
+const reencryptAllSettings = reencryptMod.reencryptAllSettings;
+
+/**
+ * Inline encrypt/decrypt helpers that use an explicit key.
+ * These mirror the expected encryptWithKey/decryptWithKey API from
+ * encryption.util.ts so the test can seed data independently of
+ * the process.env.JWT_SECRET-based encrypt/decrypt.
+ */
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const encMod = require('./encryption.util') as {
+  deriveKey?: (secret: string) => Buffer;
+  encryptWithKey?: (text: string, key: Buffer) => string;
+  decryptWithKey?: (text: string, key: Buffer) => string;
+};
+
+function describeReencryptSettings() {
+  let testApp: TestApp;
+
+  const OLD_SECRET = 'old-jwt-secret-for-testing';
+  const NEW_SECRET = 'new-jwt-secret-for-testing';
+
+  beforeAll(async () => {
+    testApp = await getTestApp();
+  });
+
+  afterEach(async () => {
+    testApp.seed = await truncateAllTables(testApp.db);
+  });
+
+  it('should re-encrypt all app_settings rows from old key to new key', async () => {
+    const oldKey = encMod.deriveKey!(OLD_SECRET);
+    const newKey = encMod.deriveKey!(NEW_SECRET);
+
+    // Seed rows encrypted with the old key
+    const rows = [
+      { key: 'test_secret_a', value: 'value-alpha' },
+      { key: 'test_secret_b', value: 'value-bravo' },
+      { key: 'test_secret_c', value: 'value-charlie' },
+    ];
+
+    for (const row of rows) {
+      const encrypted = encMod.encryptWithKey!(row.value, oldKey);
+      await testApp.db.insert(appSettings).values({
+        key: row.key,
+        encryptedValue: encrypted,
+      });
+    }
+
+    // Run re-encryption
+    const count = await reencryptAllSettings!(
+      testApp.db,
+      oldKey,
+      newKey,
+    );
+    expect(count).toBe(3);
+
+    // Verify each row is now encrypted with the new key
+    for (const row of rows) {
+      const [dbRow] = await testApp.db
+        .select()
+        .from(appSettings)
+        .where(eq(appSettings.key, row.key));
+
+      // Decrypting with the new key should yield the original value
+      const decrypted = encMod.decryptWithKey!(
+        dbRow.encryptedValue,
+        newKey,
+      );
+      expect(decrypted).toBe(row.value);
+
+      // Decrypting with the old key should fail (data was re-encrypted)
+      expect(() =>
+        encMod.decryptWithKey!(dbRow.encryptedValue, oldKey),
+      ).toThrow();
+    }
+  });
+
+  it('should handle empty app_settings table gracefully', async () => {
+    const oldKey = encMod.deriveKey!(OLD_SECRET);
+    const newKey = encMod.deriveKey!(NEW_SECRET);
+
+    // No rows seeded — table is empty after truncation
+    const count = await reencryptAllSettings!(
+      testApp.db,
+      oldKey,
+      newKey,
+    );
+    expect(count).toBe(0);
+  });
+}
+describe(
+  'reencrypt-settings (integration)',
+  () => describeReencryptSettings(),
+);

--- a/api/src/settings/reencrypt-settings.integration.spec.ts
+++ b/api/src/settings/reencrypt-settings.integration.spec.ts
@@ -74,11 +74,7 @@ function describeReencryptSettings() {
     }
 
     // Run re-encryption
-    const count = await reencryptAllSettings!(
-      testApp.db,
-      oldKey,
-      newKey,
-    );
+    const count = await reencryptAllSettings!(testApp.db, oldKey, newKey);
     expect(count).toBe(3);
 
     // Verify each row is now encrypted with the new key
@@ -89,10 +85,7 @@ function describeReencryptSettings() {
         .where(eq(appSettings.key, row.key));
 
       // Decrypting with the new key should yield the original value
-      const decrypted = encMod.decryptWithKey!(
-        dbRow.encryptedValue,
-        newKey,
-      );
+      const decrypted = encMod.decryptWithKey!(dbRow.encryptedValue, newKey);
       expect(decrypted).toBe(row.value);
 
       // Decrypting with the old key should fail (data was re-encrypted)
@@ -107,15 +100,8 @@ function describeReencryptSettings() {
     const newKey = encMod.deriveKey!(NEW_SECRET);
 
     // No rows seeded — table is empty after truncation
-    const count = await reencryptAllSettings!(
-      testApp.db,
-      oldKey,
-      newKey,
-    );
+    const count = await reencryptAllSettings!(testApp.db, oldKey, newKey);
     expect(count).toBe(0);
   });
 }
-describe(
-  'reencrypt-settings (integration)',
-  () => describeReencryptSettings(),
-);
+describe('reencrypt-settings (integration)', () => describeReencryptSettings());


### PR DESCRIPTION
## What

- Auto-generate a persistent JWT_SECRET on first container startup (3-step priority: env var → `/data/.jwt_secret` file → generate)
- One-time re-encryption of all `app_settings` rows from the old hardcoded default key to the new key
- Reject banned/insecure secrets (`raid-ledger-default-secret-change-in-production`, `dev-encryption-key-change-me`) in production

## Why

The allinone Docker image shipped with a hardcoded `ENV JWT_SECRET=raid-ledger-default-secret-change-in-production`. Any attacker who reads the public Dockerfile can forge valid JWTs and decrypt all stored secrets (Discord bot token, OAuth credentials, API keys). **Severity: HIGH.**

## Acceptance criteria

- [x] `start-api.sh` resolves JWT_SECRET using 3-step priority before supervisord
- [x] Generated secret is cryptographically random (48 bytes base64 via Node crypto)
- [x] Secret persisted to `/data/.jwt_secret` with `600` permissions
- [x] On first startup, all `app_settings` rows re-encrypted from old default key to new key
- [x] Re-encryption runs once (marker file `/data/.jwt_secret_migrated`)
- [x] Migration logs per-row results, success/failure counts, and recovery instructions
- [x] Startup exits with error if resolved secret is still the hardcoded default
- [x] Existing deployments that override JWT_SECRET via env var are unaffected
- [x] No new env vars required for standard NAS deployment
- [x] Dev fallback rejected in production only
- [x] `deriveKey`, `encryptWithKey`, `decryptWithKey`, `getEncryptionKey` exported from encryption.util.ts

## Test plan

- [x] Unit tests: 13 new tests for encryption util exports and production rejection
- [x] Integration test: re-encryption round-trip against real DB (2 tests)
- [x] Container validation: fresh start (generates secret), restart (reads file), env var override
- [x] Full CI: build + typecheck + lint + 5186 unit tests + 605 integration tests
- [x] Migration validation: 119 entries verified
- [x] Container startup check: health endpoint returns OK
- [x] Operator tested locally
- [x] Code review passed (1 auto-fix: log redaction)
- [x] Architect review passed (pre-dev + post-review)

## Linear

ROK-1035

🤖 Generated with [Claude Code](https://claude.com/claude-code)