### PR TITLE
ROK-1008: fix: deduplicate game search results across IGDB and ITAD sources

### DIFF
--- a/api/src/admin/admin.controller.ts
+++ b/api/src/admin/admin.controller.ts
@@ -1,4 +1,13 @@
-import { Controller, Get, Post, HttpCode, HttpStatus, UseGuards, Req, Inject } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  HttpCode,
+  HttpStatus,
+  UseGuards,
+  Req,
+  Inject,
+} from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { AdminGuard } from '../auth/admin.guard';

--- a/api/src/admin/admin.controller.ts
+++ b/api/src/admin/admin.controller.ts
@@ -1,18 +1,29 @@
-import { Controller, Get, UseGuards, Req } from '@nestjs/common';
+import { Controller, Get, Post, HttpCode, HttpStatus, UseGuards, Req, Inject } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { AdminGuard } from '../auth/admin.guard';
 import { RateLimit } from '../throttler/rate-limit.decorator';
 import {
   QueueHealthService,
   QueueHealthStatus,
 } from '../queue/queue-health.service';
+import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
+import * as schema from '../drizzle/schema';
 import type { AuthenticatedExpressRequest } from '../auth/types';
+import {
+  findDuplicateGames,
+  mergeAndDeleteDuplicates,
+} from '../igdb/igdb-dedup-cleanup.helpers';
 
 @RateLimit('admin')
 @Controller('admin')
 @UseGuards(AuthGuard('jwt'), AdminGuard)
 export class AdminController {
-  constructor(private readonly queueHealth: QueueHealthService) {}
+  constructor(
+    private readonly queueHealth: QueueHealthService,
+    @Inject(DrizzleAsyncProvider)
+    private readonly db: PostgresJsDatabase<typeof schema>,
+  ) {}
 
   @Get('check')
   checkAccess(@Req() req: AuthenticatedExpressRequest) {
@@ -26,5 +37,13 @@ export class AdminController {
   async getQueueHealth(): Promise<{ queues: QueueHealthStatus[] }> {
     const queues = await this.queueHealth.getHealthStatus();
     return { queues };
+  }
+
+  /** One-time cleanup: find and merge duplicate game rows (ROK-1008). */
+  @Post('games/dedup-cleanup')
+  @HttpCode(HttpStatus.OK)
+  async dedupCleanup(): Promise<{ merged: number; errors: string[] }> {
+    const groups = await findDuplicateGames(this.db);
+    return mergeAndDeleteDuplicates(this.db, groups);
   }
 }

--- a/api/src/common/search.util.ts
+++ b/api/src/common/search.util.ts
@@ -48,12 +48,22 @@ export function buildWordMatchFilters(column: Column, query: string): SQL[] {
 }
 
 const ARABIC_TO_ROMAN: Record<string, string> = {
-  '2': 'II', '3': 'III', '4': 'IV', '5': 'V',
-  '6': 'VI', '7': 'VII', '8': 'VIII',
+  '2': 'II',
+  '3': 'III',
+  '4': 'IV',
+  '5': 'V',
+  '6': 'VI',
+  '7': 'VII',
+  '8': 'VIII',
 };
 const ROMAN_TO_ARABIC: Record<string, string> = {
-  ii: '2', iii: '3', iv: '4', v: '5',
-  vi: '6', vii: '7', viii: '8',
+  ii: '2',
+  iii: '3',
+  iv: '4',
+  v: '5',
+  vi: '6',
+  vii: '7',
+  viii: '8',
 };
 
 /** Return the Roman/Arabic alternative for a word, or null if none. */

--- a/api/src/common/search.util.ts
+++ b/api/src/common/search.util.ts
@@ -1,4 +1,4 @@
-import { ilike, type Column, type SQL } from 'drizzle-orm';
+import { ilike, or, type Column, type SQL } from 'drizzle-orm';
 
 /**
  * Strip punctuation from a search query, leaving only alphanumeric
@@ -37,5 +37,27 @@ export function buildWordMatchFilters(column: Column, query: string): SQL[] {
   const normalized = stripSearchPunctuation(query).toLowerCase();
   const words = normalized.split(/\s+/).filter((w) => w.length > 0);
   if (words.length === 0) return [];
-  return words.map((word) => ilike(column, `%${escapeLikePattern(word)}%`));
+  return words.map((word) => {
+    const alt = romanArabicAlt(word);
+    if (!alt) return ilike(column, `%${escapeLikePattern(word)}%`);
+    return or(
+      ilike(column, `%${escapeLikePattern(word)}%`),
+      ilike(column, `%${escapeLikePattern(alt)}%`),
+    )!;
+  });
+}
+
+const ARABIC_TO_ROMAN: Record<string, string> = {
+  '2': 'II', '3': 'III', '4': 'IV', '5': 'V',
+  '6': 'VI', '7': 'VII', '8': 'VIII',
+};
+const ROMAN_TO_ARABIC: Record<string, string> = {
+  ii: '2', iii: '3', iv: '4', v: '5',
+  vi: '6', vii: '7', viii: '8',
+};
+
+/** Return the Roman/Arabic alternative for a word, or null if none. */
+function romanArabicAlt(word: string): string | null {
+  if (ARABIC_TO_ROMAN[word]) return ARABIC_TO_ROMAN[word];
+  return ROMAN_TO_ARABIC[word.toLowerCase()] ?? null;
 }

--- a/api/src/igdb/igdb-dedup-cleanup.helpers.spec.ts
+++ b/api/src/igdb/igdb-dedup-cleanup.helpers.spec.ts
@@ -1,0 +1,244 @@
+/**
+ * Unit tests for game deduplication DB cleanup helpers (ROK-1008 ACs 9-10).
+ *
+ * Tests the one-time cleanup logic that finds duplicate game rows in the DB
+ * and merges them by reassigning FK references to the winner row.
+ */
+import { createDrizzleMock, type MockDb } from '../common/testing/drizzle-mock';
+import {
+  findDuplicateGames,
+  mergeAndDeleteDuplicates,
+  type DuplicateGroup,
+} from './igdb-dedup-cleanup.helpers';
+
+// ─── Test data ────────────────────────────────────────────────────────────
+
+/** Build a DuplicateGroup for testing. */
+function makeGroup(
+  winnerId: number,
+  loserIds: number[],
+): DuplicateGroup {
+  return { winnerId, loserIds };
+}
+
+// ─── findDuplicateGames ───────────────────────────────────────────────────
+
+describe('findDuplicateGames', () => {
+  let mockDb: MockDb;
+
+  beforeEach(() => {
+    mockDb = createDrizzleMock();
+  });
+
+  it('returns groups from both steamAppId and igdbId duplicates', async () => {
+    const steamDups = [
+      { key_val: 646570, ids: [1, 2], itad_ids: [null, 2] },
+    ];
+    const igdbDups = [
+      { key_val: 12345, ids: [3, 4], itad_ids: [3, null] },
+    ];
+
+    // findDupsBySteamAppId: db.execute()
+    mockDb.execute.mockResolvedValueOnce(steamDups);
+    // findDupsByIgdbId: db.execute()
+    mockDb.execute.mockResolvedValueOnce(igdbDups);
+
+    const result = await findDuplicateGames(mockDb as never);
+
+    expect(result).toHaveLength(2);
+    // steamAppId group: ITAD row (id=2) wins
+    expect(result[0]).toEqual({ winnerId: 2, loserIds: [1] });
+    // igdbId group: ITAD row (id=3) wins
+    expect(result[1]).toEqual({ winnerId: 3, loserIds: [4] });
+  });
+
+  it('returns empty array when no duplicates exist', async () => {
+    mockDb.execute.mockResolvedValueOnce([]);
+    mockDb.execute.mockResolvedValueOnce([]);
+
+    const result = await findDuplicateGames(mockDb as never);
+
+    expect(result).toEqual([]);
+  });
+
+  it('picks first id as winner when no ITAD row exists', async () => {
+    const steamDups = [
+      { key_val: 100, ids: [5, 6], itad_ids: [null, null] },
+    ];
+
+    mockDb.execute.mockResolvedValueOnce(steamDups);
+    mockDb.execute.mockResolvedValueOnce([]);
+
+    const result = await findDuplicateGames(mockDb as never);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ winnerId: 5, loserIds: [6] });
+  });
+
+  it('handles multiple losers in a single group', async () => {
+    const steamDups = [
+      { key_val: 200, ids: [10, 11, 12], itad_ids: [10, null, null] },
+    ];
+
+    mockDb.execute.mockResolvedValueOnce(steamDups);
+    mockDb.execute.mockResolvedValueOnce([]);
+
+    const result = await findDuplicateGames(mockDb as never);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].winnerId).toBe(10);
+    expect(result[0].loserIds).toEqual(expect.arrayContaining([11, 12]));
+    expect(result[0].loserIds).toHaveLength(2);
+  });
+
+  it('deduplicates overlapping groups that share a winner', async () => {
+    // Both steam and igdb find the same pair as duplicates
+    const steamDups = [
+      { key_val: 300, ids: [20, 21], itad_ids: [20, null] },
+    ];
+    const igdbDups = [
+      { key_val: 400, ids: [20, 22], itad_ids: [20, null] },
+    ];
+
+    mockDb.execute.mockResolvedValueOnce(steamDups);
+    mockDb.execute.mockResolvedValueOnce(igdbDups);
+
+    const result = await findDuplicateGames(mockDb as never);
+
+    // Should merge into a single group with winner=20
+    expect(result).toHaveLength(1);
+    expect(result[0].winnerId).toBe(20);
+    expect(result[0].loserIds).toEqual(expect.arrayContaining([21, 22]));
+    expect(result[0].loserIds).toHaveLength(2);
+  });
+});
+
+// ─── mergeAndDeleteDuplicates ─────────────────────────────────────────────
+
+describe('mergeAndDeleteDuplicates', () => {
+  let mockDb: MockDb;
+
+  beforeEach(() => {
+    mockDb = createDrizzleMock();
+  });
+
+  it('returns merged count for successfully processed groups', async () => {
+    const groups = [
+      makeGroup(1, [2]),
+      makeGroup(3, [4, 5]),
+    ];
+
+    // Each mergeGroup call uses a transaction
+    // transaction mock already delegates to cb(mockDb)
+    // Inside: reassignEventFks, reassignLineupFks, reassignMiscFks, delete
+    // All of these use execute() or delete().where() chains
+    // The flat mock handles them all by default
+
+    const result = await mergeAndDeleteDuplicates(mockDb as never, groups);
+
+    expect(result.merged).toBe(2);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('returns zero merged when given empty groups', async () => {
+    const result = await mergeAndDeleteDuplicates(mockDb as never, []);
+
+    expect(result).toEqual({ merged: 0, errors: [] });
+  });
+
+  it('captures errors for failed groups and continues processing', async () => {
+    const groups = [
+      makeGroup(1, [2]),
+      makeGroup(3, [4]),
+      makeGroup(5, [6]),
+    ];
+
+    // First group succeeds (default transaction mock works)
+    // Second group: make the transaction throw
+    let callCount = 0;
+    mockDb.transaction.mockImplementation(async (fn) => {
+      callCount++;
+      if (callCount === 2) {
+        throw new Error('FK constraint violation');
+      }
+      return fn(mockDb);
+    });
+
+    const result = await mergeAndDeleteDuplicates(mockDb as never, groups);
+
+    expect(result.merged).toBe(2);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('winner=3');
+    expect(result.errors[0]).toContain('FK constraint violation');
+  });
+
+  it('reports all errors when every group fails', async () => {
+    const groups = [makeGroup(1, [2]), makeGroup(3, [4])];
+
+    mockDb.transaction.mockRejectedValue(new Error('DB down'));
+
+    const result = await mergeAndDeleteDuplicates(mockDb as never, groups);
+
+    expect(result.merged).toBe(0);
+    expect(result.errors).toHaveLength(2);
+  });
+
+  it('calls transaction for each group to ensure atomicity', async () => {
+    const groups = [makeGroup(10, [11]), makeGroup(20, [21])];
+
+    await mergeAndDeleteDuplicates(mockDb as never, groups);
+
+    expect(mockDb.transaction).toHaveBeenCalledTimes(2);
+  });
+
+  it('deletes loser rows inside the transaction', async () => {
+    const groups = [makeGroup(100, [101, 102])];
+
+    await mergeAndDeleteDuplicates(mockDb as never, groups);
+
+    // delete() is called once per loser (2 losers)
+    expect(mockDb.delete).toHaveBeenCalledTimes(2);
+  });
+
+  it('calls FK reassignment helpers for each loser', async () => {
+    const groups = [makeGroup(50, [51])];
+
+    await mergeAndDeleteDuplicates(mockDb as never, groups);
+
+    // Each loser triggers execute() calls for FK reassignment
+    // (safeReassign, safeReassignWithUnique, updateTiedGameIds, etc.)
+    expect(mockDb.execute).toHaveBeenCalled();
+  });
+});
+
+// ─── AC 10: admin endpoint return shape ───────────────────────────────────
+
+describe('mergeAndDeleteDuplicates return shape (AC 10)', () => {
+  it('returns { merged: number, errors: string[] } structure', async () => {
+    const mockDb = createDrizzleMock();
+    const groups = [makeGroup(1, [2])];
+
+    const result = await mergeAndDeleteDuplicates(mockDb as never, groups);
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        merged: expect.any(Number),
+        errors: expect.any(Array),
+      }),
+    );
+  });
+
+  it('merged count equals number of successfully processed groups', async () => {
+    const mockDb = createDrizzleMock();
+    const groups = [
+      makeGroup(1, [2]),
+      makeGroup(3, [4]),
+      makeGroup(5, [6]),
+    ];
+
+    const result = await mergeAndDeleteDuplicates(mockDb as never, groups);
+
+    expect(result.merged).toBe(3);
+    expect(result.errors).toHaveLength(0);
+  });
+});

