### PR TITLE
ROK-1038: fix: increase GameTime grid font sizes for mobile readability

### DIFF
--- a/web/src/components/features/game-time/DayHeader.tsx
+++ b/web/src/components/features/game-time/DayHeader.tsx
@@ -31,7 +31,7 @@ export function DayHeader({
 
     return (
         <div
-            className={`sticky ${noStickyOffset ? 'top-0' : isHeaderHidden ? 'top-0' : 'top-16'} z-10 text-center text-xs font-medium py-1 ${colorClass} ${interactiveClass}`}
+            className={`sticky ${noStickyOffset ? 'top-0' : isHeaderHidden ? 'top-0' : 'top-16'} z-10 text-center text-sm font-medium py-1 ${colorClass} ${interactiveClass}`}
             style={{ transition: 'top 300ms ease-in-out', ...splitBg }}
             data-testid={`day-header-${dayIndex}`}
             onClick={onClick}
@@ -65,12 +65,12 @@ function DayLabel({ displayDay, isRollingPast, isTodaySplit, dateLabel, nextDate
     dateLabel?: string; nextDateLabel?: string;
 }): JSX.Element {
     if (isRollingPast && nextDateLabel) {
-        return <DayWithDate day={displayDay} sub={<span className="text-[9px] opacity-60 leading-none">{nextDateLabel}</span>} />;
+        return <DayWithDate day={displayDay} sub={<span className="text-xs opacity-80 leading-none">{nextDateLabel}</span>} />;
     }
     if (isTodaySplit && dateLabel && nextDateLabel) {
         return (
             <DayWithDate day={displayDay} sub={
-                <span className="text-[9px] leading-none flex items-center gap-0.5">
+                <span className="text-xs leading-none flex items-center gap-0.5">
                     <span className="text-muted">{nextDateLabel}</span>
                     <span className="text-dim">/</span>
                     <span className="text-emerald-400/80">{dateLabel}</span>
@@ -79,7 +79,7 @@ function DayLabel({ displayDay, isRollingPast, isTodaySplit, dateLabel, nextDate
         );
     }
     if (dateLabel) {
-        return <DayWithDate day={displayDay} sub={<span className="text-[9px] opacity-60 leading-none">{dateLabel}</span>} />;
+        return <DayWithDate day={displayDay} sub={<span className="text-xs opacity-80 leading-none">{dateLabel}</span>} />;
     }
     return <>{displayDay}</>;
 }

--- a/web/src/components/features/game-time/GridBody.tsx
+++ b/web/src/components/features/game-time/GridBody.tsx
@@ -55,7 +55,7 @@ export function GridBody({
     return (
         <div
             ref={gridRef} className="grid gap-px select-none"
-            style={{ gridTemplateColumns: '48px repeat(7, 1fr)', touchAction: 'none', background: gridLineBackground }}
+            style={{ gridTemplateColumns: '52px repeat(7, 1fr)', touchAction: 'none', background: gridLineBackground }}
             onPointerUp={handlePointerUp}
             onPointerLeave={() => { handlePointerUp(); setHoveredCell(null); }}
             data-testid="game-time-grid"
@@ -75,7 +75,7 @@ function TzCorner({ tzLabel, noStickyOffset, isHeaderHidden }: {
             className={`sticky ${noStickyOffset ? 'top-0' : isHeaderHidden ? 'top-0' : 'top-16'} z-10 bg-surface flex items-center justify-center`}
             style={{ transition: noStickyOffset ? undefined : 'top 300ms ease-in-out' }}
         >
-            {tzLabel && <span className="text-[10px] text-dim font-medium">{tzLabel}</span>}
+            {tzLabel && <span className="text-xs text-dim font-medium">{tzLabel}</span>}
         </div>
     );
 }
@@ -106,7 +106,7 @@ function DayHeaders({ dayDates, nextWeekDayDates, fullDayNames, todayIndex, next
 function HourRow({ hour, ...cellProps }: { hour: number } & CellRenderProps): JSX.Element {
     return (
         <Fragment>
-            <div className="text-right text-xs text-dim pr-2 py-0.5 flex items-center justify-end">
+            <div className="text-right text-sm text-dim pr-2 py-0.5 flex items-center justify-end">
                 {formatHour(hour)}
             </div>
             {DAYS.map((_, dayIndex) => (


### PR DESCRIPTION
## What
Increase font sizes across the GameTime weekly grid to improve mobile readability.

## Why
Day headers (12px), date sub-text (9px), time labels (12px), and timezone labels (10px) were too small to read on mobile screens. The 9px date text was particularly unreadable.

## Changes
- **Day headers** (Sun–Sat): `text-xs` (12px) → `text-sm` (14px)
- **Date sub-text**: `text-[9px]` (9px) → `text-xs` (12px), opacity 60% → 80%
- **Time labels** (hour column): `text-xs` → `text-sm` (14px)
- **Timezone label**: `text-[10px]` → `text-xs` (12px)
- **Time column width**: 48px → 52px (accommodates larger labels)

## Linear
ROK-1038

## Test plan
- [x] CI passes (build + lint + type check + tests)
- [x] API unit tests: 377 suites, 5173 tests passed
- [x] Web unit tests: 214 suites, 2793 tests passed
- [x] API integration tests: 45 suites, 613 tests passed
- [x] Playwright smoke tests: 420 passed (desktop + mobile)
- [x] Operator tested locally
- [x] Code review: APPROVED (no issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)