### PR TITLE
ROK-1057: tech-debt — adapt /bulk skill for Agent Teams

### DIFF
--- a/.claude/skills/bulk/SKILL.md
+++ b/.claude/skills/bulk/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: bulk
-description: "Bulk pipeline: pull chore/tech-debt/perf stories from Linear, parallel dev agents in worktrees, validate, ship as single PR"
+description: "Bulk pipeline: pull chore/tech-debt/perf stories from Linear, Agent Team with parallel dev + reviewer teammates in worktrees, validate, ship as single PR"
 argument-hint: "[ROK-XXX ROK-YYY | all]"
 ---
 
 # Bulk — Chore / Tech Debt / Performance Pipeline
 
-Pulls small-scope stories (Tech Debt, Chore, Performance), batches them, spawns parallel devs in worktrees, merges all into one batch branch, validates, and ships one PR. No operator gate, no test agents, no architect. Quality gate: integration tests + full CI on the merged batch branch.
+Pulls small-scope stories (Tech Debt, Chore, Performance), batches them, spawns parallel dev and reviewer teammates inside a single Agent Team, merges all into one batch branch, validates, and ships one PR. No operator gate, no test agents, no architect. Quality gate: integration tests + full CI on the merged batch branch.
+
+**Requires Agent Teams:** `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` must be set in `~/.claude/settings.json` (already configured). Teammates self-claim tasks from a shared task list and message each other directly for auto-fix loops — the Lead only orchestrates the batch.
 
 **Linear Project:** Raid Ledger (`1bc39f98-abaa-4d85-912f-ba62c8da1532`)
 **Team:** Roknua's projects (`0728c19f-5268-4e16-aa45-c944349ce386`)
@@ -25,12 +27,12 @@ Tech debt, chores, perf improvements — light or standard scope only. If a stor
 
 ```
 Step 1: Gather    → Linear search by label, profile, operator approves
-Step 2: Implement → Batch branch, worktrees, plan, parallel devs → per-story reviewers (parallel) → merge
+Step 2: Implement → Batch branch, worktrees, Agent Team with shared task list, dev teammates self-claim → per-story reviewer teammates (parallel, message devs directly for auto-fix) → merge
 Step 3: Validate  → Test gaps, build + typecheck + lint + unit + integration + smoke, inline push
-Step 4: Ship      → Auto-merge, Linear → Done, cleanup
+Step 4: Ship      → Auto-merge, Linear → Done, team + worktree cleanup
 ```
 
-**Gates:** per-story (dev, reviewer) + batch-level (test_gaps, ci, integration, smoke). Per-story reviewers run in parallel with still-active devs, before merge — catches attribution cleanly.
+**Gates:** per-story (dev, reviewer) + batch-level (test_gaps, ci, integration, smoke). Per-story reviewer teammates run in parallel with still-active devs, before merge — catches attribution cleanly, and reviewers can message devs directly to request fixes without involving the Lead.
 
 ---
 
@@ -46,7 +48,16 @@ Step 4: Ship      → Auto-merge, Linear → Done, cleanup
 
 ## Self-Recovery (Post-Compaction)
 
-Read `planning-artifacts/batch-state.yaml`, follow `pipeline.next_action`. No agents to respawn.
+Read `planning-artifacts/batch-state.yaml`, follow `pipeline.next_action`.
+
+**Agent Teams caveat:** in-process teammates do NOT survive `/resume` or `/rewind`. The team config and shared task list persist on disk (`~/.claude/teams/batch-YYYY-MM-DD/` and `~/.claude/tasks/batch-YYYY-MM-DD/`), but the running dev/reviewer teammate processes are gone. Recovery path:
+
+1. Read `batch-state.yaml` for per-story status.
+2. Unclaim any task whose owner no longer exists (`TaskUpdate({ owner: null, status: "pending" })`).
+3. Re-`TeamCreate` (if team config also lost) and re-spawn dev/reviewer teammates using the thin spawn prompts in Step 2f/2g — they self-claim the unowned tasks.
+4. For stories already committed in their worktree, spell that out in the replacement task description so the fresh teammate doesn't redo the work.
+
+See `steps/step-2-implement.md` §2i for full detail.
 
 ---
 
@@ -72,11 +83,13 @@ Touches `packages/contract`, adds migration, or touches 3+ modules → full → 
 
 **Git:** always `git pull --rebase origin/main` or `git rebase origin/main`.
 
