### PR TITLE
ROK-948: infra — add pgvector extension to both Docker topologies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15-alpine
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_USER: user
           POSTGRES_PASSWORD: password
@@ -294,7 +294,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15-alpine
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_USER: user
           POSTGRES_PASSWORD: password

--- a/.github/workflows/discord-smoke.yml
+++ b/.github/workflows/discord-smoke.yml
@@ -45,7 +45,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:15-alpine
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_USER: user
           POSTGRES_PASSWORD: password

--- a/Dockerfile.allinone
+++ b/Dockerfile.allinone
@@ -269,6 +269,22 @@ until /sbin/su-exec postgres pg_isready -q; do
 done
 echo "✅ PostgreSQL is ready"
 
+# Ensure pgvector extension is installed (ROK-948). pgvector v0.7.x is NOT a
+# trusted extension, so the raid_ledger role cannot install it via a plain
+# drizzle migration. init-db.sh handles fresh installs; existing data volumes
+# (PG_VERSION present) skip that block — so we also install here on every
+# start as the postgres superuser. Idempotent; the migration 0120 then no-ops.
+# Fail loud if it can't install — an unbootable API is clearer than a
+# mid-migration crash.
+if ! /sbin/su-exec postgres psql -v ON_ERROR_STOP=1 -qt -d raid_ledger \
+    -c "CREATE EXTENSION IF NOT EXISTS vector;" > /dev/null 2>&1; then
+  echo "❌ FATAL: pgvector extension could not be installed"
+  echo "   The pgvector binary may be missing from this image, or the"
+  echo "   postgres data dir is corrupted. Check /data/logs/postgresql.log."
+  exit 1
+fi
+echo "✅ pgvector extension ensured"
+
 # Wait for Redis to be ready (Unix socket)
 echo "⏳ Waiting for Redis..."
 until redis-cli -s /tmp/redis.sock ping > /dev/null 2>&1; do

--- a/Dockerfile.allinone
+++ b/Dockerfile.allinone
@@ -82,6 +82,22 @@ RUN apk add --no-cache \
   logrotate \
   zstd
 
+# Build and install pgvector v0.7.4 from source (ROK-948).
+# Alpine does not ship a postgresql16-pgvector package, so we compile.
+# Build dependencies are installed under a virtual package and removed after
+# install to keep the runtime image lean. JIT (clang/llvm) is intentionally
+# omitted — pgvector works fine without it and avoids Alpine version drift
+# on unversioned clang/llvm package names.
+RUN apk add --no-cache --virtual .pgvector-build \
+    git build-base postgresql16-dev \
+  && git clone --branch v0.7.4 --depth 1 https://github.com/pgvector/pgvector.git /tmp/pgvector \
+  && cd /tmp/pgvector \
+  && make OPTFLAGS="" PG_CONFIG=/usr/libexec/postgresql16/pg_config \
+  && make install PG_CONFIG=/usr/libexec/postgresql16/pg_config \
+  && cd / \
+  && rm -rf /tmp/pgvector \
+  && apk del .pgvector-build
+
 # Copy glibc runtime for Ollama (replaces gcompat which couldn't provide fcntl64)
 COPY --from=glibc-donor /opt/glibc/lib/ /opt/glibc/lib/
 
@@ -329,9 +345,13 @@ if [ ! -s "${PGDATA}/PG_VERSION" ]; then
   /sbin/su-exec postgres psql -q -c "CREATE DATABASE raid_ledger OWNER raid_ledger;"
   /sbin/su-exec postgres psql -q -c "GRANT ALL PRIVILEGES ON DATABASE raid_ledger TO raid_ledger;"
 
+  # Enable pgvector extension (ROK-948) — requires superuser, must run before
+  # Drizzle migrations create the vector-typed columns.
+  /sbin/su-exec postgres psql -q -d raid_ledger -c "CREATE EXTENSION IF NOT EXISTS vector;"
+
   # Stop PostgreSQL (supervisor will start it)
   /sbin/su-exec postgres pg_ctl -D "${PGDATA}" -m fast -w stop 2>/dev/null
-  
+
   echo "✅ PostgreSQL initialized"
 fi
 EOF

