### PR TITLE
chore: batch 2026-04-15

### DIFF
--- a/api/src/common/testing/integration-helpers.ts
+++ b/api/src/common/testing/integration-helpers.ts
@@ -98,9 +98,15 @@ export async function truncateAllTables(
   `);
 
   if (tables.length > 0) {
-    const tableNames = tables.map((t) => t.tablename).join(', ');
     await retryOnDeadlock(() =>
-      db.execute(sql.raw(`TRUNCATE TABLE ${tableNames} CASCADE`)),
+      db.transaction(async (tx) => {
+        // Disable FK trigger checks for the session so DELETE order doesn't matter.
+        await tx.execute(sql`SET session_replication_role = 'replica'`);
+        for (const t of tables) {
+          await tx.execute(sql.raw(`DELETE FROM "${t.tablename}"`));
+        }
+        await tx.execute(sql`SET session_replication_role = 'origin'`);
+      }),
     );
   }
 

--- a/api/src/cron-jobs/cron-job.admin-helpers.ts
+++ b/api/src/cron-jobs/cron-job.admin-helpers.ts
@@ -2,7 +2,7 @@
  * Admin/runtime helpers for cron job management.
  * Extracted from cron-job.helpers.ts for file size compliance.
  */
-import { Logger } from '@nestjs/common';
+import { BadRequestException, Logger } from '@nestjs/common';
 import { SchedulerRegistry } from '@nestjs/schedule';
 import { CronTime } from 'cron';
 import { eq, desc } from 'drizzle-orm';
@@ -87,6 +87,32 @@ export function applyRuntimeSchedule(
       `Could not apply runtime schedule for "${name}": ${err instanceof Error ? err.message : err}`,
     );
   }
+}
+
+/** Validate and apply a schedule change, returning the updated row. */
+export async function updateJobSchedule(
+  db: Db,
+  registry: SchedulerRegistry,
+  id: number,
+  cronExpression: string,
+  logger: Logger,
+): Promise<CronJobRow | undefined> {
+  try {
+    new CronTime(cronExpression);
+  } catch {
+    throw new BadRequestException(
+      `Invalid cron expression: "${cronExpression}"`,
+    );
+  }
+  const nextRunAt = computeNextRun(cronExpression);
+  const [updated] = await db
+    .update(schema.cronJobs)
+    .set({ cronExpression, nextRunAt, updatedAt: new Date() })
+    .where(eq(schema.cronJobs.id, id))
+    .returning();
+  if (!updated) return updated;
+  applyRuntimeSchedule(registry, updated.name, cronExpression, logger);
+  return updated;
 }
 
 /** Update a job's paused state and return the updated row. */

--- a/api/src/cron-jobs/cron-job.constants.ts
+++ b/api/src/cron-jobs/cron-job.constants.ts
@@ -82,7 +82,7 @@ export const CORE_JOB_METADATA: Record<
   },
   ScheduledEventService_startScheduledEvents: {
     description:
-      'Auto-starts Discord scheduled events when their start time arrives every 30 seconds',
+      'Auto-starts Discord scheduled events when their start time arrives every 60 seconds',
     category: 'Events',
   },
   ScheduledEventService_completeScheduledEvents: {

--- a/api/src/cron-jobs/cron-job.constants.ts
+++ b/api/src/cron-jobs/cron-job.constants.ts
@@ -11,6 +11,9 @@ export const PRUNE_EVERY_N_EXECUTIONS = 50;
 /** How often (ms) to flush cached last_run_at updates to the DB */
 export const FLUSH_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
 
+/** Minimum interval (ms) between liveness heartbeat updates for no-op runs */
+export const NOOP_LIVENESS_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
 /**
  * Valid categories for cron jobs. Must match the `category` column values.
  */

--- a/api/src/cron-jobs/cron-job.helpers.spec.ts
+++ b/api/src/cron-jobs/cron-job.helpers.spec.ts
@@ -1,35 +1,54 @@
 import { createDrizzleMock, type MockDb } from '../common/testing/drizzle-mock';
-import { recordNoOp } from './cron-job.helpers';
+import {
+  recordNoOp,
+  recordCompleted,
+  recordFailed,
+  shouldUpdateLiveness,
+} from './cron-job.helpers';
+
+const mockJob = () => ({
+  id: 42,
+  name: 'test-job',
+  cronExpression: '0 * * * *',
+  source: 'core' as const,
+  pluginSlug: null,
+  description: null,
+  category: 'Maintenance',
+  paused: false,
+  lastRunAt: null as Date | null,
+  nextRunAt: null as Date | null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+});
 
 describe('recordNoOp', () => {
+  it('should NOT call db.insert (zero DB writes)', () => {
+    const mockDb = createDrizzleMock();
+    const startedAt = new Date('2025-01-01T00:00:00Z');
+    const finishedAt = new Date('2025-01-01T00:00:00.050Z');
+
+    // recordNoOp is now synchronous, no DB at all
+    recordNoOp('test-job', startedAt, finishedAt);
+
+    expect(mockDb.insert).not.toHaveBeenCalled();
+    expect(mockDb.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('recordCompleted', () => {
   let mockDb: MockDb;
 
   beforeEach(() => {
     mockDb = createDrizzleMock();
   });
 
-  it('should insert a no-op execution row with zero duration', async () => {
+  it('should insert an execution row and update the job', async () => {
     mockDb.values.mockReturnValueOnce(undefined);
-
-    const job = {
-      id: 42,
-      name: 'test-job',
-      cronExpression: '0 * * * *',
-      source: 'core',
-      pluginSlug: null,
-      description: null,
-      category: 'Maintenance',
-      paused: false,
-      lastRunAt: null,
-      nextRunAt: null,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
-
+    const job = mockJob();
     const startedAt = new Date('2025-01-01T00:00:00Z');
-    const finishedAt = new Date('2025-01-01T00:00:00.050Z');
+    const finishedAt = new Date('2025-01-01T00:00:01Z');
 
-    await recordNoOp(
+    await recordCompleted(
       mockDb as any,
       job as any,
       'test-job',
@@ -41,11 +60,68 @@ describe('recordNoOp', () => {
     expect(mockDb.values).toHaveBeenCalledWith(
       expect.objectContaining({
         cronJobId: 42,
-        status: 'no-op',
-        startedAt,
-        finishedAt,
-        durationMs: 50,
+        status: 'completed',
+        durationMs: 1000,
       }),
     );
+    expect(mockDb.update).toHaveBeenCalled();
+  });
+});
+
+describe('recordFailed', () => {
+  let mockDb: MockDb;
+
+  beforeEach(() => {
+    mockDb = createDrizzleMock();
+  });
+
+  it('should insert an execution row with error', async () => {
+    mockDb.values.mockReturnValueOnce(undefined);
+    const job = mockJob();
+    const startedAt = new Date('2025-01-01T00:00:00Z');
+    const finishedAt = new Date('2025-01-01T00:00:02Z');
+    const mockLogger = { error: jest.fn() } as any;
+
+    await recordFailed(
+      mockDb as any,
+      job as any,
+      'test-job',
+      startedAt,
+      finishedAt,
+      'boom',
+      mockLogger,
+    );
+
+    expect(mockDb.insert).toHaveBeenCalled();
+    expect(mockDb.values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cronJobId: 42,
+        status: 'failed',
+        error: 'boom',
+        durationMs: 2000,
+      }),
+    );
+    expect(mockLogger.error).toHaveBeenCalled();
+  });
+});
+
+describe('shouldUpdateLiveness', () => {
+  it('should return true when lastRunAt is null (first run)', () => {
+    expect(shouldUpdateLiveness(null, 300_000)).toBe(true);
+  });
+
+  it('should return false when lastRunAt is recent', () => {
+    const recent = new Date(Date.now() - 60_000); // 1 minute ago
+    expect(shouldUpdateLiveness(recent, 300_000)).toBe(false);
+  });
+
+  it('should return true when lastRunAt is stale', () => {
+    const stale = new Date(Date.now() - 600_000); // 10 minutes ago
+    expect(shouldUpdateLiveness(stale, 300_000)).toBe(true);
+  });
+
+  it('should return true when exactly at the interval boundary', () => {
+    const exact = new Date(Date.now() - 300_000); // exactly 5 minutes ago
+    expect(shouldUpdateLiveness(exact, 300_000)).toBe(true);
   });
 });

--- a/api/src/cron-jobs/cron-job.helpers.ts
+++ b/api/src/cron-jobs/cron-job.helpers.ts
@@ -110,14 +110,22 @@ async function recordExecution(
 }
 
 /** Record a no-op execution (handler ran but found nothing to do). */
-export async function recordNoOp(
-  db: Db,
-  job: CronJobRow,
+export function recordNoOp(
   jobName: string,
   startedAt: Date,
   finishedAt: Date,
-): Promise<void> {
-  await recordExecution(db, job, jobName, 'no-op', startedAt, finishedAt);
+): void {
+  const durationMs = finishedAt.getTime() - startedAt.getTime();
+  perfLog('CRON', jobName, durationMs, { status: 'no-op' });
+}
+
+/** Check whether enough time has elapsed for a liveness heartbeat update. */
+export function shouldUpdateLiveness(
+  lastRunAt: Date | null,
+  intervalMs: number,
+): boolean {
+  if (!lastRunAt) return true;
+  return Date.now() - lastRunAt.getTime() >= intervalMs;
 }
 
 /** Record a skipped (paused) execution. */

--- a/api/src/cron-jobs/cron-job.integration.spec.ts
+++ b/api/src/cron-jobs/cron-job.integration.spec.ts
@@ -158,6 +158,114 @@ function describeCronJob() {
   describe('executeWithTracking', () => describeExecuteWithTracking());
 
   // ===================================================================
+  // No-op Tracking (ROK-1042)
+  // ===================================================================
+
+  function describeNoOpTracking() {
+    it('should NOT insert execution row for no-op runs', async () => {
+      const jobId = await insertTestJob(testApp, 'test:noop-silent');
+      const cronJobService = testApp.app.get(CronJobService);
+
+      await cronJobService.executeWithTracking(
+        'test:noop-silent',
+        () => Promise.resolve(false),
+      );
+
+      const executions = await testApp.db
+        .select()
+        .from(schema.cronJobExecutions)
+        .where(eq(schema.cronJobExecutions.cronJobId, jobId));
+
+      expect(executions.length).toBe(0);
+    });
+
+    it('should NOT immediately update last_run_at for no-op runs', async () => {
+      const jobId = await insertTestJob(testApp, 'test:noop-no-update');
+      const cronJobService = testApp.app.get(CronJobService);
+
+      await cronJobService.executeWithTracking(
+        'test:noop-no-update',
+        () => Promise.resolve(false),
+      );
+
+      const [job] = await testApp.db
+        .select()
+        .from(schema.cronJobs)
+        .where(eq(schema.cronJobs.id, jobId))
+        .limit(1);
+
+      // last_run_at should not have been written directly to DB
+      // (it may be queued in pendingLastRunUpdates for liveness)
+      expect(job.lastRunAt).toBeNull();
+    });
+
+    it('should queue liveness update when lastRunAt is stale', async () => {
+      const staleDate = new Date(Date.now() - 10 * 60 * 1000); // 10 min ago
+      const jobId = await insertTestJob(testApp, 'test:noop-liveness', {
+        lastRunAt: staleDate,
+      });
+      const cronJobService = testApp.app.get(CronJobService);
+
+      await cronJobService.executeWithTracking(
+        'test:noop-liveness',
+        () => Promise.resolve(false),
+      );
+
+      // Flush pending updates to write to DB
+      await cronJobService.flushLastRunUpdates();
+
+      const [job] = await testApp.db
+        .select()
+        .from(schema.cronJobs)
+        .where(eq(schema.cronJobs.id, jobId))
+        .limit(1);
+
+      // last_run_at should have been updated via liveness flush
+      expect(job.lastRunAt).not.toBeNull();
+      expect(job.lastRunAt!.getTime()).toBeGreaterThan(staleDate.getTime());
+    });
+
+    it('should still fully track completed runs', async () => {
+      const jobId = await insertTestJob(testApp, 'test:completed-tracked');
+      const cronJobService = testApp.app.get(CronJobService);
+
+      await cronJobService.executeWithTracking(
+        'test:completed-tracked',
+        async () => {
+          /* did real work */
+        },
+      );
+
+      const executions = await testApp.db
+        .select()
+        .from(schema.cronJobExecutions)
+        .where(eq(schema.cronJobExecutions.cronJobId, jobId));
+
+      expect(executions.length).toBe(1);
+      expect(executions[0].status).toBe('completed');
+    });
+
+    it('should still fully track failed runs', async () => {
+      const jobId = await insertTestJob(testApp, 'test:failed-tracked');
+      const cronJobService = testApp.app.get(CronJobService);
+
+      await cronJobService.executeWithTracking('test:failed-tracked', () =>
+        Promise.reject(new Error('Intentional failure')),
+      );
+
+      const executions = await testApp.db
+        .select()
+        .from(schema.cronJobExecutions)
+        .where(eq(schema.cronJobExecutions.cronJobId, jobId));
+
+      expect(executions.length).toBe(1);
+      expect(executions[0].status).toBe('failed');
+      expect(executions[0].error).toBe('Intentional failure');
+    });
+  }
+  describe('no-op tracking (ROK-1042)', () => describeNoOpTracking());
+
+  // ===================================================================
   // Execution Pruning
   // ===================================================================
 

--- a/api/src/cron-jobs/cron-job.integration.spec.ts
+++ b/api/src/cron-jobs/cron-job.integration.spec.ts
@@ -166,9 +166,8 @@ function describeCronJob() {
       const jobId = await insertTestJob(testApp, 'test:noop-silent');
       const cronJobService = testApp.app.get(CronJobService);
 
-      await cronJobService.executeWithTracking(
-        'test:noop-silent',
-        () => Promise.resolve(false),
+      await cronJobService.executeWithTracking('test:noop-silent', () =>
+        Promise.resolve(false),
       );
 
       const executions = await testApp.db
@@ -183,9 +182,8 @@ function describeCronJob() {
       const jobId = await insertTestJob(testApp, 'test:noop-no-update');
       const cronJobService = testApp.app.get(CronJobService);
 
-      await cronJobService.executeWithTracking(
-        'test:noop-no-update',
-        () => Promise.resolve(false),
+      await cronJobService.executeWithTracking('test:noop-no-update', () =>
+        Promise.resolve(false),
       );
 
       const [job] = await testApp.db
@@ -206,9 +204,8 @@ function describeCronJob() {
       });
       const cronJobService = testApp.app.get(CronJobService);
 
-      await cronJobService.executeWithTracking(
-        'test:noop-liveness',
-        () => Promise.resolve(false),
+      await cronJobService.executeWithTracking('test:noop-liveness', () =>
+        Promise.resolve(false),
       );
 
       // Flush pending updates to write to DB

--- a/api/src/cron-jobs/cron-job.service.ts
+++ b/api/src/cron-jobs/cron-job.service.ts
@@ -1,5 +1,4 @@
 import {
-  BadRequestException,
   Inject,
   Injectable,
   Logger,
@@ -9,7 +8,6 @@ import {
 } from '@nestjs/common';
 import { SchedulerRegistry } from '@nestjs/schedule';
 import { OnEvent } from '@nestjs/event-emitter';
-import { CronTime } from 'cron';
 import { eq } from 'drizzle-orm';
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
@@ -40,10 +38,10 @@ import {
 } from './cron-job.helpers';
 import {
   getCronJobSafe,
-  applyRuntimeSchedule,
   setPaused,
   syncOnePluginRegistrar,
   getExecutionHistory,
+  updateJobSchedule,
 } from './cron-job.admin-helpers';
 
 type CronJobRow = typeof schema.cronJobs.$inferSelect;
@@ -317,27 +315,14 @@ export class CronJobService implements OnApplicationBootstrap, OnModuleDestroy {
 
   /** Update schedule (cron expression) for a job. */
   async updateSchedule(id: number, cronExpression: string) {
-    try {
-      new CronTime(cronExpression);
-    } catch {
-      throw new BadRequestException(
-        `Invalid cron expression: "${cronExpression}"`,
-      );
-    }
-    const nextRunAt = computeNextRun(cronExpression);
-    const [updated] = await this.db
-      .update(schema.cronJobs)
-      .set({ cronExpression, nextRunAt, updatedAt: new Date() })
-      .where(eq(schema.cronJobs.id, id))
-      .returning();
-    if (!updated) return updated;
-    this.jobCache.set(updated.name, updated);
-    applyRuntimeSchedule(
+    const updated = await updateJobSchedule(
+      this.db,
       this.schedulerRegistry,
-      updated.name,
+      id,
       cronExpression,
       this.logger,
     );
+    if (updated) this.jobCache.set(updated.name, updated);
     return updated;
   }
 

--- a/api/src/cron-jobs/cron-job.service.ts
+++ b/api/src/cron-jobs/cron-job.service.ts
@@ -22,6 +22,7 @@ import {
 import * as schema from '../drizzle/schema';
 import {
   FLUSH_INTERVAL_MS,
+  NOOP_LIVENESS_INTERVAL_MS,
   PRUNE_EVERY_N_EXECUTIONS,
 } from './cron-job.constants';
 import {
@@ -32,6 +33,7 @@ import {
   recordCompleted,
   recordFailed,
   recordNoOp,
+  shouldUpdateLiveness,
   extractRegistryJobMeta,
   flushPendingUpdates,
   recordSkippedTrigger,
@@ -188,29 +190,43 @@ export class CronJobService implements OnApplicationBootstrap, OnModuleDestroy {
     fn: () => Promise<void | boolean>,
   ): Promise<void> {
     const startedAt = new Date();
+    let didInsertRow = false;
     try {
       const result = await fn();
       const finishedAt = new Date();
       if (result === false) {
-        await recordNoOp(this.db, job, jobName, startedAt, finishedAt);
+        recordNoOp(jobName, startedAt, finishedAt);
+        this.queueLivenessIfStale(job);
       } else {
         await recordCompleted(this.db, job, jobName, startedAt, finishedAt);
+        didInsertRow = true;
       }
-    } catch (error) {
-      const finishedAt = new Date();
-      const msg = error instanceof Error ? error.message : String(error);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
       await recordFailed(
         this.db,
         job,
         jobName,
         startedAt,
-        finishedAt,
+        new Date(),
         msg,
         this.logger,
       );
+      didInsertRow = true;
     } finally {
-      await this.maybePrune(job, jobName);
+      if (didInsertRow) await this.maybePrune(job, jobName);
     }
+  }
+
+  /** Queue a liveness heartbeat if enough time has elapsed since last update. */
+  private queueLivenessIfStale(job: CronJobRow): void {
+    if (!shouldUpdateLiveness(job.lastRunAt, NOOP_LIVENESS_INTERVAL_MS)) return;
+    const now = new Date();
+    this.pendingLastRunUpdates.set(job.id, {
+      lastRunAt: now,
+      cronExpression: job.cronExpression,
+    });
+    job.lastRunAt = now;
   }
 
   /** Prune old executions periodically. */

--- a/api/src/discord-bot/services/scheduled-event.service.ts
+++ b/api/src/discord-bot/services/scheduled-event.service.ts
@@ -64,7 +64,7 @@ export class ScheduledEventService {
   ) {}
 
   /** Cron: auto-start Discord Scheduled Events whose start time has passed. */
-  @Cron('3,33 * * * * *', {
+  @Cron('0 * * * * *', {
     name: 'ScheduledEventService_startScheduledEvents',
   })
   async handleStartScheduledEvents(): Promise<void> {


### PR DESCRIPTION
## What

Batch of 3 small-scope tech-debt and performance stories:

| Story | Type | Description |
|-------|------|-------------|
| ROK-1050 | Tech Debt | Replace `TRUNCATE` with `DELETE FROM` in integration test teardown to eliminate CASCADE deadlocks |
| ROK-1042 | Performance | Skip cron tracking DB writes for no-op executions; add time-based liveness heartbeats |
| ROK-1044 | Performance | Reduce `startScheduledEvents` cron frequency from 30s to 60s |

## Why

- **ROK-1050:** `TRUNCATE ... CASCADE` intermittently deadlocked under concurrent integration tests. `DELETE FROM` with `session_replication_role='replica'` avoids the lock escalation.
- **ROK-1042:** High-frequency crons (every 30-60s) that find nothing to do were still writing execution rows and updating `last_run_at` on every tick — unnecessary DB load. Now no-ops skip DB entirely, with periodic liveness heartbeats via `pendingLastRunUpdates`.
- **ROK-1044:** 30-second polling was excessive for event start detection; 60s is sufficient and halves the cron overhead.

## Linear

ROK-1050, ROK-1042, ROK-1044

## Test plan

- [x] `validate-ci.sh --full` passes (build, typecheck, lint, tests+coverage, integration)
- [x] Unit tests: API 377 suites / 5192 tests, Web 215 suites / 2794 tests
- [x] Integration tests: 47 suites / 626 tests (including 5 new no-op tracking tests)
- [x] Playwright smoke tests: 456 passed (desktop + mobile)
- [x] No migration files — migration validation N/A
- [x] No Dockerfile changes — container startup N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)