-**Agent comms:** mailbox via `SendMessage`. Never `TaskOutput` to check on agents. Never poll with `sleep + stat`.
+**Agent comms (Agent Teams):** teammates communicate directly via `SendMessage` — dev↔reviewer for auto-fix loops, teammate→Lead for completion summaries. The Lead receives idle notifications automatically when a teammate finishes a task, so never poll: no `TaskOutput` to check on agents, no `sleep + stat` loops. Read the notifications, don't chase them.
+
+**Agent Teams dependency:** this skill requires `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` (already set in `~/.claude/settings.json`). Only one team can be active per Claude Code session — don't run `/bulk` and `/build` in the same session, and finish one bulk batch before starting another. The team lives under `~/.claude/teams/batch-YYYY-MM-DD/`; clean it up in Step 4 before exiting.
 
 **Auto-merge is the LAST action.** Never enable at PR creation.
 
-**Subagent rules (via templates):** stay in worktree, never push, never create PRs, never enable auto-merge, never force-push, never call `mcp__linear__*`, never run destructive ops.
+**Teammate rules (via templates):** stay in worktree, never push, never create PRs, never enable auto-merge, never force-push, never call `mcp__linear__*`, never run `deploy_dev.sh` or other destructive ops. Devs coordinate with reviewers via `SendMessage`; reviewers coordinate with devs for auto-fix. Only the Lead talks to Linear, Git remotes, or GitHub.
 
 ---
 
@@ -85,18 +98,18 @@ Touches `packages/contract`, adds migration, or touches 3+ modules → full → 
 | Step | File | Description |
 |------|------|-------------|
 | 1 | `steps/step-1-gather.md` | Cleanup, fetch by label, profile, present batch, init state |
-| 2 | `steps/step-2-implement.md` | Batch branch, worktrees, spawn devs, merge |
+| 2 | `steps/step-2-implement.md` | Batch branch, worktrees, Agent Team + shared task list, dev + reviewer teammates, merge |
 | 3 | `steps/step-3-validate.md` | Review, test gaps, build/type/lint/unit/integration/smoke |
-| 4 | `steps/step-4-ship.md` | PR, auto-merge, Linear → Done, cleanup, wiki sync |
+| 4 | `steps/step-4-ship.md` | PR, auto-merge, Linear → Done, team + worktree cleanup, wiki sync |
 
 ---
 
 ## Agents
 
-All agents use **opus**. One-shot.
+All agents use **opus**.
 
-| Agent | Template | When |
-|-------|----------|------|
-| Planner | Plan subagent | Step 2c (standard stories needing plan) |
-| Dev | `templates/dev-bulk.md` | Step 2d (one per story, parallel) |
-| Reviewer | `devedup-rl:reviewer` | Step 2e (one per story, parallel, before merge) |
+| Agent | Kind | Template | When |
+|-------|------|----------|------|
+| Planner | One-shot `Agent` subagent (read-only) | Plan subagent | Step 2c (standard stories needing plan) |
+| Dev | Teammate (shared task list, self-claim) | `templates/dev-bulk.md` | Step 2e–2f — task posted, then N teammates spawned |
+| Reviewer | Teammate (parallel, messages dev directly) | `templates/reviewer-bulk.md` | Step 2g — review task posted + teammate spawned when dev idles |

--- a/.claude/skills/bulk/steps/step-2-implement.md
+++ b/.claude/skills/bulk/steps/step-2-implement.md
@@ -1,6 +1,8 @@
-# Step 2: Implement — Batch Branch, Worktrees, Devs, Reviewers, Merge
+# Step 2: Implement — Agent Team, Shared Task List, Self-Claim, Direct Reviewer Messaging
 
-Lead creates the batch branch, worktrees, spawns devs and reviewers, merges results. Max 2-3 devs in parallel.
+Lead creates the batch branch, worktrees, and an Agent Team. Devs and reviewers run as **teammates** inside that team — they self-claim tasks from a shared list and coordinate directly via `SendMessage` (no Lead middleman for auto-fix loops). Max 2–3 dev teammates in parallel.
+
+**Prerequisite:** `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` is set in `~/.claude/settings.json`. Only one team can exist per session — if `/build` or a previous `/bulk` run left a team in place, clean it up before starting.
 
 ---
 
@@ -52,7 +54,7 @@ Update state: `status: "queued"` → `"worktree_ready"`.
 
 Skip entirely if all stories have `needs_planner: false`.
 
