### PR TITLE
ROK-1037: fix: seeded events don't show organizer controls when impersonating creator

### DIFF
--- a/api/src/admin/demo-data-clear.helpers.ts
+++ b/api/src/admin/demo-data-clear.helpers.ts
@@ -137,6 +137,10 @@ async function deleteDemoUserData(
       .update(schema.availability)
       .set({ sourceEventId: null })
       .where(inArray(schema.availability.sourceEventId, demoEventIds));
+    await db
+      .update(schema.communityLineups)
+      .set({ linkedEventId: null })
+      .where(inArray(schema.communityLineups.linkedEventId, demoEventIds));
   }
   await deleteDemoUserDependents(db, demoUserIds, demoEventIds);
 }

--- a/api/src/admin/demo-data-creator-distribution.integration.spec.ts
+++ b/api/src/admin/demo-data-creator-distribution.integration.spec.ts
@@ -1,0 +1,212 @@
+/**
+ * Demo Data — Event Creator Distribution (ROK-1037)
+ *
+ * Verifies that after demo data install:
+ * - ROLE_ACCOUNTS contains 3 raid leaders
+ * - ALL original events are distributed round-robin across 3 raid leaders
+ * - Edge-condition events exist: ad-hoc (live + ended), cancelled, no-game
+ */
+import { eq, isNull, isNotNull, inArray } from 'drizzle-orm';
+import { getTestApp, type TestApp } from '../common/testing/test-app';
+import {
+  truncateAllTables,
+  loginAsAdmin,
+} from '../common/testing/integration-helpers';
+import * as schema from '../drizzle/schema';
+import { ROLE_ACCOUNTS } from './demo-data.constants';
+
+/** Raid leader usernames expected after ROK-1037. */
+const EXPECTED_RAID_LEADERS = ['ShadowMage', 'ProRaider', 'TankMaster'];
+
+function describeCreatorDistribution() {
+  let testApp: TestApp;
+  let adminToken: string;
+
+  beforeAll(async () => {
+    testApp = await getTestApp();
+    adminToken = await loginAsAdmin(testApp.request, testApp.seed);
+  });
+
+  afterEach(async () => {
+    testApp.seed = await truncateAllTables(testApp.db);
+    adminToken = await loginAsAdmin(testApp.request, testApp.seed);
+  });
+
+  // =========================================================================
+  // AC1: ROLE_ACCOUNTS contains 3 raid leaders
+  // =========================================================================
+
+  it('ROLE_ACCOUNTS should contain 3 raid leaders', () => {
+    const raidLeaders = ROLE_ACCOUNTS.filter((a) => a.role === 'Raid Leader');
+    expect(raidLeaders).toHaveLength(3);
+    const names = raidLeaders.map((a) => a.username);
+    expect(names).toEqual(expect.arrayContaining(EXPECTED_RAID_LEADERS));
+  });
+
+  // =========================================================================
+  // AC2: All original events distributed round-robin across 3 raid leaders
+  // =========================================================================
+
+  it('should distribute ALL original events across 3 raid leaders with none under SeedAdmin', async () => {
+    // Install demo data
+    const installRes = await testApp.request
+      .post('/admin/settings/demo/install')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(installRes.status).toBe(200);
+    expect(installRes.body.success).toBe(true);
+
+    // Find the 3 raid leader users
+    const raidLeaderNames = EXPECTED_RAID_LEADERS;
+    const raidLeaderUsers = await testApp.db
+      .select()
+      .from(schema.users)
+      .where(inArray(schema.users.username, raidLeaderNames));
+    expect(raidLeaderUsers).toHaveLength(3);
+    const raidLeaderIds = new Set(raidLeaderUsers.map((u) => u.id));
+
+    // Find SeedAdmin
+    const [seedAdmin] = await testApp.db
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.username, 'SeedAdmin'));
+    expect(seedAdmin).toBeDefined();
+
+    // Get original events: the first 6 events inserted (non-ad-hoc,
+    // non-cancelled, with a gameId, matching the 6 original titles)
+    const originalTitles = [
+      'Heroic Amirdrassil Clear',
+      'Mythic+ Push Night',
+      'Valheim Boss Rush',
+      'FFXIV Savage Prog',
+      'Morning Dungeon Runs',
+      'Late Night Raids',
+    ];
+    const origEvents = await testApp.db
+      .select({
+        id: schema.events.id,
+        title: schema.events.title,
+        creatorId: schema.events.creatorId,
+      })
+      .from(schema.events)
+      .where(inArray(schema.events.title, originalTitles));
+
+    expect(origEvents.length).toBeGreaterThanOrEqual(6);
+
+    // AC2a: No original event remains under SeedAdmin
+    const seedAdminOrig = origEvents.filter(
+      (e) => e.creatorId === seedAdmin.id,
+    );
+    expect(seedAdminOrig).toHaveLength(0);
+
+    // AC2b: All original events are owned by one of the 3 raid leaders
+    for (const event of origEvents) {
+      expect(raidLeaderIds.has(event.creatorId)).toBe(true);
+    }
+
+    // AC2c: Each raid leader owns at least 2 original events
+    for (const leaderId of raidLeaderIds) {
+      const owned = origEvents.filter((e) => e.creatorId === leaderId);
+      expect(owned.length).toBeGreaterThanOrEqual(2);
+    }
+  });
+
+  // =========================================================================
+  // AC3: At least 1 ad-hoc event with isAdHoc=true and adHocStatus='live'
+  // =========================================================================
+
+  it('should seed at least 1 ad-hoc event with live status', async () => {
+    const installRes = await testApp.request
+      .post('/admin/settings/demo/install')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(installRes.status).toBe(200);
+
+    const liveAdHocEvents = await testApp.db
+      .select()
+      .from(schema.events)
+      .where(eq(schema.events.isAdHoc, true));
+
+    const liveOnes = liveAdHocEvents.filter((e) => e.adHocStatus === 'live');
+    expect(liveOnes.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // =========================================================================
+  // AC4: At least 1 ad-hoc event with adHocStatus='ended'
+  // =========================================================================
+
+  it('should seed at least 1 ad-hoc event with ended status', async () => {
+    const installRes = await testApp.request
+      .post('/admin/settings/demo/install')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(installRes.status).toBe(200);
+
+    const adHocEvents = await testApp.db
+      .select()
+      .from(schema.events)
+      .where(eq(schema.events.isAdHoc, true));
+
+    const endedOnes = adHocEvents.filter((e) => e.adHocStatus === 'ended');
+    expect(endedOnes.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // =========================================================================
+  // AC5: At least 1 cancelled event with cancelledAt set
+  // =========================================================================
+
+  it('should seed at least 1 cancelled event', async () => {
+    const installRes = await testApp.request
+      .post('/admin/settings/demo/install')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(installRes.status).toBe(200);
+
+    const cancelledEvents = await testApp.db
+      .select()
+      .from(schema.events)
+      .where(isNotNull(schema.events.cancelledAt));
+
+    expect(cancelledEvents.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // =========================================================================
+  // AC6: At least 1 intentionally seeded no-game event with gameId=null
+  // =========================================================================
+
+  it('should seed at least 1 intentionally no-game edge-condition event', async () => {
+    const installRes = await testApp.request
+      .post('/admin/settings/demo/install')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(installRes.status).toBe(200);
+
+    // In the test DB, all events have null gameId incidentally (the test
+    // DB has only "test-game" with no IGDB ID, so no games match by slug
+    // or IGDB ID). To distinguish *intentionally* seeded no-game events
+    // from accidental ones, we exclude:
+    //   1. The 6 original events (null gameId from missing game slugs)
+    //   2. Generated events (title pattern "X — GameName", null from
+    //      missing IGDB mappings in test DB)
+    // What remains must be an explicitly seeded no-game edge-condition event.
+    const originalTitles = [
+      'Heroic Amirdrassil Clear',
+      'Mythic+ Push Night',
+      'Valheim Boss Rush',
+      'FFXIV Savage Prog',
+      'Morning Dungeon Runs',
+      'Late Night Raids',
+    ];
+    const allNoGame = await testApp.db
+      .select({ id: schema.events.id, title: schema.events.title })
+      .from(schema.events)
+      .where(isNull(schema.events.gameId));
+
+    const intentionalNoGame = allNoGame.filter((e) => {
+      // Exclude original events
+      if (originalTitles.includes(e.title)) return false;
+      // Exclude generated events (they follow "Title — GameName" pattern)
+      if (e.title.includes(' — ')) return false;
+      return true;
+    });
+    expect(intentionalNoGame.length).toBeGreaterThanOrEqual(1);
+  });
+}
+
+describe('Demo Data — Creator Distribution (integration)', () =>
+  describeCreatorDistribution());

--- a/api/src/admin/demo-data-events.ts
+++ b/api/src/admin/demo-data-events.ts
@@ -72,6 +72,19 @@ const EVENT_TUPLES: EventTuple[] = [
   ],
 ];
 
+/** Edge-case event definition with optional extra fields. */
+export interface EdgeCaseEvent {
+  title: string;
+  description: string;
+  gameId: number | null;
+  startTime: Date;
+  endTime: Date;
+  isAdHoc?: boolean;
+  adHocStatus?: string;
+  cancelledAt?: Date;
+  cancellationReason?: string;
+}
+
 /** Build the list of event templates from raw tuples. */
 function buildEventList(
   gameIds: Record<GameKey, number | null>,
@@ -88,19 +101,78 @@ function buildEventList(
   });
 }
 
-/** Generate event definitions (time-relative, needs games table IDs) */
-export function getEventsDefinitions(games: GameEntry[]) {
-  const gameIds: Record<GameKey, number | null> = {
+/** Build edge-case events for testing (ad-hoc, cancelled, no-game). */
+function buildEdgeCaseEvents(
+  gameIds: Record<GameKey, number | null>,
+  hoursFromNow: TimeFn,
+): EdgeCaseEvent[] {
+  return [
+    {
+      title: 'Impromptu Helldivers Run',
+      description: 'Spontaneous bug-stomping session!',
+      gameId: gameIds.valheim,
+      startTime: hoursFromNow(-1),
+      endTime: hoursFromNow(2),
+      isAdHoc: true,
+      adHocStatus: 'live',
+    },
+    {
+      title: 'Late Night Warframe Session',
+      description: 'Chill relic cracking — already wrapped up.',
+      gameId: gameIds.ffxiv,
+      startTime: hoursFromNow(-5),
+      endTime: hoursFromNow(-2),
+      isAdHoc: true,
+      adHocStatus: 'ended',
+    },
+    {
+      title: 'Cancelled Mythic Prog',
+      description: 'Was supposed to be M3S prog night.',
+      gameId: gameIds.wow,
+      startTime: hoursFromNow(8),
+      endTime: hoursFromNow(11),
+      cancelledAt: new Date(),
+      cancellationReason: 'Not enough signups',
+    },
+    {
+      title: 'Community Game Night',
+      description: 'Social hangout — no specific game, just vibes.',
+      gameId: null,
+      startTime: hoursFromNow(4),
+      endTime: hoursFromNow(7),
+    },
+  ];
+}
+
+/** Build gameIds lookup from game rows. */
+function resolveGameIds(games: GameEntry[]): Record<GameKey, number | null> {
+  return {
     wow: games.find((g) => g.slug === 'world-of-warcraft')?.id ?? null,
     valheim: games.find((g) => g.slug === 'valheim')?.id ?? null,
     ffxiv: games.find((g) => g.slug === 'final-fantasy-xiv-online')?.id ?? null,
   };
-  const now = new Date();
-  const baseHour = roundToHour(now);
-  const hoursFromNow = (hours: number) =>
-    new Date(baseHour.getTime() + hours * 60 * 60 * 1000);
-  const daysFromNow = (days: number) =>
-    new Date(baseHour.getTime() + days * 24 * 60 * 60 * 1000);
+}
 
+/** Build hoursFromNow / daysFromNow helpers from the current time. */
+function buildTimeFns() {
+  const baseHour = roundToHour(new Date());
+  const hoursFromNow = (h: number) =>
+    new Date(baseHour.getTime() + h * 60 * 60 * 1000);
+  const daysFromNow = (d: number) =>
+    new Date(baseHour.getTime() + d * 24 * 60 * 60 * 1000);
+  return { hoursFromNow, daysFromNow };
+}
+
+/** Generate event definitions (time-relative, needs games table IDs) */
+export function getEventsDefinitions(games: GameEntry[]) {
+  const gameIds = resolveGameIds(games);
+  const { hoursFromNow, daysFromNow } = buildTimeFns();
   return buildEventList(gameIds, hoursFromNow, daysFromNow);
+}
+
+/** Generate edge-case event definitions (ad-hoc, cancelled, no-game). */
+export function getEdgeCaseDefinitions(games: GameEntry[]): EdgeCaseEvent[] {
+  const gameIds = resolveGameIds(games);
+  const { hoursFromNow } = buildTimeFns();
+  return buildEdgeCaseEvents(gameIds, hoursFromNow);
 }

--- a/api/src/admin/demo-data-install-core.helpers.ts
+++ b/api/src/admin/demo-data-install-core.helpers.ts
@@ -101,10 +101,9 @@ export async function installEvents(
     schema.events,
     allValues,
   )) as (typeof schema.events.$inferSelect)[];
-  const origCount = origEventDefs.length;
-  const edgeCount = edgeCaseDefs.length;
-  const origEvents = created.slice(0, origCount);
-  const genEvents = created.slice(origCount + edgeCount);
+  const handcraftedCount = origEventDefs.length + edgeCaseDefs.length;
+  const origEvents = created.slice(0, handcraftedCount);
+  const genEvents = created.slice(handcraftedCount);
   return { createdEvents: created, origEvents, genEvents };
 }
 

--- a/api/src/admin/demo-data-install-core.helpers.ts
+++ b/api/src/admin/demo-data-install-core.helpers.ts
@@ -11,7 +11,9 @@ import {
   CHARACTERS_CONFIG,
   getClassIconUrl,
   getEventsDefinitions,
+  getEdgeCaseDefinitions,
 } from './demo-data.constants';
+import type { EdgeCaseEvent } from './demo-data.constants';
 import {
   generateEvents,
   generateCharacters,
@@ -52,7 +54,24 @@ export async function installUsers(
   return { allUsers, userByName };
 }
 
-/** Insert original + generated events. */
+/** Map an edge-case event definition to a DB-ready insert value. */
+function mapEdgeCaseEvent(e: EdgeCaseEvent, creatorId: number) {
+  return {
+    title: e.title,
+    description: e.description,
+    gameId: e.gameId,
+    creatorId,
+    duration: [e.startTime, e.endTime] as [Date, Date],
+    ...(e.isAdHoc != null && { isAdHoc: e.isAdHoc }),
+    ...(e.adHocStatus != null && { adHocStatus: e.adHocStatus }),
+    ...(e.cancelledAt != null && { cancelledAt: e.cancelledAt }),
+    ...(e.cancellationReason != null && {
+      cancellationReason: e.cancellationReason,
+    }),
+  };
+}
+
+/** Insert original + edge-case + generated events. */
 export async function installEvents(
   batchInsertReturning: BatchInsertReturning,
   seedAdminId: number,
@@ -60,14 +79,16 @@ export async function installEvents(
   generatedEvents: ReturnType<typeof generateEvents>,
 ) {
   const origEventDefs = getEventsDefinitions(allGames);
-  const origEventValues = origEventDefs.map((e) => ({
+  const edgeCaseDefs = getEdgeCaseDefinitions(allGames);
+  const origValues = origEventDefs.map((e) => ({
     title: e.title,
     description: e.description,
     gameId: e.gameId,
     creatorId: seedAdminId,
     duration: [e.startTime, e.endTime] as [Date, Date],
   }));
-  const genEventValues = generatedEvents.map((e) => ({
+  const edgeValues = edgeCaseDefs.map((e) => mapEdgeCaseEvent(e, seedAdminId));
+  const genValues = generatedEvents.map((e) => ({
     title: e.title,
     description: e.description,
     gameId: e.gameId,
@@ -75,13 +96,16 @@ export async function installEvents(
     duration: [e.startTime, e.endTime] as [Date, Date],
     maxAttendees: e.maxPlayers,
   }));
-  const createdEvents = (await batchInsertReturning(schema.events, [
-    ...origEventValues,
-    ...genEventValues,
-  ])) as (typeof schema.events.$inferSelect)[];
-  const origEvents = createdEvents.slice(0, origEventDefs.length);
-  const genEvents = createdEvents.slice(origEventDefs.length);
-  return { createdEvents, origEvents, genEvents };
+  const allValues = [...origValues, ...edgeValues, ...genValues];
+  const created = (await batchInsertReturning(
+    schema.events,
+    allValues,
+  )) as (typeof schema.events.$inferSelect)[];
+  const origCount = origEventDefs.length;
+  const edgeCount = edgeCaseDefs.length;
+  const origEvents = created.slice(0, origCount);
+  const genEvents = created.slice(origCount + edgeCount);
+  return { createdEvents: created, origEvents, genEvents };
 }
 
 /** Insert original + generated characters. */

--- a/api/src/admin/demo-data-install-secondary.helpers.ts
+++ b/api/src/admin/demo-data-install-secondary.helpers.ts
@@ -295,7 +295,7 @@ async function reassignOrigEventsToRaidLeader(
   }
 }
 
-/** Randomly reassign ~30% of generated events to non-admin creators. */
+/** Reassign ALL generated events to non-admin creators (round-robin). */
 async function reassignGenEventsRandomly(
   db: Db,
   allUsers: (typeof schema.users.$inferSelect)[],
@@ -303,15 +303,12 @@ async function reassignGenEventsRandomly(
 ): Promise<void> {
   const nonAdminUsers = allUsers.filter((u) => u.role !== 'admin');
   if (nonAdminUsers.length === 0) return;
-  const rng = createRng(0xeee);
   const reassignByCreator = new Map<number, number[]>();
-  for (const event of genEvents) {
-    if (rng() < 0.3) {
-      const creator = nonAdminUsers[Math.floor(rng() * nonAdminUsers.length)];
-      const ids = reassignByCreator.get(creator.id) ?? [];
-      ids.push(event.id);
-      reassignByCreator.set(creator.id, ids);
-    }
+  for (let i = 0; i < genEvents.length; i++) {
+    const creator = nonAdminUsers[i % nonAdminUsers.length];
+    const ids = reassignByCreator.get(creator.id) ?? [];
+    ids.push(genEvents[i].id);
+    reassignByCreator.set(creator.id, ids);
   }
   for (const [creatorId, eventIds] of reassignByCreator) {
     await db

--- a/api/src/admin/demo-data-install-secondary.helpers.ts
+++ b/api/src/admin/demo-data-install-secondary.helpers.ts
@@ -271,19 +271,28 @@ export async function reassignEventCreators(
   await reassignGenEventsRandomly(db, allUsers, genEvents);
 }
 
-/** Reassign first 2 original events to the raid leader (single query). */
+/** Reassign ALL original events round-robin across raid leaders. */
 async function reassignOrigEventsToRaidLeader(
   db: Db,
   userByName: Map<string, typeof schema.users.$inferSelect>,
   origEvents: (typeof schema.events.$inferSelect)[],
 ): Promise<void> {
-  const raidLeader = userByName.get(ROLE_ACCOUNTS[0].username);
-  if (!raidLeader || origEvents.length < 2) return;
-  const eventIds = origEvents.slice(0, 2).map((e) => e.id);
-  await db
-    .update(schema.events)
-    .set({ creatorId: raidLeader.id })
-    .where(inArray(schema.events.id, eventIds));
+  const raidLeaders = ROLE_ACCOUNTS.filter((a) => a.role === 'Raid Leader');
+  const byLeader = new Map<number, number[]>();
+  for (let i = 0; i < origEvents.length; i++) {
+    const leader = raidLeaders[i % raidLeaders.length];
+    const user = userByName.get(leader.username);
+    if (!user) continue;
+    const ids = byLeader.get(user.id) ?? [];
+    ids.push(origEvents[i].id);
+    byLeader.set(user.id, ids);
+  }
+  for (const [creatorId, eventIds] of byLeader) {
+    await db
+      .update(schema.events)
+      .set({ creatorId })
+      .where(inArray(schema.events.id, eventIds));
+  }
 }
 
 /** Randomly reassign ~30% of generated events to non-admin creators. */

--- a/api/src/admin/demo-data.constants.ts
+++ b/api/src/admin/demo-data.constants.ts
@@ -226,6 +226,8 @@ export const THEME_ASSIGNMENTS: Record<string, string> = {
 /** Role accounts for impersonation testing */
 export const ROLE_ACCOUNTS = [
   { username: 'ShadowMage', role: 'Raid Leader' },
+  { username: 'ProRaider', role: 'Raid Leader' },
+  { username: 'TankMaster', role: 'Raid Leader' },
   { username: 'CasualCarl', role: 'Player' },
 ] as const;
 
@@ -311,5 +313,9 @@ export function getGameTimeDefinitions(): {
 
 // Re-export from extracted modules for backward compatibility
 export { getAvailabilityDefinitions } from './demo-data-availability';
-export { getEventsDefinitions } from './demo-data-events';
+export {
+  getEventsDefinitions,
+  getEdgeCaseDefinitions,
+} from './demo-data-events';
+export type { EdgeCaseEvent } from './demo-data-events';
 export { getNotificationTemplates } from './demo-data-notifications';


### PR DESCRIPTION
## What
- Add ProRaider + TankMaster as raid leaders in `ROLE_ACCOUNTS` (3 total)
- Distribute ALL original + edge-case events round-robin across raid leaders
- Distribute ALL generated events round-robin across non-admin users (was 30%)
- Add 4 edge-case seed events: ad-hoc live, ad-hoc ended, cancelled, no-game
- Fix FK constraint error when clearing demo data (`community_lineups.linked_event_id`)

## Why
Impersonated users couldn't see organizer controls because all seeded events were owned by SeedAdmin (who can't be impersonated). Now every non-admin user owns events, enabling testing of reschedule/cancel/edit flows during impersonation.

## Acceptance criteria
- [x] ROLE_ACCOUNTS contains 3 raid leaders: ShadowMage, ProRaider, TankMaster
- [x] All original events distributed round-robin across raid leaders (none under SeedAdmin)
- [x] Ad-hoc live + ended events seeded
- [x] Cancelled event seeded
- [x] No-game event seeded
- [x] Demo data clear handles community_lineups FK

## Test plan
- [x] Integration tests added (6 tests, all passing)
- [x] CI passes (build + lint + type check + unit tests + integration tests)
- [x] Operator tested locally (impersonation + organizer controls verified)
- [x] Code review passed (APPROVED, no critical issues)
- [x] Architect review passed (PRE_DEV + POST_REVIEW both APPROVED)
- [x] Smoke tests passed (api: 377 suites/5173 tests, web: 215 suites/2794 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)