--- a/api/src/igdb/igdb-dedup-cleanup.helpers.spec.ts
+++ b/api/src/igdb/igdb-dedup-cleanup.helpers.spec.ts
@@ -14,10 +14,7 @@ import {
 // ─── Test data ────────────────────────────────────────────────────────────
 
 /** Build a DuplicateGroup for testing. */
-function makeGroup(
-  winnerId: number,
-  loserIds: number[],
-): DuplicateGroup {
+function makeGroup(winnerId: number, loserIds: number[]): DuplicateGroup {
   return { winnerId, loserIds };
 }
 
@@ -31,12 +28,8 @@ describe('findDuplicateGames', () => {
   });
 
   it('returns groups from both steamAppId and igdbId duplicates', async () => {
-    const steamDups = [
-      { key_val: 646570, ids: [1, 2], itad_ids: [null, 2] },
-    ];
-    const igdbDups = [
-      { key_val: 12345, ids: [3, 4], itad_ids: [3, null] },
-    ];
+    const steamDups = [{ key_val: 646570, ids: [1, 2], itad_ids: [null, 2] }];
+    const igdbDups = [{ key_val: 12345, ids: [3, 4], itad_ids: [3, null] }];
 
     // findDupsBySteamAppId: db.execute()
     mockDb.execute.mockResolvedValueOnce(steamDups);
@@ -62,9 +55,7 @@ describe('findDuplicateGames', () => {
   });
 
   it('picks first id as winner when no ITAD row exists', async () => {
-    const steamDups = [
-      { key_val: 100, ids: [5, 6], itad_ids: [null, null] },
-    ];
+    const steamDups = [{ key_val: 100, ids: [5, 6], itad_ids: [null, null] }];
 
     mockDb.execute.mockResolvedValueOnce(steamDups);
     mockDb.execute.mockResolvedValueOnce([]);
@@ -93,12 +84,8 @@ describe('findDuplicateGames', () => {
 
   it('deduplicates overlapping groups that share a winner', async () => {
     // Both steam and igdb find the same pair as duplicates
-    const steamDups = [
-      { key_val: 300, ids: [20, 21], itad_ids: [20, null] },
-    ];
-    const igdbDups = [
-      { key_val: 400, ids: [20, 22], itad_ids: [20, null] },
-    ];
+    const steamDups = [{ key_val: 300, ids: [20, 21], itad_ids: [20, null] }];
+    const igdbDups = [{ key_val: 400, ids: [20, 22], itad_ids: [20, null] }];
 
     mockDb.execute.mockResolvedValueOnce(steamDups);
     mockDb.execute.mockResolvedValueOnce(igdbDups);
@@ -123,10 +110,7 @@ describe('mergeAndDeleteDuplicates', () => {
   });
 
   it('returns merged count for successfully processed groups', async () => {
-    const groups = [
-      makeGroup(1, [2]),
-      makeGroup(3, [4, 5]),
-    ];
+    const groups = [makeGroup(1, [2]), makeGroup(3, [4, 5])];
 
     // Each mergeGroup call uses a transaction
     // transaction mock already delegates to cb(mockDb)
@@ -147,22 +131,20 @@ describe('mergeAndDeleteDuplicates', () => {
   });
 
   it('captures errors for failed groups and continues processing', async () => {
-    const groups = [
-      makeGroup(1, [2]),
-      makeGroup(3, [4]),
-      makeGroup(5, [6]),
-    ];
+    const groups = [makeGroup(1, [2]), makeGroup(3, [4]), makeGroup(5, [6])];
 
     // First group succeeds (default transaction mock works)
     // Second group: make the transaction throw
     let callCount = 0;
-    mockDb.transaction.mockImplementation(async (fn) => {
-      callCount++;
-      if (callCount === 2) {
-        throw new Error('FK constraint violation');
-      }
-      return fn(mockDb);
-    });
+    mockDb.transaction.mockImplementation(
+      (fn: (tx: unknown) => Promise<void>) => {
+        callCount++;
+        if (callCount === 2) {
+          return Promise.reject(new Error('FK constraint violation'));
+        }
+        return fn(mockDb);
+      },
+    );
 
     const result = await mergeAndDeleteDuplicates(mockDb as never, groups);
 
@@ -230,11 +212,7 @@ describe('mergeAndDeleteDuplicates return shape (AC 10)', () => {
 
   it('merged count equals number of successfully processed groups', async () => {
     const mockDb = createDrizzleMock();
-    const groups = [
-      makeGroup(1, [2]),
-      makeGroup(3, [4]),
-      makeGroup(5, [6]),
-    ];
+    const groups = [makeGroup(1, [2]), makeGroup(3, [4]), makeGroup(5, [6])];
 
     const result = await mergeAndDeleteDuplicates(mockDb as never, groups);
 

--- a/api/src/igdb/igdb-dedup-cleanup.helpers.ts
+++ b/api/src/igdb/igdb-dedup-cleanup.helpers.ts
@@ -117,9 +117,7 @@ async function mergeGroup(
       await reassignEventFks(tx, loserId, group.winnerId);
       await reassignLineupFks(tx, loserId, group.winnerId);
       await reassignMiscFks(tx, loserId, group.winnerId);
-      await tx
-        .delete(schema.games)
-        .where(eq(schema.games.id, loserId));
+      await tx.delete(schema.games).where(eq(schema.games.id, loserId));
     }
   });
 }

--- a/api/src/igdb/igdb-dedup-cleanup.helpers.ts
+++ b/api/src/igdb/igdb-dedup-cleanup.helpers.ts
@@ -1,0 +1,125 @@
+/**
+ * One-time DB cleanup for duplicate game rows (ROK-1008).
+ * Finds games sharing the same steamAppId or igdbId and merges them,
+ * reassigning FK references to the winner row.
+ */
+import { sql, eq } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from '../drizzle/schema';
+import {
+  reassignEventFks,
+  reassignLineupFks,
+  reassignMiscFks,
+} from './igdb-dedup-fk-reassign.helpers';
+
+/** A group of duplicate games with a designated winner and losers. */
+export interface DuplicateGroup {
+  winnerId: number;
+  loserIds: number[];
+}
+
+/** Find duplicate game rows grouped by steamAppId or igdbId. */
+export async function findDuplicateGames(
+  db: PostgresJsDatabase<typeof schema>,
+): Promise<DuplicateGroup[]> {
+  const steamDups = await findDupsBySteamAppId(db);
+  const igdbDups = await findDupsByIgdbId(db);
+  return deduplicateGroups([...steamDups, ...igdbDups]);
+}
+
+/** Merge and delete duplicate game rows in a transaction. */
+export async function mergeAndDeleteDuplicates(
+  db: PostgresJsDatabase<typeof schema>,
+  groups: DuplicateGroup[],
+): Promise<{ merged: number; errors: string[] }> {
+  let merged = 0;
+  const errors: string[] = [];
+
+  for (const group of groups) {
+    try {
+      await mergeGroup(db, group);
+      merged++;
+    } catch (err) {
+      errors.push(`Group winner=${group.winnerId}: ${err}`);
+    }
+  }
+
+  return { merged, errors };
+}
+
+/** Find duplicates by steamAppId. */
+async function findDupsBySteamAppId(
+  db: PostgresJsDatabase<typeof schema>,
+): Promise<DuplicateGroup[]> {
+  const g = schema.games;
+  const rows = await db.execute(sql`
+    SELECT ${g.steamAppId} AS key_val, array_agg(${g.id}) AS ids,
+           array_agg(CASE WHEN ${g.itadGameId} IS NOT NULL THEN ${g.id} END) AS itad_ids
+    FROM ${g}
+    WHERE ${g.steamAppId} IS NOT NULL
+    GROUP BY ${g.steamAppId}
+    HAVING count(*) > 1
+  `);
+  return (rows as unknown as DupRow[]).map(buildGroupFromRow);
+}
+
+/** Find duplicates by igdbId. */
+async function findDupsByIgdbId(
+  db: PostgresJsDatabase<typeof schema>,
+): Promise<DuplicateGroup[]> {
+  const g = schema.games;
+  const rows = await db.execute(sql`
+    SELECT ${g.igdbId} AS key_val, array_agg(${g.id}) AS ids,
+           array_agg(CASE WHEN ${g.itadGameId} IS NOT NULL THEN ${g.id} END) AS itad_ids
+    FROM ${g}
+    WHERE ${g.igdbId} IS NOT NULL
+    GROUP BY ${g.igdbId}
+    HAVING count(*) > 1
+  `);
+  return (rows as unknown as DupRow[]).map(buildGroupFromRow);
+}
+
+interface DupRow {
+  key_val: number;
+  ids: number[];
+  itad_ids: (number | null)[];
+}
+
+/** Build a DuplicateGroup from a raw DB row. */
+function buildGroupFromRow(row: DupRow): DuplicateGroup {
+  const itadId = row.itad_ids.find((id) => id != null);
+  const winnerId = itadId ?? row.ids[0];
+  const loserIds = row.ids.filter((id) => id !== winnerId);
+  return { winnerId, loserIds };
+}
+
+/** Deduplicate groups that may share the same winner. */
+function deduplicateGroups(groups: DuplicateGroup[]): DuplicateGroup[] {
+  const byWinner = new Map<number, Set<number>>();
+  for (const g of groups) {
+    const existing = byWinner.get(g.winnerId) ?? new Set<number>();
+    for (const id of g.loserIds) existing.add(id);
+    byWinner.set(g.winnerId, existing);
+  }
+  return Array.from(byWinner.entries()).map(([winnerId, loserSet]) => ({
+    winnerId,
+    loserIds: [...loserSet],
+  }));
+}
+
+/** Merge a single duplicate group: reassign FKs and delete losers. */
+async function mergeGroup(
+  db: PostgresJsDatabase<typeof schema>,
+  group: DuplicateGroup,
+): Promise<void> {
+  await db.transaction(async (tx) => {
+    for (const loserId of group.loserIds) {
+      await reassignEventFks(tx, loserId, group.winnerId);
+      await reassignLineupFks(tx, loserId, group.winnerId);
+      await reassignMiscFks(tx, loserId, group.winnerId);
+      await tx
+        .delete(schema.games)
+        .where(eq(schema.games.id, loserId));
+    }
+  });
+}

--- a/api/src/igdb/igdb-dedup-cleanup.helpers.ts
+++ b/api/src/igdb/igdb-dedup-cleanup.helpers.ts
@@ -54,7 +54,8 @@ async function findDupsBySteamAppId(
   const g = schema.games;
   const rows = await db.execute(sql`
     SELECT ${g.steamAppId} AS key_val, array_agg(${g.id}) AS ids,
-           array_agg(CASE WHEN ${g.itadGameId} IS NOT NULL THEN ${g.id} END) AS itad_ids
+           array_agg(CASE WHEN ${g.itadGameId} IS NOT NULL THEN ${g.id} END) AS itad_ids,
+           array_agg(CASE WHEN ${g.igdbId} IS NOT NULL THEN ${g.id} END) AS igdb_ids
     FROM ${g}
     WHERE ${g.steamAppId} IS NOT NULL
     GROUP BY ${g.steamAppId}
@@ -70,7 +71,8 @@ async function findDupsByIgdbId(
   const g = schema.games;
   const rows = await db.execute(sql`
     SELECT ${g.igdbId} AS key_val, array_agg(${g.id}) AS ids,
-           array_agg(CASE WHEN ${g.itadGameId} IS NOT NULL THEN ${g.id} END) AS itad_ids
+           array_agg(CASE WHEN ${g.itadGameId} IS NOT NULL THEN ${g.id} END) AS itad_ids,
+           array_agg(CASE WHEN ${g.igdbId} IS NOT NULL THEN ${g.id} END) AS igdb_ids
     FROM ${g}
     WHERE ${g.igdbId} IS NOT NULL
     GROUP BY ${g.igdbId}
@@ -81,15 +83,36 @@ async function findDupsByIgdbId(
 
 interface DupRow {
   key_val: number;
-  ids: number[];
-  itad_ids: (number | null)[];
+  ids: number[] | string;
+  itad_ids: number[] | string;
+  igdb_ids: number[] | string;
+}
+
+/** Parse a PostgreSQL array value (may be a string or already an array). */
+function parsePgArray(val: number[] | string): number[] {
+  if (Array.isArray(val)) {
+    return val.filter((n): n is number => typeof n === 'number' && !isNaN(n));
+  }
+  if (typeof val !== 'string') return [];
+  return val
+    .replace(/[{}]/g, '')
+    .split(',')
+    .map((s) => parseInt(s.trim(), 10))
+    .filter((n) => !isNaN(n));
 }
 
 /** Build a DuplicateGroup from a raw DB row. */
 function buildGroupFromRow(row: DupRow): DuplicateGroup {
-  const itadId = row.itad_ids.find((id) => id != null);
-  const winnerId = itadId ?? row.ids[0];
-  const loserIds = row.ids.filter((id) => id !== winnerId);
+  const ids = parsePgArray(row.ids);
+  const itadIds = new Set(parsePgArray(row.itad_ids));
+  const igdbIds = new Set(parsePgArray(row.igdb_ids));
+  // Prefer game with both IGDB+ITAD, then IGDB only, then ITAD only
+  const winnerId =
+    ids.find((id) => igdbIds.has(id) && itadIds.has(id)) ??
+    ids.find((id) => igdbIds.has(id)) ??
+    ids.find((id) => itadIds.has(id)) ??
+    ids[0];
+  const loserIds = ids.filter((id) => id !== winnerId);
   return { winnerId, loserIds };
 }
 

--- a/api/src/igdb/igdb-dedup-fk-reassign.helpers.ts
+++ b/api/src/igdb/igdb-dedup-fk-reassign.helpers.ts
@@ -3,7 +3,7 @@
  * Moves foreign key references from loser game rows to the winner,
  * handling unique constraint violations by skipping conflicting rows.
  */
-import { eq, sql } from 'drizzle-orm';
+import { sql } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type * as schema from '../drizzle/schema';
 
@@ -39,7 +39,6 @@ export async function reassignLineupFks(
     'game_id',
     loserId,
     winnerId,
-    'uq_lineup_entry_game',
   );
   await safeReassignWithUnique(
     tx,
@@ -47,7 +46,6 @@ export async function reassignLineupFks(
     'game_id',
     loserId,
     winnerId,
-    'uq_lineup_vote_user_game',
   );
   await reassignLineupMatchFks(tx, loserId, winnerId);
 }
@@ -64,7 +62,6 @@ async function reassignLineupMatchFks(
     'game_id',
     loserId,
     winnerId,
-    'uq_lineup_match_game',
   );
   await reassignTiebreakerFks(tx, loserId, winnerId);
 }
@@ -123,13 +120,7 @@ export async function reassignMiscFks(
   loserId: number,
   winnerId: number,
 ): Promise<void> {
-  await safeReassign(
-    tx,
-    'discord_game_mappings',
-    'game_id',
-    loserId,
-    winnerId,
-  );
+  await safeReassign(tx, 'discord_game_mappings', 'game_id', loserId, winnerId);
   await safeReassign(tx, 'channel_bindings', 'game_id', loserId, winnerId);
   await safeReassignWithUnique(
     tx,
@@ -137,7 +128,6 @@ export async function reassignMiscFks(
     'game_id',
     loserId,
     winnerId,
-    'uq_user_game_suppression',
   );
 }
 
@@ -166,7 +156,6 @@ async function safeReassignWithUnique(
   column: string,
   loserId: number,
   winnerId: number,
-  _constraintName: string,
 ): Promise<void> {
   // Delete loser rows that would conflict with existing winner rows
   await deleteConflictingRows(tx, table, column, loserId, winnerId);

--- a/api/src/igdb/igdb-dedup-fk-reassign.helpers.ts
+++ b/api/src/igdb/igdb-dedup-fk-reassign.helpers.ts
@@ -1,0 +1,230 @@
+/**
+ * FK reassignment helpers for game deduplication cleanup (ROK-1008).
+ * Moves foreign key references from loser game rows to the winner,
+ * handling unique constraint violations by skipping conflicting rows.
+ */
+import { eq, sql } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import type * as schema from '../drizzle/schema';
+
+type Tx = Parameters<
+  Parameters<PostgresJsDatabase<typeof schema>['transaction']>[0]
+>[0];
+
+/** Reassign event-related FKs from loser to winner. */
+export async function reassignEventFks(
+  tx: Tx,
+  loserId: number,
+  winnerId: number,
+): Promise<void> {
+  await safeReassign(tx, 'events', 'game_id', loserId, winnerId);
+}
+
+/** Reassign community lineup FKs from loser to winner. */
+export async function reassignLineupFks(
+  tx: Tx,
+  loserId: number,
+  winnerId: number,
+): Promise<void> {
+  await safeReassign(
+    tx,
+    'community_lineups',
+    'decided_game_id',
+    loserId,
+    winnerId,
+  );
+  await safeReassignWithUnique(
+    tx,
+    'community_lineup_entries',
+    'game_id',
+    loserId,
+    winnerId,
+    'uq_lineup_entry_game',
+  );
+  await safeReassignWithUnique(
+    tx,
+    'community_lineup_votes',
+    'game_id',
+    loserId,
+    winnerId,
+    'uq_lineup_vote_user_game',
+  );
+  await reassignLineupMatchFks(tx, loserId, winnerId);
+}
+
+/** Reassign lineup match and tiebreaker FKs. */
+async function reassignLineupMatchFks(
+  tx: Tx,
+  loserId: number,
+  winnerId: number,
+): Promise<void> {
+  await safeReassignWithUnique(
+    tx,
+    'community_lineup_matches',
+    'game_id',
+    loserId,
+    winnerId,
+    'uq_lineup_match_game',
+  );
+  await reassignTiebreakerFks(tx, loserId, winnerId);
+}
+
+/** Reassign tiebreaker-related FKs. */
+async function reassignTiebreakerFks(
+  tx: Tx,
+  loserId: number,
+  winnerId: number,
+): Promise<void> {
+  // tiebreakers.winnerGameId
+  await safeReassign(
+    tx,
+    'community_lineup_tiebreakers',
+    'winner_game_id',
+    loserId,
+    winnerId,
+  );
+  // tiebreakers.tiedGameIds (jsonb array)
+  await updateTiedGameIds(tx, loserId, winnerId);
+  // bracket matchups (gameAId, gameBId, winnerGameId)
+  await reassignBracketFks(tx, loserId, winnerId);
+  // bracket votes
+  await safeReassign(
+    tx,
+    'community_lineup_tiebreaker_bracket_votes',
+    'game_id',
+    loserId,
+    winnerId,
+  );
+  // vetoes
+  await safeReassign(
+    tx,
+    'community_lineup_tiebreaker_vetoes',
+    'game_id',
+    loserId,
+    winnerId,
+  );
+}
+
+/** Reassign bracket matchup FK columns. */
+async function reassignBracketFks(
+  tx: Tx,
+  loserId: number,
+  winnerId: number,
+): Promise<void> {
+  const table = 'community_lineup_tiebreaker_bracket_matchups';
+  await safeReassign(tx, table, 'game_a_id', loserId, winnerId);
+  await safeReassign(tx, table, 'game_b_id', loserId, winnerId);
+  await safeReassign(tx, table, 'winner_game_id', loserId, winnerId);
+}
+
+/** Reassign misc FKs: discord mappings, channel bindings, suppressions. */
+export async function reassignMiscFks(
+  tx: Tx,
+  loserId: number,
+  winnerId: number,
+): Promise<void> {
+  await safeReassign(
+    tx,
+    'discord_game_mappings',
+    'game_id',
+    loserId,
+    winnerId,
+  );
+  await safeReassign(tx, 'channel_bindings', 'game_id', loserId, winnerId);
+  await safeReassignWithUnique(
+    tx,
+    'game_interest_suppressions',
+    'game_id',
+    loserId,
+    winnerId,
+    'uq_user_game_suppression',
+  );
+}
+
+/** Simple FK reassignment (no unique constraints to worry about). */
+async function safeReassign(
+  tx: Tx,
+  table: string,
+  column: string,
+  loserId: number,
+  winnerId: number,
+): Promise<void> {
+  await tx.execute(
+    sql.raw(
+      `UPDATE ${table} SET ${column} = ${winnerId} WHERE ${column} = ${loserId}`,
+    ),
+  );
+}
+
+/**
+ * FK reassignment with unique constraint handling.
+ * Deletes conflicting rows before reassignment.
+ */
+async function safeReassignWithUnique(
+  tx: Tx,
+  table: string,
+  column: string,
+  loserId: number,
+  winnerId: number,
+  _constraintName: string,
+): Promise<void> {
+  // Delete loser rows that would conflict with existing winner rows
+  await deleteConflictingRows(tx, table, column, loserId, winnerId);
+  await safeReassign(tx, table, column, loserId, winnerId);
+}
+
+/** Delete rows for loserId that would conflict with winnerId. */
+async function deleteConflictingRows(
+  tx: Tx,
+  table: string,
+  column: string,
+  loserId: number,
+  winnerId: number,
+): Promise<void> {
+  // Get context columns for the unique constraint
+  const contextCol = getContextColumn(table);
+  if (!contextCol) return;
+
+  await tx.execute(
+    sql.raw(
+      `DELETE FROM ${table} AS l
+       USING ${table} AS w
+       WHERE l.${column} = ${loserId}
+         AND w.${column} = ${winnerId}
+         AND l.${contextCol} = w.${contextCol}`,
+    ),
+  );
+}
+
+/** Get the context column for unique constraint checks. */
+function getContextColumn(table: string): string | null {
+  const map: Record<string, string> = {
+    community_lineup_entries: 'lineup_id',
+    community_lineup_votes: 'lineup_id',
+    community_lineup_matches: 'lineup_id',
+    game_interest_suppressions: 'user_id',
+  };
+  return map[table] ?? null;
+}
+
+/** Update tiedGameIds jsonb array, replacing loserId with winnerId. */
+async function updateTiedGameIds(
+  tx: Tx,
+  loserId: number,
+  winnerId: number,
+): Promise<void> {
+  const table = 'community_lineup_tiebreakers';
+  // Replace loserId with winnerId in the jsonb array
+  await tx.execute(
+    sql.raw(
+      `UPDATE ${table}
+       SET tied_game_ids = (
+         SELECT jsonb_agg(DISTINCT
+           CASE WHEN elem::int = ${loserId} THEN ${winnerId} ELSE elem::int END
+         )
+         FROM jsonb_array_elements(tied_game_ids) AS elem
+       )
+       WHERE tied_game_ids @> '${loserId}'::jsonb`,
+    ),
+  );
+}

--- a/api/src/igdb/igdb-dedup-fk-reassign.helpers.ts
+++ b/api/src/igdb/igdb-dedup-fk-reassign.helpers.ts
@@ -114,7 +114,7 @@ async function reassignBracketFks(
   await safeReassign(tx, table, 'winner_game_id', loserId, winnerId);
 }
 
-/** Reassign misc FKs: discord mappings, channel bindings, suppressions. */
+/** Reassign misc FKs: all remaining tables with game_id references. */
 export async function reassignMiscFks(
   tx: Tx,
   loserId: number,
@@ -122,12 +122,28 @@ export async function reassignMiscFks(
 ): Promise<void> {
   await safeReassign(tx, 'discord_game_mappings', 'game_id', loserId, winnerId);
   await safeReassign(tx, 'channel_bindings', 'game_id', loserId, winnerId);
-  await safeReassignWithUnique(
-    tx,
-    'game_interest_suppressions',
-    'game_id',
-    loserId,
-    winnerId,
+  await deleteAndReassign(tx, 'game_interests', 'game_id', loserId, winnerId);
+  await safeReassign(tx, 'game_activity_sessions', 'game_id', loserId, winnerId);
+  await safeReassign(tx, 'game_activity_rollups', 'game_id', loserId, winnerId);
+  await safeReassign(tx, 'availability', 'game_id', loserId, winnerId);
+  await safeReassign(tx, 'characters', 'game_id', loserId, winnerId);
+  await safeReassign(tx, 'event_types', 'game_id', loserId, winnerId);
+  await safeReassign(tx, 'event_plans', 'game_id', loserId, winnerId);
+}
+
+/** Delete loser rows that conflict with winner, then reassign the rest. */
+async function deleteAndReassign(
+  tx: Tx,
+  table: string,
+  column: string,
+  loserId: number,
+  winnerId: number,
+): Promise<void> {
+  // Delete loser rows where winner already has a matching row
+  await tx.execute(
+    sql.raw(
+      `DELETE FROM ${table} WHERE ${column} = ${loserId} AND ${column} IS NOT NULL`,
+    ),
   );
 }
 
@@ -139,12 +155,20 @@ async function safeReassign(
   loserId: number,
   winnerId: number,
 ): Promise<void> {
-  await tx.execute(
-    sql.raw(
-      `UPDATE ${table} SET ${column} = ${winnerId} WHERE ${column} = ${loserId}`,
-    ),
-  );
+  const sp = `sp_${table}_${loserId}`;
+  await tx.execute(sql.raw(`SAVEPOINT ${sp}`));
+  try {
+    await tx.execute(
+      sql.raw(
+        `UPDATE ${table} SET ${column} = ${winnerId} WHERE ${column} = ${loserId}`,
+      ),
+    );
+    await tx.execute(sql.raw(`RELEASE SAVEPOINT ${sp}`));
+  } catch {
+    await tx.execute(sql.raw(`ROLLBACK TO SAVEPOINT ${sp}`));
+  }
 }
+
 
 /**
  * FK reassignment with unique constraint handling.
@@ -170,19 +194,25 @@ async function deleteConflictingRows(
   loserId: number,
   winnerId: number,
 ): Promise<void> {
-  // Get context columns for the unique constraint
   const contextCol = getContextColumn(table);
   if (!contextCol) return;
 
-  await tx.execute(
-    sql.raw(
-      `DELETE FROM ${table} AS l
-       USING ${table} AS w
-       WHERE l.${column} = ${loserId}
-         AND w.${column} = ${winnerId}
-         AND l.${contextCol} = w.${contextCol}`,
-    ),
-  );
+  const sp = `sp_del_${table}`;
+  await tx.execute(sql.raw(`SAVEPOINT ${sp}`));
+  try {
+    await tx.execute(
+      sql.raw(
+        `DELETE FROM ${table} AS l
+         USING ${table} AS w
+         WHERE l.${column} = ${loserId}
+           AND w.${column} = ${winnerId}
+           AND l.${contextCol} = w.${contextCol}`,
+      ),
+    );
+    await tx.execute(sql.raw(`RELEASE SAVEPOINT ${sp}`));
+  } catch {
+    await tx.execute(sql.raw(`ROLLBACK TO SAVEPOINT ${sp}`));
+  }
 }
 
 /** Get the context column for unique constraint checks. */

--- a/api/src/igdb/igdb-dedup-fk-reassign.helpers.ts
+++ b/api/src/igdb/igdb-dedup-fk-reassign.helpers.ts
@@ -123,15 +123,29 @@ export async function reassignMiscFks(
   await safeReassign(tx, 'discord_game_mappings', 'game_id', loserId, winnerId);
   await safeReassign(tx, 'channel_bindings', 'game_id', loserId, winnerId);
   await deleteAndReassign(tx, 'game_interests', 'game_id', loserId, winnerId);
-  await safeReassign(tx, 'game_activity_sessions', 'game_id', loserId, winnerId);
+  await safeReassign(
+    tx,
+    'game_activity_sessions',
+    'game_id',
+    loserId,
+    winnerId,
+  );
   await safeReassign(tx, 'game_activity_rollups', 'game_id', loserId, winnerId);
   await safeReassign(tx, 'availability', 'game_id', loserId, winnerId);
   await safeReassign(tx, 'characters', 'game_id', loserId, winnerId);
   await safeReassign(tx, 'event_types', 'game_id', loserId, winnerId);
   await safeReassign(tx, 'event_plans', 'game_id', loserId, winnerId);
+  // Table may not exist yet (pending migration) — savepoint protects txn
+  await safeReassign(
+    tx,
+    'game_interest_suppressions',
+    'game_id',
+    loserId,
+    winnerId,
+  );
 }
 
-/** Delete loser rows that conflict with winner, then reassign the rest. */
+/** Delete conflicting loser rows (same user+source), then reassign rest. */
 async function deleteAndReassign(
   tx: Tx,
   table: string,
@@ -139,12 +153,14 @@ async function deleteAndReassign(
   loserId: number,
   winnerId: number,
 ): Promise<void> {
-  // Delete loser rows where winner already has a matching row
   await tx.execute(
     sql.raw(
-      `DELETE FROM ${table} WHERE ${column} = ${loserId} AND ${column} IS NOT NULL`,
+      `DELETE FROM ${table} AS l USING ${table} AS w
+       WHERE l.${column} = ${loserId} AND w.${column} = ${winnerId}
+         AND l.user_id = w.user_id AND l.source = w.source`,
     ),
   );
+  await safeReassign(tx, table, column, loserId, winnerId);
 }
 
 /** Simple FK reassignment (no unique constraints to worry about). */
@@ -168,7 +184,6 @@ async function safeReassign(
     await tx.execute(sql.raw(`ROLLBACK TO SAVEPOINT ${sp}`));
   }
 }
-
 
 /**
  * FK reassignment with unique constraint handling.

--- a/api/src/igdb/igdb-itad-upsert.helpers.spec.ts
+++ b/api/src/igdb/igdb-itad-upsert.helpers.spec.ts
@@ -152,7 +152,7 @@ function buildUpsertDb(limitResults: unknown[][]) {
 
   db.transaction = jest
     .fn()
-    .mockImplementation(async (cb: (tx: typeof db) => unknown) => cb(db));
+    .mockImplementation((cb: (tx: typeof db) => unknown) => cb(db));
   db.delete = jest.fn().mockReturnValue(db);
 
   return db;

--- a/api/src/igdb/igdb-itad-upsert.helpers.spec.ts
+++ b/api/src/igdb/igdb-itad-upsert.helpers.spec.ts
@@ -1,0 +1,369 @@
+/**
+ * Unit tests for ITAD game upsert pre-check logic (ROK-1008 AC 8).
+ *
+ * Tests that upsertItadGame prevents duplicate rows when ITAD and IGDB
+ * slugs differ by finding existing rows via steamAppId or igdbId before
+ * falling through to normal slug-based upsert.
+ *
+ * Uses a custom mock builder because the upsert helper chains
+ * select().from().where().limit() (where must return mock for chaining)
+ * AND update().set().where() (where terminates the chain).
+ * The flat mock can't handle both patterns on the same `where` method.
+ */
+import { upsertItadGame } from './igdb-itad-upsert.helpers';
+
+// ─── Test data builders ───────────────────────────────────────────────────
+
+/** Build a minimal GameDetailDto-like object with defaults. */
+function makeGameDto(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 0,
+    igdbId: null,
+    name: 'Test Game',
+    slug: 'test-game',
+    coverUrl: null,
+    genres: [],
+    summary: null,
+    rating: null,
+    aggregatedRating: null,
+    popularity: null,
+    gameModes: [],
+    themes: [],
+    platforms: [],
+    screenshots: [],
+    videos: [],
+    firstReleaseDate: null,
+    playerCount: null,
+    twitchGameId: null,
+    crossplay: null,
+    ...overrides,
+  };
+}
+
+/** Build a mock DB row matching the games table shape. */
+function makeDbRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    igdbId: null,
+    name: 'Test Game',
+    slug: 'test-game',
+    coverUrl: null,
+    genres: [],
+    summary: null,
+    rating: null,
+    aggregatedRating: null,
+    popularity: null,
+    gameModes: [],
+    themes: [],
+    platforms: [],
+    screenshots: [],
+    videos: [],
+    firstReleaseDate: null,
+    playerCount: null,
+    twitchGameId: null,
+    crossplay: null,
+    cachedAt: new Date(),
+    steamAppId: null,
+    hidden: false,
+    banned: false,
+    shortName: null,
+    colorHex: null,
+    hasRoles: false,
+    hasSpecs: false,
+    enabled: true,
+    itadGameId: null,
+    itadBoxartUrl: null,
+    itadTags: [],
+    maxCharactersPerUser: 10,
+    apiNamespacePrefix: null,
+    itadCurrentPrice: null,
+    itadCurrentCut: null,
+    itadCurrentShop: null,
+    itadCurrentUrl: null,
+    itadLowestPrice: null,
+    itadLowestCut: null,
+    itadPriceUpdatedAt: null,
+    earlyAccess: false,
+    igdbEnrichmentStatus: 'pending',
+    igdbEnrichmentRetryCount: 0,
+    ...overrides,
+  };
+}
+
+// ─── Mock builder ─────────────────────────────────────────────────────────
+
+/**
+ * Build a mock DB that supports the upsert helper's query patterns:
+ *  - SELECT queries: select().from().where().limit() (limit terminates)
+ *  - UPDATE queries: update().set().where() (where terminates)
+ *  - INSERT queries: insert().values().onConflictDoUpdate() (terminates)
+ *
+ * @param limitResults - Sequential results for .limit() calls
+ */
+function buildUpsertDb(limitResults: unknown[][]) {
+  const db: Record<string, jest.Mock> = {};
+  const chainMethods = [
+    'select',
+    'from',
+    'innerJoin',
+    'leftJoin',
+    'orderBy',
+    'groupBy',
+    'insert',
+    'values',
+    'update',
+    'set',
+    'onConflictDoUpdate',
+    'onConflictDoNothing',
+    'returning',
+    'execute',
+  ];
+
+  for (const m of chainMethods) {
+    db[m] = jest.fn().mockReturnValue(db);
+  }
+
+  // limit() is terminal for SELECT queries
+  let limitCallIdx = 0;
+  db.limit = jest.fn().mockImplementation(() => {
+    const result = limitResults[limitCallIdx] ?? [];
+    limitCallIdx++;
+    return Promise.resolve(result);
+  });
+
+  // where() serves two roles:
+  // - Chain step in SELECT (returns db for further chaining)
+  // - Terminal in UPDATE (returns resolved Promise)
+  // We detect which by checking if update() was called before where()
+  let inUpdate = false;
+  const origUpdate = db.update;
+  db.update = jest.fn().mockImplementation((...args: unknown[]) => {
+    inUpdate = true;
+    return origUpdate(...args);
+  });
+
+  db.where = jest.fn().mockImplementation(() => {
+    if (inUpdate) {
+      inUpdate = false;
+      return Promise.resolve(undefined);
+    }
+    return db;
+  });
+
+  db.transaction = jest
+    .fn()
+    .mockImplementation(async (cb: (tx: typeof db) => unknown) => cb(db));
+  db.delete = jest.fn().mockReturnValue(db);
+
+  return db;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+describe('upsertItadGame', () => {
+  describe('AC 8: pre-check by steamAppId', () => {
+    it('updates existing row when steamAppId matches', async () => {
+      const game = makeGameDto({
+        name: 'Slay the Spire 2',
+        slug: 'slay-the-spire-2',
+        steamAppId: 646570,
+        itadGameId: 'itad-uuid-1',
+      });
+      const existingRow = makeDbRow({
+        id: 42,
+        name: 'Slay the Spire II',
+        slug: 'slay-the-spire-ii',
+        steamAppId: 646570,
+        igdbId: 12345,
+      });
+
+      // limit(1) calls:
+      // 1. findExistingByAltKey steamAppId query -> match
+      // 2. fetchBySlug after update -> return existing row
+      const db = buildUpsertDb([[existingRow], [existingRow]]);
+
+      const result = await upsertItadGame(db as never, game as never);
+
+      expect(db.update).toHaveBeenCalled();
+      expect(db.insert).not.toHaveBeenCalled();
+      expect(result).toMatchObject({
+        id: expect.any(Number),
+        slug: 'slay-the-spire-ii',
+      });
+    });
+  });
+
+  describe('AC 8: pre-check by igdbId', () => {
+    it('updates existing row when igdbId matches', async () => {
+      const game = makeGameDto({
+        name: 'Slay the Spire 2',
+        slug: 'slay-the-spire-2',
+        igdbId: 12345,
+        itadGameId: 'itad-uuid-1',
+      });
+      const existingRow = makeDbRow({
+        id: 99,
+        name: 'Slay the Spire II',
+        slug: 'slay-the-spire-ii',
+        igdbId: 12345,
+      });
+
+      // limit(1) calls:
+      // 1. findExistingByAltKey igdbId query -> match
+      //    (no steamAppId on game, so steamAppId branch is skipped)
+      // 2. fetchBySlug after update -> return existing row
+      const db = buildUpsertDb([[existingRow], [existingRow]]);
+
+      const result = await upsertItadGame(db as never, game as never);
+
+      expect(db.update).toHaveBeenCalled();
+      expect(result).toMatchObject({
+        id: expect.any(Number),
+        slug: 'slay-the-spire-ii',
+      });
+    });
+
+    it('checks igdbId after steamAppId finds no match', async () => {
+      const game = makeGameDto({
+        name: 'Game X',
+        slug: 'game-x-itad',
+        steamAppId: 99999,
+        igdbId: 500,
+        itadGameId: 'itad-x',
+      });
+      const existingRow = makeDbRow({
+        id: 77,
+        slug: 'game-x-igdb',
+        igdbId: 500,
+      });
+
+      // limit(1) calls:
+      // 1. steamAppId query -> no match
+      // 2. igdbId query -> match
+      // 3. fetchBySlug after update -> return row
+      const db = buildUpsertDb([[], [existingRow], [existingRow]]);
+
+      const result = await upsertItadGame(db as never, game as never);
+
+      expect(db.update).toHaveBeenCalled();
+      expect(result).toMatchObject({ slug: 'game-x-igdb' });
+    });
+  });
+
+  describe('AC 8: falls through to slug-based upsert', () => {
+    it('inserts when no match by steamAppId or igdbId', async () => {
+      const game = makeGameDto({
+        name: 'Brand New Game',
+        slug: 'brand-new-game',
+        steamAppId: 11111,
+        igdbId: 222,
+        itadGameId: 'itad-new',
+      });
+      const insertedRow = makeDbRow({
+        id: 50,
+        name: 'Brand New Game',
+        slug: 'brand-new-game',
+        steamAppId: 11111,
+        igdbId: 222,
+        itadGameId: 'itad-new',
+      });
+
+      // limit(1) calls:
+      // 1. steamAppId query -> no match
+      // 2. igdbId query -> no match
+      // 3. fetchBySlug after insert -> return new row
+      const db = buildUpsertDb([[], [], [insertedRow]]);
+
+      const result = await upsertItadGame(db as never, game as never);
+
+      expect(db.insert).toHaveBeenCalled();
+      expect(result).toMatchObject({
+        id: expect.any(Number),
+        slug: 'brand-new-game',
+      });
+    });
+
+    it('skips alt key checks when game has no keys', async () => {
+      const game = makeGameDto({
+        name: 'ITAD Only Game',
+        slug: 'itad-only-game',
+        igdbId: null,
+        itadGameId: 'itad-only',
+      });
+      const insertedRow = makeDbRow({
+        id: 60,
+        slug: 'itad-only-game',
+        itadGameId: 'itad-only',
+      });
+
+      // limit(1) calls:
+      // No steamAppId or igdbId so findExistingByAltKey skips both
+      // 1. fetchBySlug after insert -> return row
+      const db = buildUpsertDb([[insertedRow]]);
+
+      const result = await upsertItadGame(db as never, game as never);
+
+      expect(db.insert).toHaveBeenCalled();
+      expect(result).toMatchObject({ slug: 'itad-only-game' });
+    });
+  });
+
+  describe('edge cases', () => {
+    it('steamAppId match short-circuits igdbId check', async () => {
+      const game = makeGameDto({
+        name: 'Dual-key Game',
+        slug: 'dual-key-itad',
+        steamAppId: 777,
+        igdbId: 888,
+      });
+      const existingRow = makeDbRow({
+        id: 33,
+        slug: 'dual-key-igdb',
+        steamAppId: 777,
+        igdbId: 888,
+      });
+
+      // limit(1) calls:
+      // 1. steamAppId query -> match (skips igdbId check)
+      // 2. fetchBySlug after update
+      const db = buildUpsertDb([[existingRow], [existingRow]]);
+
+      const result = await upsertItadGame(db as never, game as never);
+
+      expect(db.update).toHaveBeenCalled();
+      expect(db.limit).toHaveBeenCalledTimes(2);
+      expect(result).toMatchObject({ slug: 'dual-key-igdb' });
+    });
+
+    it('returns mapped GameDetailDto from fetched row', async () => {
+      const game = makeGameDto({
+        name: 'Mapped Game',
+        slug: 'mapped-game-itad',
+        steamAppId: 555,
+      });
+      const existingRow = makeDbRow({
+        id: 10,
+        slug: 'mapped-game-igdb',
+        name: 'Mapped Game DB',
+        steamAppId: 555,
+        igdbId: 600,
+        genres: [12, 31],
+        summary: 'A mapped summary',
+      });
+
+      const db = buildUpsertDb([[existingRow], [existingRow]]);
+
+      const result = await upsertItadGame(db as never, game as never);
+
+      // Verify the result is a properly mapped GameDetailDto
+      expect(result).toMatchObject({
+        id: 10,
+        igdbId: 600,
+        name: 'Mapped Game DB',
+        slug: 'mapped-game-igdb',
+        genres: [12, 31],
+        summary: 'A mapped summary',
+      });
+    });
+  });
+});

--- a/api/src/igdb/igdb-itad-upsert.helpers.ts
+++ b/api/src/igdb/igdb-itad-upsert.helpers.ts
@@ -3,7 +3,7 @@
  * Persists ITAD search results to the games table using slug
  * as the conflict target (since ITAD games may lack igdbId).
  */
-import { sql, eq } from 'drizzle-orm';
+import { sql, eq, and, ne } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type { GameDetailDto } from '@raid-ledger/contract';
 import * as schema from '../drizzle/schema';
@@ -12,14 +12,18 @@ import { mapDbRowToDetail } from './igdb.mappers';
 /**
  * Upsert a single ITAD game to the database.
  * Uses slug as the conflict target since ITAD games may not have igdbId.
+ * Pre-checks for existing rows by steamAppId or igdbId to prevent
+ * duplicates with different slugs (ROK-1008).
  * Returns the persisted row with a real DB id.
  */
 export async function upsertItadGame(
   db: PostgresJsDatabase<typeof schema>,
   game: GameDetailDto,
 ): Promise<GameDetailDto> {
-  const values = buildItadInsertValues(game);
+  const existing = await findExistingByAltKey(db, game);
+  if (existing) return updateExistingRow(db, existing, game);
 
+  const values = buildItadInsertValues(game);
   await db
     .insert(schema.games)
     .values(values)
@@ -29,6 +33,47 @@ export async function upsertItadGame(
     });
 
   return fetchBySlug(db, game.slug);
+}
+
+/** Find an existing game row by steamAppId or igdbId with a different slug. */
+async function findExistingByAltKey(
+  db: PostgresJsDatabase<typeof schema>,
+  game: GameDetailDto,
+): Promise<typeof schema.games.$inferSelect | null> {
+  const g = schema.games;
+  const steamId = (game as Record<string, unknown>).steamAppId as
+    | number
+    | undefined;
+  if (steamId) {
+    const rows = await db
+      .select()
+      .from(g)
+      .where(and(eq(g.steamAppId, steamId), ne(g.slug, game.slug)))
+      .limit(1);
+    if (rows.length > 0) return rows[0];
+  }
+  if (game.igdbId) {
+    const rows = await db
+      .select()
+      .from(g)
+      .where(and(eq(g.igdbId, game.igdbId), ne(g.slug, game.slug)))
+      .limit(1);
+    if (rows.length > 0) return rows[0];
+  }
+  return null;
+}
+
+/** Update an existing row (found by alt key) with ITAD data. */
+async function updateExistingRow(
+  db: PostgresJsDatabase<typeof schema>,
+  existing: typeof schema.games.$inferSelect,
+  game: GameDetailDto,
+): Promise<GameDetailDto> {
+  await db
+    .update(schema.games)
+    .set(buildItadUpdateSet(game))
+    .where(eq(schema.games.id, existing.id));
+  return fetchBySlug(db, existing.slug);
 }
 
 /** Build insert values from a GameDetailDto. */

--- a/api/src/igdb/igdb-rok375.service.spec.ts
+++ b/api/src/igdb/igdb-rok375.service.spec.ts
@@ -165,6 +165,9 @@ describe('IgdbService — ROK-375: enriched search, cache guard, Redis re-query'
       const fullPage = Array.from({ length: 20 }, (_, i) => ({
         ...fullGameRow,
         id: i + 1,
+        igdbId: 1234 + i,
+        slug: `halo-infinite-${i}`,
+        name: `Halo Infinite ${i}`,
       }));
       mockDb.select = jest.fn().mockImplementation(() => ({
         from: jest.fn().mockImplementation(() => ({
@@ -584,6 +587,9 @@ describe('IgdbService — ROK-375: enriched search, cache guard, Redis re-query'
       const fullPage = Array.from({ length: 20 }, (_, i) => ({
         ...fullGameRow,
         id: i + 1,
+        igdbId: 1234 + i,
+        slug: `halo-infinite-${i}`,
+        name: `Halo Infinite ${i}`,
       }));
       mockDb.select = jest.fn().mockImplementation(() => ({
         from: jest.fn().mockImplementation(() => ({

--- a/api/src/igdb/igdb-search-dedup.helpers.spec.ts
+++ b/api/src/igdb/igdb-search-dedup.helpers.spec.ts
@@ -658,9 +658,7 @@ describe('mergeEnrichment', () => {
 
     mergeEnrichment(winner, donor);
 
-    expect(winner.itadBoxartUrl).toBe(
-      'https://itad.example.com/boxart.jpg',
-    );
+    expect(winner.itadBoxartUrl).toBe('https://itad.example.com/boxart.jpg');
   });
 
   it('copies itadTags from donor when winner has empty array', () => {

--- a/api/src/igdb/igdb-search-dedup.helpers.spec.ts
+++ b/api/src/igdb/igdb-search-dedup.helpers.spec.ts
@@ -578,6 +578,24 @@ describe('deduplicateGames', () => {
 // ============================================================
 
 describe('mergeEnrichment', () => {
+  it('copies id from donor when winner has id 0', () => {
+    const winner = makeGame({ id: 0 });
+    const donor = makeGame({ id: 12345 });
+
+    mergeEnrichment(winner, donor);
+
+    expect(winner.id).toBe(12345);
+  });
+
+  it('does not overwrite non-zero id on winner', () => {
+    const winner = makeGame({ id: 100 });
+    const donor = makeGame({ id: 12345 });
+
+    mergeEnrichment(winner, donor);
+
+    expect(winner.id).toBe(100);
+  });
+
   it('copies igdbId from donor when winner has null', () => {
     const winner = makeGame({ igdbId: null });
     const donor = makeGame({ igdbId: 999 });

--- a/api/src/igdb/igdb-search-dedup.helpers.spec.ts
+++ b/api/src/igdb/igdb-search-dedup.helpers.spec.ts
@@ -1,0 +1,737 @@
+/**
+ * Tests for game search deduplication across IGDB and ITAD sources (ROK-1008).
+ *
+ * These tests are written BEFORE the implementation exists.
+ * They should fail with an import error until igdb-search-dedup.helpers.ts is created.
+ */
+import type { GameDetailDto } from '@raid-ledger/contract';
+import {
+  normalizeForDedup,
+  deduplicateGames,
+  mergeEnrichment,
+} from './igdb-search-dedup.helpers';
+
+/** Build a minimal GameDetailDto with sensible defaults. */
+function makeGame(
+  overrides: Partial<GameDetailDto> & { steamAppId?: number },
+): GameDetailDto & { steamAppId?: number } {
+  return {
+    id: 0,
+    igdbId: null,
+    name: 'Test Game',
+    slug: 'test-game',
+    coverUrl: null,
+    genres: [],
+    summary: null,
+    rating: null,
+    aggregatedRating: null,
+    popularity: null,
+    gameModes: [],
+    themes: [],
+    platforms: [],
+    screenshots: [],
+    videos: [],
+    firstReleaseDate: null,
+    playerCount: null,
+    twitchGameId: null,
+    crossplay: null,
+    ...overrides,
+  };
+}
+
+// ============================================================
+// normalizeForDedup
+// ============================================================
+
+describe('normalizeForDedup', () => {
+  it('lowercases names', () => {
+    expect(normalizeForDedup('Slay The Spire')).toBe(
+      normalizeForDedup('slay the spire'),
+    );
+  });
+
+  // AC: normalizeForDedup("Slay the Spire II") equals normalizeForDedup("Slay the Spire 2")
+  it('converts Roman numeral II to 2', () => {
+    expect(normalizeForDedup('Slay the Spire II')).toBe(
+      normalizeForDedup('Slay the Spire 2'),
+    );
+  });
+
+  // AC: Roman numerals at word boundaries are normalized: III->3
+  it('converts Roman numeral III to 3', () => {
+    expect(normalizeForDedup('Final Fantasy III')).toBe(
+      normalizeForDedup('Final Fantasy 3'),
+    );
+  });
+
+  // AC: Roman numerals at word boundaries are normalized: IV->4
+  it('converts Roman numeral IV to 4', () => {
+    expect(normalizeForDedup('Civilization IV')).toBe(
+      normalizeForDedup('Civilization 4'),
+    );
+  });
+
+  // AC: Roman numerals at word boundaries are normalized: V->5
+  it('converts Roman numeral V to 5', () => {
+    expect(normalizeForDedup('Grand Theft Auto V')).toBe(
+      normalizeForDedup('Grand Theft Auto 5'),
+    );
+  });
+
+  // AC: Roman numerals at word boundaries are normalized: VI->6
+  it('converts Roman numeral VI to 6', () => {
+    expect(normalizeForDedup('Resident Evil VI')).toBe(
+      normalizeForDedup('Resident Evil 6'),
+    );
+  });
+
+  // AC: Roman numerals at word boundaries are normalized: VII->7
+  it('converts Roman numeral VII to 7', () => {
+    expect(normalizeForDedup('Final Fantasy VII')).toBe(
+      normalizeForDedup('Final Fantasy 7'),
+    );
+  });
+
+  // AC: Roman numerals at word boundaries are normalized: VIII->8
+  it('converts Roman numeral VIII to 8', () => {
+    expect(normalizeForDedup('Final Fantasy VIII')).toBe(
+      normalizeForDedup('Final Fantasy 8'),
+    );
+  });
+
+  it('only converts Roman numerals at word boundaries', () => {
+    // "Vivid" contains "VI" but should not be converted
+    const result = normalizeForDedup('Vivid Knight');
+    expect(result).not.toContain('6');
+  });
+
+  // AC: normalizeForDedup("Game: Subtitle") equals normalizeForDedup("Game - Subtitle")
+  it('strips subtitle punctuation (colons)', () => {
+    expect(normalizeForDedup('Game: Subtitle')).toBe(
+      normalizeForDedup('Game Subtitle'),
+    );
+  });
+
+  it('strips subtitle punctuation (dashes)', () => {
+    expect(normalizeForDedup('Game - Subtitle')).toBe(
+      normalizeForDedup('Game Subtitle'),
+    );
+  });
+
+  it('colon and dash subtitles normalize to the same value', () => {
+    expect(normalizeForDedup('Game: Subtitle')).toBe(
+      normalizeForDedup('Game - Subtitle'),
+    );
+  });
+
+  it('collapses multiple whitespace into single space', () => {
+    expect(normalizeForDedup('Game   Name')).toBe(
+      normalizeForDedup('Game Name'),
+    );
+  });
+
+  it('handles combined normalization (Roman numeral + subtitle)', () => {
+    expect(normalizeForDedup('Slay the Spire II: Remastered')).toBe(
+      normalizeForDedup('Slay the Spire 2 Remastered'),
+    );
+  });
+});
+
+// ============================================================
+// deduplicateGames
+// ============================================================
+
+describe('deduplicateGames', () => {
+  // AC: Games with matching igdbId but different slugs are deduplicated
+  describe('dedup by igdbId', () => {
+    it('deduplicates games sharing the same igdbId', () => {
+      const itadEntry = makeGame({
+        name: 'Slay the Spire 2',
+        slug: 'slay-the-spire-2',
+        igdbId: 12345,
+        itadGameId: 'itad-uuid-1',
+        coverUrl: null,
+      });
+      const igdbEntry = makeGame({
+        name: 'Slay the Spire II',
+        slug: 'slay-the-spire-ii',
+        igdbId: 12345,
+        summary: 'A great deckbuilder',
+        genres: [12, 31],
+      });
+
+      const result = deduplicateGames([itadEntry, igdbEntry]);
+
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  // AC: Games with matching steamAppId but different slugs are deduplicated
+  describe('dedup by steamAppId', () => {
+    it('deduplicates games sharing the same steamAppId', () => {
+      const itadEntry = makeGame({
+        name: 'Slay the Spire 2',
+        slug: 'slay-the-spire-2',
+        steamAppId: 646570,
+        itadGameId: 'itad-uuid-1',
+      });
+      const igdbEntry = makeGame({
+        name: 'Slay the Spire II',
+        slug: 'slay-the-spire-ii',
+        steamAppId: 646570,
+        igdbId: 12345,
+        summary: 'A great deckbuilder',
+      });
+
+      const result = deduplicateGames([itadEntry, igdbEntry]);
+
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  // AC: Games matching via normalized name are deduplicated
+  describe('dedup by normalized name', () => {
+    it('deduplicates games with same normalized name', () => {
+      const itadEntry = makeGame({
+        name: 'Slay the Spire 2',
+        slug: 'slay-the-spire-2',
+        itadGameId: 'itad-uuid-1',
+      });
+      const igdbEntry = makeGame({
+        name: 'Slay the Spire II',
+        slug: 'slay-the-spire-ii',
+        igdbId: 12345,
+      });
+
+      const result = deduplicateGames([itadEntry, igdbEntry]);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('deduplicates games differing only in subtitle punctuation', () => {
+      const colonVersion = makeGame({
+        name: 'Dark Souls: Remastered',
+        slug: 'dark-souls-remastered-a',
+        itadGameId: 'itad-uuid-2',
+      });
+      const dashVersion = makeGame({
+        name: 'Dark Souls - Remastered',
+        slug: 'dark-souls-remastered-b',
+        igdbId: 999,
+      });
+
+      const result = deduplicateGames([colonVersion, dashVersion]);
+
+      expect(result).toHaveLength(1);
+    });
+  });
+
+  // AC: When deduplicating, the ITAD entry (has itadGameId) wins
+  describe('winner selection', () => {
+    it('keeps the ITAD entry as winner when deduplicating by igdbId', () => {
+      const itadEntry = makeGame({
+        name: 'Slay the Spire 2',
+        slug: 'slay-the-spire-2',
+        igdbId: 12345,
+        itadGameId: 'itad-uuid-1',
+        itadBoxartUrl: 'https://itad.example.com/boxart.jpg',
+      });
+      const igdbEntry = makeGame({
+        name: 'Slay the Spire II',
+        slug: 'slay-the-spire-ii',
+        igdbId: 12345,
+        summary: 'A great deckbuilder',
+        genres: [12, 31],
+      });
+
+      const result = deduplicateGames([igdbEntry, itadEntry]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].itadGameId).toBe('itad-uuid-1');
+      expect(result[0].name).toBe('Slay the Spire 2');
+    });
+
+    it('keeps the ITAD entry as winner when deduplicating by name', () => {
+      const igdbEntry = makeGame({
+        name: 'Slay the Spire II',
+        slug: 'slay-the-spire-ii',
+        igdbId: 12345,
+        summary: 'A great deckbuilder',
+      });
+      const itadEntry = makeGame({
+        name: 'Slay the Spire 2',
+        slug: 'slay-the-spire-2',
+        itadGameId: 'itad-uuid-1',
+      });
+
+      const result = deduplicateGames([igdbEntry, itadEntry]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].itadGameId).toBe('itad-uuid-1');
+    });
+
+    it('uses first-seen when neither entry has itadGameId', () => {
+      const first = makeGame({
+        name: 'Game Alpha',
+        slug: 'game-alpha-1',
+        igdbId: 100,
+        summary: 'First summary',
+      });
+      const second = makeGame({
+        name: 'Game Alpha',
+        slug: 'game-alpha-2',
+        igdbId: 100,
+        summary: 'Second summary',
+      });
+
+      const result = deduplicateGames([first, second]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].summary).toBe('First summary');
+    });
+  });
+
+  // AC: IGDB metadata from the loser is merged into the winner
+  describe('enrichment merge on dedup', () => {
+    it('copies IGDB metadata from loser into winner', () => {
+      const itadWinner = makeGame({
+        name: 'Slay the Spire 2',
+        slug: 'slay-the-spire-2',
+        igdbId: null,
+        itadGameId: 'itad-uuid-1',
+        summary: null,
+        genres: [],
+        rating: null,
+        aggregatedRating: null,
+        screenshots: [],
+        videos: [],
+        themes: [],
+        platforms: [],
+        gameModes: [],
+        twitchGameId: null,
+        playerCount: null,
+        crossplay: null,
+      });
+      const igdbLoser = makeGame({
+        name: 'Slay the Spire II',
+        slug: 'slay-the-spire-ii',
+        igdbId: 12345,
+        summary: 'A great deckbuilder sequel',
+        genres: [12, 31],
+        rating: 92.5,
+        aggregatedRating: 90.0,
+        screenshots: ['https://igdb.com/ss1.jpg'],
+        videos: [{ name: 'Trailer', videoId: 'abc123' }],
+        themes: [1, 17],
+        platforms: [6, 14],
+        gameModes: [1],
+        twitchGameId: 'twitch-123',
+        playerCount: { min: 1, max: 1 },
+        crossplay: false,
+      });
+
+      const result = deduplicateGames([itadWinner, igdbLoser]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].itadGameId).toBe('itad-uuid-1');
+      expect(result[0].igdbId).toBe(12345);
+      expect(result[0].summary).toBe('A great deckbuilder sequel');
+      expect(result[0].genres).toEqual([12, 31]);
+      expect(result[0].rating).toBe(92.5);
+      expect(result[0].screenshots).toEqual(['https://igdb.com/ss1.jpg']);
+      expect(result[0].twitchGameId).toBe('twitch-123');
+    });
+
+    it('copies ITAD fields from loser into winner', () => {
+      const igdbWinner = makeGame({
+        name: 'Game Alpha',
+        slug: 'game-alpha-igdb',
+        igdbId: 500,
+        itadGameId: null,
+        itadBoxartUrl: null,
+        itadTags: [],
+      });
+      const itadLoser = makeGame({
+        name: 'Game Alpha',
+        slug: 'game-alpha-itad',
+        igdbId: 500,
+        itadGameId: 'itad-uuid-99',
+        itadBoxartUrl: 'https://itad.example.com/boxart.jpg',
+        itadTags: ['rpg', 'indie'],
+        itadCurrentPrice: 19.99,
+        itadCurrentCut: 20,
+        itadCurrentShop: 'Steam',
+        itadLowestPrice: 9.99,
+        itadLowestCut: 50,
+      });
+
+      // itadLoser has itadGameId so it should win
+      const result = deduplicateGames([igdbWinner, itadLoser]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].itadGameId).toBe('itad-uuid-99');
+      expect(result[0].itadBoxartUrl).toBe(
+        'https://itad.example.com/boxart.jpg',
+      );
+      expect(result[0].itadTags).toEqual(['rpg', 'indie']);
+      // IGDB metadata from the first entry should be preserved
+      expect(result[0].igdbId).toBe(500);
+    });
+
+    it('does not overwrite winner fields that already have values', () => {
+      const winner = makeGame({
+        name: 'Game Beta',
+        slug: 'game-beta-1',
+        igdbId: 200,
+        itadGameId: 'itad-uuid-beta',
+        summary: 'Winner summary',
+        genres: [5],
+        rating: 80,
+      });
+      const loser = makeGame({
+        name: 'Game Beta',
+        slug: 'game-beta-2',
+        igdbId: 200,
+        summary: 'Loser summary',
+        genres: [5, 10],
+        rating: 95,
+      });
+
+      const result = deduplicateGames([winner, loser]);
+
+      expect(result).toHaveLength(1);
+      // Winner already had summary and rating, so they should NOT be overwritten
+      expect(result[0].summary).toBe('Winner summary');
+      expect(result[0].rating).toBe(80);
+    });
+  });
+
+  // AC: Games with no matching igdbId, steamAppId, or normalized name are NOT falsely deduplicated
+  describe('no false deduplication', () => {
+    it('keeps distinct games separate', () => {
+      const gameA = makeGame({
+        name: 'Elden Ring',
+        slug: 'elden-ring',
+        igdbId: 100,
+        itadGameId: 'itad-elden',
+      });
+      const gameB = makeGame({
+        name: 'Dark Souls',
+        slug: 'dark-souls',
+        igdbId: 200,
+        itadGameId: 'itad-dark-souls',
+      });
+      const gameC = makeGame({
+        name: 'Hollow Knight',
+        slug: 'hollow-knight',
+        igdbId: 300,
+      });
+
+      const result = deduplicateGames([gameA, gameB, gameC]);
+
+      expect(result).toHaveLength(3);
+    });
+
+    it('does not merge games with similar but different names', () => {
+      const gameA = makeGame({
+        name: 'Slay the Spire',
+        slug: 'slay-the-spire',
+        igdbId: 100,
+      });
+      const gameB = makeGame({
+        name: 'Slay the Spire 2',
+        slug: 'slay-the-spire-2',
+        igdbId: 200,
+      });
+
+      const result = deduplicateGames([gameA, gameB]);
+
+      expect(result).toHaveLength(2);
+    });
+
+    it('does not merge games where igdbId is null on both', () => {
+      const gameA = makeGame({
+        name: 'Alpha Game',
+        slug: 'alpha-game',
+        igdbId: null,
+        itadGameId: 'itad-1',
+      });
+      const gameB = makeGame({
+        name: 'Beta Game',
+        slug: 'beta-game',
+        igdbId: null,
+        itadGameId: 'itad-2',
+      });
+
+      const result = deduplicateGames([gameA, gameB]);
+
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  // AC: Original result order is preserved after deduplication
+  describe('order preservation', () => {
+    it('preserves original result order', () => {
+      const first = makeGame({
+        name: 'Alpha',
+        slug: 'alpha',
+        igdbId: 1,
+      });
+      const second = makeGame({
+        name: 'Slay the Spire 2',
+        slug: 'slay-the-spire-2',
+        itadGameId: 'itad-slay',
+      });
+      const duplicate = makeGame({
+        name: 'Slay the Spire II',
+        slug: 'slay-the-spire-ii',
+        igdbId: 999,
+      });
+      const third = makeGame({
+        name: 'Zeta',
+        slug: 'zeta',
+        igdbId: 3,
+      });
+
+      const result = deduplicateGames([first, second, duplicate, third]);
+
+      expect(result).toHaveLength(3);
+      expect(result[0].name).toBe('Alpha');
+      // The ITAD entry should win for position of the deduped pair
+      expect(result[1].itadGameId).toBe('itad-slay');
+      expect(result[2].name).toBe('Zeta');
+    });
+
+    it('winner occupies the earliest position of the duplicates', () => {
+      const igdbFirst = makeGame({
+        name: 'Slay the Spire II',
+        slug: 'slay-the-spire-ii',
+        igdbId: 12345,
+        summary: 'IGDB summary',
+      });
+      const itadSecond = makeGame({
+        name: 'Slay the Spire 2',
+        slug: 'slay-the-spire-2',
+        igdbId: 12345,
+        itadGameId: 'itad-uuid',
+      });
+      const other = makeGame({
+        name: 'Other Game',
+        slug: 'other-game',
+        igdbId: 999,
+      });
+
+      const result = deduplicateGames([igdbFirst, itadSecond, other]);
+
+      expect(result).toHaveLength(2);
+      // ITAD winner should be at index 0 (earliest position of the pair)
+      expect(result[0].itadGameId).toBe('itad-uuid');
+      expect(result[1].name).toBe('Other Game');
+    });
+  });
+
+  // Dedup priority: igdbId > steamAppId > normalized name
+  describe('dedup priority ordering', () => {
+    it('matches by igdbId even when names differ', () => {
+      const gameA = makeGame({
+        name: 'Completely Different Name',
+        slug: 'different-name',
+        igdbId: 500,
+        itadGameId: 'itad-a',
+      });
+      const gameB = makeGame({
+        name: 'Another Name Entirely',
+        slug: 'another-name',
+        igdbId: 500,
+      });
+
+      const result = deduplicateGames([gameA, gameB]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].itadGameId).toBe('itad-a');
+    });
+
+    it('matches by steamAppId when igdbIds differ', () => {
+      const gameA = makeGame({
+        name: 'Steam Game A',
+        slug: 'steam-game-a',
+        igdbId: 100,
+        steamAppId: 12345,
+        itadGameId: 'itad-steam',
+      });
+      const gameB = makeGame({
+        name: 'Steam Game B',
+        slug: 'steam-game-b',
+        igdbId: 200,
+        steamAppId: 12345,
+      });
+
+      const result = deduplicateGames([gameA, gameB]);
+
+      expect(result).toHaveLength(1);
+    });
+  });
+});
+
+// ============================================================
+// mergeEnrichment
+// ============================================================
+
+describe('mergeEnrichment', () => {
+  it('copies igdbId from donor when winner has null', () => {
+    const winner = makeGame({ igdbId: null });
+    const donor = makeGame({ igdbId: 999 });
+
+    mergeEnrichment(winner, donor);
+
+    expect(winner.igdbId).toBe(999);
+  });
+
+  it('does not overwrite non-null igdbId on winner', () => {
+    const winner = makeGame({ igdbId: 100 });
+    const donor = makeGame({ igdbId: 999 });
+
+    mergeEnrichment(winner, donor);
+
+    expect(winner.igdbId).toBe(100);
+  });
+
+  it('copies genres from donor when winner has empty array', () => {
+    const winner = makeGame({ genres: [] });
+    const donor = makeGame({ genres: [12, 31] });
+
+    mergeEnrichment(winner, donor);
+
+    expect(winner.genres).toEqual([12, 31]);
+  });
+
+  it('does not overwrite non-empty genres on winner', () => {
+    const winner = makeGame({ genres: [5] });
+    const donor = makeGame({ genres: [12, 31] });
+
+    mergeEnrichment(winner, donor);
+
+    expect(winner.genres).toEqual([5]);
+  });
+
+  it('copies summary from donor when winner has null', () => {
+    const winner = makeGame({ summary: null });
+    const donor = makeGame({ summary: 'A great game' });
+
+    mergeEnrichment(winner, donor);
+
+    expect(winner.summary).toBe('A great game');
+  });
+
+  it('copies rating from donor when winner has null', () => {
+    const winner = makeGame({ rating: null });
+    const donor = makeGame({ rating: 85.5 });
+
+    mergeEnrichment(winner, donor);
+
+    expect(winner.rating).toBe(85.5);
+  });
+
+  it('copies screenshots from donor when winner has empty array', () => {
+    const winner = makeGame({ screenshots: [] });
+    const donor = makeGame({ screenshots: ['https://img.com/ss1.jpg'] });
+
+    mergeEnrichment(winner, donor);
+
+    expect(winner.screenshots).toEqual(['https://img.com/ss1.jpg']);
+  });
+
+  it('copies itadGameId from donor when winner has null/undefined', () => {
+    const winner = makeGame({ itadGameId: null });
+    const donor = makeGame({ itadGameId: 'itad-uuid-donor' });
+
+    mergeEnrichment(winner, donor);
+
+    expect(winner.itadGameId).toBe('itad-uuid-donor');
+  });
+
+  it('copies itadBoxartUrl from donor when winner has null', () => {
+    const winner = makeGame({ itadBoxartUrl: null });
+    const donor = makeGame({
+      itadBoxartUrl: 'https://itad.example.com/boxart.jpg',
+    });
+
+    mergeEnrichment(winner, donor);
+
+    expect(winner.itadBoxartUrl).toBe(
+      'https://itad.example.com/boxart.jpg',
+    );
+  });
+
+  it('copies itadTags from donor when winner has empty array', () => {
+    const winner = makeGame({ itadTags: [] });
+    const donor = makeGame({ itadTags: ['rpg', 'indie'] });
+
+    mergeEnrichment(winner, donor);
+
+    expect(winner.itadTags).toEqual(['rpg', 'indie']);
+  });
+
+  it('copies ITAD pricing from donor when winner fields are null', () => {
+    const winner = makeGame({
+      itadCurrentPrice: null,
+      itadCurrentCut: null,
+      itadCurrentShop: null,
+      itadLowestPrice: null,
+      itadLowestCut: null,
+    });
+    const donor = makeGame({
+      itadCurrentPrice: 19.99,
+      itadCurrentCut: 20,
+      itadCurrentShop: 'Steam',
+      itadLowestPrice: 9.99,
+      itadLowestCut: 50,
+    });
+
+    mergeEnrichment(winner, donor);
+
+    expect(winner.itadCurrentPrice).toBe(19.99);
+    expect(winner.itadCurrentCut).toBe(20);
+    expect(winner.itadCurrentShop).toBe('Steam');
+    expect(winner.itadLowestPrice).toBe(9.99);
+    expect(winner.itadLowestCut).toBe(50);
+  });
+
+  it('copies videos from donor when winner has empty array', () => {
+    const winner = makeGame({ videos: [] });
+    const donor = makeGame({
+      videos: [{ name: 'Trailer', videoId: 'xyz' }],
+    });
+
+    mergeEnrichment(winner, donor);
+
+    expect(winner.videos).toEqual([{ name: 'Trailer', videoId: 'xyz' }]);
+  });
+
+  it('copies twitchGameId from donor when winner has null', () => {
+    const winner = makeGame({ twitchGameId: null });
+    const donor = makeGame({ twitchGameId: 'twitch-456' });
+
+    mergeEnrichment(winner, donor);
+
+    expect(winner.twitchGameId).toBe('twitch-456');
+  });
+
+  it('copies playerCount from donor when winner has null', () => {
+    const winner = makeGame({ playerCount: null });
+    const donor = makeGame({ playerCount: { min: 1, max: 4 } });
+
+    mergeEnrichment(winner, donor);
+
+    expect(winner.playerCount).toEqual({ min: 1, max: 4 });
+  });
+
+  it('copies crossplay from donor when winner has null', () => {
+    const winner = makeGame({ crossplay: null });
+    const donor = makeGame({ crossplay: true });
+
+    mergeEnrichment(winner, donor);
+
+    expect(winner.crossplay).toBe(true);
+  });
+});

--- a/api/src/igdb/igdb-search-dedup.helpers.ts
+++ b/api/src/igdb/igdb-search-dedup.helpers.ts
@@ -27,6 +27,7 @@ const ROMAN_REPLACEMENTS: [RegExp, string][] = [
  * - Collapse whitespace
  */
 export function normalizeForDedup(name: string): string {
+  if (!name) return '';
   let result = name.toLowerCase();
   for (const [pattern, replacement] of ROMAN_REPLACEMENTS) {
     result = result.replace(pattern, replacement);
@@ -148,8 +149,10 @@ export function deduplicateGames(games: GameDetailDto[]): GameDetailDto[] {
 function buildDedupKeys(game: GameDetailDto): string[] {
   const keys: string[] = [];
   if (game.igdbId != null) keys.push(`igdb:${game.igdbId}`);
-  const steamId = (game as Record<string, unknown>).steamAppId;
-  if (steamId != null) keys.push(`steam:${steamId}`);
+  const steamId = (game as Record<string, unknown>).steamAppId as
+    | number
+    | undefined;
+  if (steamId != null) keys.push(`steam:${String(steamId)}`);
   keys.push(`name:${normalizeForDedup(game.name)}`);
   return keys;
 }

--- a/api/src/igdb/igdb-search-dedup.helpers.ts
+++ b/api/src/igdb/igdb-search-dedup.helpers.ts
@@ -85,6 +85,7 @@ export function mergeEnrichment(
   winner: GameDetailDto,
   donor: GameDetailDto,
 ): void {
+  if (winner.id === 0 && donor.id !== 0) winner.id = donor.id;
   copyNullFields(winner, donor, IGDB_NULL_FIELDS);
   copyEmptyArrayFields(winner, donor, IGDB_ARRAY_FIELDS);
   copyNullFields(winner, donor, ITAD_NULL_FIELDS);

--- a/api/src/igdb/igdb-search-dedup.helpers.ts
+++ b/api/src/igdb/igdb-search-dedup.helpers.ts
@@ -1,0 +1,202 @@
+/**
+ * Game search deduplication across IGDB and ITAD sources (ROK-1008).
+ * Removes duplicate entries when the same game exists in both sources
+ * with slightly different names (e.g., "Slay the Spire II" vs "Slay the Spire 2").
+ */
+import type { GameDetailDto } from '@raid-ledger/contract';
+
+/**
+ * Roman numeral replacements, ordered longest-first to avoid
+ * partial matches (e.g., "VIII" before "VII" before "VI").
+ */
+const ROMAN_REPLACEMENTS: [RegExp, string][] = [
+  [/\bVIII\b/gi, '8'],
+  [/\bVII\b/gi, '7'],
+  [/\bVI\b/gi, '6'],
+  [/\bIV\b/gi, '4'],
+  [/\bV\b/gi, '5'],
+  [/\bIII\b/gi, '3'],
+  [/\bII\b/gi, '2'],
+];
+
+/**
+ * Normalize a game name for deduplication comparison.
+ * - Lowercase
+ * - Replace Roman numerals at word boundaries with Arabic equivalents
+ * - Strip subtitle separator punctuation (colons, dashes surrounded by space)
+ * - Collapse whitespace
+ */
+export function normalizeForDedup(name: string): string {
+  let result = name.toLowerCase();
+  for (const [pattern, replacement] of ROMAN_REPLACEMENTS) {
+    result = result.replace(pattern, replacement);
+  }
+  // Strip colons (subtitle separators)
+  result = result.replace(/\s*:\s*/g, ' ');
+  // Strip dashes acting as subtitle separators (surrounded by whitespace)
+  result = result.replace(/\s+-\s+/g, ' ');
+  // Collapse whitespace
+  result = result.replace(/\s+/g, ' ').trim();
+  return result;
+}
+
+/** Fields to copy from donor where winner has null/empty (IGDB metadata). */
+const IGDB_NULL_FIELDS: (keyof GameDetailDto)[] = [
+  'igdbId',
+  'coverUrl',
+  'summary',
+  'rating',
+  'aggregatedRating',
+  'twitchGameId',
+  'playerCount',
+  'crossplay',
+];
+
+/** Array fields to copy from donor where winner has empty array. */
+const IGDB_ARRAY_FIELDS: (keyof GameDetailDto)[] = [
+  'genres',
+  'gameModes',
+  'themes',
+  'platforms',
+  'screenshots',
+  'videos',
+];
+
+/** ITAD fields to copy from donor where winner has null/empty. */
+const ITAD_NULL_FIELDS: (keyof GameDetailDto)[] = [
+  'itadGameId',
+  'itadBoxartUrl',
+  'itadCurrentPrice',
+  'itadCurrentCut',
+  'itadCurrentShop',
+  'itadLowestPrice',
+  'itadLowestCut',
+];
+
+/** ITAD array fields to copy from donor where winner has empty array. */
+const ITAD_ARRAY_FIELDS: (keyof GameDetailDto)[] = ['itadTags'];
+
+/**
+ * Copy enrichment data from donor into winner, without overwriting
+ * fields that already have values on the winner.
+ */
+export function mergeEnrichment(
+  winner: GameDetailDto,
+  donor: GameDetailDto,
+): void {
+  copyNullFields(winner, donor, IGDB_NULL_FIELDS);
+  copyEmptyArrayFields(winner, donor, IGDB_ARRAY_FIELDS);
+  copyNullFields(winner, donor, ITAD_NULL_FIELDS);
+  copyEmptyArrayFields(winner, donor, ITAD_ARRAY_FIELDS);
+}
+
+/** Copy fields from donor where winner's value is null or undefined. */
+function copyNullFields(
+  winner: GameDetailDto,
+  donor: GameDetailDto,
+  fields: (keyof GameDetailDto)[],
+): void {
+  for (const field of fields) {
+    if (winner[field] == null && donor[field] != null) {
+      (winner as Record<string, unknown>)[field] = donor[field];
+    }
+  }
+}
+
+/** Copy array fields from donor where winner's array is empty. */
+function copyEmptyArrayFields(
+  winner: GameDetailDto,
+  donor: GameDetailDto,
+  fields: (keyof GameDetailDto)[],
+): void {
+  for (const field of fields) {
+    const winVal = winner[field];
+    const donVal = donor[field];
+    if (Array.isArray(winVal) && winVal.length === 0 && Array.isArray(donVal)) {
+      (winner as Record<string, unknown>)[field] = donVal;
+    }
+  }
+}
+
+/**
+ * Deduplicate games across IGDB and ITAD sources.
+ *
+ * Priority order: igdbId match > steamAppId match > normalized name match.
+ * When deduplicating, the entry with itadGameId wins (ITAD is source of truth).
+ * Enrichment from the loser is merged into the winner.
+ */
+export function deduplicateGames(games: GameDetailDto[]): GameDetailDto[] {
+  const dedupIndex = new Map<string, number>();
+  const result: (GameDetailDto | null)[] = [];
+
+  for (let i = 0; i < games.length; i++) {
+    const game = games[i];
+    const matchIdx = findMatchInIndex(dedupIndex, game);
+
+    if (matchIdx !== null) {
+      handleDuplicate(result, dedupIndex, matchIdx, game);
+    } else {
+      addToIndex(dedupIndex, game, result.length);
+      result.push(game);
+    }
+  }
+
+  return result.filter((g): g is GameDetailDto => g !== null);
+}
+
+/** Build dedup keys for a game (igdbId, steamAppId, normalized name). */
+function buildDedupKeys(game: GameDetailDto): string[] {
+  const keys: string[] = [];
+  if (game.igdbId != null) keys.push(`igdb:${game.igdbId}`);
+  const steamId = (game as Record<string, unknown>).steamAppId;
+  if (steamId != null) keys.push(`steam:${steamId}`);
+  keys.push(`name:${normalizeForDedup(game.name)}`);
+  return keys;
+}
+
+/** Find an existing match in the dedup index for the given game. */
+function findMatchInIndex(
+  index: Map<string, number>,
+  game: GameDetailDto,
+): number | null {
+  for (const key of buildDedupKeys(game)) {
+    const existing = index.get(key);
+    if (existing !== undefined) return existing;
+  }
+  return null;
+}
+
+/** Add a game's keys to the dedup index. */
+function addToIndex(
+  index: Map<string, number>,
+  game: GameDetailDto,
+  position: number,
+): void {
+  for (const key of buildDedupKeys(game)) {
+    index.set(key, position);
+  }
+}
+
+/** Handle a duplicate: pick winner, merge enrichment, update index. */
+function handleDuplicate(
+  result: (GameDetailDto | null)[],
+  dedupIndex: Map<string, number>,
+  existingIdx: number,
+  newGame: GameDetailDto,
+): void {
+  const existing = result[existingIdx]!;
+  const { winner, loser } = pickWinner(existing, newGame);
+  mergeEnrichment(winner, loser);
+  result[existingIdx] = winner;
+  // Re-index with the winner's keys in case they changed
+  addToIndex(dedupIndex, winner, existingIdx);
+}
+
+/** Pick the winner between two duplicate games. ITAD entry wins. */
+function pickWinner(
+  a: GameDetailDto,
+  b: GameDetailDto,
+): { winner: GameDetailDto; loser: GameDetailDto } {
+  if (b.itadGameId && !a.itadGameId) return { winner: b, loser: a };
+  return { winner: a, loser: b };
+}

--- a/api/src/igdb/igdb-search-pipeline.helpers.spec.ts
+++ b/api/src/igdb/igdb-search-pipeline.helpers.spec.ts
@@ -84,7 +84,7 @@ describe('runSearchPipeline', () => {
       triggerRefresh,
     );
 
-    expect(result).toBe(itadResult);
+    expect(result).toEqual(itadResult);
     expect(executeSearch).not.toHaveBeenCalled();
   });
 
@@ -112,7 +112,7 @@ describe('runSearchPipeline', () => {
       triggerRefresh,
     );
 
-    expect(result).toBe(igdbResult);
+    expect(result).toEqual(igdbResult);
     expect(executeSearch).toHaveBeenCalled();
   });
 
@@ -135,7 +135,7 @@ describe('runSearchPipeline', () => {
       triggerRefresh,
     );
 
-    expect(result).toBe(igdbResult);
+    expect(result).toEqual(igdbResult);
   });
 
   it('falls back to IGDB when ITAD throws non-Error', async () => {
@@ -157,7 +157,7 @@ describe('runSearchPipeline', () => {
       triggerRefresh,
     );
 
-    expect(result).toBe(igdbResult);
+    expect(result).toEqual(igdbResult);
   });
 
   it('passes triggerRefresh callback to IGDB executeSearch', async () => {
@@ -203,7 +203,7 @@ describe('runSearchPipeline', () => {
       triggerRefresh,
     );
 
-    expect(result).toBe(igdbResult);
+    expect(result).toEqual(igdbResult);
     expect(executeItadSearch).not.toHaveBeenCalled();
     expect(executeSearch).toHaveBeenCalled();
   });
@@ -226,7 +226,7 @@ describe('runSearchPipeline', () => {
       triggerRefresh,
     );
 
-    expect(result).toBe(itadResult);
+    expect(result).toEqual(itadResult);
     expect(executeItadSearch).toHaveBeenCalled();
   });
 });

--- a/api/src/igdb/igdb-search-pipeline.helpers.ts
+++ b/api/src/igdb/igdb-search-pipeline.helpers.ts
@@ -11,6 +11,7 @@ import type { ItadService } from '../itad/itad.service';
 import type { IgdbApiGame, SearchResult } from './igdb.constants';
 import { buildItadSearchDeps } from './igdb-itad-deps.helpers';
 import { executeItadSearch } from './igdb-itad-search.helpers';
+import { deduplicateGames } from './igdb-search-dedup.helpers';
 import {
   executeSearch,
   doSearchRefresh,
@@ -60,6 +61,21 @@ export function isPartialPrefixQuery(normalized: string): boolean {
  * @returns Search results
  */
 export async function runSearchPipeline(
+  params: SearchPipelineParams,
+  query: string,
+  normalized: string,
+  triggerRefresh: (q: string, n: string, k: string) => void,
+): Promise<SearchResult> {
+  const result = await runSearchPipelineCore(
+    params,
+    query,
+    normalized,
+    triggerRefresh,
+  );
+  return { ...result, games: deduplicateGames(result.games) };
+}
+
+async function runSearchPipelineCore(
   params: SearchPipelineParams,
   query: string,
   normalized: string,

--- a/api/src/igdb/igdb.service.ts
+++ b/api/src/igdb/igdb.service.ts
@@ -60,6 +60,7 @@ import {
   triggerSearchRefreshIfNeeded,
   type SearchPipelineParams,
 } from './igdb-search-pipeline.helpers';
+import { deduplicateGames } from './igdb-search-dedup.helpers';
 
 @Injectable()
 export class IgdbService {
@@ -216,6 +217,7 @@ export class IgdbService {
     const promise = runSearchPipeline(params, query, normalized, (q, n, k) =>
       triggerSearchRefreshIfNeeded(this.inFlightRefreshes, params, q, n, k),
     )
+      .then((r) => ({ ...r, games: deduplicateGames(r.games) }))
       .then((r) => sortByRelevance(this.db, r, normalized))
       .finally(() => this.inFlightSearches.delete(normalized));
     this.inFlightSearches.set(normalized, promise);

--- a/api/src/igdb/igdb.service.ts
+++ b/api/src/igdb/igdb.service.ts
@@ -60,7 +60,6 @@ import {
   triggerSearchRefreshIfNeeded,
   type SearchPipelineParams,
 } from './igdb-search-pipeline.helpers';
-import { deduplicateGames } from './igdb-search-dedup.helpers';
 
 @Injectable()
 export class IgdbService {
@@ -217,7 +216,6 @@ export class IgdbService {
     const promise = runSearchPipeline(params, query, normalized, (q, n, k) =>
       triggerSearchRefreshIfNeeded(this.inFlightRefreshes, params, q, n, k),
     )
-      .then((r) => ({ ...r, games: deduplicateGames(r.games) }))
       .then((r) => sortByRelevance(this.db, r, normalized))
       .finally(() => this.inFlightSearches.delete(normalized));
     this.inFlightSearches.set(normalized, promise);


### PR DESCRIPTION
## What

Deduplicate game search results when the same game exists in both IGDB and ITAD with different names (e.g., "Slay the Spire II" vs "Slay the Spire 2").

## Why

Users saw duplicate entries in search results across all game search surfaces (event creation, lineup nomination, game library), making it confusing which entry to select.

## Acceptance criteria

- [x] Search returns one result per game (not separate IGDB + ITAD entries)
- [x] ITAD entry preferred; IGDB metadata (genres, summary, rating) merged in
- [x] Games with matching steamAppId/igdbId deduplicated
- [x] Name normalization: "Game II" ↔ "Game 2", "Game: Subtitle" ↔ "Game - Subtitle"
- [x] No false deduplication for unrelated games
- [x] Upsert pre-check prevents new duplicate DB rows
- [x] Admin cleanup endpoint merges existing duplicates with FK reassignment
- [x] Search for "slay the spire 2" finds "Slay the Spire II" (Roman ↔ Arabic matching)

## Test plan

- [x] 96 unit tests (dedup helpers, cleanup helpers, upsert pre-check, pipeline)
- [x] CI passes (build + lint + typecheck + tests + container startup)
- [x] Operator tested locally — search, game detail pages, dedup cleanup
- [x] Code review passed (2 critical fixes applied: data loss in deleteAndReassign, missing FK table)
- [x] Full smoke test suite passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)