-For each planner story, spawn a Plan subagent:
+Planners remain **one-shot `Agent()` subagents** (read-only, no coordination needed — they don't become teammates):
 
 ```
 Agent(subagent_type: "Plan", description: "Plan ROK-<num>",
@@ -74,115 +76,213 @@ Keep it concise — tech-debt/chore/perf story, not a feature.
 """)
 ```
 
-Planners run in parallel (read-only). When each completes:
+Planners run in parallel. When each completes:
 
 1. Record in state: `plan_summary: <concise plan>`.
 2. If planner reveals full scope → remove from batch, `status: "deferred"`, recommend `/build`.
 
 ---
 
-## 2d. Create Team and Spawn Devs
+## 2d. Create the Agent Team
 
 ```
-TeamCreate({ team_name: "batch-YYYY-MM-DD", description: "Batch for YYYY-MM-DD" })
+TeamCreate({ team_name: "batch-YYYY-MM-DD", description: "Bulk batch YYYY-MM-DD — parallel devs + reviewers" })
 ```
 
-For each story: read `templates/dev-bulk.md`, fill variables, spawn.
-
-```
-Task(subagent_type: "general-purpose", team_name: "batch-YYYY-MM-DD",
-     name: "dev-rok-<num>", model: "opus", mode: "bypassPermissions",
-     prompt: <filled dev-bulk.md>)
-```
-
-Up to 2-3 in parallel (single message, multiple Task calls).
-
-Update state: `status: "dev_active"`, `gates.dev: PENDING`.
-Pipeline: `next_action: "Devs active: X, Y. On dev completion → spawn per-story reviewer. On reviewer completion → merge. All merged → step-3."`.
+The team's shared task list and mailbox live at `~/.claude/teams/batch-YYYY-MM-DD/` and `~/.claude/tasks/batch-YYYY-MM-DD/`.
 
 ---
 
-## 2e. When Dev Completes → Spawn Per-Story Reviewer (parallel)
+## 2e. Post Dev Tasks to the Shared List
 
-When a dev messages completion:
+For each story, read `templates/dev-bulk.md`, splice in the story-specific details, and post a task. Teammates will self-claim.
 
-1. Verify commit: `cd ../Raid-Ledger--rok-<num> && git log --oneline -3`.
-2. Record `dev_commit_sha: <sha>`, `status: "reviewing"`, `gates.dev: PASS`.
-3. **Spawn reviewer immediately** (parallel with any still-active devs):
+```
+TaskCreate({
+  subject: "ROK-<num>: dev",
+  description: """
+<entire filled-in contents of templates/dev-bulk.md, with:>
+  - ROK story title + label
+  - Spec + ACs pasted from Linear
+  - WORKTREE_PATH: ../Raid-Ledger--rok-<num>
+  - Branch: batch/rok-<num>
+  - plan_summary (if a planner ran)
+""",
+  metadata: {
+    role: "dev",
+    story: "ROK-<num>",
+    worktree: "../Raid-Ledger--rok-<num>",
+    branch: "batch/rok-<num>"
+  }
+})
+```
+
+Tasks start `pending`, unowned. Update state: `status: "queued_for_claim"` for each story.
+
+---
+
+## 2f. Spawn Dev Teammates
+
+Spawn N generic dev teammates (N = batch size, 2–3). The spawn prompt is thin — real task details live in the shared task descriptions.
+
+```
+Agent(
+  subagent_type: "general-purpose",
+  team_name: "batch-YYYY-MM-DD",
+  name: "dev-rok-<num>",
+  model: "opus",
+  mode: "bypassPermissions",
+  prompt: """
+You are a dev teammate for Raid Ledger (bulk pipeline).
+
+1. TaskList to find a pending task with metadata.role == "dev" and no owner.
+2. Follow the workflow in .claude/skills/bulk/templates/dev-bulk.md verbatim.
+3. Claim exactly one task (TaskUpdate owner=<your name>, status=in_progress).
+4. The task description contains your worktree path, branch, spec, and ACs. Read it fully before coding.
+5. When done, TaskUpdate status=completed, then SendMessage to the Lead with summary.
+6. A reviewer teammate will spawn after you complete — coordinate with them directly via SendMessage.
+
+Standing rules: stay in your claimed worktree; never push/PR/auto-merge/force-push/mcp__linear__*/deploy_dev.sh.
+"""
+)
+```
+
+Spawn in parallel (single message, multiple `Agent` calls) — up to 2–3. The `name` is the address other teammates use to reach this dev via `SendMessage`.
+
+Update state: `status: "dev_active"`, `gates.dev: PENDING` per story.
+Pipeline: `next_action: "Team active. Devs self-claiming dev tasks. On dev idle → post review task + spawn reviewer. On reviewer idle → merge. All merged → step-3."`.
+
+---
+
+## 2g. Dev Idle → Post Review Task + Spawn Reviewer
+
+When a dev teammate marks its task `completed` **and** sends a completion message, the Lead receives an idle notification automatically. Do NOT poll for agent state.
+
+On idle:
+
+1. **Verify commit** — `cd ../Raid-Ledger--rok-<num> && git log --oneline -3`.
+2. **Record state** — `dev_commit_sha: <sha>`, `status: "reviewing"`, `gates.dev: PASS`.
+3. **Post a review task** — read `templates/reviewer-bulk.md`, fill in, `TaskCreate`:
 
    ```
-   Agent(subagent_type: "devedup-rl:reviewer",
-         description: "Review ROK-<num>",
-         prompt: """
-   Review changes on branch batch/rok-<num> compared to origin/main.
-   Worktree: ../Raid-Ledger--rok-<num> — stay in this worktree for all reads/edits.
+   TaskCreate({
+     subject: "ROK-<num>: review",
+     description: """
+   <entire filled-in contents of templates/reviewer-bulk.md, with:>
+     - ROK story + label
+     - Spec + ACs (same paste as the dev task)
+     - WORKTREE_PATH: ../Raid-Ledger--rok-<num>
+     - Branch: batch/rok-<num>
+     - Dev teammate name: dev-rok-<num>   ← the reviewer uses this for SendMessage fix loops
+     - Dev commit SHA: <sha>
+   """,
+     metadata: {
+       role: "reviewer",
+       story: "ROK-<num>",
+       worktree: "../Raid-Ledger--rok-<num>",
+       branch: "batch/rok-<num>",
+       dev_teammate: "dev-rok-<num>"
+     }
+   })
+   ```
 
-   Story: ROK-<num> — <title>
-   Label: <Tech Debt | Chore | Performance>
-   Spec + ACs: <paste full Linear issue description>
+4. **Spawn reviewer teammate** — thin spawn prompt, same pattern as 2f:
 
-   Checklist:
-   1. Correctness — logic bugs, edge cases, error handling, AC trace end-to-end
-   2. Security — injection, auth bypass, data exposure
-   3. Performance — N+1, allocations, missing indexes
-   4. Contract integrity — shared types changed? consumers updated?
-   5. Standards — ESLint, file/function size limits, naming
+   ```
+   Agent(
+     subagent_type: "general-purpose",
+     team_name: "batch-YYYY-MM-DD",
+     name: "reviewer-rok-<num>",
+     model: "opus",
+     mode: "bypassPermissions",
+     prompt: """
+   You are a reviewer teammate for Raid Ledger (bulk pipeline).
 
-   Classify findings: [critical], [high], [medium], [low].
-   - If BLOCKING issues exist: DO NOT commit auto-fixes. Report all findings so the Lead can respawn the dev with the full list.
-   - If only critical/high fixable issues: auto-fix directly in the worktree, run `npx tsc --noEmit` + `npm run lint -w <workspace>` + relevant tests, then commit as `review: auto-fix critical issues (ROK-<num>)`.
-   - Report medium/low as tech debt.
+   1. TaskList to find a pending task with metadata.role == "reviewer" and metadata.story == "ROK-<num>".
+   2. Follow the workflow in .claude/skills/bulk/templates/reviewer-bulk.md verbatim.
+   3. Claim the task (TaskUpdate owner=<your name>, status=in_progress).
+   4. Review the branch in the worktree. For critical/high FIXABLE issues, prefer SendMessage to the dev teammate (dev-rok-<num>) rather than self-fixing.
+   5. When done, TaskUpdate status=completed, then SendMessage the Lead with verdict + findings.
 
-   Standing rules: stay in worktree; never push, create PRs, enable auto-merge, force-push, or call `mcp__linear__*` — Lead handles all of that. Do NOT run `deploy_dev.sh`. Output final verdict: APPROVED | APPROVED WITH FIXES | BLOCKED.
-   """)
+   Standing rules: stay in worktree; never push/PR/auto-merge/force-push/mcp__linear__*/deploy_dev.sh.
+   """
+   )
    ```
 
 Update state: `gates.reviewer: PENDING`.
 
+Devs and reviewers now coordinate auto-fix loops directly via `SendMessage`. The Lead is not involved until the reviewer idles with a final verdict.
+
 ---
 
-## 2f. When Reviewer Completes → Merge into Batch Branch
+## 2h. Reviewer Idle → Merge into Batch Branch
 
-For each story where reviewer finishes:
+When a reviewer teammate marks its task `completed` and sends a verdict message, the Lead receives an idle notification.
 
-1. Check reviewer verdict:
-   - **APPROVED / APPROVED WITH FIXES:** `gates.reviewer: PASS`. Continue to merge.
-   - **BLOCKED:** respawn dev with blockers. Don't merge yet.
-2. Merge into batch branch:
+1. **Parse the verdict** from the reviewer's message:
+   - **APPROVED / APPROVED WITH FIXES** → `gates.reviewer: PASS`. Continue to merge.
+   - **BLOCKED** → do NOT merge. Post a fresh dev task with the blocking list:
+     ```
+     TaskCreate({
+       subject: "ROK-<num>: dev (rework)",
+       description: "<filled dev-bulk.md with blocking findings appended>",
+       metadata: { role: "dev", story: "ROK-<num>", ... }
+     })
+     ```
+     The dev teammate (still alive) self-claims it. Reviewer teammate can stay alive for the re-review, or be shut down and a fresh reviewer spawned when the new dev task completes.
+
+2. **Merge into batch branch:**
    ```bash
    git checkout batch/YYYY-MM-DD
    git merge --no-ff batch/rok-<num> -m "merge ROK-<num> into batch"
    ```
-3. Conflicts:
-   - Trivial (whitespace, imports) → Lead resolves.
-   - Substantive (logic) → respawn dev with conflict context.
+
+3. **Conflicts:**
+   - Trivial (whitespace, imports) → Lead resolves inline.
+   - Substantive (logic) → post a fresh dev task with conflict context; dev teammate resolves.
    - Unresolvable → remove from batch, `status: "queued"`, notify operator.
-4. Cleanup:
+
+4. **Cleanup:**
    ```bash
    git worktree remove ../Raid-Ledger--rok-<num>
    git branch -d batch/rok-<num>
    ```
-5. State: `status: "merged_to_batch"`, record any tech debt findings for the batch-level TD story.
-6. Shutdown dev agent: `SendMessage({ type: "shutdown_request", recipient: "dev-rok-<num>", content: "Work reviewed and merged." })`.
+
+5. **State:** `status: "merged_to_batch"`, record tech-debt findings for the batch-level TD story.
+
+6. **Shut down the teammates** for this story:
+   ```
+   SendMessage({ to: "dev-rok-<num>", message: { type: "shutdown_request", reason: "merged" } })
+   SendMessage({ to: "reviewer-rok-<num>", message: { type: "shutdown_request", reason: "merged" } })
+   ```
 
 ---
 
-## 2g. Post-Compaction Recovery
+## 2i. Post-Compaction / Session Recovery
 
-If state shows `dev_active` or `reviewing`:
-1. Ping agents via `SendMessage` to check liveness.
-2. Dead → check worktree: `cd <worktree> && git log --oneline -5`.
-3. Committed + reviewer gate PENDING → spawn reviewer (2e).
-4. Reviewer complete → merge (2f).
-5. Not committed → respawn dev.
+**Important Agent Teams limitation:** in-process teammates do **not** survive `/resume` or `/rewind`. The shared task list and team config on disk survive, but the running teammate processes are gone. If the Lead attempts to message a teammate that no longer exists, it fails silently.
+
+If state shows `dev_active`, `reviewing`, or `queued_for_claim` and you suspect the session was resumed:
+
+1. **Check team state on disk** — `ls ~/.claude/teams/batch-YYYY-MM-DD/` — does the team still exist?
+2. **List orphaned tasks** — any task with `status: "in_progress"` whose owner's teammate no longer exists is orphaned.
+3. **Unclaim orphans** — `TaskUpdate({ owner: null, status: "pending" })` on each orphaned task.
+4. **Re-spawn missing teammates** — if the team itself was deleted, `TeamCreate` again. Then re-run 2f (and 2g for any stories already in review) to spawn fresh teammates. They self-claim the unowned tasks and continue.
+5. **Reconcile with worktrees** — for stories already committed in the worktree (`git log --oneline -5` shows the fix commit), the fresh dev teammate's task should reflect "already implemented — just mark completed and notify Lead" in its description, to avoid re-doing work.
+
+`batch-state.yaml` remains the source of truth across compactions — the team is ephemeral, the state file persists.
 
 ---
 
-When ALL stories reach `merged_to_batch`, shut down the team and proceed to **Step 3**.
+## 2j. Transition to Step 3
+
+When ALL stories reach `merged_to_batch`:
 
 ```bash
 git log --oneline batch/YYYY-MM-DD ^origin/main  # verify merges
 ```
+
+The team is still alive at this point — we keep it around through Step 3 in case a batch-level validation failure traces back to a specific story and we need to post a new dev task. Final team cleanup happens in Step 4 after the PR merges.
 
 Update state:
 ```yaml

--- a/.claude/skills/bulk/steps/step-4-ship.md
+++ b/.claude/skills/bulk/steps/step-4-ship.md
@@ -36,9 +36,21 @@ gh pr view batch/YYYY-MM-DD --json state  # wait for merged
 git checkout main && git pull --rebase origin main
 git branch -d batch/YYYY-MM-DD 2>/dev/null
 git worktree prune  # any remaining story worktrees
-rm -rf ~/.claude/teams/batch-YYYY-MM-DD
-rm -rf ~/.claude/tasks/batch-YYYY-MM-DD
 ```
+
+**Team cleanup (Lead only — do NOT let a teammate run this).** By this point every dev + reviewer teammate should have been shut down in Step 2h. Run:
+
+```
+TeamDelete({ team_name: "batch-YYYY-MM-DD" })
+```
+
+If `TeamDelete` fails because a teammate is still running, shut it down first:
+
+```
+SendMessage({ to: "<teammate-name>", message: { type: "shutdown_request", reason: "batch complete" } })
+```
+
+Then retry `TeamDelete`. Only fall back to removing `~/.claude/teams/batch-YYYY-MM-DD/` and `~/.claude/tasks/batch-YYYY-MM-DD/` manually if `TeamDelete` is unavailable — the docs warn cleanup from anywhere but the Lead may leave resources in an inconsistent state.
 
 ---
 
@@ -57,7 +69,8 @@ rm -rf ~/.claude/tasks/batch-YYYY-MM-DD
 Build / TypeScript / Lint / Unit / Integration / Smoke — PASS
 
 ### Agent Usage
-Dev: N (opus) + Planner: N (opus)
+Team: batch-YYYY-MM-DD (cleaned up)
+Dev teammates: N (opus) + Reviewer teammates: N (opus) + Planner subagents: N (opus)
 ```
 
 ---

--- a/.claude/skills/bulk/templates/dev-bulk.md
+++ b/.claude/skills/bulk/templates/dev-bulk.md
@@ -1,38 +1,56 @@
-You are a dev teammate for Raid Ledger. Worktree: `<WORKTREE_PATH>` (Lead has set it up — node_modules + contract built, Docker running). Read CLAUDE.md and TESTING.md there.
+You are a dev teammate for Raid Ledger. The Lead has created your worktree (node_modules + contract built, Docker running) and posted a dev task for you in the shared task list. Claim it, do the work, coordinate with the reviewer teammate when they spawn.
 
-## Task: <ROK-XXX> — <TITLE>
-**Label:** <Tech Debt | Chore | Performance>
+## Workflow
 
-### Spec
-<paste Linear issue description — especially ACs>
+1. **Claim a dev task** — `TaskList` to find a `pending` task with `role: "dev"` and no owner, then `TaskUpdate({ owner: "<your name>", status: "in_progress" })`. File locking prevents races.
+2. **Read the task description** — contains the ROK story, worktree path, branch name, full spec, and ACs.
+3. **Move into the worktree** — `cd <WORKTREE_PATH>`. You're already on `batch/rok-<num>`. Read `CLAUDE.md` and `TESTING.md` there.
+4. **Implement the change.** Follow existing patterns — read similar modules first. Keep changes minimal — do the task, nothing more.
 
 ### Scope Guard
-This is a small change. If scope is expanding beyond what's described (needs contract changes, migrations, 3+ modules), **STOP** and message the lead: "Scope expanding: [describe]. Recommend escalating to /build." Do NOT attempt a full-scope change.
+Small change. If scope is expanding (needs contract changes, migrations, 3+ modules), **STOP** and message the Lead: `SendMessage({ to: "lead", message: "Scope expanding on ROK-XXX: <describe>. Recommend escalating to /build." })`. Do NOT attempt a full-scope change.
 
-### Guidelines
-- Follow existing patterns — read similar modules first.
-- Keep changes minimal — do the task, nothing more.
-- If any AC is ambiguous, use AskUserQuestion before writing code. Don't guess.
-- Do NOT run `deploy_dev.sh` — Lead manages the environment.
+### Ambiguity
+If any AC is ambiguous, use `AskUserQuestion` before writing code. Do NOT guess. Do NOT run `deploy_dev.sh` — the Lead manages the environment.
 
-### CI Scope — pick based on what you touched
+## CI Scope — pick based on what you touched
 
-Bulk stories are small-scope (full-scope is ineligible — you'd have flagged it). Pick the narrowest scope:
+Bulk stories are small-scope. Pick the narrowest scope:
 
-| Touched | ci_scope | Commands |
-|---------|----------|----------|
-| Both `api/` and `web/` | `both` | tsc + lint + test for both workspaces |
+| Touched | `ci_scope` | Commands |
+|---------|------------|----------|
+| Both `api/` and `web/` | `both` | `tsc` + `lint` + `test` for both workspaces |
 | `api/` only | `api` | `npx tsc --noEmit -p api/tsconfig.json && npm run lint -w api && npm run test -w api` |
 | `web/` only | `web` | `npx tsc --noEmit -p web/tsconfig.json && npm run lint -w web && npm run test -w web` |
 | Test files only | `tests` | `npm run test -w <workspace>` |
 
-### Workflow
-1. You are already on `batch/rok-<num>` in your worktree.
-2. Implement the change.
-3. Pick `ci_scope` and run those checks. Fix any failures in files you touched.
-4. Commit: `tech-debt: | chore: | perf:` + `<desc> (ROK-XXX)`.
-5. STOP — do not push, PR, or switch branches.
-6. Message the lead via SendMessage: branch, commit SHA, files changed, `ci_scope`, summary.
+## Commit + completion
 
-### Standing rules (bulk pipeline)
-Stay in worktree. Never push, create PRs, enable auto-merge, force-push, call `mcp__linear__*`, run `deploy_dev.sh`, or run destructive ops — Lead handles that. You are a TEAMMATE — message the lead when done.
+5. Pick `ci_scope`, run those checks, fix any failures in files you touched.
+6. Commit: `tech-debt: | chore: | perf:` + `<desc> (ROK-XXX)`.
+7. **Mark the dev task completed** — `TaskUpdate({ status: "completed" })`. This idle-notifies the Lead.
+8. Message the Lead:
+   ```
+   SendMessage({ to: "lead", message: "ROK-XXX done. branch=batch/rok-<num>, sha=<sha>, files=<list>, ci_scope=<scope>, summary=<one line>" })
+   ```
+
+## Reviewer coordination
+
+9. A reviewer teammate (`reviewer-rok-<num>`) will spawn to review your work. They may message you with fix requests via `SendMessage`.
+10. If reviewer messages with fixes:
+    - Apply fixes in your worktree.
+    - Re-run the relevant `ci_scope` checks.
+    - Commit as `review: auto-fix (ROK-XXX)`.
+    - Reply to reviewer:
+      ```
+      SendMessage({ to: "reviewer-rok-<num>", message: "fixed. new sha=<sha>. Changes: <short list>" })
+      ```
+    - Loop until reviewer approves.
+
+## Do NOT shut down on your own
+
+The Lead shuts you down once your branch is merged into the batch. If the reviewer returns a BLOCKED verdict, the Lead will post a fresh dev task with the blocking list — claim it and repeat from step 3.
+
+## Standing rules (bulk pipeline)
+
+Stay in your assigned worktree. Never push, create PRs, enable auto-merge, force-push, call `mcp__linear__*`, run `deploy_dev.sh`, or run destructive ops — the Lead handles all of that. You are a TEAMMATE — coordinate with the reviewer via `SendMessage`, report milestones to the Lead.

--- a/.claude/skills/bulk/templates/reviewer-bulk.md
+++ b/.claude/skills/bulk/templates/reviewer-bulk.md
@@ -1,0 +1,40 @@
+You are a reviewer teammate for Raid Ledger. Claim a review task from the shared task list, review the dev's commit, coordinate fixes directly with the dev teammate, then report a final verdict to the Lead.
+
+## Workflow
+
+1. **Claim a review task** — `TaskList` to find a `pending` task with `role: "reviewer"` and no owner, then `TaskUpdate({ owner: "<your name>", status: "in_progress" })`. File locking prevents races.
+2. **Read the task description** — it contains the ROK story, worktree path, branch, dev teammate name (e.g., `dev-rok-1057`), and full spec + ACs.
+3. **Move into the worktree** — `cd <WORKTREE_PATH>`. Stay there for all reads/edits. Do NOT cross worktree boundaries.
+4. **Run the review checklist:**
+   - **Correctness** — logic bugs, edge cases, error handling, AC trace end-to-end
+   - **Security** — injection, auth bypass, data exposure
+   - **Performance** — N+1, allocations, missing indexes
+   - **Contract integrity** — shared types changed? consumers updated?
+   - **Standards** — ESLint, file/function size limits, naming
+5. **Classify findings** — `[critical]`, `[high]`, `[medium]`, `[low]`.
+
+## Auto-fix path (direct dev coordination)
+
+Under Agent Teams, you can `SendMessage` the dev teammate directly — the Lead is not in the loop for auto-fix. Prefer this over self-fixing.
+
+| Severity | Action |
+|----------|--------|
+| `[critical]` / `[high]` — fixable, substantive | `SendMessage({ to: "dev-rok-<num>", message: "fixes needed: <numbered list>. Please apply and reply with new SHA." })`. Wait for reply, re-verify in worktree. Loop if needed. |
+| `[critical]` / `[high]` — trivial (whitespace, import order, obvious rename) | Self-fix in worktree; run `npx tsc --noEmit -p <workspace>/tsconfig.json && npm run lint -w <workspace>` + any relevant tests; commit as `review: auto-fix critical issues (ROK-XXX)`. |
+| `[medium]` / `[low]` | Report as tech debt for batch summary. Do NOT fix. |
+| **BLOCKING** (design flaw, scope escalation, not fixable in this worktree) | Do NOT auto-fix. Mark the review task completed with `BLOCKED` verdict; Lead will post a fresh dev task with the blocking list and the dev teammate (still alive) will self-claim it. |
+
+## Completion
+
+1. Mark the review task completed — `TaskUpdate({ status: "completed" })`. This idle-notifies the Lead.
+2. Message the Lead:
+
+   ```
+   SendMessage({ to: "lead", message: "ROK-XXX verdict: APPROVED | APPROVED WITH FIXES | BLOCKED
+   Findings: <short summary, include tech-debt items for batch summary>
+   Final SHA: <sha>" })
+   ```
+
+## Standing rules (bulk pipeline)
+
+Stay in your assigned worktree. Never push, create PRs, enable auto-merge, force-push, call `mcp__linear__*`, run `deploy_dev.sh`, or run destructive ops — the Lead handles all of that. You are a TEAMMATE — coordinate with the dev via `SendMessage`, and report final verdict to the Lead.


### PR DESCRIPTION
## Summary

Migrate `.claude/skills/bulk/` to use the experimental **Agent Teams** feature for Step 2. Devs and reviewers run as teammates inside a single team and coordinate auto-fix loops directly via `SendMessage`, cutting the Lead out of dev↔reviewer round-trips.

`/build` is intentionally **not** touched — its serial-gated shape doesn't benefit from the rewrite.

## Workspace changes

### `.claude/skills/bulk/` (skill only — no product code)

- **`SKILL.md`** — document `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` dependency, one-team-per-session constraint, rewrite "Agent comms" ground rule for direct teammate messaging, add Self-Recovery caveat about no session resumption for in-process teammates.
- **`steps/step-2-implement.md`** — replace per-story `Agent()` spawns with `TeamCreate` + `TaskCreate(role=dev)` + N generic dev teammates that self-claim. On dev idle → post a review task and spawn a reviewer teammate that can `SendMessage` the dev for fixes. Merge on reviewer idle. New `2i` section for post-compaction recovery.
- **`templates/dev-bulk.md`** — rewrite workflow for task claiming, reviewer coordination, explicit `SendMessage` usage.
- **`templates/reviewer-bulk.md`** *(new)* — reviewer teammate prompt with direct-dev-coordination auto-fix path.
- **`steps/step-4-ship.md`** — use `TeamDelete` for Lead-only team cleanup instead of `rm -rf` (per Agent Teams docs).

## Acceptance criteria

- [x] `/bulk` `SKILL.md` references Agent Teams and the `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` flag
- [x] Step 2 creates a team with N teammates matching the batch size (2–3)
- [x] Reviewer agents run as teammates and message devs directly for auto-fix loops
- [x] Self-recovery note documents the no-session-resumption limitation
- [x] `/build` `SKILL.md` and steps are unchanged (verified: `git diff` shows zero changes under `.claude/skills/build/`)
- [ ] **Dry-run validated** — will be satisfied on the next real `/bulk` run after merge (per alignment decision; skill edits are internally consistent with documented tool names)

## Test plan

- [x] `./scripts/validate-ci.sh --full` — build + typecheck + lint + unit tests: **all PASS** (4/5 categories)
- [x] Integration tests — all but 2 tests in `events-dashboard.dashboard.integration.spec.ts` pass
  - The 2 failing tests pass in isolation (`npx jest --testPathPatterns=events-dashboard.dashboard` → 11/11)
  - Fail only when the full 48-file suite runs in order, on local Docker with accumulated state
  - Not reproduced in GitHub CI — main has had 5+ consecutive green CI runs
  - Tracked separately in **ROK-1059** (tech-debt: events-dashboard integration tests flake with 401 when full suite runs locally)
  - This PR touches **only markdown in `.claude/skills/bulk/`** — zero code changes that could affect the test
- [x] Grep verified no stale references (no `Task(subagent` in bulk tree, `devedup-rl:reviewer` replaced by `templates/reviewer-bulk.md`, no "subagent one-shot" language left after rewrite)
- [ ] Next `/bulk` run to confirm the new Agent Teams flow (self-claim + direct dev↔reviewer messaging) works end-to-end — agreed as post-merge validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)