--- a/api/src/common/testing/test-app.ts
+++ b/api/src/common/testing/test-app.ts
@@ -142,7 +142,7 @@ async function provisionDatabase(): Promise<{
   if (process.env.DATABASE_URL) {
     return { connectionString: process.env.DATABASE_URL, container: null };
   }
-  const container = await new PostgreSqlContainer('postgres:15-alpine')
+  const container = await new PostgreSqlContainer('pgvector/pgvector:pg16')
     .withDatabase('raid_ledger_test')
     .withUsername('test')
     .withPassword('test')

--- a/api/src/drizzle/migrations/0120_enable_pgvector.sql
+++ b/api/src/drizzle/migrations/0120_enable_pgvector.sql
@@ -1,0 +1,5 @@
+-- ROK-948: Enable the pgvector extension so player_taste_vectors (added in a
+-- later migration) can use the vector(7) column type for cosine-similarity
+-- queries. Extension is trusted (v0.5.0+), so any role with CREATE on the
+-- database — including the raid_ledger app role — can install it.
+CREATE EXTENSION IF NOT EXISTS vector;

--- a/api/src/drizzle/migrations/meta/_journal.json
+++ b/api/src/drizzle/migrations/meta/_journal.json
@@ -841,6 +841,13 @@
       "when": 1775949315716,
       "tag": "0119_vengeful_king_cobra",
       "breakpoints": true
+    },
+    {
+      "idx": 120,
+      "version": "7",
+      "when": 1775949415716,
+      "tag": "0120_enable_pgvector",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/drizzle/pgvector.integration.spec.ts
+++ b/api/src/drizzle/pgvector.integration.spec.ts
@@ -1,0 +1,44 @@
+/**
+ * pgvector Integration Tests (ROK-948)
+ *
+ * Verifies that migration 0120 enables the pgvector extension and that the
+ * `vector` type is usable against the running Postgres instance. This guards
+ * the infrastructure change that underpins the upcoming player_taste_vectors
+ * table and its cosine-similarity queries.
+ */
+import { sql } from 'drizzle-orm';
+import { getTestApp, type TestApp } from '../common/testing/test-app';
+
+describe('pgvector extension (ROK-948)', () => {
+  let testApp: TestApp;
+
+  beforeAll(async () => {
+    testApp = await getTestApp();
+  });
+
+  it('is installed by migration 0120', async () => {
+    const rows = await testApp.db.execute<{ extname: string }>(
+      sql`SELECT extname FROM pg_extension WHERE extname = 'vector'`,
+    );
+    expect(rows.length).toBe(1);
+    expect(rows[0].extname).toBe('vector');
+  });
+
+  it('supports vector(7) casts and cosine distance operator', async () => {
+    const rows = await testApp.db.execute<{
+      identical: string;
+      partial: string;
+      orthogonal: string;
+    }>(sql`
+      SELECT
+        ('[1,0,0,0,0,0,0]'::vector(7) <=> '[1,0,0,0,0,0,0]'::vector(7))::text AS identical,
+        ('[1,0,0,0,0,0,0]'::vector(7) <=> '[1,1,0,0,0,0,0]'::vector(7))::text AS partial,
+        ('[1,0,0,0,0,0,0]'::vector(7) <=> '[0,0,0,0,0,0,1]'::vector(7))::text AS orthogonal
+    `);
+    const [row] = rows;
+    expect(Number(row.identical)).toBeCloseTo(0);
+    expect(Number(row.partial)).toBeGreaterThan(0);
+    expect(Number(row.partial)).toBeLessThan(1);
+    expect(Number(row.orthogonal)).toBeCloseTo(1);
+  });
+});

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -7,7 +7,7 @@
 #   docker compose -f docker-compose.test.yml down -v
 services:
   test-postgres:
-    image: postgres:15-alpine
+    image: pgvector/pgvector:pg16
     environment:
       POSTGRES_USER: test
       POSTGRES_PASSWORD: test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   db:
-    image: postgres:15-alpine
+    image: pgvector/pgvector:pg16
     container_name: raid-ledger-db
     restart: always
     environment:

--- a/scripts/deploy_dev.sh
+++ b/scripts/deploy_dev.sh
@@ -272,10 +272,38 @@ validate_db_volume() {
     print_success "DB volume verified: $volume_name"
 }
 
+# Verify the DB container image matches what docker-compose.yml currently expects.
+# A mismatch means the dev upgraded (e.g. ROK-948: pg15 -> pgvector/pgvector:pg16)
+# without recreating the volume — migrations that depend on the new image's
+# extensions will fail with cryptic errors. We stop loudly and tell the user
+# exactly which one-time command fixes it.
+validate_db_image() {
+    local expected_image
+    expected_image=$(grep -E '^\s+image:\s*' "$MAIN_REPO/docker-compose.yml" | head -1 | awk '{print $2}')
+    [ -z "$expected_image" ] && return 0  # Can't parse — skip
+
+    local actual_image
+    actual_image=$(docker inspect raid-ledger-db --format '{{.Config.Image}}' 2>/dev/null || true)
+    [ -z "$actual_image" ] && return 0  # No container yet — skip
+
+    if [ "$actual_image" != "$expected_image" ]; then
+        print_error "DB container image MISMATCH"
+        print_error "  Running: $actual_image"
+        print_error "  Expected: $expected_image"
+        echo ""
+        print_warning "Postgres major-version upgrades are NOT in-place. Fix (destroys local DB data):"
+        echo "  docker compose down -v && ./scripts/deploy_dev.sh --ci --fresh --rebuild"
+        exit 1
+    fi
+}
+
 # Start Docker containers safely — uses 'docker start' first to avoid
 # creating wrong volumes from worktree directory prefixes.
 ensure_docker() {
     echo "Ensuring Docker DB + Redis are running..."
+
+    # Catch an image mismatch before starting the stale container.
+    validate_db_image
 
     # Try starting existing containers by name first (safe from any directory)
     local db_started=false

--- a/scripts/validate-ci.sh
+++ b/scripts/validate-ci.sh
@@ -183,6 +183,17 @@ _wait_for_container_health() {
     return 1
   fi
   echo -e "${GREEN}Nginx proxy: healthy${NC}"
+
+  # Verify pgvector extension is loaded (ROK-948). Indirectly covered by the
+  # migration run during startup — but an explicit check catches silent-success
+  # bugs (e.g. build step swapped to a different Postgres major with no pgvector).
+  if ! docker exec "$cname" su-exec postgres \
+    psql -d raid_ledger -tAc "SELECT extname FROM pg_extension WHERE extname='vector'" \
+    | grep -q '^vector$'; then
+    echo -e "${RED}pgvector extension not loaded in allinone DB${NC}"
+    return 1
+  fi
+  echo -e "${GREEN}pgvector: loaded${NC}"
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/validate-migrations.sh
+++ b/scripts/validate-migrations.sh
@@ -46,7 +46,7 @@ start_postgres() {
     -e POSTGRES_PASSWORD=password \
     -e POSTGRES_DB=raid_ledger \
     -p 0:5432 \
-    postgres:16-alpine >/dev/null
+    pgvector/pgvector:pg16 >/dev/null
 }
 
 get_mapped_port() {


### PR DESCRIPTION
## Summary

- Adds pgvector (v0.7.4 allinone / v0.8.2 dev) to both Docker topologies so the upcoming ROK-948 code PR can store `vector(7)` taste-profile columns and query via `<=>` cosine distance.
- Compiles pgvector from source in `Dockerfile.allinone` (Alpine has no `postgresql16-pgvector` package); switches docker-compose + Testcontainers + CI service images + `validate-migrations.sh` from `postgres:15-alpine` and `postgres:16-alpine` to `pgvector/pgvector:pg16`. Dev Postgres aligns with prod at pg16.
- `start-api.sh` elevates to postgres superuser and runs `CREATE EXTENSION IF NOT EXISTS vector` on every allinone boot — pgvector v0.7.x is NOT trusted, so `raid_ledger` cannot install it via a plain migration. `init-db.sh` still covers fresh installs; `start-api.sh` covers upgrades (where `PG_VERSION` exists and init-db skips).
- New integration test `pgvector.integration.spec.ts` asserts extension presence + `vector(7)` + `<=>` operator.
- Explicit `\dx` check added to `scripts/validate-ci.sh` container-startup step so a missing pgvector binary fails CI loudly instead of at migration time.
- New `validate_db_image()` in `scripts/deploy_dev.sh` catches the pg15→pg16 image mismatch on dev machines with existing `raid-ledger-db` containers and prints the one-time remediation command instead of letting migration 0120 crash cryptically.

## Why

Per CLAUDE.md, infrastructure changes ship separately from code. This PR delivers the 1 infra AC of ROK-948 ("pgvector extension enabled in both Docker topologies") so the follow-up code PR can be focused on schema, pipelines, and endpoints.

## Linear

ROK-948 (this story stays "In Progress" until the follow-up code PR lands)

## Test plan

- [x] `./scripts/validate-ci.sh --full` → 7/7 PASS locally (build, typecheck, lint, unit+coverage, integration, migration validation, container startup)
- [x] `pgvector.integration.spec.ts` → 2/2 PASS (extension installed, `vector(7)` + `<=>` cosine operator work)
- [x] Allinone built locally; `\dx` lists `vector 0.7.4`, `/api/health` → 200
- [x] **Prod upgrade simulated** locally: DROPped extension + DELETEd 0120 from drizzle journal, restarted container; `start-api.sh` re-created extension as postgres superuser, migration 0120 re-ran successfully as `raid_ledger`, API healthy. Without this path, `raid_ledger` gets `ERROR: permission denied to create extension "vector". Must be superuser.`
- [x] Integration test exercises the happy path end-to-end; GitHub Actions will run both `ci.yml` and `container-startup` on `pgvector/pgvector:pg16`

## Breaking change (local dev only)

Existing local `db_data` volumes are on pg15 and cannot upgrade in-place. `deploy_dev.sh` now detects the mismatch and prints:

```
docker compose down -v && ./scripts/deploy_dev.sh --ci --fresh --rebuild
```

One-time for each dev.