### PR TITLE
ROK-949: feat: player taste profile UI — dynamic radar + archetype + partners

### DIFF
--- a/api/src/taste-profile/axis-mapping.constants.ts
+++ b/api/src/taste-profile/axis-mapping.constants.ts
@@ -1,18 +1,21 @@
 import type { TasteProfilePoolAxis } from '@raid-ledger/contract';
 
 /**
- * Per-axis IGDB ID matchers (ROK-948 / ROK-949 dynamic-axes extension).
+ * Per-axis matchers (ROK-948 / ROK-949 dynamic-axes extension).
  *
- * Each axis matches on any of gameModes / genres / themes present on the
- * game row. A game that matches multiple categories for the same axis
- * still only contributes weight 1.0 for that axis (see taste-vector.helpers).
+ * Priority order when classifying a game for an axis:
+ *   1. `tags` (Steam/IsThereAnyDeal user tags — richest vocabulary,
+ *      covers specific sub-genres IGDB's schema lacks: "Automation",
+ *      "Crafting", "Roguelike", "Battle Royale", etc.)
+ *   2. `gameModes` / `genres` / `themes` (IGDB IDs — fallback for
+ *      games whose itad tags haven't been fetched yet)
  *
- * Mappings target *specific* IGDB IDs so an "Open world" theme tag doesn't
- * bleed into RPG and "Adventure" genre doesn't bleed into RPG either. The
- * backend computes scores across every pool axis; the UI renders only the
- * top 7 for each player.
+ * A game hits an axis if ANY listed identifier matches; the axis then
+ * contributes `1.0 * signalWeight(user, game)` to that user's raw score
+ * (see taste-vector.helpers). Tag matching is case-insensitive.
  */
 export interface AxisMapping {
+  tags: string[];
   gameModes: number[];
   genres: number[];
   themes: number[];
@@ -20,104 +23,177 @@ export interface AxisMapping {
 
 export const AXIS_MAPPINGS: Record<TasteProfilePoolAxis, AxisMapping> = {
   co_op: {
-    gameModes: [3, 4], // Co-operative, Split screen
+    tags: ['Co-op', 'Online Co-Op', 'Local Co-Op'],
+    gameModes: [3, 4],
     genres: [],
     themes: [],
   },
   pvp: {
-    gameModes: [2], // Multiplayer (broad — may overlap co-op)
+    tags: ['PvP', 'Competitive'],
+    gameModes: [2],
     genres: [],
     themes: [],
   },
   battle_royale: {
+    tags: ['Battle Royale'],
     gameModes: [6],
     genres: [],
     themes: [],
   },
   mmo: {
+    tags: ['MMORPG', 'MMO', 'Massively Multiplayer'],
     gameModes: [5],
     genres: [],
     themes: [],
   },
   moba: {
+    tags: ['MOBA'],
     gameModes: [],
     genres: [36],
     themes: [],
   },
   fighting: {
+    tags: ['Fighting', "Beat 'em up", '2D Fighter', '3D Fighter'],
     gameModes: [],
-    genres: [4, 25], // Fighting, Hack and slash / Beat 'em up
+    genres: [4, 25],
     themes: [],
   },
   shooter: {
+    tags: ['FPS', 'Shooter', 'First-Person', 'Third-Person Shooter'],
     gameModes: [],
     genres: [5],
     themes: [],
   },
   racing: {
+    tags: ['Racing', 'Driving'],
     gameModes: [],
     genres: [10],
     themes: [],
   },
   sports: {
+    tags: ['Sports', 'Football', 'Basketball', 'Soccer'],
     gameModes: [],
     genres: [14],
     themes: [],
   },
   rpg: {
+    tags: ['RPG', 'Action RPG', 'JRPG', 'CRPG', 'Party-Based RPG'],
     gameModes: [],
-    genres: [12, 34], // Role-playing, Visual Novel (Adventure split out)
+    genres: [12, 34],
     themes: [],
   },
   fantasy: {
+    tags: ['Fantasy', 'Magic', 'Dragons'],
     gameModes: [],
     genres: [],
     themes: [17],
   },
   sci_fi: {
+    tags: ['Sci-fi', 'Space', 'Cyberpunk', 'Futuristic'],
     gameModes: [],
     genres: [],
     themes: [18],
   },
   adventure: {
+    tags: ['Adventure', 'Story Rich', 'Exploration'],
     gameModes: [],
     genres: [31],
-    themes: [31], // Drama
+    themes: [31],
   },
   strategy: {
+    tags: [
+      'Strategy',
+      'RTS',
+      'Real Time Strategy',
+      'Turn-Based Strategy',
+      'Turn-Based',
+      '4X',
+      'Grand Strategy',
+      'Wargame',
+      'Tactics',
+      'Auto Battler',
+      'Tower Defense',
+    ],
     gameModes: [],
-    genres: [15, 24], // Strategy, Tactical
-    themes: [41], // 4X
-  },
-  rts: {
-    gameModes: [],
-    genres: [11],
-    themes: [],
-  },
-  tbs: {
-    gameModes: [],
-    genres: [16],
-    themes: [],
+    genres: [11, 15, 16, 24],
+    themes: [41],
   },
   survival: {
+    tags: ['Survival', 'Open World Survival Craft'],
     gameModes: [],
     genres: [],
     themes: [21],
   },
-  sandbox: {
+  crafting: {
+    tags: ['Crafting', 'Open World Survival Craft'],
     gameModes: [],
     genres: [],
-    themes: [33, 38], // Sandbox, Open world
+    themes: [],
+  },
+  automation: {
+    tags: [
+      'Automation',
+      'Base Building',
+      'Factory Building',
+      'Factory Sim',
+      'Resource Management',
+      'City Builder',
+      'Building',
+    ],
+    gameModes: [],
+    genres: [],
+    themes: [],
+  },
+  sandbox: {
+    tags: ['Sandbox', 'Open World'],
+    gameModes: [],
+    genres: [],
+    themes: [33, 38],
   },
   horror: {
+    tags: ['Horror', 'Psychological Horror', 'Survival Horror'],
     gameModes: [],
     genres: [],
     themes: [19],
   },
   social: {
+    tags: ['Party', 'Casual', 'Local Multiplayer'],
     gameModes: [],
-    genres: [9, 35], // Puzzle, Card & Board
-    themes: [40, 27], // Party, Comedy
+    genres: [9, 35],
+    themes: [40, 27],
+  },
+  roguelike: {
+    tags: [
+      'Roguelike',
+      'Roguelite',
+      'Rogue-like',
+      'Rogue-lite',
+      'Action Roguelike',
+      'Traditional Roguelike',
+      'Roguelike Deckbuilder',
+      'Roguevania',
+    ],
+    gameModes: [],
+    genres: [],
+    themes: [],
+  },
+  puzzle: {
+    tags: ['Puzzle', 'Point & Click', 'Logic', 'Math'],
+    gameModes: [],
+    genres: [9],
+    themes: [],
+  },
+  platformer: {
+    tags: ['Platformer', '2D Platformer', '3D Platformer', 'Metroidvania'],
+    gameModes: [],
+    genres: [8],
+    themes: [],
+  },
+  stealth: {
+    tags: ['Stealth'],
+    gameModes: [],
+    genres: [],
+    themes: [43],
   },
 };
 

--- a/api/src/taste-profile/axis-mapping.constants.ts
+++ b/api/src/taste-profile/axis-mapping.constants.ts
@@ -1,11 +1,16 @@
-import type { TasteProfileAxis } from '@raid-ledger/contract';
+import type { TasteProfilePoolAxis } from '@raid-ledger/contract';
 
 /**
- * Per-axis IGDB ID matchers (ROK-948).
+ * Per-axis IGDB ID matchers (ROK-948 / ROK-949 dynamic-axes extension).
  *
  * Each axis matches on any of gameModes / genres / themes present on the
  * game row. A game that matches multiple categories for the same axis
  * still only contributes weight 1.0 for that axis (see taste-vector.helpers).
+ *
+ * Mappings target *specific* IGDB IDs so an "Open world" theme tag doesn't
+ * bleed into RPG and "Adventure" genre doesn't bleed into RPG either. The
+ * backend computes scores across every pool axis; the UI renders only the
+ * top 7 for each player.
  */
 export interface AxisMapping {
   gameModes: number[];
@@ -13,41 +18,106 @@ export interface AxisMapping {
   themes: number[];
 }
 
-export const AXIS_MAPPINGS: Record<TasteProfileAxis, AxisMapping> = {
+export const AXIS_MAPPINGS: Record<TasteProfilePoolAxis, AxisMapping> = {
   co_op: {
-    gameModes: [3, 4], // Coop, Split screen
+    gameModes: [3, 4], // Co-operative, Split screen
     genres: [],
-    themes: [40], // Party
+    themes: [],
   },
   pvp: {
-    gameModes: [2, 6], // Multiplayer, Battle Royale
-    genres: [4, 36], // Fighting, MOBA
+    gameModes: [2], // Multiplayer (broad — may overlap co-op)
+    genres: [],
+    themes: [],
+  },
+  battle_royale: {
+    gameModes: [6],
+    genres: [],
+    themes: [],
+  },
+  mmo: {
+    gameModes: [5],
+    genres: [],
+    themes: [],
+  },
+  moba: {
+    gameModes: [],
+    genres: [36],
+    themes: [],
+  },
+  fighting: {
+    gameModes: [],
+    genres: [4, 25], // Fighting, Hack and slash / Beat 'em up
+    themes: [],
+  },
+  shooter: {
+    gameModes: [],
+    genres: [5],
+    themes: [],
+  },
+  racing: {
+    gameModes: [],
+    genres: [10],
+    themes: [],
+  },
+  sports: {
+    gameModes: [],
+    genres: [14],
     themes: [],
   },
   rpg: {
     gameModes: [],
-    genres: [12, 31, 34], // RPG, Adventure, Visual Novel
-    themes: [17, 31, 38], // Fantasy, Drama, Open world
+    genres: [12, 34], // Role-playing, Visual Novel (Adventure split out)
+    themes: [],
   },
-  survival: {
+  fantasy: {
     gameModes: [],
-    genres: [13], // Simulator
-    themes: [21, 33, 38], // Survival, Sandbox, Open world
+    genres: [],
+    themes: [17],
+  },
+  sci_fi: {
+    gameModes: [],
+    genres: [],
+    themes: [18],
+  },
+  adventure: {
+    gameModes: [],
+    genres: [31],
+    themes: [31], // Drama
   },
   strategy: {
     gameModes: [],
-    genres: [11, 15, 16, 24, 35], // RTS, Strategy, TBS, Tactical, Card & Board
+    genres: [15, 24], // Strategy, Tactical
     themes: [41], // 4X
+  },
+  rts: {
+    gameModes: [],
+    genres: [11],
+    themes: [],
+  },
+  tbs: {
+    gameModes: [],
+    genres: [16],
+    themes: [],
+  },
+  survival: {
+    gameModes: [],
+    genres: [],
+    themes: [21],
+  },
+  sandbox: {
+    gameModes: [],
+    genres: [],
+    themes: [33, 38], // Sandbox, Open world
+  },
+  horror: {
+    gameModes: [],
+    genres: [],
+    themes: [19],
   },
   social: {
     gameModes: [],
-    genres: [9, 32, 33], // Puzzle, Indie, Arcade
-    themes: [27, 40], // Comedy, Party
-  },
-  mmo: {
-    gameModes: [5], // MMO
-    genres: [],
-    themes: [],
+    genres: [9, 35], // Puzzle, Card & Board
+    themes: [40, 27], // Party, Comedy
   },
 };
 

--- a/api/src/taste-profile/axis-mapping.constants.ts
+++ b/api/src/taste-profile/axis-mapping.constants.ts
@@ -197,6 +197,11 @@ export const AXIS_MAPPINGS: Record<TasteProfilePoolAxis, AxisMapping> = {
   },
 };
 
-/** MMO playtime bonus threshold: games with this much lifetime playtime
- * (in minutes) also contribute to the MMO axis regardless of tags. */
-export const MMO_PLAYTIME_BONUS_MIN = 3000;
+/**
+ * Lifetime Steam playtime threshold (minutes) above which a game is
+ * considered "heavily played" — its signal weight jumps to 1.0 for
+ * every matching axis. No longer MMO-specific (a prior version applied
+ * an MMO-axis bonus here; that was removed in favour of tag/gameMode
+ * based MMO detection).
+ */
+export const HIGH_PLAYTIME_WEIGHT_MIN = 3000;

--- a/api/src/taste-profile/intensity-rollup.helpers.spec.ts
+++ b/api/src/taste-profile/intensity-rollup.helpers.spec.ts
@@ -1,9 +1,8 @@
 /**
- * Intensity metrics unit tests (ROK-948 AC 6).
+ * Intensity metrics unit tests (ROK-948 AC 6, refactored in ROK-949).
  *
- * Written TDD-style — imports from helpers that do not exist yet.
- * Validates the exact formulas from the enriched spec:
- *   intensity  = percentile rank of totalHours vs community (0–100)
+ * Validates the formulas:
+ *   intensity  = blended percentile rank (60% week / 30% last 4w / 10% all-time)
  *   focus      = longestSessionHours / totalHours * 100
  *   breadth    = uniqueGames / communityMaxUniqueGames * 100
  *   consistency = 100 - normalized std-dev of weekly hours (0–100)
@@ -14,15 +13,19 @@ import {
   type CommunityStats,
 } from './intensity-rollup.helpers';
 
-describe('intensity metrics (ROK-948 AC 6)', () => {
+describe('intensity metrics (ROK-948 / ROK-949 blend)', () => {
   const defaultCommunity: CommunityStats = {
     totalHoursDistribution: [5, 10, 15, 20, 25, 30],
+    last4wHoursDistribution: [20, 40, 60, 80, 100, 120],
+    allTimeHoursDistribution: [50, 100, 200, 400, 800, 1600],
     maxUniqueGames: 10,
   };
 
-  it('intensity is 0 at the bottom of the distribution', () => {
+  it('intensity is 0 at the bottom of every distribution', () => {
     const snap: WeeklySnapshotInput = {
       totalHours: 0,
+      last4wHours: 0,
+      allTimeHours: 0,
       longestSessionHours: 0,
       uniqueGames: 0,
       weeklyHistory: [0, 0, 0, 0, 0, 0, 0, 0],
@@ -31,9 +34,11 @@ describe('intensity metrics (ROK-948 AC 6)', () => {
     expect(intensity).toBe(0);
   });
 
-  it('intensity is 100 at the top of the distribution', () => {
+  it('intensity is 100 at the top of every distribution', () => {
     const snap: WeeklySnapshotInput = {
       totalHours: 100,
+      last4wHours: 1000,
+      allTimeHours: 10000,
       longestSessionHours: 50,
       uniqueGames: 10,
       weeklyHistory: [90, 95, 98, 100, 100, 100, 100, 100],
@@ -42,9 +47,29 @@ describe('intensity metrics (ROK-948 AC 6)', () => {
     expect(intensity).toBe(100);
   });
 
+  it('blends the three tiers with 60/30/10 weights', () => {
+    // Week at p50 (value 15 ties the middle of the distribution),
+    // last4w at p100 (value 120 is the max), all-time at p0 (value 0).
+    const snap: WeeklySnapshotInput = {
+      totalHours: 15,
+      last4wHours: 1000, // way above max -> 100
+      allTimeHours: 0, // below min -> 0
+      longestSessionHours: 5,
+      uniqueGames: 3,
+      weeklyHistory: [15, 15, 15],
+    };
+    const { intensity } = computeIntensityMetrics(snap, defaultCommunity);
+    // weekPct ≈ 41.67 (below=2, equal=1), last4wPct=100, allTimePct=0
+    // blended = 0.6*41.67 + 0.3*100 + 0.1*0 = 25 + 30 + 0 = 55
+    expect(intensity).toBeGreaterThanOrEqual(54);
+    expect(intensity).toBeLessThanOrEqual(56);
+  });
+
   it('focus = longestSession/total * 100, clamped to [0, 100]', () => {
     const snap: WeeklySnapshotInput = {
       totalHours: 10,
+      last4wHours: 40,
+      allTimeHours: 200,
       longestSessionHours: 8,
       uniqueGames: 3,
       weeklyHistory: [10, 10, 10, 10, 10, 10, 10, 10],
@@ -56,6 +81,8 @@ describe('intensity metrics (ROK-948 AC 6)', () => {
   it('focus is 0 when totalHours is 0', () => {
     const snap: WeeklySnapshotInput = {
       totalHours: 0,
+      last4wHours: 0,
+      allTimeHours: 0,
       longestSessionHours: 0,
       uniqueGames: 0,
       weeklyHistory: [0],
@@ -67,6 +94,8 @@ describe('intensity metrics (ROK-948 AC 6)', () => {
   it('breadth = uniqueGames / communityMax * 100', () => {
     const snap: WeeklySnapshotInput = {
       totalHours: 10,
+      last4wHours: 40,
+      allTimeHours: 200,
       longestSessionHours: 2,
       uniqueGames: 5,
       weeklyHistory: [10, 10, 10, 10, 10, 10, 10, 10],
@@ -78,6 +107,8 @@ describe('intensity metrics (ROK-948 AC 6)', () => {
   it('consistency is 100 for a perfectly constant weekly history', () => {
     const snap: WeeklySnapshotInput = {
       totalHours: 10,
+      last4wHours: 40,
+      allTimeHours: 200,
       longestSessionHours: 3,
       uniqueGames: 3,
       weeklyHistory: [10, 10, 10, 10, 10, 10, 10, 10],
@@ -89,6 +120,8 @@ describe('intensity metrics (ROK-948 AC 6)', () => {
   it('consistency is low when weekly hours vary wildly', () => {
     const snap: WeeklySnapshotInput = {
       totalHours: 10,
+      last4wHours: 40,
+      allTimeHours: 200,
       longestSessionHours: 10,
       uniqueGames: 1,
       weeklyHistory: [0, 40, 0, 40, 0, 40, 0, 40],
@@ -100,6 +133,8 @@ describe('intensity metrics (ROK-948 AC 6)', () => {
   it('all four metrics are returned and clamped to [0, 100]', () => {
     const snap: WeeklySnapshotInput = {
       totalHours: 20,
+      last4wHours: 80,
+      allTimeHours: 500,
       longestSessionHours: 15,
       uniqueGames: 4,
       weeklyHistory: [18, 19, 20, 21, 22, 20, 18, 22],

--- a/api/src/taste-profile/intensity-rollup.helpers.ts
+++ b/api/src/taste-profile/intensity-rollup.helpers.ts
@@ -1,8 +1,9 @@
 /**
- * Intensity metrics computation (ROK-948 AC 6).
+ * Intensity metrics computation (ROK-948 AC 6, tuned in ROK-949).
  *
- * Formulas (from the enriched spec):
- *   intensity   = percentile rank of totalHours vs community (0–100)
+ * Formulas:
+ *   intensity   = blended percentile rank (60% current week, 30% rolling
+ *                 4-week, 10% all-time — see `BLEND_WEIGHTS`)
  *   focus       = longestSessionHours / totalHours * 100 (clamped 0–100)
  *   breadth     = uniqueGames / communityMaxUniqueGames * 100 (clamped 0–100)
  *   consistency = 100 - normalized stddev of weekly hours (clamped 0–100)
@@ -10,6 +11,8 @@
 
 export interface WeeklySnapshotInput {
   totalHours: number;
+  last4wHours: number;
+  allTimeHours: number;
   longestSessionHours: number;
   uniqueGames: number;
   /** Rolling 8-week history of totalHours (oldest first, most recent last). */
@@ -17,8 +20,12 @@ export interface WeeklySnapshotInput {
 }
 
 export interface CommunityStats {
-  /** Distribution of totalHours across the community. */
+  /** Distribution of current-week totalHours across the community. */
   totalHoursDistribution: number[];
+  /** Distribution of rolling 4-week hours across the community. */
+  last4wHoursDistribution: number[];
+  /** Distribution of all-time hours across the community. */
+  allTimeHoursDistribution: number[];
   /** Max uniqueGames value across the community. */
   maxUniqueGames: number;
 }
@@ -29,6 +36,13 @@ export interface IntensityMetricsResult {
   breadth: number;
   consistency: number;
 }
+
+/** Blend weights for the intensity percentile (must sum to 1.0). */
+export const BLEND_WEIGHTS = {
+  week: 0.6,
+  last4w: 0.3,
+  allTime: 0.1,
+} as const;
 
 function clamp(value: number, min = 0, max = 100): number {
   if (!Number.isFinite(value)) return min;
@@ -65,14 +79,38 @@ function consistencyScore(weeklyHistory: number[]): number {
   return clamp(100 * (1 - coefOfVariation));
 }
 
+/**
+ * Blend the three percentile ranks into a single intensity score.
+ * Returns a 0–100 number (not yet rounded/clamped).
+ */
+function blendedIntensity(
+  snap: WeeklySnapshotInput,
+  community: CommunityStats,
+): number {
+  const weekPct = percentileRank(
+    snap.totalHours,
+    community.totalHoursDistribution,
+  );
+  const last4wPct = percentileRank(
+    snap.last4wHours,
+    community.last4wHoursDistribution,
+  );
+  const allTimePct = percentileRank(
+    snap.allTimeHours,
+    community.allTimeHoursDistribution,
+  );
+  return (
+    weekPct * BLEND_WEIGHTS.week +
+    last4wPct * BLEND_WEIGHTS.last4w +
+    allTimePct * BLEND_WEIGHTS.allTime
+  );
+}
+
 export function computeIntensityMetrics(
   snap: WeeklySnapshotInput,
   community: CommunityStats,
 ): IntensityMetricsResult {
-  const intensityRaw = percentileRank(
-    snap.totalHours,
-    community.totalHoursDistribution,
-  );
+  const intensityRaw = blendedIntensity(snap, community);
   const focusRaw =
     snap.totalHours > 0
       ? (snap.longestSessionHours / snap.totalHours) * 100

--- a/api/src/taste-profile/pipelines/aggregate-vectors-loaders.ts
+++ b/api/src/taste-profile/pipelines/aggregate-vectors-loaders.ts
@@ -1,0 +1,155 @@
+import { sql } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from '../../drizzle/schema';
+import type { GameMetadata } from '../taste-vector.helpers';
+import type { SignalSummary } from '../signal-hash.helpers';
+
+type Db = PostgresJsDatabase<typeof schema>;
+
+/** Load all games with their IGDB metadata + lowercased ITAD tags. */
+export async function loadGameMetadata(
+  db: Db,
+): Promise<Map<number, GameMetadata>> {
+  const rows = await db
+    .select({
+      id: schema.games.id,
+      genres: schema.games.genres,
+      gameModes: schema.games.gameModes,
+      themes: schema.games.themes,
+      itadTags: schema.games.itadTags,
+    })
+    .from(schema.games);
+  const map = new Map<number, GameMetadata>();
+  for (const r of rows) {
+    const rawTags = Array.isArray(r.itadTags) ? r.itadTags : [];
+    map.set(r.id, {
+      gameId: r.id,
+      genres: r.genres ?? [],
+      gameModes: r.gameModes ?? [],
+      themes: r.themes ?? [],
+      tags: rawTags.map((t) => t.toLowerCase()),
+    });
+  }
+  return map;
+}
+
+/** Per-user co-play partner counts — one query, grouped. */
+export async function loadCoPlayCounts(db: Db): Promise<Map<number, number>> {
+  const rows = await db.execute<{ user_id: number; c: number }>(sql`
+    SELECT user_id, COUNT(*)::int AS c FROM (
+      SELECT user_id_a AS user_id FROM player_co_play
+      UNION ALL
+      SELECT user_id_b AS user_id FROM player_co_play
+    ) t GROUP BY user_id
+  `);
+  const map = new Map<number, number>();
+  for (const r of rows as unknown as Array<{ user_id: number; c: number }>) {
+    map.set(r.user_id, Number(r.c));
+  }
+  return map;
+}
+
+type UserCountRow = {
+  user_id: number;
+  count: string;
+  max_updated: Date | null;
+};
+type UserPeriodRow = {
+  user_id: number;
+  count: string;
+  max_period: string | null;
+};
+
+function freshSummary(): SignalSummary {
+  return {
+    gameInterests: { count: 0, maxUpdatedAt: null },
+    gameActivityRollups: { count: 0, maxPeriodStart: null },
+    eventSignups: { count: 0, maxUpdatedAt: null },
+    eventVoiceSessions: { count: 0, maxLastLeaveAt: null },
+  };
+}
+
+/** Per-user summary inputs for `computeSignalHash`. */
+export async function loadSignalHashComponents(
+  db: Db,
+): Promise<Map<number, SignalSummary>> {
+  const interests = (await db.execute(sql`
+    SELECT user_id, COUNT(*)::text AS count, MAX(created_at) AS max_updated
+    FROM ${schema.gameInterests} GROUP BY user_id
+  `)) as unknown as UserCountRow[];
+  const rollups = (await db.execute(sql`
+    SELECT user_id, COUNT(*)::text AS count, MAX(period_start::text) AS max_period
+    FROM ${schema.gameActivityRollups} GROUP BY user_id
+  `)) as unknown as UserPeriodRow[];
+  const signups = (await db.execute(sql`
+    SELECT user_id, COUNT(*)::text AS count, MAX(signed_up_at) AS max_updated
+    FROM ${schema.eventSignups} GROUP BY user_id
+  `)) as unknown as UserCountRow[];
+  const voice = (await db.execute(sql`
+    SELECT user_id, COUNT(*)::text AS count, MAX(last_leave_at) AS max_updated
+    FROM ${schema.eventVoiceSessions} GROUP BY user_id
+  `)) as unknown as UserCountRow[];
+
+  const summaries = new Map<number, SignalSummary>();
+  const ensure = (id: number): SignalSummary => {
+    const existing = summaries.get(id);
+    if (existing) return existing;
+    const s = freshSummary();
+    summaries.set(id, s);
+    return s;
+  };
+
+  for (const r of interests) {
+    ensure(r.user_id).gameInterests = {
+      count: Number(r.count),
+      maxUpdatedAt: r.max_updated,
+    };
+  }
+  for (const r of rollups) {
+    ensure(r.user_id).gameActivityRollups = {
+      count: Number(r.count),
+      maxPeriodStart: r.max_period,
+    };
+  }
+  for (const r of signups) {
+    ensure(r.user_id).eventSignups = {
+      count: Number(r.count),
+      maxUpdatedAt: r.max_updated,
+    };
+  }
+  for (const r of voice) {
+    ensure(r.user_id).eventVoiceSessions = {
+      count: Number(r.count),
+      maxLastLeaveAt: r.max_updated,
+    };
+  }
+
+  return summaries;
+}
+
+export function groupBy<T, K>(rows: T[], key: (row: T) => K): Map<K, T[]> {
+  const map = new Map<K, T[]>();
+  for (const row of rows) {
+    const k = key(row);
+    const list = map.get(k);
+    if (list) list.push(row);
+    else map.set(k, [row]);
+  }
+  return map;
+}
+
+export function groupMap<T, K, V>(
+  rows: T[],
+  key: (row: T) => K,
+  value: (row: T) => V,
+): Map<K, V[]> {
+  const map = new Map<K, V[]>();
+  for (const row of rows) {
+    const k = key(row);
+    const v = value(row);
+    const list = map.get(k);
+    if (list) list.push(v);
+    else map.set(k, [v]);
+  }
+  return map;
+}

--- a/api/src/taste-profile/pipelines/aggregate-vectors.ts
+++ b/api/src/taste-profile/pipelines/aggregate-vectors.ts
@@ -2,6 +2,7 @@ import { and, eq, sql } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import * as schema from '../../drizzle/schema';
 import {
+  computeAxisIdf,
   computeTasteVector,
   type GameMetadata,
   type UserGameSignal,
@@ -15,6 +16,7 @@ type Db = PostgresJsDatabase<typeof schema>;
 export async function runAggregateVectors(db: Db): Promise<void> {
   const users = await db.select({ id: schema.users.id }).from(schema.users);
   const gameMap = await loadGameMetadata(db);
+  const axisIdf = computeAxisIdf(gameMap);
 
   for (const { id: userId } of users) {
     const signals = await loadUserSignals(db, userId);
@@ -28,7 +30,7 @@ export async function runAggregateVectors(db: Db): Promise<void> {
       .limit(1);
     if (existing.length > 0 && existing[0].signalHash === signalHash) continue;
 
-    const { dimensions, vector } = computeTasteVector(signals, gameMap);
+    const { dimensions, vector } = computeTasteVector(signals, gameMap, axisIdf);
     const intensityMetrics = existing[0]?.intensityMetrics ?? {
       intensity: 0,
       focus: 0,

--- a/api/src/taste-profile/pipelines/aggregate-vectors.ts
+++ b/api/src/taste-profile/pipelines/aggregate-vectors.ts
@@ -12,104 +12,180 @@ import { computeSignalHash, type SignalSummary } from '../signal-hash.helpers';
 
 type Db = PostgresJsDatabase<typeof schema>;
 
-/** Main entry point — iterates users, recomputes when signals changed. */
+interface BatchedInputs {
+  gameMap: Map<number, GameMetadata>;
+  existingByUser: Map<
+    number,
+    { signalHash: string; intensityMetrics: SignalSummary extends never ? never : NonNullable<unknown> }
+  >;
+  coPlayCounts: Map<number, number>;
+  eventGameId: Map<number, number>;
+  interestsByUser: Map<number, Array<typeof schema.gameInterests.$inferSelect>>;
+  presenceByUser: Map<number, Array<{ gameId: number | null; totalSeconds: number }>>;
+  signupsByUser: Map<number, number[]>;
+  voiceByUser: Map<number, number[]>;
+  hashByUser: Map<number, string>;
+}
+
+/** Main entry point — iterates users, recomputes when signals changed.
+ *
+ * All per-user state is batch-loaded up front to avoid an N+1 round-trip
+ * pattern (9+ queries × user count). Writes are still per-user because
+ * drizzle-orm's onConflictDoUpdate is single-row; a future pass could
+ * batch them with INSERT ... VALUES (...), (...) ON CONFLICT.
+ */
 export async function runAggregateVectors(db: Db): Promise<void> {
   const users = await db.select({ id: schema.users.id }).from(schema.users);
-  const gameMap = await loadGameMetadata(db);
-  const axisIdf = computeAxisIdf(gameMap);
+  const batch = await loadBatch(db);
+  const axisIdf = computeAxisIdf(batch.gameMap);
 
   for (const { id: userId } of users) {
-    const signals = await loadUserSignals(db, userId);
+    const signals = assembleSignals(userId, batch);
     if (signals.length === 0) continue;
 
-    const signalHash = await computeUserSignalHash(db, userId);
-    const existing = await db
-      .select()
-      .from(schema.playerTasteVectors)
-      .where(eq(schema.playerTasteVectors.userId, userId))
-      .limit(1);
-    if (existing.length > 0 && existing[0].signalHash === signalHash) continue;
+    const signalHash = batch.hashByUser.get(userId) ?? '';
+    const existing = batch.existingByUser.get(userId);
+    if (existing && existing.signalHash === signalHash) continue;
 
-    const { dimensions, vector } = computeTasteVector(signals, gameMap, axisIdf);
-    const intensityMetrics = existing[0]?.intensityMetrics ?? {
-      intensity: 0,
-      focus: 0,
-      breadth: 0,
-      consistency: 0,
-    };
+    await upsertVector(db, userId, signals, signalHash, batch, axisIdf);
+  }
+}
 
-    const coPlayPartners = await coPlayPartnerCount(db, userId);
-    const archetype = deriveArchetype({
-      ...intensityMetrics,
-      coPlayPartners,
-    });
+async function upsertVector(
+  db: Db,
+  userId: number,
+  signals: UserGameSignal[],
+  signalHash: string,
+  batch: BatchedInputs,
+  axisIdf: ReturnType<typeof computeAxisIdf>,
+): Promise<void> {
+  const { dimensions, vector } = computeTasteVector(
+    signals,
+    batch.gameMap,
+    axisIdf,
+  );
+  const existing = batch.existingByUser.get(userId);
+  const intensityMetrics =
+    (existing?.intensityMetrics as {
+      intensity: number;
+      focus: number;
+      breadth: number;
+      consistency: number;
+    }) ?? { intensity: 0, focus: 0, breadth: 0, consistency: 0 };
+  const coPlayPartners = batch.coPlayCounts.get(userId) ?? 0;
+  const archetype = deriveArchetype({ ...intensityMetrics, coPlayPartners });
 
-    await db
-      .insert(schema.playerTasteVectors)
-      .values({
-        userId,
+  await db
+    .insert(schema.playerTasteVectors)
+    .values({
+      userId,
+      vector,
+      dimensions,
+      intensityMetrics,
+      archetype,
+      signalHash,
+    })
+    .onConflictDoUpdate({
+      target: schema.playerTasteVectors.userId,
+      set: {
         vector,
         dimensions,
         intensityMetrics,
         archetype,
         signalHash,
-      })
-      .onConflictDoUpdate({
-        target: schema.playerTasteVectors.userId,
-        set: {
-          vector,
-          dimensions,
-          intensityMetrics,
-          archetype,
-          signalHash,
-          computedAt: new Date(),
-        },
-      });
-  }
+        computedAt: new Date(),
+      },
+    });
 }
 
-async function loadUserSignals(
-  db: Db,
-  userId: number,
-): Promise<UserGameSignal[]> {
-  const interests = await db
-    .select()
-    .from(schema.gameInterests)
-    .where(eq(schema.gameInterests.userId, userId));
-
-  const presence = await db
-    .select({
-      gameId: schema.gameActivityRollups.gameId,
-      totalSeconds: schema.gameActivityRollups.totalSeconds,
-    })
-    .from(schema.gameActivityRollups)
-    .where(
-      and(
-        eq(schema.gameActivityRollups.userId, userId),
-        eq(schema.gameActivityRollups.period, 'week'),
-      ),
-    );
-
-  const signups = await db
-    .select({ eventId: schema.eventSignups.eventId })
-    .from(schema.eventSignups)
-    .where(eq(schema.eventSignups.userId, userId));
-
-  const voice = await db
-    .select({ eventId: schema.eventVoiceSessions.eventId })
-    .from(schema.eventVoiceSessions)
-    .where(
-      and(
-        eq(schema.eventVoiceSessions.userId, userId),
+async function loadBatch(db: Db): Promise<BatchedInputs> {
+  const gameMap = await loadGameMetadata(db);
+  const [
+    interests,
+    presence,
+    signups,
+    voice,
+    events,
+    existingVectors,
+    coPlayRows,
+    hashComponents,
+  ] = await Promise.all([
+    db.select().from(schema.gameInterests),
+    db
+      .select({
+        userId: schema.gameActivityRollups.userId,
+        gameId: schema.gameActivityRollups.gameId,
+        totalSeconds: schema.gameActivityRollups.totalSeconds,
+      })
+      .from(schema.gameActivityRollups)
+      .where(eq(schema.gameActivityRollups.period, 'week')),
+    db
+      .select({
+        userId: schema.eventSignups.userId,
+        eventId: schema.eventSignups.eventId,
+      })
+      .from(schema.eventSignups),
+    db
+      .select({
+        userId: schema.eventVoiceSessions.userId,
+        eventId: schema.eventVoiceSessions.eventId,
+      })
+      .from(schema.eventVoiceSessions)
+      .where(
         sql`${schema.eventVoiceSessions.classification} IN ('full', 'partial')`,
       ),
-    );
+    db.select({ id: schema.events.id, gameId: schema.events.gameId }).from(schema.events),
+    db.select().from(schema.playerTasteVectors),
+    loadCoPlayCounts(db),
+    loadSignalHashComponents(db),
+  ]);
 
-  const events = await db
-    .select({ id: schema.events.id, gameId: schema.events.gameId })
-    .from(schema.events);
-  const eventGame = new Map(events.map((e) => [e.id, e.gameId]));
+  const interestsByUser = groupBy(interests, (i) => i.userId);
+  const presenceByUser = groupBy(presence, (p) => p.userId);
+  const signupsByUser = groupMap(
+    signups.filter((s): s is { userId: number; eventId: number } =>
+      s.userId !== null,
+    ),
+    (s) => s.userId,
+    (s) => s.eventId,
+  );
+  const voiceByUser = groupMap(
+    voice.filter((v): v is { userId: number; eventId: number } =>
+      v.userId !== null,
+    ),
+    (v) => v.userId,
+    (v) => v.eventId,
+  );
+  const eventGameId = new Map(
+    events
+      .filter((e) => e.gameId !== null)
+      .map((e) => [e.id, e.gameId as number]),
+  );
+  const existingByUser = new Map(
+    existingVectors.map((v) => [
+      v.userId,
+      { signalHash: v.signalHash, intensityMetrics: v.intensityMetrics },
+    ]),
+  );
+  const hashByUser = new Map<number, string>();
+  for (const [userId, summary] of hashComponents) {
+    hashByUser.set(userId, computeSignalHash(summary));
+  }
 
+  return {
+    gameMap,
+    existingByUser,
+    coPlayCounts: coPlayRows,
+    eventGameId,
+    interestsByUser,
+    presenceByUser,
+    signupsByUser,
+    voiceByUser,
+    hashByUser,
+  };
+}
+
+function assembleSignals(userId: number, batch: BatchedInputs): UserGameSignal[] {
   const byGame = new Map<number, UserGameSignal>();
   const touch = (gameId: number): UserGameSignal => {
     const existing = byGame.get(gameId);
@@ -119,48 +195,42 @@ async function loadUserSignals(
     return fresh;
   };
 
-  for (const row of interests) {
-    const signal = touch(row.gameId);
+  for (const row of batch.interestsByUser.get(userId) ?? []) {
+    const sig = touch(row.gameId);
     switch (row.source) {
       case 'steam_library':
-        signal.steamOwnership = {
+        sig.steamOwnership = {
           playtimeForever: row.playtimeForever ?? 0,
           playtime2weeks: row.playtime2weeks ?? 0,
         };
         break;
       case 'steam_wishlist':
-        signal.steamWishlist = true;
+        sig.steamWishlist = true;
         break;
       case 'manual':
-        signal.manualHeart = true;
+        sig.manualHeart = true;
         break;
       case 'poll':
-        signal.pollSource = true;
+        sig.pollSource = true;
         break;
       default:
         break;
     }
   }
-
-  for (const p of presence) {
+  for (const p of batch.presenceByUser.get(userId) ?? []) {
     if (p.gameId === null) continue;
-    const signal = touch(p.gameId);
-    signal.presenceWeeklyHours =
-      (signal.presenceWeeklyHours ?? 0) + p.totalSeconds / 3600;
+    const sig = touch(p.gameId);
+    sig.presenceWeeklyHours =
+      (sig.presenceWeeklyHours ?? 0) + p.totalSeconds / 3600;
   }
-
-  for (const s of signups) {
-    const gameId = eventGame.get(s.eventId);
-    if (!gameId) continue;
-    touch(gameId).eventSignup = true;
+  for (const eventId of batch.signupsByUser.get(userId) ?? []) {
+    const gameId = batch.eventGameId.get(eventId);
+    if (gameId) touch(gameId).eventSignup = true;
   }
-
-  for (const v of voice) {
-    const gameId = eventGame.get(v.eventId);
-    if (!gameId) continue;
-    touch(gameId).voiceAttendance = true;
+  for (const eventId of batch.voiceByUser.get(userId) ?? []) {
+    const gameId = batch.eventGameId.get(eventId);
+    if (gameId) touch(gameId).voiceAttendance = true;
   }
-
   return [...byGame.values()];
 }
 
@@ -176,7 +246,7 @@ async function loadGameMetadata(db: Db): Promise<Map<number, GameMetadata>> {
     .from(schema.games);
   const map = new Map<number, GameMetadata>();
   for (const r of rows) {
-    const rawTags = Array.isArray(r.itadTags) ? (r.itadTags as string[]) : [];
+    const rawTags = Array.isArray(r.itadTags) ? r.itadTags : [];
     map.set(r.id, {
       gameId: r.id,
       genres: r.genres ?? [],
@@ -188,66 +258,138 @@ async function loadGameMetadata(db: Db): Promise<Map<number, GameMetadata>> {
   return map;
 }
 
-async function computeUserSignalHash(db: Db, userId: number): Promise<string> {
-  const [interests] = await db.execute<{
+async function loadCoPlayCounts(db: Db): Promise<Map<number, number>> {
+  const rows = await db.execute<{ user_id: number; c: number }>(sql`
+    SELECT user_id, COUNT(*)::int AS c FROM (
+      SELECT user_id_a AS user_id FROM player_co_play
+      UNION ALL
+      SELECT user_id_b AS user_id FROM player_co_play
+    ) t GROUP BY user_id
+  `);
+  const map = new Map<number, number>();
+  for (const r of rows as unknown as Array<{ user_id: number; c: number }>) {
+    map.set(r.user_id, Number(r.c));
+  }
+  return map;
+}
+
+async function loadSignalHashComponents(
+  db: Db,
+): Promise<Map<number, SignalSummary>> {
+  const interests = await db.execute<{
+    user_id: number;
     count: string;
     max_updated: Date | null;
   }>(sql`
-    SELECT COUNT(*)::text AS count, MAX(created_at) AS max_updated
-    FROM ${schema.gameInterests}
-    WHERE user_id = ${userId}
+    SELECT user_id, COUNT(*)::text AS count, MAX(created_at) AS max_updated
+    FROM ${schema.gameInterests} GROUP BY user_id
   `);
-  const [rollups] = await db.execute<{
+  const rollups = await db.execute<{
+    user_id: number;
     count: string;
     max_period: string | null;
   }>(sql`
-    SELECT COUNT(*)::text AS count, MAX(period_start::text) AS max_period
-    FROM ${schema.gameActivityRollups}
-    WHERE user_id = ${userId}
+    SELECT user_id, COUNT(*)::text AS count, MAX(period_start::text) AS max_period
+    FROM ${schema.gameActivityRollups} GROUP BY user_id
   `);
-  const [signups] = await db.execute<{
+  const signups = await db.execute<{
+    user_id: number;
     count: string;
     max_updated: Date | null;
   }>(sql`
-    SELECT COUNT(*)::text AS count, MAX(signed_up_at) AS max_updated
-    FROM ${schema.eventSignups}
-    WHERE user_id = ${userId}
+    SELECT user_id, COUNT(*)::text AS count, MAX(signed_up_at) AS max_updated
+    FROM ${schema.eventSignups} GROUP BY user_id
   `);
-  const [voice] = await db.execute<{
+  const voice = await db.execute<{
+    user_id: number;
     count: string;
     max_updated: Date | null;
   }>(sql`
-    SELECT COUNT(*)::text AS count, MAX(last_leave_at) AS max_updated
-    FROM ${schema.eventVoiceSessions}
-    WHERE user_id = ${userId}
+    SELECT user_id, COUNT(*)::text AS count, MAX(last_leave_at) AS max_updated
+    FROM ${schema.eventVoiceSessions} GROUP BY user_id
   `);
 
-  const summary: SignalSummary = {
-    gameInterests: {
-      count: Number(interests.count),
-      maxUpdatedAt: interests.max_updated,
-    },
-    gameActivityRollups: {
-      count: Number(rollups.count),
-      maxPeriodStart: rollups.max_period,
-    },
-    eventSignups: {
-      count: Number(signups.count),
-      maxUpdatedAt: signups.max_updated,
-    },
-    eventVoiceSessions: {
-      count: Number(voice.count),
-      maxLastLeaveAt: voice.max_updated,
-    },
+  const summaries = new Map<number, SignalSummary>();
+  const ensure = (userId: number): SignalSummary => {
+    const existing = summaries.get(userId);
+    if (existing) return existing;
+    const fresh: SignalSummary = {
+      gameInterests: { count: 0, maxUpdatedAt: null },
+      gameActivityRollups: { count: 0, maxPeriodStart: null },
+      eventSignups: { count: 0, maxUpdatedAt: null },
+      eventVoiceSessions: { count: 0, maxLastLeaveAt: null },
+    };
+    summaries.set(userId, fresh);
+    return fresh;
   };
-  return computeSignalHash(summary);
+
+  for (const r of interests as unknown as Array<{
+    user_id: number;
+    count: string;
+    max_updated: Date | null;
+  }>) {
+    ensure(r.user_id).gameInterests = {
+      count: Number(r.count),
+      maxUpdatedAt: r.max_updated,
+    };
+  }
+  for (const r of rollups as unknown as Array<{
+    user_id: number;
+    count: string;
+    max_period: string | null;
+  }>) {
+    ensure(r.user_id).gameActivityRollups = {
+      count: Number(r.count),
+      maxPeriodStart: r.max_period,
+    };
+  }
+  for (const r of signups as unknown as Array<{
+    user_id: number;
+    count: string;
+    max_updated: Date | null;
+  }>) {
+    ensure(r.user_id).eventSignups = {
+      count: Number(r.count),
+      maxUpdatedAt: r.max_updated,
+    };
+  }
+  for (const r of voice as unknown as Array<{
+    user_id: number;
+    count: string;
+    max_updated: Date | null;
+  }>) {
+    ensure(r.user_id).eventVoiceSessions = {
+      count: Number(r.count),
+      maxLastLeaveAt: r.max_updated,
+    };
+  }
+
+  return summaries;
 }
 
-async function coPlayPartnerCount(db: Db, userId: number): Promise<number> {
-  const rows = await db.execute<{ c: number }>(sql`
-    SELECT COUNT(*)::int AS c
-    FROM player_co_play
-    WHERE user_id_a = ${userId} OR user_id_b = ${userId}
-  `);
-  return Number(rows[0]?.c ?? 0);
+function groupBy<T, K>(rows: T[], key: (row: T) => K): Map<K, T[]> {
+  const map = new Map<K, T[]>();
+  for (const row of rows) {
+    const k = key(row);
+    const list = map.get(k);
+    if (list) list.push(row);
+    else map.set(k, [row]);
+  }
+  return map;
+}
+
+function groupMap<T, K, V>(
+  rows: T[],
+  key: (row: T) => K,
+  value: (row: T) => V,
+): Map<K, V[]> {
+  const map = new Map<K, V[]>();
+  for (const row of rows) {
+    const k = key(row);
+    const v = value(row);
+    const list = map.get(k);
+    if (list) list.push(v);
+    else map.set(k, [v]);
+  }
+  return map;
 }

--- a/api/src/taste-profile/pipelines/aggregate-vectors.ts
+++ b/api/src/taste-profile/pipelines/aggregate-vectors.ts
@@ -169,15 +169,18 @@ async function loadGameMetadata(db: Db): Promise<Map<number, GameMetadata>> {
       genres: schema.games.genres,
       gameModes: schema.games.gameModes,
       themes: schema.games.themes,
+      itadTags: schema.games.itadTags,
     })
     .from(schema.games);
   const map = new Map<number, GameMetadata>();
   for (const r of rows) {
+    const rawTags = Array.isArray(r.itadTags) ? (r.itadTags as string[]) : [];
     map.set(r.id, {
       gameId: r.id,
       genres: r.genres ?? [],
       gameModes: r.gameModes ?? [],
       themes: r.themes ?? [],
+      tags: rawTags.map((t) => t.toLowerCase()),
     });
   }
   return map;

--- a/api/src/taste-profile/pipelines/aggregate-vectors.ts
+++ b/api/src/taste-profile/pipelines/aggregate-vectors.ts
@@ -1,4 +1,4 @@
-import { and, eq, sql } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import * as schema from '../../drizzle/schema';
 import {
@@ -8,7 +8,14 @@ import {
   type UserGameSignal,
 } from '../taste-vector.helpers';
 import { deriveArchetype } from '../archetype.helpers';
-import { computeSignalHash, type SignalSummary } from '../signal-hash.helpers';
+import { computeSignalHash } from '../signal-hash.helpers';
+import {
+  groupBy,
+  groupMap,
+  loadCoPlayCounts,
+  loadGameMetadata,
+  loadSignalHashComponents,
+} from './aggregate-vectors-loaders';
 
 type Db = PostgresJsDatabase<typeof schema>;
 
@@ -16,23 +23,32 @@ interface BatchedInputs {
   gameMap: Map<number, GameMetadata>;
   existingByUser: Map<
     number,
-    { signalHash: string; intensityMetrics: SignalSummary extends never ? never : NonNullable<unknown> }
+    { signalHash: string; intensityMetrics: NonNullable<unknown> }
   >;
   coPlayCounts: Map<number, number>;
   eventGameId: Map<number, number>;
   interestsByUser: Map<number, Array<typeof schema.gameInterests.$inferSelect>>;
-  presenceByUser: Map<number, Array<{ gameId: number | null; totalSeconds: number }>>;
+  presenceByUser: Map<
+    number,
+    Array<{ gameId: number | null; totalSeconds: number }>
+  >;
   signupsByUser: Map<number, number[]>;
   voiceByUser: Map<number, number[]>;
   hashByUser: Map<number, string>;
 }
 
+type IntensityMetrics = {
+  intensity: number;
+  focus: number;
+  breadth: number;
+  consistency: number;
+};
+
 /** Main entry point — iterates users, recomputes when signals changed.
  *
  * All per-user state is batch-loaded up front to avoid an N+1 round-trip
  * pattern (9+ queries × user count). Writes are still per-user because
- * drizzle-orm's onConflictDoUpdate is single-row; a future pass could
- * batch them with INSERT ... VALUES (...), (...) ON CONFLICT.
+ * drizzle-orm's onConflictDoUpdate is single-row.
  */
 export async function runAggregateVectors(db: Db): Promise<void> {
   const users = await db.select({ id: schema.users.id }).from(schema.users);
@@ -65,13 +81,12 @@ async function upsertVector(
     axisIdf,
   );
   const existing = batch.existingByUser.get(userId);
-  const intensityMetrics =
-    (existing?.intensityMetrics as {
-      intensity: number;
-      focus: number;
-      breadth: number;
-      consistency: number;
-    }) ?? { intensity: 0, focus: 0, breadth: 0, consistency: 0 };
+  const intensityMetrics = (existing?.intensityMetrics as IntensityMetrics) ?? {
+    intensity: 0,
+    focus: 0,
+    breadth: 0,
+    consistency: 0,
+  };
   const coPlayPartners = batch.coPlayCounts.get(userId) ?? 0;
   const archetype = deriveArchetype({ ...intensityMetrics, coPlayPartners });
 
@@ -134,7 +149,9 @@ async function loadBatch(db: Db): Promise<BatchedInputs> {
       .where(
         sql`${schema.eventVoiceSessions.classification} IN ('full', 'partial')`,
       ),
-    db.select({ id: schema.events.id, gameId: schema.events.gameId }).from(schema.events),
+    db
+      .select({ id: schema.events.id, gameId: schema.events.gameId })
+      .from(schema.events),
     db.select().from(schema.playerTasteVectors),
     loadCoPlayCounts(db),
     loadSignalHashComponents(db),
@@ -143,15 +160,15 @@ async function loadBatch(db: Db): Promise<BatchedInputs> {
   const interestsByUser = groupBy(interests, (i) => i.userId);
   const presenceByUser = groupBy(presence, (p) => p.userId);
   const signupsByUser = groupMap(
-    signups.filter((s): s is { userId: number; eventId: number } =>
-      s.userId !== null,
+    signups.filter(
+      (s): s is { userId: number; eventId: number } => s.userId !== null,
     ),
     (s) => s.userId,
     (s) => s.eventId,
   );
   const voiceByUser = groupMap(
-    voice.filter((v): v is { userId: number; eventId: number } =>
-      v.userId !== null,
+    voice.filter(
+      (v): v is { userId: number; eventId: number } => v.userId !== null,
     ),
     (v) => v.userId,
     (v) => v.eventId,
@@ -185,7 +202,35 @@ async function loadBatch(db: Db): Promise<BatchedInputs> {
   };
 }
 
-function assembleSignals(userId: number, batch: BatchedInputs): UserGameSignal[] {
+function applyInterestSignal(
+  sig: UserGameSignal,
+  row: typeof schema.gameInterests.$inferSelect,
+): void {
+  switch (row.source) {
+    case 'steam_library':
+      sig.steamOwnership = {
+        playtimeForever: row.playtimeForever ?? 0,
+        playtime2weeks: row.playtime2weeks ?? 0,
+      };
+      break;
+    case 'steam_wishlist':
+      sig.steamWishlist = true;
+      break;
+    case 'manual':
+      sig.manualHeart = true;
+      break;
+    case 'poll':
+      sig.pollSource = true;
+      break;
+    default:
+      break;
+  }
+}
+
+function assembleSignals(
+  userId: number,
+  batch: BatchedInputs,
+): UserGameSignal[] {
   const byGame = new Map<number, UserGameSignal>();
   const touch = (gameId: number): UserGameSignal => {
     const existing = byGame.get(gameId);
@@ -196,26 +241,7 @@ function assembleSignals(userId: number, batch: BatchedInputs): UserGameSignal[]
   };
 
   for (const row of batch.interestsByUser.get(userId) ?? []) {
-    const sig = touch(row.gameId);
-    switch (row.source) {
-      case 'steam_library':
-        sig.steamOwnership = {
-          playtimeForever: row.playtimeForever ?? 0,
-          playtime2weeks: row.playtime2weeks ?? 0,
-        };
-        break;
-      case 'steam_wishlist':
-        sig.steamWishlist = true;
-        break;
-      case 'manual':
-        sig.manualHeart = true;
-        break;
-      case 'poll':
-        sig.pollSource = true;
-        break;
-      default:
-        break;
-    }
+    applyInterestSignal(touch(row.gameId), row);
   }
   for (const p of batch.presenceByUser.get(userId) ?? []) {
     if (p.gameId === null) continue;
@@ -232,164 +258,4 @@ function assembleSignals(userId: number, batch: BatchedInputs): UserGameSignal[]
     if (gameId) touch(gameId).voiceAttendance = true;
   }
   return [...byGame.values()];
-}
-
-async function loadGameMetadata(db: Db): Promise<Map<number, GameMetadata>> {
-  const rows = await db
-    .select({
-      id: schema.games.id,
-      genres: schema.games.genres,
-      gameModes: schema.games.gameModes,
-      themes: schema.games.themes,
-      itadTags: schema.games.itadTags,
-    })
-    .from(schema.games);
-  const map = new Map<number, GameMetadata>();
-  for (const r of rows) {
-    const rawTags = Array.isArray(r.itadTags) ? r.itadTags : [];
-    map.set(r.id, {
-      gameId: r.id,
-      genres: r.genres ?? [],
-      gameModes: r.gameModes ?? [],
-      themes: r.themes ?? [],
-      tags: rawTags.map((t) => t.toLowerCase()),
-    });
-  }
-  return map;
-}
-
-async function loadCoPlayCounts(db: Db): Promise<Map<number, number>> {
-  const rows = await db.execute<{ user_id: number; c: number }>(sql`
-    SELECT user_id, COUNT(*)::int AS c FROM (
-      SELECT user_id_a AS user_id FROM player_co_play
-      UNION ALL
-      SELECT user_id_b AS user_id FROM player_co_play
-    ) t GROUP BY user_id
-  `);
-  const map = new Map<number, number>();
-  for (const r of rows as unknown as Array<{ user_id: number; c: number }>) {
-    map.set(r.user_id, Number(r.c));
-  }
-  return map;
-}
-
-async function loadSignalHashComponents(
-  db: Db,
-): Promise<Map<number, SignalSummary>> {
-  const interests = await db.execute<{
-    user_id: number;
-    count: string;
-    max_updated: Date | null;
-  }>(sql`
-    SELECT user_id, COUNT(*)::text AS count, MAX(created_at) AS max_updated
-    FROM ${schema.gameInterests} GROUP BY user_id
-  `);
-  const rollups = await db.execute<{
-    user_id: number;
-    count: string;
-    max_period: string | null;
-  }>(sql`
-    SELECT user_id, COUNT(*)::text AS count, MAX(period_start::text) AS max_period
-    FROM ${schema.gameActivityRollups} GROUP BY user_id
-  `);
-  const signups = await db.execute<{
-    user_id: number;
-    count: string;
-    max_updated: Date | null;
-  }>(sql`
-    SELECT user_id, COUNT(*)::text AS count, MAX(signed_up_at) AS max_updated
-    FROM ${schema.eventSignups} GROUP BY user_id
-  `);
-  const voice = await db.execute<{
-    user_id: number;
-    count: string;
-    max_updated: Date | null;
-  }>(sql`
-    SELECT user_id, COUNT(*)::text AS count, MAX(last_leave_at) AS max_updated
-    FROM ${schema.eventVoiceSessions} GROUP BY user_id
-  `);
-
-  const summaries = new Map<number, SignalSummary>();
-  const ensure = (userId: number): SignalSummary => {
-    const existing = summaries.get(userId);
-    if (existing) return existing;
-    const fresh: SignalSummary = {
-      gameInterests: { count: 0, maxUpdatedAt: null },
-      gameActivityRollups: { count: 0, maxPeriodStart: null },
-      eventSignups: { count: 0, maxUpdatedAt: null },
-      eventVoiceSessions: { count: 0, maxLastLeaveAt: null },
-    };
-    summaries.set(userId, fresh);
-    return fresh;
-  };
-
-  for (const r of interests as unknown as Array<{
-    user_id: number;
-    count: string;
-    max_updated: Date | null;
-  }>) {
-    ensure(r.user_id).gameInterests = {
-      count: Number(r.count),
-      maxUpdatedAt: r.max_updated,
-    };
-  }
-  for (const r of rollups as unknown as Array<{
-    user_id: number;
-    count: string;
-    max_period: string | null;
-  }>) {
-    ensure(r.user_id).gameActivityRollups = {
-      count: Number(r.count),
-      maxPeriodStart: r.max_period,
-    };
-  }
-  for (const r of signups as unknown as Array<{
-    user_id: number;
-    count: string;
-    max_updated: Date | null;
-  }>) {
-    ensure(r.user_id).eventSignups = {
-      count: Number(r.count),
-      maxUpdatedAt: r.max_updated,
-    };
-  }
-  for (const r of voice as unknown as Array<{
-    user_id: number;
-    count: string;
-    max_updated: Date | null;
-  }>) {
-    ensure(r.user_id).eventVoiceSessions = {
-      count: Number(r.count),
-      maxLastLeaveAt: r.max_updated,
-    };
-  }
-
-  return summaries;
-}
-
-function groupBy<T, K>(rows: T[], key: (row: T) => K): Map<K, T[]> {
-  const map = new Map<K, T[]>();
-  for (const row of rows) {
-    const k = key(row);
-    const list = map.get(k);
-    if (list) list.push(row);
-    else map.set(k, [row]);
-  }
-  return map;
-}
-
-function groupMap<T, K, V>(
-  rows: T[],
-  key: (row: T) => K,
-  value: (row: T) => V,
-): Map<K, V[]> {
-  const map = new Map<K, V[]>();
-  for (const row of rows) {
-    const k = key(row);
-    const v = value(row);
-    const list = map.get(k);
-    if (list) list.push(v);
-    else map.set(k, [v]);
-  }
-  return map;
 }

--- a/api/src/taste-profile/pipelines/weekly-intensity.ts
+++ b/api/src/taste-profile/pipelines/weekly-intensity.ts
@@ -15,6 +15,13 @@ interface WeeklySnapshot {
   longestGameId: number | null;
 }
 
+interface CommunityDists {
+  week: Map<number, number>;
+  last4w: Map<number, number>;
+  allTime: Map<number, number>;
+  maxUniqueGames: number;
+}
+
 /** Rolling 4-week window start (28 days ago, floor to midnight). */
 function fourWeekStart(now: Date): Date {
   const d = new Date(now);
@@ -23,19 +30,20 @@ function fourWeekStart(now: Date): Date {
   return d;
 }
 
-async function communityDistributions(
+/**
+ * Fetch the week's per-user rollup totals AND the max unique-games count
+ * in a single pass over the current-week rollup slice. Saves one full
+ * table scan vs. separating the two queries.
+ */
+async function loadCurrentWeekStats(
   db: Db,
   weekStart: Date,
-  fourWkStart: Date,
-): Promise<{
-  week: Map<number, number>;
-  last4w: Map<number, number>;
-  allTime: Map<number, number>;
-}> {
-  const weekRows = await db
+): Promise<{ totals: Map<number, number>; maxUniqueGames: number }> {
+  const rows = await db
     .select({
       userId: schema.gameActivityRollups.userId,
-      total: sql<number>`sum(${schema.gameActivityRollups.totalSeconds})`,
+      totalSeconds: sql<number>`sum(${schema.gameActivityRollups.totalSeconds})`,
+      uniqueGames: sql<number>`count(distinct ${schema.gameActivityRollups.gameId})`,
     })
     .from(schema.gameActivityRollups)
     .where(
@@ -49,7 +57,35 @@ async function communityDistributions(
     )
     .groupBy(schema.gameActivityRollups.userId);
 
-  const last4wRows = await db.execute<{ user_id: number; total: number }>(sql`
+  const totals = new Map<number, number>();
+  let maxUniqueGames = 0;
+  for (const r of rows) {
+    totals.set(r.userId, Number(r.totalSeconds) / 3600);
+    const unique = Number(r.uniqueGames);
+    if (unique > maxUniqueGames) maxUniqueGames = unique;
+  }
+  return { totals, maxUniqueGames };
+}
+
+type RawTotalsRow = {
+  user_id: number;
+  total: number;
+} & Record<string, unknown>;
+
+function totalsMap(rows: RawTotalsRow[]): Map<number, number> {
+  const map = new Map<number, number>();
+  for (const r of rows) map.set(r.user_id, Number(r.total) / 3600);
+  return map;
+}
+
+async function communityDistributions(
+  db: Db,
+  weekStart: Date,
+  fourWkStart: Date,
+): Promise<CommunityDists> {
+  const currentWeek = await loadCurrentWeekStats(db, weekStart);
+
+  const last4wRows = await db.execute<RawTotalsRow>(sql`
     SELECT user_id, SUM(total_seconds)::bigint AS total
     FROM ${schema.gameActivityRollups}
     WHERE period = 'day'
@@ -57,26 +93,18 @@ async function communityDistributions(
     GROUP BY user_id
   `);
 
-  const allTimeRows = await db.execute<{ user_id: number; total: number }>(sql`
+  const allTimeRows = await db.execute<RawTotalsRow>(sql`
     SELECT user_id, SUM(total_seconds)::bigint AS total
     FROM ${schema.gameActivityRollups}
     WHERE period = 'day'
     GROUP BY user_id
   `);
 
-  const toMap = (rows: Array<{ userId?: number; user_id?: number; total: number }>) => {
-    const map = new Map<number, number>();
-    for (const r of rows) {
-      const id = r.userId ?? r.user_id;
-      if (id === undefined) continue;
-      map.set(id, Number(r.total) / 3600);
-    }
-    return map;
-  };
   return {
-    week: toMap(weekRows),
-    last4w: toMap(last4wRows as unknown as Array<{ user_id: number; total: number }>),
-    allTime: toMap(allTimeRows as unknown as Array<{ user_id: number; total: number }>),
+    week: currentWeek.totals,
+    last4w: totalsMap(last4wRows as unknown as RawTotalsRow[]),
+    allTime: totalsMap(allTimeRows as unknown as RawTotalsRow[]),
+    maxUniqueGames: currentWeek.maxUniqueGames,
   };
 }
 
@@ -90,17 +118,11 @@ export async function runWeeklyIntensityRollup(db: Db): Promise<void> {
     totalHoursDistribution: [...dists.week.values()],
     last4wHoursDistribution: [...dists.last4w.values()],
     allTimeHoursDistribution: [...dists.allTime.values()],
-    maxUniqueGames: await maxUniqueGamesThisWeek(db, weekStart),
+    maxUniqueGames: dists.maxUniqueGames,
   };
 
   for (const { id: userId } of users) {
-    const snap = await buildWeeklySnapshot(
-      db,
-      userId,
-      weekStart,
-      fourWkStart,
-      dists,
-    );
+    const snap = await buildWeeklySnapshot(db, userId, weekStart, dists);
     if (!snap) continue;
 
     const metrics = computeIntensityMetrics(snap.input, community);
@@ -146,31 +168,11 @@ export function currentWeekStart(): Date {
   return d;
 }
 
-async function maxUniqueGamesThisWeek(
-  db: Db,
-  weekStart: Date,
-): Promise<number> {
-  const rows = await db.execute<{ c: number }>(sql`
-    SELECT MAX(c)::int AS c FROM (
-      SELECT COUNT(DISTINCT game_id) AS c
-      FROM game_activity_rollups
-      WHERE period = 'week' AND period_start = ${weekStart.toISOString().slice(0, 10)}
-      GROUP BY user_id
-    ) t
-  `);
-  return Number(rows[0]?.c ?? 0);
-}
-
 async function buildWeeklySnapshot(
   db: Db,
   userId: number,
   weekStart: Date,
-  _fourWkStart: Date,
-  dists: {
-    week: Map<number, number>;
-    last4w: Map<number, number>;
-    allTime: Map<number, number>;
-  },
+  dists: CommunityDists,
 ): Promise<WeeklySnapshot | null> {
   const rollups = await db
     .select()

--- a/api/src/taste-profile/pipelines/weekly-intensity.ts
+++ b/api/src/taste-profile/pipelines/weekly-intensity.ts
@@ -15,11 +15,24 @@ interface WeeklySnapshot {
   longestGameId: number | null;
 }
 
-export async function runWeeklyIntensityRollup(db: Db): Promise<void> {
-  const weekStart = currentWeekStart();
-  const users = await db.select({ id: schema.users.id }).from(schema.users);
+/** Rolling 4-week window start (28 days ago, floor to midnight). */
+function fourWeekStart(now: Date): Date {
+  const d = new Date(now);
+  d.setDate(d.getDate() - 28);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
 
-  const allWeekly = await db
+async function communityDistributions(
+  db: Db,
+  weekStart: Date,
+  fourWkStart: Date,
+): Promise<{
+  week: Map<number, number>;
+  last4w: Map<number, number>;
+  allTime: Map<number, number>;
+}> {
+  const weekRows = await db
     .select({
       userId: schema.gameActivityRollups.userId,
       total: sql<number>`sum(${schema.gameActivityRollups.totalSeconds})`,
@@ -36,13 +49,58 @@ export async function runWeeklyIntensityRollup(db: Db): Promise<void> {
     )
     .groupBy(schema.gameActivityRollups.userId);
 
+  const last4wRows = await db.execute<{ user_id: number; total: number }>(sql`
+    SELECT user_id, SUM(total_seconds)::bigint AS total
+    FROM ${schema.gameActivityRollups}
+    WHERE period = 'day'
+      AND period_start >= ${fourWkStart.toISOString().slice(0, 10)}
+    GROUP BY user_id
+  `);
+
+  const allTimeRows = await db.execute<{ user_id: number; total: number }>(sql`
+    SELECT user_id, SUM(total_seconds)::bigint AS total
+    FROM ${schema.gameActivityRollups}
+    WHERE period = 'day'
+    GROUP BY user_id
+  `);
+
+  const toMap = (rows: Array<{ userId?: number; user_id?: number; total: number }>) => {
+    const map = new Map<number, number>();
+    for (const r of rows) {
+      const id = r.userId ?? r.user_id;
+      if (id === undefined) continue;
+      map.set(id, Number(r.total) / 3600);
+    }
+    return map;
+  };
+  return {
+    week: toMap(weekRows),
+    last4w: toMap(last4wRows as unknown as Array<{ user_id: number; total: number }>),
+    allTime: toMap(allTimeRows as unknown as Array<{ user_id: number; total: number }>),
+  };
+}
+
+export async function runWeeklyIntensityRollup(db: Db): Promise<void> {
+  const weekStart = currentWeekStart();
+  const fourWkStart = fourWeekStart(new Date());
+  const users = await db.select({ id: schema.users.id }).from(schema.users);
+
+  const dists = await communityDistributions(db, weekStart, fourWkStart);
   const community: CommunityStats = {
-    totalHoursDistribution: allWeekly.map((r) => Number(r.total) / 3600),
+    totalHoursDistribution: [...dists.week.values()],
+    last4wHoursDistribution: [...dists.last4w.values()],
+    allTimeHoursDistribution: [...dists.allTime.values()],
     maxUniqueGames: await maxUniqueGamesThisWeek(db, weekStart),
   };
 
   for (const { id: userId } of users) {
-    const snap = await buildWeeklySnapshot(db, userId, weekStart);
+    const snap = await buildWeeklySnapshot(
+      db,
+      userId,
+      weekStart,
+      fourWkStart,
+      dists,
+    );
     if (!snap) continue;
 
     const metrics = computeIntensityMetrics(snap.input, community);
@@ -107,6 +165,12 @@ async function buildWeeklySnapshot(
   db: Db,
   userId: number,
   weekStart: Date,
+  _fourWkStart: Date,
+  dists: {
+    week: Map<number, number>;
+    last4w: Map<number, number>;
+    allTime: Map<number, number>;
+  },
 ): Promise<WeeklySnapshot | null> {
   const rollups = await db
     .select()
@@ -121,7 +185,6 @@ async function buildWeeklySnapshot(
         ),
       ),
     );
-  if (rollups.length === 0) return null;
 
   const totalHours = rollups.reduce((acc, r) => acc + r.totalSeconds / 3600, 0);
   const gameBreakdown = rollups.map((r) => ({
@@ -129,10 +192,12 @@ async function buildWeeklySnapshot(
     hours: Number((r.totalSeconds / 3600).toFixed(2)),
     source: 'presence',
   }));
-  const longest = rollups.reduce((a, b) =>
-    b.totalSeconds > a.totalSeconds ? b : a,
-  );
-  const longestSessionHours = Number((longest.totalSeconds / 3600).toFixed(2));
+  const longest = rollups.length
+    ? rollups.reduce((a, b) => (b.totalSeconds > a.totalSeconds ? b : a))
+    : null;
+  const longestSessionHours = longest
+    ? Number((longest.totalSeconds / 3600).toFixed(2))
+    : 0;
 
   const historyRows = await db
     .select({
@@ -155,14 +220,29 @@ async function buildWeeklySnapshot(
     .orderBy(desc(schema.gameActivityRollups.periodStart));
   const weeklyHistory = historyRows.map((r) => Number(r.total) / 3600);
 
+  const last4wHours = dists.last4w.get(userId) ?? 0;
+  const allTimeHours = dists.allTime.get(userId) ?? 0;
+
+  // Skip users with zero signal across all three tiers — nothing to rank.
+  if (
+    totalHours === 0 &&
+    last4wHours === 0 &&
+    allTimeHours === 0 &&
+    rollups.length === 0
+  ) {
+    return null;
+  }
+
   return {
     input: {
       totalHours: Number(totalHours.toFixed(2)),
+      last4wHours: Number(last4wHours.toFixed(2)),
+      allTimeHours: Number(allTimeHours.toFixed(2)),
       longestSessionHours,
       uniqueGames: rollups.length,
       weeklyHistory,
     },
     gameBreakdown,
-    longestGameId: longest.gameId,
+    longestGameId: longest?.gameId ?? null,
   };
 }

--- a/api/src/taste-profile/queries/taste-profile-queries.ts
+++ b/api/src/taste-profile/queries/taste-profile-queries.ts
@@ -4,7 +4,9 @@ import * as schema from '../../drizzle/schema';
 import type {
   TasteProfileArchetype,
   TasteProfileDimensionsDto,
+  TasteProfilePoolAxis,
 } from '@raid-ledger/contract';
+import { TASTE_PROFILE_AXIS_POOL } from '@raid-ledger/contract';
 
 type Db = PostgresJsDatabase<typeof schema>;
 
@@ -155,13 +157,7 @@ async function topCoPlayPartners(
 }
 
 function zeroedDimensions(): TasteProfileDimensionsDto {
-  return {
-    co_op: 0,
-    pvp: 0,
-    rpg: 0,
-    survival: 0,
-    strategy: 0,
-    social: 0,
-    mmo: 0,
-  };
+  const dims = {} as Record<TasteProfilePoolAxis, number>;
+  for (const axis of TASTE_PROFILE_AXIS_POOL) dims[axis] = 0;
+  return dims as TasteProfileDimensionsDto;
 }

--- a/api/src/taste-profile/taste-vector.helpers.spec.ts
+++ b/api/src/taste-profile/taste-vector.helpers.spec.ts
@@ -89,29 +89,24 @@ describe('axisMatchFactor (ROK-948 AC 11)', () => {
   };
 
   it('matches co_op via gameModes', () => {
-    expect(axisMatchFactor('co_op', coopGame, { gameId: 1 })).toBe(1.0);
+    expect(axisMatchFactor('co_op', coopGame)).toBe(1.0);
   });
 
   it('matches rpg via genres', () => {
-    expect(axisMatchFactor('rpg', rpgGame, { gameId: 2 })).toBe(1.0);
+    expect(axisMatchFactor('rpg', rpgGame)).toBe(1.0);
   });
 
   it('does not match when none of the mappings apply', () => {
-    expect(axisMatchFactor('pvp', coopGame, { gameId: 1 })).toBe(0);
-    expect(axisMatchFactor('mmo', rpgGame, { gameId: 2 })).toBe(0);
+    expect(axisMatchFactor('pvp', coopGame)).toBe(0);
+    expect(axisMatchFactor('mmo', rpgGame)).toBe(0);
   });
 
   it('does not award MMO axis based on playtime alone', () => {
     // Prior code awarded a +1.0 MMO bonus for games with >3000min playtime
     // regardless of genre. That was over-broad (PUBG/Satisfactory hit MMO).
     // MMO is now detected via tags (MMORPG/MMO/Massively Multiplayer) or
-    // IGDB gameMode 5 only.
-    expect(
-      axisMatchFactor('mmo', bareGame, {
-        gameId: 3,
-        steamOwnership: { playtimeForever: 50000, playtime2weeks: 0 },
-      }),
-    ).toBe(0);
+    // IGDB gameMode 5 only. `axisMatchFactor` no longer takes a signal.
+    expect(axisMatchFactor('mmo', bareGame)).toBe(0);
   });
 
   it('matches mmo via IGDB gameMode 5 (Massively Multiplayer)', () => {
@@ -122,7 +117,7 @@ describe('axisMatchFactor (ROK-948 AC 11)', () => {
       themes: [],
       tags: [],
     };
-    expect(axisMatchFactor('mmo', mmoGame, { gameId: 99 })).toBe(1.0);
+    expect(axisMatchFactor('mmo', mmoGame)).toBe(1.0);
   });
 });
 

--- a/api/src/taste-profile/taste-vector.helpers.spec.ts
+++ b/api/src/taste-profile/taste-vector.helpers.spec.ts
@@ -10,13 +10,13 @@ import {
 } from './taste-vector.helpers';
 
 describe('signalWeight (ROK-948 AC 11)', () => {
-  it('returns 0.1 for ownership with no playtime', () => {
+  it('returns 0.02 for bare ownership with no playtime (library-tail weak signal)', () => {
     expect(
       signalWeight({
         gameId: 1,
         steamOwnership: { playtimeForever: 0, playtime2weeks: 0 },
       }),
-    ).toBeCloseTo(0.1);
+    ).toBeCloseTo(0.02);
   });
 
   it('returns 1.0 for ownership with >3000 min lifetime playtime', () => {

--- a/api/src/taste-profile/taste-vector.helpers.spec.ts
+++ b/api/src/taste-profile/taste-vector.helpers.spec.ts
@@ -71,18 +71,21 @@ describe('axisMatchFactor (ROK-948 AC 11)', () => {
     genres: [],
     gameModes: [3], // Coop
     themes: [],
+    tags: [],
   };
   const rpgGame: GameMetadata = {
     gameId: 2,
     genres: [12], // RPG
     gameModes: [],
     themes: [],
+    tags: [],
   };
   const bareGame: GameMetadata = {
     gameId: 3,
     genres: [],
     gameModes: [],
     themes: [],
+    tags: [],
   };
 
   it('matches co_op via gameModes', () => {
@@ -98,30 +101,36 @@ describe('axisMatchFactor (ROK-948 AC 11)', () => {
     expect(axisMatchFactor('mmo', rpgGame, { gameId: 2 })).toBe(0);
   });
 
-  it('awards MMO playtime bonus when playtimeForever exceeds the threshold', () => {
+  it('does not award MMO axis based on playtime alone', () => {
+    // Prior code awarded a +1.0 MMO bonus for games with >3000min playtime
+    // regardless of genre. That was over-broad (PUBG/Satisfactory hit MMO).
+    // MMO is now detected via tags (MMORPG/MMO/Massively Multiplayer) or
+    // IGDB gameMode 5 only.
     expect(
       axisMatchFactor('mmo', bareGame, {
         gameId: 3,
-        steamOwnership: { playtimeForever: 5000, playtime2weeks: 0 },
-      }),
-    ).toBe(1.0);
-  });
-
-  it('does not award MMO bonus for small playtime on untagged games', () => {
-    expect(
-      axisMatchFactor('mmo', bareGame, {
-        gameId: 3,
-        steamOwnership: { playtimeForever: 500, playtime2weeks: 0 },
+        steamOwnership: { playtimeForever: 50000, playtime2weeks: 0 },
       }),
     ).toBe(0);
+  });
+
+  it('matches mmo via IGDB gameMode 5 (Massively Multiplayer)', () => {
+    const mmoGame: GameMetadata = {
+      gameId: 99,
+      genres: [],
+      gameModes: [5],
+      themes: [],
+      tags: [],
+    };
+    expect(axisMatchFactor('mmo', mmoGame, { gameId: 99 })).toBe(1.0);
   });
 });
 
 describe('computeTasteVector (ROK-948 AC 11)', () => {
   const games = new Map<number, GameMetadata>([
-    [10, { gameId: 10, genres: [12], gameModes: [], themes: [] }], // RPG
-    [11, { gameId: 11, genres: [], gameModes: [3], themes: [] }], // Coop
-    [12, { gameId: 12, genres: [15], gameModes: [], themes: [] }], // Strategy
+    [10, { gameId: 10, genres: [12], gameModes: [], themes: [], tags: [] }], // RPG
+    [11, { gameId: 11, genres: [], gameModes: [3], themes: [], tags: [] }], // Coop
+    [12, { gameId: 12, genres: [15], gameModes: [], themes: [], tags: [] }], // Strategy
   ]);
 
   it('returns zeroed dimensions + zero vector for an empty signal list', () => {

--- a/api/src/taste-profile/taste-vector.helpers.ts
+++ b/api/src/taste-profile/taste-vector.helpers.ts
@@ -9,7 +9,7 @@ import {
 } from '@raid-ledger/contract';
 import {
   AXIS_MAPPINGS,
-  MMO_PLAYTIME_BONUS_MIN,
+  HIGH_PLAYTIME_WEIGHT_MIN,
 } from './axis-mapping.constants';
 
 /**
@@ -32,6 +32,12 @@ export interface UserGameSignal {
  * `tags` are lowercased IsThereAnyDeal/Steam user tags — far richer than
  * IGDB's genre taxonomy. They take priority in axis matching; IGDB IDs
  * act as fallback for games whose tags haven't been fetched yet.
+ *
+ * Known limitation: tag matching is English-only. ITAD supplies localized
+ * tags but we only compare against the English axis-mapping vocabulary,
+ * so non-English tag sets silently fall through to the IGDB fallback.
+ * Acceptable today because Steam's non-English tag coverage is sparse;
+ * revisit if we ever internationalize the axis vocabulary.
  */
 export interface GameMetadata {
   gameId: number;
@@ -41,55 +47,96 @@ export interface GameMetadata {
   tags: string[];
 }
 
+/**
+ * Signal-source contribution weights (tuning knobs — adjust here, not
+ * inline). The `signalWeight` sum for a single game is intentionally
+ * unbounded; self-normalization at the dimensions layer handles the
+ * scale.
+ */
+export const SIGNAL_WEIGHTS = {
+  /** Lifetime Steam playtime above this threshold (minutes) → weight 1.0. */
+  steamHighPlaytime: 1.0,
+  /** Base weight for recent-playtime owners. */
+  steamRecentBase: 0.5,
+  /** Additive bonus per `playtime2weeks` minute, capped at 0.5. */
+  steamRecentCap: 0.5,
+  /** Divisor for the recent-playtime bonus: `min(mins/600, cap)`. */
+  steamRecentDivisor: 600,
+  /** Library-tail ownership with no playtime. Kept tiny so a 1000-game
+   *  Steam library doesn't drown out actual play habits via axis
+   *  tail-aggregation. */
+  steamBareOwnership: 0.02,
+  /** Steam wishlist hint. */
+  steamWishlist: 0.2,
+  /** Presence divisor — weekly hours scaled to [0, 1]. */
+  presenceDivisor: 10,
+  /** Cap on presence contribution regardless of hours. */
+  presenceCap: 1.0,
+  /** Manual heart (explicit interest). */
+  manualHeart: 0.5,
+  /** Signed up for an event for this game. */
+  eventSignup: 0.7,
+  /** Attended voice for an event — strongest "active interest" signal. */
+  voiceAttendance: 1.0,
+  /** Auto-hearted via a scheduling poll. */
+  pollSource: 0.4,
+} as const;
+
 export function signalWeight(signal: UserGameSignal): number {
   let weight = 0;
 
   if (signal.steamOwnership) {
     const { playtimeForever, playtime2weeks } = signal.steamOwnership;
-    if (playtimeForever > MMO_PLAYTIME_BONUS_MIN) {
-      weight += 1.0;
+    if (playtimeForever > HIGH_PLAYTIME_WEIGHT_MIN) {
+      weight += SIGNAL_WEIGHTS.steamHighPlaytime;
     } else if (playtime2weeks > 0) {
-      weight += 0.5 + Math.min(playtime2weeks / 600, 0.5);
+      weight +=
+        SIGNAL_WEIGHTS.steamRecentBase +
+        Math.min(
+          playtime2weeks / SIGNAL_WEIGHTS.steamRecentDivisor,
+          SIGNAL_WEIGHTS.steamRecentCap,
+        );
     } else {
-      // Bare ownership (no playtime) is a very weak signal — a 1000-game
-      // Steam library shouldn't drown out actual play habits via axis
-      // tail-aggregation. Keep just enough to whisper through.
-      weight += 0.02;
+      weight += SIGNAL_WEIGHTS.steamBareOwnership;
     }
   }
-  if (signal.steamWishlist) weight += 0.2;
+  if (signal.steamWishlist) weight += SIGNAL_WEIGHTS.steamWishlist;
   if (signal.presenceWeeklyHours !== undefined) {
-    weight += Math.min(signal.presenceWeeklyHours / 10, 1.0);
+    weight += Math.min(
+      signal.presenceWeeklyHours / SIGNAL_WEIGHTS.presenceDivisor,
+      SIGNAL_WEIGHTS.presenceCap,
+    );
   }
-  if (signal.manualHeart) weight += 0.5;
-  if (signal.eventSignup) weight += 0.7;
-  if (signal.voiceAttendance) weight += 1.0;
-  if (signal.pollSource) weight += 0.4;
+  if (signal.manualHeart) weight += SIGNAL_WEIGHTS.manualHeart;
+  if (signal.eventSignup) weight += SIGNAL_WEIGHTS.eventSignup;
+  if (signal.voiceAttendance) weight += SIGNAL_WEIGHTS.voiceAttendance;
+  if (signal.pollSource) weight += SIGNAL_WEIGHTS.pollSource;
 
   return weight;
 }
 
+/**
+ * Does this game match the given axis?
+ * - If the game has tags, match only against the axis's tag list
+ *   (trust the richer Steam/ITAD vocabulary).
+ * - Otherwise, fall back to IGDB gameMode/genre/theme IDs.
+ *
+ * Returns 1.0 on match, 0 otherwise. Does NOT depend on per-user signal —
+ * classification is purely a property of the game. Used by both the
+ * vector computation and `computeAxisIdf` rarity calculation.
+ */
 export function axisMatchFactor(
   axis: TasteProfilePoolAxis,
   game: GameMetadata,
-  signal: UserGameSignal,
 ): number {
   const mapping = AXIS_MAPPINGS[axis];
 
-  // Tag-first classification: when user tags are present, they're a far
-  // richer signal than IGDB's coarse genre IDs. Trust them exclusively
-  // so that e.g. Satisfactory's "Automation" tag drives the Automation
-  // axis instead of also bleeding into Adventure via the IGDB fallback.
   if (game.tags.length > 0) {
     return mapping.tags.some((t) => game.tags.includes(t.toLowerCase()))
       ? 1.0
       : 0;
   }
 
-  // No tags on this game — fall back to IGDB IDs (older / unfetched games).
-  // Used to apply an MMO_PLAYTIME_BONUS here but it was over-broad: any
-  // 50h+ game would hit MMO regardless of genre. Real MMOs are caught by
-  // gameMode 5 or the MMORPG/Massively Multiplayer tags.
   const hits =
     mapping.gameModes.some((m) => game.gameModes.includes(m)) ||
     mapping.genres.some((g) => game.genres.includes(g)) ||
@@ -124,10 +171,9 @@ export function computeAxisIdf(
   const coverage = {} as Record<TasteProfilePoolAxis, number>;
   for (const axis of TASTE_PROFILE_AXIS_POOL) coverage[axis] = 0;
 
-  const emptySignal: UserGameSignal = { gameId: 0 };
   for (const game of games.values()) {
     for (const axis of TASTE_PROFILE_AXIS_POOL) {
-      if (axisMatchFactor(axis, game, emptySignal) > 0) coverage[axis] += 1;
+      if (axisMatchFactor(axis, game) > 0) coverage[axis] += 1;
     }
   }
   for (const axis of TASTE_PROFILE_AXIS_POOL) {
@@ -159,7 +205,7 @@ export function computeTasteVector(
     const w = signalWeight(signal);
     if (w === 0) continue;
     for (const axis of TASTE_PROFILE_AXIS_POOL) {
-      raw[axis] += w * axisMatchFactor(axis, game, signal);
+      raw[axis] += w * axisMatchFactor(axis, game);
     }
   }
 

--- a/api/src/taste-profile/taste-vector.helpers.ts
+++ b/api/src/taste-profile/taste-vector.helpers.ts
@@ -1,8 +1,12 @@
 import type {
   TasteProfileAxis,
   TasteProfileDimensionsDto,
+  TasteProfilePoolAxis,
 } from '@raid-ledger/contract';
-import { TASTE_PROFILE_AXES } from '@raid-ledger/contract';
+import {
+  TASTE_PROFILE_AXES,
+  TASTE_PROFILE_AXIS_POOL,
+} from '@raid-ledger/contract';
 import {
   AXIS_MAPPINGS,
   MMO_PLAYTIME_BONUS_MIN,
@@ -59,7 +63,7 @@ export function signalWeight(signal: UserGameSignal): number {
 }
 
 export function axisMatchFactor(
-  axis: TasteProfileAxis,
+  axis: TasteProfilePoolAxis,
   game: GameMetadata,
   signal: UserGameSignal,
 ): number {
@@ -83,12 +87,19 @@ export function axisMatchFactor(
   return 0;
 }
 
+function zeroedPool(): Record<TasteProfilePoolAxis, number> {
+  const init = {} as Record<TasteProfilePoolAxis, number>;
+  for (const axis of TASTE_PROFILE_AXIS_POOL) init[axis] = 0;
+  return init;
+}
+
 /**
- * Compute the 7-axis dimensions jsonb (display scale 0–100) + the
- * normalized unit vector (length 7, for pgvector cosine queries).
+ * Compute the full-pool dimensions jsonb (display scale 0–100) + the
+ * normalized 7-element vector (for pgvector cosine queries keyed by
+ * `TASTE_PROFILE_AXES`).
  *
- * Self-normalized per-user: the user's strongest axis maps to 100, so
- * new users and heavy users both produce comparable radar shapes. Community
+ * Self-normalized per-user: the user's strongest pool axis maps to 100,
+ * so new users and heavy users produce comparable radar shapes. Community
  * normalization (percentile rank) is layered on top by the intensity
  * metrics, not the dimensions vector.
  */
@@ -96,35 +107,30 @@ export function computeTasteVector(
   signals: UserGameSignal[],
   games: Map<number, GameMetadata>,
 ): { dimensions: TasteProfileDimensionsDto; vector: number[] } {
-  const raw: Record<TasteProfileAxis, number> = {
-    co_op: 0,
-    pvp: 0,
-    rpg: 0,
-    survival: 0,
-    strategy: 0,
-    social: 0,
-    mmo: 0,
-  };
+  const raw = zeroedPool();
 
   for (const signal of signals) {
     const game = games.get(signal.gameId);
     if (!game) continue;
     const w = signalWeight(signal);
     if (w === 0) continue;
-    for (const axis of TASTE_PROFILE_AXES) {
+    for (const axis of TASTE_PROFILE_AXIS_POOL) {
       raw[axis] += w * axisMatchFactor(axis, game, signal);
     }
   }
 
-  const values = TASTE_PROFILE_AXES.map((a) => raw[a]);
+  const values = TASTE_PROFILE_AXIS_POOL.map((a) => raw[a]);
   const max = Math.max(0, ...values);
-  const dimensions = {} as Record<TasteProfileAxis, number>;
-  for (const axis of TASTE_PROFILE_AXES) {
+  const dimensions = {} as Record<TasteProfilePoolAxis, number>;
+  for (const axis of TASTE_PROFILE_AXIS_POOL) {
     dimensions[axis] = max > 0 ? Math.round((raw[axis] / max) * 100) : 0;
   }
 
-  // Vector is the raw dimensions in [0, 1] for cosine distance.
-  const vector = TASTE_PROFILE_AXES.map((axis) => dimensions[axis] / 100);
+  // Similarity vector stays 7-dim and keyed by the original core axes so
+  // the pgvector column and similar-players cosine stay stable.
+  const vector = TASTE_PROFILE_AXES.map(
+    (axis: TasteProfileAxis) => dimensions[axis] / 100,
+  );
 
   return {
     dimensions: dimensions as TasteProfileDimensionsDto,

--- a/api/src/taste-profile/taste-vector.helpers.ts
+++ b/api/src/taste-profile/taste-vector.helpers.ts
@@ -29,12 +29,16 @@ export interface UserGameSignal {
 
 /**
  * Metadata subset used by the mapper.
+ * `tags` are lowercased IsThereAnyDeal/Steam user tags — far richer than
+ * IGDB's genre taxonomy. They take priority in axis matching; IGDB IDs
+ * act as fallback for games whose tags haven't been fetched yet.
  */
 export interface GameMetadata {
   gameId: number;
   genres: number[];
   gameModes: number[];
   themes: number[];
+  tags: string[];
 }
 
 export function signalWeight(signal: UserGameSignal): number {
@@ -71,23 +75,27 @@ export function axisMatchFactor(
   signal: UserGameSignal,
 ): number {
   const mapping = AXIS_MAPPINGS[axis];
+
+  // Tag-first classification: when user tags are present, they're a far
+  // richer signal than IGDB's coarse genre IDs. Trust them exclusively
+  // so that e.g. Satisfactory's "Automation" tag drives the Automation
+  // axis instead of also bleeding into Adventure via the IGDB fallback.
+  if (game.tags.length > 0) {
+    return mapping.tags.some((t) => game.tags.includes(t.toLowerCase()))
+      ? 1.0
+      : 0;
+  }
+
+  // No tags on this game — fall back to IGDB IDs (older / unfetched games).
+  // Used to apply an MMO_PLAYTIME_BONUS here but it was over-broad: any
+  // 50h+ game would hit MMO regardless of genre. Real MMOs are caught by
+  // gameMode 5 or the MMORPG/Massively Multiplayer tags.
   const hits =
     mapping.gameModes.some((m) => game.gameModes.includes(m)) ||
     mapping.genres.some((g) => game.genres.includes(g)) ||
     mapping.themes.some((t) => game.themes.includes(t));
 
-  if (hits) return 1.0;
-
-  // MMO playtime bonus: a high-playtime game also drives the MMO axis.
-  if (
-    axis === 'mmo' &&
-    signal.steamOwnership &&
-    signal.steamOwnership.playtimeForever > MMO_PLAYTIME_BONUS_MIN
-  ) {
-    return 1.0;
-  }
-
-  return 0;
+  return hits ? 1.0 : 0;
 }
 
 function zeroedPool(): Record<TasteProfilePoolAxis, number> {

--- a/api/src/taste-profile/taste-vector.helpers.ts
+++ b/api/src/taste-profile/taste-vector.helpers.ts
@@ -105,6 +105,38 @@ function zeroedPool(): Record<TasteProfilePoolAxis, number> {
 }
 
 /**
+ * Compute per-axis rarity weights using the inverse-document-frequency
+ * formula: `idf(axis) = ln((N + 1) / (coverage + 1)) + 1`.
+ *
+ * - Broad axes (e.g. "Adventure" — 200+ games) get a small multiplier.
+ * - Specific axes (e.g. "Automation" — ~20 games) get a large one.
+ * - Zero-coverage axes get the maximum multiplier (shouldn't dominate
+ *   anything because the raw score will still be 0 if nobody hits them).
+ *
+ * The `+ 1` terms are Laplace smoothing so the formula doesn't divide
+ * by zero and stays bounded on a small library.
+ */
+export function computeAxisIdf(
+  games: Map<number, GameMetadata>,
+): Record<TasteProfilePoolAxis, number> {
+  const idf = {} as Record<TasteProfilePoolAxis, number>;
+  const n = games.size;
+  const coverage = {} as Record<TasteProfilePoolAxis, number>;
+  for (const axis of TASTE_PROFILE_AXIS_POOL) coverage[axis] = 0;
+
+  const emptySignal: UserGameSignal = { gameId: 0 };
+  for (const game of games.values()) {
+    for (const axis of TASTE_PROFILE_AXIS_POOL) {
+      if (axisMatchFactor(axis, game, emptySignal) > 0) coverage[axis] += 1;
+    }
+  }
+  for (const axis of TASTE_PROFILE_AXIS_POOL) {
+    idf[axis] = Math.log((n + 1) / (coverage[axis] + 1)) + 1;
+  }
+  return idf;
+}
+
+/**
  * Compute the full-pool dimensions jsonb (display scale 0–100) + the
  * normalized 7-element vector (for pgvector cosine queries keyed by
  * `TASTE_PROFILE_AXES`).
@@ -117,6 +149,7 @@ function zeroedPool(): Record<TasteProfilePoolAxis, number> {
 export function computeTasteVector(
   signals: UserGameSignal[],
   games: Map<number, GameMetadata>,
+  axisIdf?: Record<TasteProfilePoolAxis, number>,
 ): { dimensions: TasteProfileDimensionsDto; vector: number[] } {
   const raw = zeroedPool();
 
@@ -127,6 +160,14 @@ export function computeTasteVector(
     if (w === 0) continue;
     for (const axis of TASTE_PROFILE_AXIS_POOL) {
       raw[axis] += w * axisMatchFactor(axis, game, signal);
+    }
+  }
+
+  // Apply rarity (IDF) weighting so specific axes aren't swamped by
+  // broad ones that match a huge chunk of the library.
+  if (axisIdf) {
+    for (const axis of TASTE_PROFILE_AXIS_POOL) {
+      raw[axis] *= axisIdf[axis];
     }
   }
 

--- a/api/src/taste-profile/taste-vector.helpers.ts
+++ b/api/src/taste-profile/taste-vector.helpers.ts
@@ -47,7 +47,10 @@ export function signalWeight(signal: UserGameSignal): number {
     } else if (playtime2weeks > 0) {
       weight += 0.5 + Math.min(playtime2weeks / 600, 0.5);
     } else {
-      weight += 0.1;
+      // Bare ownership (no playtime) is a very weak signal — a 1000-game
+      // Steam library shouldn't drown out actual play habits via axis
+      // tail-aggregation. Keep just enough to whisper through.
+      weight += 0.02;
     }
   }
   if (signal.steamWishlist) weight += 0.2;

--- a/packages/contract/src/taste-profile.schema.ts
+++ b/packages/contract/src/taste-profile.schema.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod';
 
+/**
+ * The 7 core axes kept for the `vector vector(7)` pgvector column.
+ * Used by similar-players cosine similarity — do not widen without a
+ * pgvector column migration.
+ */
 export const TASTE_PROFILE_AXES = [
   'co_op',
   'pvp',
@@ -12,6 +17,39 @@ export const TASTE_PROFILE_AXES = [
 
 export type TasteProfileAxis = (typeof TASTE_PROFILE_AXES)[number];
 
+/**
+ * Full taste-profile axis pool (ROK-949 dynamic-axes extension).
+ *
+ * The backend computes scores for every axis in this pool and stores
+ * them in `player_taste_vectors.dimensions` (jsonb — no schema change
+ * needed). The UI picks the top 7 by value for each player so every
+ * radar chart is tailored to that player's actual play habits.
+ */
+export const TASTE_PROFILE_AXIS_POOL = [
+  'co_op',
+  'pvp',
+  'battle_royale',
+  'mmo',
+  'moba',
+  'fighting',
+  'shooter',
+  'racing',
+  'sports',
+  'rpg',
+  'fantasy',
+  'sci_fi',
+  'adventure',
+  'strategy',
+  'rts',
+  'tbs',
+  'survival',
+  'sandbox',
+  'horror',
+  'social',
+] as const;
+
+export type TasteProfilePoolAxis = (typeof TASTE_PROFILE_AXIS_POOL)[number];
+
 export const TASTE_PROFILE_ARCHETYPES = [
   'Dedicated',
   'Specialist',
@@ -22,15 +60,18 @@ export const TASTE_PROFILE_ARCHETYPES = [
 
 export type TasteProfileArchetype = (typeof TASTE_PROFILE_ARCHETYPES)[number];
 
-export const TasteProfileDimensionsSchema = z.object({
-  co_op: z.number(),
-  pvp: z.number(),
-  rpg: z.number(),
-  survival: z.number(),
-  strategy: z.number(),
-  social: z.number(),
-  mmo: z.number(),
-});
+/**
+ * Dimensions object keyed by the full axis pool (~20 keys).
+ * `catchall(z.number())` keeps the shape forward-compatible if the
+ * pool grows without requiring every consumer to be updated at once.
+ */
+export const TasteProfileDimensionsSchema = z
+  .object(
+    Object.fromEntries(
+      TASTE_PROFILE_AXIS_POOL.map((axis) => [axis, z.number()]),
+    ) as Record<TasteProfilePoolAxis, z.ZodNumber>,
+  )
+  .catchall(z.number());
 
 export const IntensityMetricsSchema = z.object({
   intensity: z.number(),

--- a/packages/contract/src/taste-profile.schema.ts
+++ b/packages/contract/src/taste-profile.schema.ts
@@ -65,17 +65,17 @@ export const TASTE_PROFILE_ARCHETYPES = [
 export type TasteProfileArchetype = (typeof TASTE_PROFILE_ARCHETYPES)[number];
 
 /**
- * Dimensions object keyed by the full axis pool (~20 keys).
- * `catchall(z.number())` keeps the shape forward-compatible if the
- * pool grows without requiring every consumer to be updated at once.
+ * Dimensions object — strict shape keyed by the full axis pool.
+ * Every pool axis must be present with a numeric score (0–100). Extra
+ * keys are rejected; growing the pool requires updating
+ * `TASTE_PROFILE_AXIS_POOL` and rebuilding the contract so consumers
+ * see the new type.
  */
-export const TasteProfileDimensionsSchema = z
-  .object(
-    Object.fromEntries(
-      TASTE_PROFILE_AXIS_POOL.map((axis) => [axis, z.number()]),
-    ) as Record<TasteProfilePoolAxis, z.ZodNumber>,
-  )
-  .catchall(z.number());
+export const TasteProfileDimensionsSchema = z.object(
+  Object.fromEntries(
+    TASTE_PROFILE_AXIS_POOL.map((axis) => [axis, z.number()]),
+  ) as Record<TasteProfilePoolAxis, z.ZodNumber>,
+);
 
 export const IntensityMetricsSchema = z.object({
   intensity: z.number(),

--- a/packages/contract/src/taste-profile.schema.ts
+++ b/packages/contract/src/taste-profile.schema.ts
@@ -40,12 +40,16 @@ export const TASTE_PROFILE_AXIS_POOL = [
   'sci_fi',
   'adventure',
   'strategy',
-  'rts',
-  'tbs',
   'survival',
+  'crafting',
+  'automation',
   'sandbox',
   'horror',
   'social',
+  'roguelike',
+  'puzzle',
+  'platformer',
+  'stealth',
 ] as const;
 
 export type TasteProfilePoolAxis = (typeof TASTE_PROFILE_AXIS_POOL)[number];

--- a/scripts/smoke/user-profile-taste.smoke.spec.ts
+++ b/scripts/smoke/user-profile-taste.smoke.spec.ts
@@ -1,0 +1,192 @@
+/**
+ * User profile taste-profile section smoke tests (ROK-949).
+ *
+ * Verifies the `<TasteProfileSection>` rendering on another user's profile:
+ *   - "Taste Profile" heading always visible
+ *   - Either the radar chart SVG or the empty-state message renders
+ *   - When non-empty, an archetype pill is present on the page
+ *   - "Show all" partners button (when present) opens a modal
+ *   - Page loads without tripping the error boundary
+ *
+ * Mobile parity: all selectors rely on ARIA roles or text matchers so the
+ * suite runs on both the desktop and mobile Playwright projects without
+ * skips.  Backend already ships via ROK-948; this suite is TDD-first and
+ * expected to fail until ROK-949 implementation lands.
+ */
+import { test, expect } from './base';
+
+const ARCHETYPE_NAMES = [
+    'Dedicated',
+    'Specialist',
+    'Explorer',
+    'Social Drifter',
+    'Casual',
+];
+
+/**
+ * Navigate to the Players page and follow a user link to reach another
+ * user's profile.  Mirrors the helper from `user-profile.smoke.spec.ts`.
+ */
+async function navigateToUserProfile(
+    page: import('@playwright/test').Page,
+): Promise<string> {
+    await page.goto('/players');
+    await expect(page.getByRole('heading', { name: 'Players' })).toBeVisible({
+        timeout: 15_000,
+    });
+
+    const playerLink = page.locator('a[href*="/users/"]').first();
+    await expect(playerLink).toBeVisible({ timeout: 10_000 });
+
+    const href = await playerLink.getAttribute('href');
+    expect(href).toBeTruthy();
+
+    // Prefer a link that isn't the currently-logged-in user (/users/41).
+    const allLinks = page.locator('a[href*="/users/"]');
+    const count = await allLinks.count();
+    let targetHref = href!;
+    for (let i = 0; i < count; i++) {
+        const h = await allLinks.nth(i).getAttribute('href');
+        if (h && !h.endsWith('/users/41')) {
+            targetHref = h;
+            break;
+        }
+    }
+
+    await page.goto(targetHref);
+    // Wait for profile header to mount so taste profile has a chance to
+    // fetch and render before assertions run.
+    await expect(page.getByRole('heading', { level: 1 })).toBeVisible({
+        timeout: 15_000,
+    });
+    return targetHref;
+}
+
+test.describe('User profile taste section', () => {
+    test('renders the "Taste Profile" heading (AC2)', async ({ page }) => {
+        await navigateToUserProfile(page);
+
+        // The section heading is always present (empty state and loaded
+        // state both render it).  This is the source-of-truth selector
+        // for the implementation.
+        await expect(
+            page.getByRole('heading', { name: 'Taste Profile' }),
+        ).toBeVisible({ timeout: 15_000 });
+    });
+
+    test('renders either the radar chart or the empty-state message (AC3/AC4)', async ({
+        page,
+    }) => {
+        await navigateToUserProfile(page);
+
+        await expect(
+            page.getByRole('heading', { name: 'Taste Profile' }),
+        ).toBeVisible({ timeout: 15_000 });
+
+        // Scope to the taste profile section's region so we don't pick up
+        // unrelated SVGs elsewhere on the profile page.
+        const tasteSection = page
+            .locator('section, [data-testid="taste-profile-section"]')
+            .filter({
+                has: page.getByRole('heading', { name: 'Taste Profile' }),
+            })
+            .first();
+
+        const radarSvg = tasteSection.locator('svg').first();
+        const emptyState = page.getByText(
+            'Not enough data yet — play more games!',
+            { exact: false },
+        );
+
+        // Either the chart is visible OR the empty-state message is.
+        const chartOrEmptyState = radarSvg.or(emptyState).first();
+        await expect(chartOrEmptyState).toBeVisible({ timeout: 15_000 });
+    });
+
+    test('shows an archetype pill when the profile has data (AC1)', async ({
+        page,
+    }) => {
+        await navigateToUserProfile(page);
+
+        await expect(
+            page.getByRole('heading', { name: 'Taste Profile' }),
+        ).toBeVisible({ timeout: 15_000 });
+
+        // Skip the archetype-pill assertion if the empty state is shown —
+        // per spec, empty profiles do NOT render a pill.
+        const emptyState = page.getByText(
+            'Not enough data yet — play more games!',
+            { exact: false },
+        );
+        if (await emptyState.isVisible().catch(() => false)) {
+            test.info().annotations.push({
+                type: 'skip-reason',
+                description:
+                    'Empty taste profile — no archetype pill expected (AC4).',
+            });
+            return;
+        }
+
+        // Non-empty: exactly one of the 5 archetype names must be on the
+        // page.  We look for the regex union so the test is robust to the
+        // pill's exact DOM structure (span / badge / pill component).
+        const archetypeRegex = new RegExp(
+            `\\b(${ARCHETYPE_NAMES.join('|')})\\b`,
+        );
+        await expect(page.getByText(archetypeRegex).first()).toBeVisible({
+            timeout: 10_000,
+        });
+    });
+
+    test('"Show all" partners button opens a modal when present (AC6)', async ({
+        page,
+    }) => {
+        await navigateToUserProfile(page);
+
+        await expect(
+            page.getByRole('heading', { name: 'Taste Profile' }),
+        ).toBeVisible({ timeout: 15_000 });
+
+        // The "Show all (N)" button only renders when there are more than
+        // 3 co-play partners.  Make the assertion conditional so the test
+        // is stable across seeded users with varying partner counts.
+        const showAllButton = page.getByRole('button', {
+            name: /^Show all\s*\(\d+\)$/,
+        });
+        const hasButton = await showAllButton
+            .first()
+            .isVisible()
+            .catch(() => false);
+        if (!hasButton) {
+            test.info().annotations.push({
+                type: 'skip-reason',
+                description:
+                    'Seeded user has ≤3 partners — no "Show all" button rendered.',
+            });
+            return;
+        }
+
+        await showAllButton.first().click();
+
+        // Clicking should open a dialog/modal.  Accept either a native
+        // role="dialog" or an explicit modal container.
+        const dialog = page.getByRole('dialog');
+        await expect(dialog).toBeVisible({ timeout: 5_000 });
+    });
+
+    test('page loads without the error boundary (AC7)', async ({ page }) => {
+        await navigateToUserProfile(page);
+
+        await expect(page.getByRole('heading', { level: 1 })).toBeVisible({
+            timeout: 15_000,
+        });
+        await expect(
+            page.getByRole('heading', { name: 'Taste Profile' }),
+        ).toBeVisible({ timeout: 15_000 });
+
+        await expect(page.locator('body')).not.toHaveText(
+            /something went wrong/i,
+        );
+        await expect(page.getByText('User Not Found')).not.toBeVisible();
+    });
+});

--- a/scripts/smoke/user-profile-taste.smoke.spec.ts
+++ b/scripts/smoke/user-profile-taste.smoke.spec.ts
@@ -112,12 +112,24 @@ test.describe('User profile taste section', () => {
             page.getByRole('heading', { name: 'Taste Profile' }),
         ).toBeVisible({ timeout: 15_000 });
 
-        // Skip the archetype-pill assertion if the empty state is shown —
-        // per spec, empty profiles do NOT render a pill.
+        // Wait for the section body to settle — either empty-state or a
+        // non-empty body must be rendered before we decide which branch
+        // of the AC to assert. This avoids a race where the query is
+        // still loading when isVisible() runs.
         const emptyState = page.getByText(
             'Not enough data yet — play more games!',
             { exact: false },
         );
+        const archetypeRegex = new RegExp(
+            `\\b(${ARCHETYPE_NAMES.join('|')})\\b`,
+        );
+        const archetypeText = page.getByText(archetypeRegex).first();
+        await expect(emptyState.or(archetypeText)).toBeVisible({
+            timeout: 15_000,
+        });
+
+        // Skip the archetype-pill assertion if the empty state is shown —
+        // per spec, empty profiles do NOT render a pill.
         if (await emptyState.isVisible().catch(() => false)) {
             test.info().annotations.push({
                 type: 'skip-reason',
@@ -130,12 +142,7 @@ test.describe('User profile taste section', () => {
         // Non-empty: exactly one of the 5 archetype names must be on the
         // page.  We look for the regex union so the test is robust to the
         // pill's exact DOM structure (span / badge / pill component).
-        const archetypeRegex = new RegExp(
-            `\\b(${ARCHETYPE_NAMES.join('|')})\\b`,
-        );
-        await expect(page.getByText(archetypeRegex).first()).toBeVisible({
-            timeout: 10_000,
-        });
+        await expect(archetypeText).toBeVisible({ timeout: 10_000 });
     });
 
     test('"Show all" partners button opens a modal when present (AC6)', async ({

--- a/web/src/hooks/use-taste-profile.ts
+++ b/web/src/hooks/use-taste-profile.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import { getTasteProfile } from "../lib/api-client";
+import type { TasteProfileResponseDto } from "@raid-ledger/contract";
+
+/**
+ * ROK-949: Fetch a user's taste profile (radar + intensity + co-play
+ * partners). Mirrors the 5-minute staleTime used by `useUserProfile`.
+ */
+export function useTasteProfile(userId: number | undefined) {
+    return useQuery<TasteProfileResponseDto>({
+        queryKey: ["userTasteProfile", userId],
+        queryFn: async () => {
+            if (!userId) throw new Error("User ID required");
+            return getTasteProfile(userId);
+        },
+        enabled: !!userId,
+        staleTime: 5 * 60 * 1000,
+        retry: false,
+    });
+}

--- a/web/src/lib/api-client.ts
+++ b/web/src/lib/api-client.ts
@@ -88,6 +88,7 @@ export {
     deleteMyAccount,
     adminRemoveUser,
     unlinkDiscord,
+    getTasteProfile,
 } from './api/users-api';
 
 // Preferences

--- a/web/src/lib/api/users-api.ts
+++ b/web/src/lib/api/users-api.ts
@@ -8,6 +8,7 @@ import type {
   UserActivityResponseDto,
   UserManagementListResponseDto,
   UserRole,
+  TasteProfileResponseDto,
 } from "@raid-ledger/contract";
 import { fetchApi } from "./fetch-api";
 
@@ -131,4 +132,11 @@ export async function adminRemoveUser(userId: number): Promise<void> {
 /** Unlink Discord from current user's account (ROK-195) */
 export async function unlinkDiscord(): Promise<void> {
   return fetchApi("/users/me/discord", { method: "DELETE" });
+}
+
+/** Fetch a user's taste profile (radar + intensity + co-play partners, ROK-948/949) */
+export async function getTasteProfile(
+  userId: number,
+): Promise<TasteProfileResponseDto> {
+  return fetchApi(`/users/${userId}/taste-profile`);
 }

--- a/web/src/pages/user-profile-page.tsx
+++ b/web/src/pages/user-profile-page.tsx
@@ -8,13 +8,18 @@ import {
   useUserSteamWishlist,
   useUserActivity,
 } from "../hooks/use-user-profile";
+import { useTasteProfile } from "../hooks/use-taste-profile";
 import { useGamesPricingBatch } from "../hooks/use-games-pricing-batch";
 import { useGameRegistry } from "../hooks/use-game-registry";
 import { useAuth } from "../hooks/use-auth";
 import { formatDistanceToNow } from "date-fns";
 import { resolveAvatar, toAvatarUser } from "../lib/avatar";
 import { UserEventSignups } from "../components/profile/UserEventSignups";
-import type { UserProfileDto, ItadGamePricingDto } from "@raid-ledger/contract";
+import type {
+  UserProfileDto,
+  ItadGamePricingDto,
+  TasteProfileArchetype,
+} from "@raid-ledger/contract";
 import {
   HeartedGameCard,
   GroupedCharacters,
@@ -25,6 +30,9 @@ import {
 } from "./user-profile/user-profile-components";
 import { HeartedGamesModal } from "./user-profile/hearted-games-modal";
 import { isGuestRouteState } from "./user-profile/user-profile-helpers";
+import { TasteProfileSection } from "./user-profile/taste-profile/TasteProfileSection";
+import { ArchetypePill } from "./user-profile/taste-profile/ArchetypePill";
+import { isEmptyTasteProfile } from "./user-profile/taste-profile/taste-profile-helpers";
 import "./user-profile-page.css";
 
 /** Loading skeleton for user profile */
@@ -107,31 +115,75 @@ function useProfilePricing(userId: number | undefined): PricingMap {
   return useGamesPricingBatch(allIds);
 }
 
-/** Loaded profile content */
-function ProfileContent({
+/** Profile sections body (split out so `ProfileContent` stays <30 lines). */
+function ProfileSections({
   profile,
   numericId,
   isOwnProfile,
   games,
+  pricingMap,
+  tasteProfile,
 }: {
   profile: UserProfileDto;
   numericId: number | undefined;
   isOwnProfile: boolean;
   games: { id: number; name: string }[];
+  pricingMap: PricingMap;
+  tasteProfile: ReturnType<typeof useTasteProfile>;
 }): JSX.Element {
+  return (
+    <>
+      {numericId && <ActivitySection userId={numericId} isOwnProfile={isOwnProfile} pricingMap={pricingMap} />}
+      {numericId && <UserEventSignups userId={numericId} />}
+      {profile.characters.length > 0 && <GroupedCharacters characters={profile.characters} games={games} />}
+      {numericId && <HeartedGamesSection userId={numericId} pricingMap={pricingMap} />}
+      {numericId && <SteamLibrarySection userId={numericId} pricingMap={pricingMap} />}
+      {numericId && <SteamWishlistSection userId={numericId} pricingMap={pricingMap} />}
+      {numericId !== undefined && (
+        <TasteProfileSection userId={numericId} queryResult={tasteProfile} />
+      )}
+    </>
+  );
+}
+
+/**
+ * Resolve the archetype pill for the profile header.
+ * Returns null when the user has no data yet (empty profile).
+ */
+function useHeaderArchetype(
+  tasteProfile: ReturnType<typeof useTasteProfile>,
+): TasteProfileArchetype | null {
+  if (!tasteProfile.data) return null;
+  if (isEmptyTasteProfile(tasteProfile.data)) return null;
+  return tasteProfile.data.archetype;
+}
+
+interface ProfileContentProps {
+  profile: UserProfileDto;
+  numericId: number | undefined;
+  isOwnProfile: boolean;
+  games: { id: number; name: string }[];
+}
+
+/** Loaded profile content */
+function ProfileContent({ profile, numericId, isOwnProfile, games }: ProfileContentProps): JSX.Element {
   const memberSince = formatDistanceToNow(new Date(profile.createdAt), { addSuffix: true });
   const profileAvatar = resolveAvatar(toAvatarUser(profile));
   const pricingMap = useProfilePricing(numericId);
+  const tasteProfile = useTasteProfile(numericId);
+  const headerArchetype = useHeaderArchetype(tasteProfile);
   return (
     <div className="user-profile-page">
       <div className="user-profile-card">
-        <ProfileHeader profile={profile} profileAvatar={profileAvatar} memberSince={memberSince} />
-        {numericId && <ActivitySection userId={numericId} isOwnProfile={isOwnProfile} pricingMap={pricingMap} />}
-        {numericId && <UserEventSignups userId={numericId} />}
-        {profile.characters.length > 0 && <GroupedCharacters characters={profile.characters} games={games} />}
-        {numericId && <HeartedGamesSection userId={numericId} pricingMap={pricingMap} />}
-        {numericId && <SteamLibrarySection userId={numericId} pricingMap={pricingMap} />}
-        {numericId && <SteamWishlistSection userId={numericId} pricingMap={pricingMap} />}
+        <ProfileHeader profile={profile} profileAvatar={profileAvatar} memberSince={memberSince} archetype={headerArchetype} />
+        <ProfileSections
+          profile={profile}
+          numericId={numericId}
+          isOwnProfile={isOwnProfile}
+          games={games}
+          pricingMap={pricingMap}
+          tasteProfile={tasteProfile}
+        />
       </div>
     </div>
   );
@@ -180,10 +232,12 @@ function ProfileHeader({
   profile,
   profileAvatar,
   memberSince,
+  archetype,
 }: {
   profile: { username: string };
   profileAvatar: { url: string | null };
   memberSince: string;
+  archetype: TasteProfileArchetype | null;
 }): JSX.Element {
   return (
     <div className="user-profile-header">
@@ -194,7 +248,10 @@ function ProfileHeader({
         <div className="user-profile-avatar user-profile-avatar--initials">{profile.username.charAt(0).toUpperCase()}</div>
       )}
       <div className="user-profile-info">
-        <h1 className="user-profile-name">{profile.username}</h1>
+        <h1 className="user-profile-name">
+          {profile.username}
+          {archetype && <ArchetypePill archetype={archetype} />}
+        </h1>
         <p className="user-profile-meta">Member {memberSince}</p>
       </div>
     </div>

--- a/web/src/pages/user-profile-page.tsx
+++ b/web/src/pages/user-profile-page.tsx
@@ -133,15 +133,15 @@ function ProfileSections({
 }): JSX.Element {
   return (
     <>
+      {numericId !== undefined && (
+        <TasteProfileSection userId={numericId} queryResult={tasteProfile} />
+      )}
       {numericId && <ActivitySection userId={numericId} isOwnProfile={isOwnProfile} pricingMap={pricingMap} />}
       {numericId && <UserEventSignups userId={numericId} />}
       {profile.characters.length > 0 && <GroupedCharacters characters={profile.characters} games={games} />}
       {numericId && <HeartedGamesSection userId={numericId} pricingMap={pricingMap} />}
       {numericId && <SteamLibrarySection userId={numericId} pricingMap={pricingMap} />}
       {numericId && <SteamWishlistSection userId={numericId} pricingMap={pricingMap} />}
-      {numericId !== undefined && (
-        <TasteProfileSection userId={numericId} queryResult={tasteProfile} />
-      )}
     </>
   );
 }

--- a/web/src/pages/user-profile/taste-profile/ArchetypePill.tsx
+++ b/web/src/pages/user-profile/taste-profile/ArchetypePill.tsx
@@ -1,0 +1,39 @@
+import type { JSX } from "react";
+import type { TasteProfileArchetype } from "@raid-ledger/contract";
+
+type Size = "sm" | "lg";
+
+interface ArchetypePillProps {
+    archetype: TasteProfileArchetype;
+    /** Pill (`sm`) for header use, hero title (`lg`) for radar overlay. */
+    size?: Size;
+    className?: string;
+}
+
+function toVariant(archetype: TasteProfileArchetype): string {
+    // Normalise to a kebab-case CSS token: "Social Drifter" -> "social-drifter".
+    return archetype.toLowerCase().replace(/\s+/g, "-");
+}
+
+/**
+ * Archetype badge shown next to usernames AND above the radar chart.
+ * Colour variants are driven by CSS (`taste-profile-section.css`) so the
+ * component stays pure and testable.
+ */
+export function ArchetypePill({
+    archetype,
+    size = "sm",
+    className = "",
+}: ArchetypePillProps): JSX.Element {
+    const variant = toVariant(archetype);
+    const sizeClass =
+        size === "lg" ? "archetype-pill--lg" : "archetype-pill--sm";
+    return (
+        <span
+            className={`archetype-pill archetype-pill--${variant} ${sizeClass} ${className}`.trim()}
+            data-archetype={archetype}
+        >
+            {archetype}
+        </span>
+    );
+}

--- a/web/src/pages/user-profile/taste-profile/FrequentlyPlaysWith.tsx
+++ b/web/src/pages/user-profile/taste-profile/FrequentlyPlaysWith.tsx
@@ -1,0 +1,60 @@
+import type { JSX } from "react";
+import { useState } from "react";
+import type { CoPlayPartnerDto } from "@raid-ledger/contract";
+import { PartnerRow } from "./PartnerRow";
+import { FrequentlyPlaysWithModal } from "./FrequentlyPlaysWithModal";
+
+interface FrequentlyPlaysWithProps {
+    partners: CoPlayPartnerDto[];
+}
+
+function PartnerPreviewList({
+    partners,
+}: {
+    partners: CoPlayPartnerDto[];
+}): JSX.Element {
+    return (
+        <ul className="frequently-plays-with__list">
+            {partners.map((partner) => (
+                <li key={partner.userId}>
+                    <PartnerRow partner={partner} />
+                </li>
+            ))}
+        </ul>
+    );
+}
+
+/**
+ * Shows the user's top 3 co-play partners inline; renders a "Show all
+ * (N)" button when there are more than 3 that opens a modal listing
+ * every partner. Hides itself entirely when the list is empty.
+ */
+export function FrequentlyPlaysWith({
+    partners,
+}: FrequentlyPlaysWithProps): JSX.Element | null {
+    const [isModalOpen, setIsModalOpen] = useState(false);
+    if (partners.length === 0) return null;
+    const total = partners.length;
+    return (
+        <div className="frequently-plays-with">
+            <h3 className="frequently-plays-with__title">
+                Frequently Plays With
+            </h3>
+            <PartnerPreviewList partners={partners.slice(0, 3)} />
+            {total > 3 && (
+                <button
+                    type="button"
+                    onClick={() => setIsModalOpen(true)}
+                    className="frequently-plays-with__show-all"
+                >
+                    Show all ({total})
+                </button>
+            )}
+            <FrequentlyPlaysWithModal
+                partners={partners}
+                isOpen={isModalOpen}
+                onClose={() => setIsModalOpen(false)}
+            />
+        </div>
+    );
+}

--- a/web/src/pages/user-profile/taste-profile/FrequentlyPlaysWithModal.tsx
+++ b/web/src/pages/user-profile/taste-profile/FrequentlyPlaysWithModal.tsx
@@ -1,0 +1,38 @@
+import type { JSX } from "react";
+import type { CoPlayPartnerDto } from "@raid-ledger/contract";
+import { Modal } from "../../../components/ui/modal";
+import { PartnerRow } from "./PartnerRow";
+
+interface FrequentlyPlaysWithModalProps {
+    partners: CoPlayPartnerDto[];
+    isOpen: boolean;
+    onClose: () => void;
+}
+
+/**
+ * Full partner list modal — mirrors `HeartedGamesModal`'s pattern but
+ * renders from a pre-loaded array (taste profile already includes up to
+ * 10 partners, so we do not need infinite scroll).
+ */
+export function FrequentlyPlaysWithModal({
+    partners,
+    isOpen,
+    onClose,
+}: FrequentlyPlaysWithModalProps): JSX.Element {
+    return (
+        <Modal
+            isOpen={isOpen}
+            onClose={onClose}
+            title={`Frequently Plays With (${partners.length})`}
+            maxWidth="max-w-md"
+        >
+            <ul className="frequently-plays-with__modal-list">
+                {partners.map((partner) => (
+                    <li key={partner.userId}>
+                        <PartnerRow partner={partner} />
+                    </li>
+                ))}
+            </ul>
+        </Modal>
+    );
+}

--- a/web/src/pages/user-profile/taste-profile/IntensityBadge.tsx
+++ b/web/src/pages/user-profile/taste-profile/IntensityBadge.tsx
@@ -1,0 +1,43 @@
+import type { JSX } from "react";
+import type {
+    IntensityMetricsDto,
+    TasteProfileArchetype,
+} from "@raid-ledger/contract";
+import {
+    formatFocusIndicator,
+    formatIntensity,
+} from "./taste-profile-helpers";
+
+interface IntensityBadgeProps {
+    archetype: TasteProfileArchetype;
+    metrics: IntensityMetricsDto;
+}
+
+/**
+ * Two-row summary:
+ *   Row 1: `{intensity}/100 · {archetype}`
+ *   Row 2: focus / varied indicator (hidden when neither threshold hit)
+ */
+export function IntensityBadge({
+    archetype,
+    metrics,
+}: IntensityBadgeProps): JSX.Element {
+    const intensityText = formatIntensity(metrics.intensity);
+    const focusLine = formatFocusIndicator(metrics.focus, metrics.breadth);
+    return (
+        <div className="intensity-badge" data-testid="intensity-badge">
+            <p className="intensity-badge__primary">
+                <span className="intensity-badge__intensity">
+                    {intensityText}
+                </span>
+                <span className="intensity-badge__sep" aria-hidden="true">
+                    {" · "}
+                </span>
+                <span className="intensity-badge__archetype">{archetype}</span>
+            </p>
+            {focusLine && (
+                <p className="intensity-badge__focus">{focusLine}</p>
+            )}
+        </div>
+    );
+}

--- a/web/src/pages/user-profile/taste-profile/PartnerRow.tsx
+++ b/web/src/pages/user-profile/taste-profile/PartnerRow.tsx
@@ -1,0 +1,68 @@
+import type { JSX } from "react";
+import { Link } from "react-router-dom";
+import { formatDistanceToNow } from "date-fns";
+import type { CoPlayPartnerDto } from "@raid-ledger/contract";
+import { resolveAvatar, toAvatarUser } from "../../../lib/avatar";
+
+interface PartnerRowProps {
+    partner: CoPlayPartnerDto;
+}
+
+function PartnerAvatar({
+    url,
+    username,
+}: {
+    url: string | null;
+    username: string;
+}): JSX.Element {
+    if (url) {
+        return (
+            <img
+                src={url}
+                alt=""
+                className="partner-row__avatar"
+                onError={(e) => {
+                    e.currentTarget.style.display = "none";
+                }}
+            />
+        );
+    }
+    return (
+        <span className="partner-row__avatar partner-row__avatar--initials">
+            {username.charAt(0).toUpperCase()}
+        </span>
+    );
+}
+
+function formatPartnerMeta(partner: CoPlayPartnerDto): string {
+    const lastPlayed = formatDistanceToNow(new Date(partner.lastPlayedAt), {
+        addSuffix: true,
+    });
+    const sessionLabel = partner.sessionCount === 1 ? "session" : "sessions";
+    return `${partner.sessionCount} ${sessionLabel} · last ${lastPlayed}`;
+}
+
+/**
+ * One row of the "Frequently plays with" list: avatar + username link +
+ * meta line showing session count and relative last-play time.
+ */
+export function PartnerRow({ partner }: PartnerRowProps): JSX.Element {
+    const avatar = resolveAvatar(
+        toAvatarUser({ id: partner.userId, avatar: partner.avatar }),
+    );
+    return (
+        <Link
+            to={`/users/${partner.userId}`}
+            className="partner-row"
+            title={`View ${partner.username}'s profile`}
+        >
+            <PartnerAvatar url={avatar.url} username={partner.username} />
+            <span className="partner-row__body">
+                <span className="partner-row__name">{partner.username}</span>
+                <span className="partner-row__meta">
+                    {formatPartnerMeta(partner)}
+                </span>
+            </span>
+        </Link>
+    );
+}

--- a/web/src/pages/user-profile/taste-profile/TasteProfileSection.test.tsx
+++ b/web/src/pages/user-profile/taste-profile/TasteProfileSection.test.tsx
@@ -1,0 +1,171 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { UseQueryResult } from "@tanstack/react-query";
+import type { TasteProfileResponseDto } from "@raid-ledger/contract";
+import { renderWithProviders } from "../../../test/render-helpers";
+import { TasteProfileSection } from "./TasteProfileSection";
+
+const mockUseTasteProfile = vi.fn();
+
+vi.mock("../../../hooks/use-taste-profile", () => ({
+    useTasteProfile: (...args: unknown[]) => mockUseTasteProfile(...args),
+}));
+
+function makeResult(
+    overrides?: Partial<UseQueryResult<TasteProfileResponseDto, Error>>,
+): UseQueryResult<TasteProfileResponseDto, Error> {
+    return {
+        data: undefined,
+        isLoading: false,
+        isError: false,
+        isSuccess: true,
+        isPending: false,
+        isFetching: false,
+        error: null,
+        status: "success",
+        refetch: vi.fn(),
+        ...overrides,
+    } as unknown as UseQueryResult<TasteProfileResponseDto, Error>;
+}
+
+function makeProfile(
+    overrides?: Partial<TasteProfileResponseDto>,
+): TasteProfileResponseDto {
+    return {
+        userId: 42,
+        dimensions: {
+            co_op: 60,
+            pvp: 10,
+            rpg: 35,
+            survival: 20,
+            strategy: 45,
+            social: 50,
+            mmo: 5,
+        },
+        intensityMetrics: {
+            intensity: 72,
+            focus: 75,
+            breadth: 20,
+            consistency: 55,
+        },
+        archetype: "Specialist",
+        coPlayPartners: [],
+        computedAt: "2026-04-16T00:00:00.000Z",
+        ...overrides,
+    };
+}
+
+beforeEach(() => {
+    mockUseTasteProfile.mockReset();
+});
+
+describe("<TasteProfileSection> (states)", () => {
+    it("always renders the 'Taste Profile' heading", () => {
+        mockUseTasteProfile.mockReturnValue(
+            makeResult({ isLoading: true, data: undefined }),
+        );
+        renderWithProviders(<TasteProfileSection userId={1} />);
+        expect(
+            screen.getByRole("heading", { name: "Taste Profile" }),
+        ).toBeInTheDocument();
+    });
+
+    it("renders the empty-state message when all dimensions are zero", () => {
+        const profile = makeProfile({
+            dimensions: {
+                co_op: 0,
+                pvp: 0,
+                rpg: 0,
+                survival: 0,
+                strategy: 0,
+                social: 0,
+                mmo: 0,
+            },
+        });
+        mockUseTasteProfile.mockReturnValue(
+            makeResult({ data: profile, isLoading: false }),
+        );
+        renderWithProviders(<TasteProfileSection userId={1} />);
+        expect(
+            screen.getByText(/Not enough data yet — play more games!/),
+        ).toBeInTheDocument();
+        // Empty state should suppress the intensity badge.
+        expect(
+            screen.queryByTestId("intensity-badge"),
+        ).not.toBeInTheDocument();
+    });
+
+    it("renders the empty-state message on error (no crash)", () => {
+        mockUseTasteProfile.mockReturnValue(
+            makeResult({
+                isError: true,
+                isLoading: false,
+                data: undefined,
+                error: new Error("boom"),
+            }),
+        );
+        renderWithProviders(<TasteProfileSection userId={1} />);
+        expect(
+            screen.getByText(/Not enough data yet — play more games!/),
+        ).toBeInTheDocument();
+    });
+
+    it("shows a loading indicator while fetching", () => {
+        mockUseTasteProfile.mockReturnValue(
+            makeResult({
+                isLoading: true,
+                data: undefined,
+                isSuccess: false,
+                status: "pending",
+            }),
+        );
+        renderWithProviders(<TasteProfileSection userId={1} />);
+        expect(screen.getByText(/Loading/)).toBeInTheDocument();
+    });
+});
+
+describe("<TasteProfileSection> (content)", () => {
+    it("renders intensity badge + archetype + focus line for populated profiles", () => {
+        const profile = makeProfile();
+        mockUseTasteProfile.mockReturnValue(
+            makeResult({ data: profile, isLoading: false }),
+        );
+        renderWithProviders(<TasteProfileSection userId={1} />);
+        expect(screen.getByTestId("intensity-badge")).toBeInTheDocument();
+        expect(
+            screen.getByText(/Intensity: 72\/100/),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(/Focused play \(75%\)/),
+        ).toBeInTheDocument();
+        // Archetype appears somewhere on the page (pill overlay + badge).
+        expect(screen.getAllByText("Specialist").length).toBeGreaterThan(0);
+    });
+
+    it("opens the partners modal when 'Show all' is clicked", async () => {
+        const partners = Array.from({ length: 5 }, (_, i) => ({
+            userId: 100 + i,
+            username: `Friend${i + 1}`,
+            avatar: null,
+            sessionCount: 4 + i,
+            totalMinutes: 120,
+            lastPlayedAt: "2026-04-10T00:00:00.000Z",
+        }));
+        const profile = makeProfile({ coPlayPartners: partners });
+        mockUseTasteProfile.mockReturnValue(
+            makeResult({ data: profile, isLoading: false }),
+        );
+        const user = userEvent.setup();
+        renderWithProviders(<TasteProfileSection userId={1} />);
+
+        const showAll = screen.getByRole("button", {
+            name: /^Show all \(5\)$/,
+        });
+        await user.click(showAll);
+
+        // Modal adds another copy of each partner name — assert at least
+        // one dialog is now open.
+        expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+});

--- a/web/src/pages/user-profile/taste-profile/TasteProfileSection.tsx
+++ b/web/src/pages/user-profile/taste-profile/TasteProfileSection.tsx
@@ -1,0 +1,85 @@
+import type { JSX } from "react";
+import type { UseQueryResult } from "@tanstack/react-query";
+import type { TasteProfileResponseDto } from "@raid-ledger/contract";
+import { useTasteProfile } from "../../../hooks/use-taste-profile";
+import { TasteRadarChart } from "./TasteRadarChart";
+import { IntensityBadge } from "./IntensityBadge";
+import { FrequentlyPlaysWith } from "./FrequentlyPlaysWith";
+import { isEmptyTasteProfile } from "./taste-profile-helpers";
+import "./taste-profile-section.css";
+
+interface TasteProfileSectionProps {
+    userId: number;
+    /** Optional: allow the parent to pass an already-loaded query result so
+     *  we don't double-fetch. When omitted, the section fetches its own. */
+    queryResult?: UseQueryResult<TasteProfileResponseDto, Error>;
+}
+
+/**
+ * Renders a single section heading ("Taste Profile") plus loading /
+ * empty / loaded states. Always renders the heading so the Playwright
+ * smoke test can latch onto it before data resolves.
+ */
+export function TasteProfileSection({
+    userId,
+    queryResult,
+}: TasteProfileSectionProps): JSX.Element {
+    const ownQuery = useTasteProfile(queryResult ? undefined : userId);
+    const query = queryResult ?? ownQuery;
+    return (
+        <section
+            className="user-profile-section taste-profile-section"
+            data-testid="taste-profile-section"
+        >
+            <h2 className="user-profile-section-title">Taste Profile</h2>
+            <TasteProfileBody
+                isLoading={query.isLoading}
+                isError={query.isError}
+                profile={query.data}
+            />
+        </section>
+    );
+}
+
+interface TasteProfileBodyProps {
+    isLoading: boolean;
+    isError: boolean;
+    profile: TasteProfileResponseDto | undefined;
+}
+
+function TasteProfileBody({
+    isLoading,
+    isError,
+    profile,
+}: TasteProfileBodyProps): JSX.Element {
+    if (isLoading) {
+        return <div className="taste-profile-section__loading">Loading…</div>;
+    }
+    if (isError || !profile) {
+        return <EmptyTasteMessage />;
+    }
+    if (isEmptyTasteProfile(profile)) {
+        return <EmptyTasteMessage />;
+    }
+    return (
+        <div className="taste-profile-section__body">
+            <TasteRadarChart
+                archetype={profile.archetype}
+                dimensions={profile.dimensions}
+            />
+            <IntensityBadge
+                archetype={profile.archetype}
+                metrics={profile.intensityMetrics}
+            />
+            <FrequentlyPlaysWith partners={profile.coPlayPartners} />
+        </div>
+    );
+}
+
+function EmptyTasteMessage(): JSX.Element {
+    return (
+        <p className="taste-profile-section__empty">
+            Not enough data yet — play more games!
+        </p>
+    );
+}

--- a/web/src/pages/user-profile/taste-profile/TasteProfileSection.tsx
+++ b/web/src/pages/user-profile/taste-profile/TasteProfileSection.tsx
@@ -66,6 +66,7 @@ function TasteProfileBody({
             <TasteRadarChart
                 archetype={profile.archetype}
                 dimensions={profile.dimensions}
+                intensityMetrics={profile.intensityMetrics}
             />
             <IntensityBadge
                 archetype={profile.archetype}

--- a/web/src/pages/user-profile/taste-profile/TasteRadarChart.tsx
+++ b/web/src/pages/user-profile/taste-profile/TasteRadarChart.tsx
@@ -1,0 +1,105 @@
+import type { JSX } from "react";
+import {
+    Radar,
+    RadarChart,
+    PolarGrid,
+    PolarAngleAxis,
+    PolarRadiusAxis,
+    ResponsiveContainer,
+} from "recharts";
+import {
+    TASTE_PROFILE_AXES,
+    type TasteProfileArchetype,
+    type TasteProfileDimensionsDto,
+} from "@raid-ledger/contract";
+import { ArchetypePill } from "./ArchetypePill";
+import { axisLabel } from "./taste-profile-helpers";
+
+interface TasteRadarChartProps {
+    archetype: TasteProfileArchetype;
+    dimensions: TasteProfileDimensionsDto;
+}
+
+/**
+ * Build the aria-label that summarises the whole chart for screen
+ * readers — AC7: "aria-label includes archetype + each axis + value".
+ */
+function buildAriaLabel(
+    archetype: TasteProfileArchetype,
+    dims: TasteProfileDimensionsDto,
+): string {
+    const parts = TASTE_PROFILE_AXES.map(
+        (axis) => `${axisLabel(axis)} ${dims[axis]}`,
+    ).join(", ");
+    return `Taste profile for ${archetype}: ${parts}.`;
+}
+
+function RadarGradientDefs(): JSX.Element {
+    return (
+        <defs>
+            <radialGradient id="taste-radial" cx="50%" cy="50%" r="50%">
+                <stop offset="0%" stopColor="#ef4444" stopOpacity={0.55} />
+                <stop offset="55%" stopColor="#fbbf24" stopOpacity={0.55} />
+                <stop offset="100%" stopColor="#22c55e" stopOpacity={0.55} />
+            </radialGradient>
+        </defs>
+    );
+}
+
+function RadarBody({
+    data,
+}: {
+    data: { axis: string; value: number }[];
+}): JSX.Element {
+    return (
+        <ResponsiveContainer width="100%" height="100%">
+            <RadarChart data={data} outerRadius="75%">
+                <RadarGradientDefs />
+                <PolarGrid stroke="rgba(255,255,255,0.15)" />
+                <PolarAngleAxis dataKey="axis" tick={{ fill: "#a1a1aa", fontSize: 12 }} />
+                <PolarRadiusAxis domain={[0, 100]} tick={false} axisLine={false} />
+                <Radar
+                    dataKey="value"
+                    stroke="#a855f7"
+                    strokeWidth={2}
+                    fill="url(#taste-radial)"
+                    fillOpacity={0.85}
+                    isAnimationActive={false}
+                />
+            </RadarChart>
+        </ResponsiveContainer>
+    );
+}
+
+/**
+ * 7-axis radar chart with radial red→yellow→green fill and an archetype
+ * hero title above. Chart height is driven by CSS (300px desktop, 240px
+ * mobile) via `.taste-radar__chart-wrap`.
+ */
+export function TasteRadarChart({
+    archetype,
+    dimensions,
+}: TasteRadarChartProps): JSX.Element {
+    const data = TASTE_PROFILE_AXES.map((axis) => ({
+        axis: axisLabel(axis),
+        value: dimensions[axis],
+    }));
+    const ariaLabel = buildAriaLabel(archetype, dimensions);
+    return (
+        <div className="taste-radar">
+            <div className="taste-radar__title">
+                <span className="taste-radar__title-prefix">
+                    Taste Radar —{" "}
+                </span>
+                <ArchetypePill archetype={archetype} size="lg" />
+            </div>
+            <div
+                className="taste-radar__chart-wrap"
+                role="img"
+                aria-label={ariaLabel}
+            >
+                <RadarBody data={data} />
+            </div>
+        </div>
+    );
+}

--- a/web/src/pages/user-profile/taste-profile/TasteRadarChart.tsx
+++ b/web/src/pages/user-profile/taste-profile/TasteRadarChart.tsx
@@ -7,30 +7,26 @@ import {
     PolarRadiusAxis,
     ResponsiveContainer,
 } from "recharts";
-import {
-    TASTE_PROFILE_AXES,
-    type TasteProfileArchetype,
-    type TasteProfileDimensionsDto,
+import type {
+    TasteProfileArchetype,
+    TasteProfileDimensionsDto,
 } from "@raid-ledger/contract";
 import { ArchetypePill } from "./ArchetypePill";
-import { axisLabel } from "./taste-profile-helpers";
+import { axisLabel, topAxes, type AxisScore } from "./taste-profile-helpers";
 
 interface TasteRadarChartProps {
     archetype: TasteProfileArchetype;
     dimensions: TasteProfileDimensionsDto;
 }
 
-/**
- * Build the aria-label that summarises the whole chart for screen
- * readers — AC7: "aria-label includes archetype + each axis + value".
- */
+/** Build the aria-label summary for screen readers (AC7). */
 function buildAriaLabel(
     archetype: TasteProfileArchetype,
-    dims: TasteProfileDimensionsDto,
+    scores: AxisScore[],
 ): string {
-    const parts = TASTE_PROFILE_AXES.map(
-        (axis) => `${axisLabel(axis)} ${dims[axis]}`,
-    ).join(", ");
+    const parts = scores
+        .map((s) => `${axisLabel(s.axis)} ${s.value}`)
+        .join(", ");
     return `Taste profile for ${archetype}: ${parts}.`;
 }
 
@@ -75,16 +71,20 @@ function RadarBody({
  * 7-axis radar chart with radial red→yellow→green fill and an archetype
  * hero title above. Chart height is driven by CSS (300px desktop, 240px
  * mobile) via `.taste-radar__chart-wrap`.
+ *
+ * Each player sees their personal top 7 axes selected from the full pool,
+ * so the radar reflects what they actually play (ROK-949 dynamic axes).
  */
 export function TasteRadarChart({
     archetype,
     dimensions,
 }: TasteRadarChartProps): JSX.Element {
-    const data = TASTE_PROFILE_AXES.map((axis) => ({
-        axis: axisLabel(axis),
-        value: dimensions[axis],
+    const scores = topAxes(dimensions, 7);
+    const data = scores.map((s) => ({
+        axis: axisLabel(s.axis),
+        value: s.value,
     }));
-    const ariaLabel = buildAriaLabel(archetype, dimensions);
+    const ariaLabel = buildAriaLabel(archetype, scores);
     return (
         <div className="taste-radar">
             <div className="taste-radar__title">

--- a/web/src/pages/user-profile/taste-profile/TasteRadarChart.tsx
+++ b/web/src/pages/user-profile/taste-profile/TasteRadarChart.tsx
@@ -8,6 +8,7 @@ import {
     ResponsiveContainer,
 } from "recharts";
 import type {
+    IntensityMetricsDto,
     TasteProfileArchetype,
     TasteProfileDimensionsDto,
 } from "@raid-ledger/contract";
@@ -17,17 +18,30 @@ import { axisLabel, topAxes, type AxisScore } from "./taste-profile-helpers";
 interface TasteRadarChartProps {
     archetype: TasteProfileArchetype;
     dimensions: TasteProfileDimensionsDto;
+    intensityMetrics?: IntensityMetricsDto;
 }
 
-/** Build the aria-label summary for screen readers (AC7). */
+/**
+ * Screen-reader summary of the radar (AC7). Includes the archetype,
+ * every rendered axis with its score, and — when available — the
+ * top-level intensity/focus/breadth numbers so non-sighted users get
+ * the same at-a-glance picture the chart provides visually.
+ */
 function buildAriaLabel(
     archetype: TasteProfileArchetype,
     scores: AxisScore[],
+    metrics?: IntensityMetricsDto,
 ): string {
-    const parts = scores
+    const axes = scores
         .map((s) => `${axisLabel(s.axis)} ${s.value}`)
         .join(", ");
-    return `Taste profile for ${archetype}: ${parts}.`;
+    const header = `Taste profile for ${archetype}`;
+    if (!metrics) return `${header}: ${axes}.`;
+    return (
+        `${header}. Intensity ${metrics.intensity} of 100, ` +
+        `focus ${metrics.focus}, breadth ${metrics.breadth}, ` +
+        `consistency ${metrics.consistency}. Axes: ${axes}.`
+    );
 }
 
 function RadarGradientDefs(): JSX.Element {
@@ -78,13 +92,14 @@ function RadarBody({
 export function TasteRadarChart({
     archetype,
     dimensions,
+    intensityMetrics,
 }: TasteRadarChartProps): JSX.Element {
     const scores = topAxes(dimensions, 7);
     const data = scores.map((s) => ({
         axis: axisLabel(s.axis),
         value: s.value,
     }));
-    const ariaLabel = buildAriaLabel(archetype, scores);
+    const ariaLabel = buildAriaLabel(archetype, scores, intensityMetrics);
     return (
         <div className="taste-radar">
             <div className="taste-radar__title">

--- a/web/src/pages/user-profile/taste-profile/taste-profile-helpers.test.ts
+++ b/web/src/pages/user-profile/taste-profile/taste-profile-helpers.test.ts
@@ -4,24 +4,26 @@ import {
     axisLabel,
     formatFocusIndicator,
     formatIntensity,
+    topAxes,
 } from "./taste-profile-helpers";
-import type { TasteProfileResponseDto } from "@raid-ledger/contract";
+import {
+    TASTE_PROFILE_AXIS_POOL,
+    type TasteProfileResponseDto,
+} from "@raid-ledger/contract";
+
+function zeroPool(): TasteProfileResponseDto["dimensions"] {
+    const dims: Record<string, number> = {};
+    for (const axis of TASTE_PROFILE_AXIS_POOL) dims[axis] = 0;
+    return dims as TasteProfileResponseDto["dimensions"];
+}
 
 function makeProfile(
-    overrides?: Partial<TasteProfileResponseDto["dimensions"]>,
+    overrides?: Partial<Record<string, number>>,
 ): TasteProfileResponseDto {
+    const dims = { ...zeroPool(), ...overrides } as Record<string, number>;
     return {
         userId: 42,
-        dimensions: {
-            co_op: 0,
-            pvp: 0,
-            rpg: 0,
-            survival: 0,
-            strategy: 0,
-            social: 0,
-            mmo: 0,
-            ...overrides,
-        },
+        dimensions: dims as TasteProfileResponseDto["dimensions"],
         intensityMetrics: {
             intensity: 0,
             focus: 0,
@@ -35,25 +37,76 @@ function makeProfile(
 }
 
 describe("isEmptyTasteProfile", () => {
-    it("returns true when every dimension is zero", () => {
+    it("returns true when every pool dimension is zero", () => {
         expect(isEmptyTasteProfile(makeProfile())).toBe(true);
     });
 
-    it("returns false when any dimension is non-zero", () => {
+    it("returns false when any pool dimension is non-zero", () => {
         expect(isEmptyTasteProfile(makeProfile({ co_op: 5 }))).toBe(false);
         expect(isEmptyTasteProfile(makeProfile({ mmo: 1 }))).toBe(false);
+        expect(isEmptyTasteProfile(makeProfile({ horror: 42 }))).toBe(false);
     });
 });
 
 describe("axisLabel", () => {
-    it("maps every axis to a human-readable label", () => {
+    it("returns a non-empty label for every pool axis", () => {
+        for (const axis of TASTE_PROFILE_AXIS_POOL) {
+            const label = axisLabel(axis);
+            expect(label).toBeTruthy();
+            expect(label.length).toBeGreaterThan(0);
+        }
+    });
+
+    it("maps core axes to their display labels", () => {
         expect(axisLabel("co_op")).toBe("Co-op");
         expect(axisLabel("pvp")).toBe("PvP");
         expect(axisLabel("rpg")).toBe("RPG");
-        expect(axisLabel("survival")).toBe("Survival");
-        expect(axisLabel("strategy")).toBe("Strategy");
-        expect(axisLabel("social")).toBe("Social");
-        expect(axisLabel("mmo")).toBe("MMO");
+        expect(axisLabel("battle_royale")).toBe("Battle Royale");
+        expect(axisLabel("sci_fi")).toBe("Sci-Fi");
+    });
+});
+
+describe("topAxes", () => {
+    it("returns the top 7 axes sorted by value descending", () => {
+        const profile = makeProfile({
+            shooter: 100,
+            pvp: 90,
+            battle_royale: 80,
+            adventure: 70,
+            co_op: 60,
+            fantasy: 55,
+            rpg: 40,
+            survival: 20,
+        });
+        const result = topAxes(profile.dimensions, 7);
+        expect(result.map((r) => r.axis)).toEqual([
+            "shooter",
+            "pvp",
+            "battle_royale",
+            "adventure",
+            "co_op",
+            "fantasy",
+            "rpg",
+        ]);
+    });
+
+    it("defaults to 7 when n is not provided", () => {
+        const profile = makeProfile({ shooter: 90, pvp: 80, co_op: 70 });
+        expect(topAxes(profile.dimensions)).toHaveLength(7);
+    });
+
+    it("returns all pool entries when n is larger than pool", () => {
+        const profile = makeProfile({ shooter: 10 });
+        expect(topAxes(profile.dimensions, 99)).toHaveLength(
+            TASTE_PROFILE_AXIS_POOL.length,
+        );
+    });
+
+    it("returns deterministic order for all-zero profiles", () => {
+        const profile = makeProfile();
+        const result = topAxes(profile.dimensions, 7);
+        expect(result).toHaveLength(7);
+        for (const entry of result) expect(entry.value).toBe(0);
     });
 });
 

--- a/web/src/pages/user-profile/taste-profile/taste-profile-helpers.test.ts
+++ b/web/src/pages/user-profile/taste-profile/taste-profile-helpers.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from "vitest";
+import {
+    isEmptyTasteProfile,
+    axisLabel,
+    formatFocusIndicator,
+    formatIntensity,
+} from "./taste-profile-helpers";
+import type { TasteProfileResponseDto } from "@raid-ledger/contract";
+
+function makeProfile(
+    overrides?: Partial<TasteProfileResponseDto["dimensions"]>,
+): TasteProfileResponseDto {
+    return {
+        userId: 42,
+        dimensions: {
+            co_op: 0,
+            pvp: 0,
+            rpg: 0,
+            survival: 0,
+            strategy: 0,
+            social: 0,
+            mmo: 0,
+            ...overrides,
+        },
+        intensityMetrics: {
+            intensity: 0,
+            focus: 0,
+            breadth: 0,
+            consistency: 0,
+        },
+        archetype: "Casual",
+        coPlayPartners: [],
+        computedAt: "2026-04-16T00:00:00.000Z",
+    };
+}
+
+describe("isEmptyTasteProfile", () => {
+    it("returns true when every dimension is zero", () => {
+        expect(isEmptyTasteProfile(makeProfile())).toBe(true);
+    });
+
+    it("returns false when any dimension is non-zero", () => {
+        expect(isEmptyTasteProfile(makeProfile({ co_op: 5 }))).toBe(false);
+        expect(isEmptyTasteProfile(makeProfile({ mmo: 1 }))).toBe(false);
+    });
+});
+
+describe("axisLabel", () => {
+    it("maps every axis to a human-readable label", () => {
+        expect(axisLabel("co_op")).toBe("Co-op");
+        expect(axisLabel("pvp")).toBe("PvP");
+        expect(axisLabel("rpg")).toBe("RPG");
+        expect(axisLabel("survival")).toBe("Survival");
+        expect(axisLabel("strategy")).toBe("Strategy");
+        expect(axisLabel("social")).toBe("Social");
+        expect(axisLabel("mmo")).toBe("MMO");
+    });
+});
+
+describe("formatFocusIndicator", () => {
+    it("returns 'Focused play' when focus is > 60", () => {
+        expect(formatFocusIndicator(75, 10)).toBe("Focused play (75%)");
+    });
+
+    it("returns 'Varied play' when breadth is > 60 and focus is not", () => {
+        expect(formatFocusIndicator(30, 72)).toBe("Varied play (72%)");
+    });
+
+    it("prefers 'Focused play' when both are > 60", () => {
+        expect(formatFocusIndicator(80, 70)).toBe("Focused play (80%)");
+    });
+
+    it("returns null when neither crosses the threshold", () => {
+        expect(formatFocusIndicator(60, 60)).toBeNull();
+        expect(formatFocusIndicator(0, 0)).toBeNull();
+        expect(formatFocusIndicator(50, 55)).toBeNull();
+    });
+});
+
+describe("formatIntensity", () => {
+    it("formats intensity as an /100 score", () => {
+        expect(formatIntensity(0)).toBe("Intensity: 0/100");
+        expect(formatIntensity(82)).toBe("Intensity: 82/100");
+    });
+});

--- a/web/src/pages/user-profile/taste-profile/taste-profile-helpers.ts
+++ b/web/src/pages/user-profile/taste-profile/taste-profile-helpers.ts
@@ -5,41 +5,92 @@
  * any rendering or network calls.
  */
 import {
-    TASTE_PROFILE_AXES,
-    type TasteProfileAxis,
+    TASTE_PROFILE_AXIS_POOL,
+    type TasteProfilePoolAxis,
     type TasteProfileResponseDto,
 } from "@raid-ledger/contract";
 
 /**
- * Returns true when every dimension value is 0 — the signal that the
- * user has not accumulated any play history yet.
+ * Returns true when every dimension value in the pool is 0 — the signal
+ * that the user has not accumulated any play history yet.
  */
 export function isEmptyTasteProfile(
     profile: TasteProfileResponseDto,
 ): boolean {
-    return TASTE_PROFILE_AXES.every((axis) => profile.dimensions[axis] === 0);
+    const dims = profile.dimensions as Record<string, number>;
+    return TASTE_PROFILE_AXIS_POOL.every((axis) => (dims[axis] ?? 0) === 0);
+}
+
+/** Sorted `{ axis, value }` tuples — highest values first. */
+export interface AxisScore {
+    axis: TasteProfilePoolAxis;
+    value: number;
 }
 
 /**
- * Human-readable axis labels (text only — no emoji/SVG). Used both for
+ * Returns the top `n` axes for a player, sorted by score descending.
+ * Ties are broken by `TASTE_PROFILE_AXIS_POOL` order for determinism.
+ * Output length is always `min(n, pool size)`.
+ */
+export function topAxes(
+    dimensions: TasteProfileResponseDto["dimensions"],
+    n = 7,
+): AxisScore[] {
+    const dims = dimensions as Record<string, number>;
+    const scored: AxisScore[] = TASTE_PROFILE_AXIS_POOL.map((axis) => ({
+        axis,
+        value: dims[axis] ?? 0,
+    }));
+    scored.sort((a, b) => b.value - a.value);
+    return scored.slice(0, n);
+}
+
+/**
+ * Human-readable axis labels covering the full 20-axis pool. Used for
  * chart labels and for the radar chart's `aria-label`.
  */
-export function axisLabel(axis: TasteProfileAxis): string {
+export function axisLabel(axis: TasteProfilePoolAxis): string {
     switch (axis) {
         case "co_op":
             return "Co-op";
         case "pvp":
             return "PvP";
-        case "rpg":
-            return "RPG";
-        case "survival":
-            return "Survival";
-        case "strategy":
-            return "Strategy";
-        case "social":
-            return "Social";
+        case "battle_royale":
+            return "Battle Royale";
         case "mmo":
             return "MMO";
+        case "moba":
+            return "MOBA";
+        case "fighting":
+            return "Fighting";
+        case "shooter":
+            return "Shooter";
+        case "racing":
+            return "Racing";
+        case "sports":
+            return "Sports";
+        case "rpg":
+            return "RPG";
+        case "fantasy":
+            return "Fantasy";
+        case "sci_fi":
+            return "Sci-Fi";
+        case "adventure":
+            return "Adventure";
+        case "strategy":
+            return "Strategy";
+        case "rts":
+            return "RTS";
+        case "tbs":
+            return "TBS";
+        case "survival":
+            return "Survival";
+        case "sandbox":
+            return "Sandbox";
+        case "horror":
+            return "Horror";
+        case "social":
+            return "Social";
     }
 }
 
@@ -59,7 +110,7 @@ export function formatFocusIndicator(
 }
 
 /**
- * Formats the primary intensity text.  `intensity` is a 0–100 percentile
+ * Formats the primary intensity text. `intensity` is a 0–100 percentile
  * rank (see `api/src/taste-profile/intensity-rollup.helpers.ts`) so we
  * render it as `Intensity: {n}/100` rather than inventing hours.
  */

--- a/web/src/pages/user-profile/taste-profile/taste-profile-helpers.ts
+++ b/web/src/pages/user-profile/taste-profile/taste-profile-helpers.ts
@@ -46,7 +46,7 @@ export function topAxes(
 }
 
 /**
- * Human-readable axis labels covering the full 20-axis pool. Used for
+ * Human-readable axis labels covering the full axis pool. Used for
  * chart labels and for the radar chart's `aria-label`.
  */
 export function axisLabel(axis: TasteProfilePoolAxis): string {
@@ -79,18 +79,26 @@ export function axisLabel(axis: TasteProfilePoolAxis): string {
             return "Adventure";
         case "strategy":
             return "Strategy";
-        case "rts":
-            return "RTS";
-        case "tbs":
-            return "TBS";
         case "survival":
             return "Survival";
+        case "crafting":
+            return "Crafting";
+        case "automation":
+            return "Automation";
         case "sandbox":
             return "Sandbox";
         case "horror":
             return "Horror";
         case "social":
             return "Social";
+        case "roguelike":
+            return "Roguelike";
+        case "puzzle":
+            return "Puzzle";
+        case "platformer":
+            return "Platformer";
+        case "stealth":
+            return "Stealth";
     }
 }
 

--- a/web/src/pages/user-profile/taste-profile/taste-profile-helpers.ts
+++ b/web/src/pages/user-profile/taste-profile/taste-profile-helpers.ts
@@ -1,0 +1,68 @@
+/**
+ * Pure helpers for the taste-profile UI (ROK-949).
+ *
+ * All functions are side-effect free so they can be unit-tested without
+ * any rendering or network calls.
+ */
+import {
+    TASTE_PROFILE_AXES,
+    type TasteProfileAxis,
+    type TasteProfileResponseDto,
+} from "@raid-ledger/contract";
+
+/**
+ * Returns true when every dimension value is 0 — the signal that the
+ * user has not accumulated any play history yet.
+ */
+export function isEmptyTasteProfile(
+    profile: TasteProfileResponseDto,
+): boolean {
+    return TASTE_PROFILE_AXES.every((axis) => profile.dimensions[axis] === 0);
+}
+
+/**
+ * Human-readable axis labels (text only — no emoji/SVG). Used both for
+ * chart labels and for the radar chart's `aria-label`.
+ */
+export function axisLabel(axis: TasteProfileAxis): string {
+    switch (axis) {
+        case "co_op":
+            return "Co-op";
+        case "pvp":
+            return "PvP";
+        case "rpg":
+            return "RPG";
+        case "survival":
+            return "Survival";
+        case "strategy":
+            return "Strategy";
+        case "social":
+            return "Social";
+        case "mmo":
+            return "MMO";
+    }
+}
+
+/**
+ * Returns the "focused play" / "varied play" indicator line, or `null`
+ * when neither threshold applies. Both focus and breadth are scaled
+ * 0–100 server-side; we render the indicator when one clearly
+ * dominates (> 60).
+ */
+export function formatFocusIndicator(
+    focus: number,
+    breadth: number,
+): string | null {
+    if (focus > 60) return `Focused play (${focus}%)`;
+    if (breadth > 60) return `Varied play (${breadth}%)`;
+    return null;
+}
+
+/**
+ * Formats the primary intensity text.  `intensity` is a 0–100 percentile
+ * rank (see `api/src/taste-profile/intensity-rollup.helpers.ts`) so we
+ * render it as `Intensity: {n}/100` rather than inventing hours.
+ */
+export function formatIntensity(intensity: number): string {
+    return `Intensity: ${intensity}/100`;
+}

--- a/web/src/pages/user-profile/taste-profile/taste-profile-section.css
+++ b/web/src/pages/user-profile/taste-profile/taste-profile-section.css
@@ -1,0 +1,307 @@
+/* Taste profile section (ROK-949) --------------------------------- */
+
+.taste-profile-section__body {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.taste-profile-section__empty {
+    color: #a1a1aa;
+    font-size: 0.9375rem;
+    margin: 0;
+    padding: 0.5rem 0;
+}
+
+.taste-profile-section__loading {
+    color: #a1a1aa;
+    font-size: 0.875rem;
+    padding: 1rem 0;
+}
+
+/* Radar chart ------------------------------------------------------ */
+
+.taste-radar {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 0.5rem;
+}
+
+.taste-radar__title {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: #e4e4e7;
+    font-size: 0.8125rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-weight: 600;
+}
+
+.taste-radar__title-prefix {
+    color: #71717a;
+}
+
+.taste-radar__chart-wrap {
+    width: 100%;
+    height: 300px;
+}
+
+@media (max-width: 640px) {
+    .taste-radar__chart-wrap {
+        height: 240px;
+    }
+}
+
+/* Archetype pill --------------------------------------------------- */
+
+.archetype-pill {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 9999px;
+    padding: 0.125rem 0.625rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    line-height: 1.4;
+    white-space: nowrap;
+    border: 1px solid transparent;
+}
+
+.archetype-pill--sm {
+    font-size: 0.6875rem;
+}
+
+.archetype-pill--lg {
+    font-size: 0.875rem;
+    padding: 0.25rem 0.875rem;
+}
+
+.archetype-pill--dedicated {
+    color: #f472b6;
+    background: rgba(244, 114, 182, 0.12);
+    border-color: rgba(244, 114, 182, 0.35);
+}
+
+.archetype-pill--specialist {
+    color: #a78bfa;
+    background: rgba(167, 139, 250, 0.12);
+    border-color: rgba(167, 139, 250, 0.35);
+}
+
+.archetype-pill--explorer {
+    color: #34d399;
+    background: rgba(52, 211, 153, 0.12);
+    border-color: rgba(52, 211, 153, 0.35);
+}
+
+.archetype-pill--social-drifter {
+    color: #60a5fa;
+    background: rgba(96, 165, 250, 0.12);
+    border-color: rgba(96, 165, 250, 0.35);
+}
+
+.archetype-pill--casual {
+    color: #a1a1aa;
+    background: rgba(161, 161, 170, 0.12);
+    border-color: rgba(161, 161, 170, 0.3);
+}
+
+/* Intensity badge -------------------------------------------------- */
+
+.intensity-badge {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+}
+
+.intensity-badge__primary {
+    margin: 0;
+    color: #e4e4e7;
+    font-size: 0.9375rem;
+    font-weight: 500;
+}
+
+.intensity-badge__intensity {
+    font-weight: 600;
+    color: #fafafa;
+}
+
+.intensity-badge__sep {
+    color: #71717a;
+    padding: 0 0.125rem;
+}
+
+.intensity-badge__archetype {
+    color: #c4b5fd;
+}
+
+.intensity-badge__focus {
+    margin: 0;
+    color: #a1a1aa;
+    font-size: 0.8125rem;
+}
+
+/* Frequently plays with ------------------------------------------- */
+
+.frequently-plays-with {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.frequently-plays-with__title {
+    margin: 0;
+    color: #e4e4e7;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+}
+
+.frequently-plays-with__list,
+.frequently-plays-with__modal-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+}
+
+.frequently-plays-with__show-all {
+    align-self: flex-start;
+    margin-top: 0.25rem;
+    background: transparent;
+    color: #34d399;
+    border: none;
+    padding: 0.25rem 0;
+    font-size: 0.8125rem;
+    cursor: pointer;
+}
+
+.frequently-plays-with__show-all:hover {
+    color: #6ee7b7;
+}
+
+.partner-row {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 0.5rem;
+    background: rgba(255, 255, 255, 0.04);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    text-decoration: none;
+    color: inherit;
+    transition: background 0.15s ease;
+}
+
+.partner-row:hover {
+    background: rgba(255, 255, 255, 0.08);
+}
+
+.partner-row__avatar {
+    width: 36px;
+    height: 36px;
+    border-radius: 9999px;
+    object-fit: cover;
+    flex-shrink: 0;
+}
+
+.partner-row__avatar--initials {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(255, 255, 255, 0.08);
+    color: #a1a1aa;
+    font-weight: 600;
+    font-size: 0.9375rem;
+}
+
+.partner-row__body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    min-width: 0;
+}
+
+.partner-row__name {
+    color: #fafafa;
+    font-weight: 600;
+    font-size: 0.9375rem;
+}
+
+.partner-row__meta {
+    color: #a1a1aa;
+    font-size: 0.75rem;
+}
+
+/* Profile header archetype pill anchor */
+
+.user-profile-header .archetype-pill {
+    margin-left: 0.5rem;
+    vertical-align: middle;
+}
+
+/* Light theme overrides ------------------------------------------- */
+
+:is([data-scheme="light"], [data-scheme="quest-log"], [data-scheme="sky"],
+    [data-scheme="dawn"], [data-scheme="holy"], [data-scheme="celestial"])
+    .taste-profile-section__empty,
+:is([data-scheme="light"], [data-scheme="quest-log"], [data-scheme="sky"],
+    [data-scheme="dawn"], [data-scheme="holy"], [data-scheme="celestial"])
+    .taste-profile-section__loading {
+    color: #64748b;
+}
+
+:is([data-scheme="light"], [data-scheme="quest-log"], [data-scheme="sky"],
+    [data-scheme="dawn"], [data-scheme="holy"], [data-scheme="celestial"])
+    .intensity-badge__primary {
+    color: #0f172a;
+}
+
+:is([data-scheme="light"], [data-scheme="quest-log"], [data-scheme="sky"],
+    [data-scheme="dawn"], [data-scheme="holy"], [data-scheme="celestial"])
+    .intensity-badge__intensity {
+    color: #0f172a;
+}
+
+:is([data-scheme="light"], [data-scheme="quest-log"], [data-scheme="sky"],
+    [data-scheme="dawn"], [data-scheme="holy"], [data-scheme="celestial"])
+    .intensity-badge__focus,
+:is([data-scheme="light"], [data-scheme="quest-log"], [data-scheme="sky"],
+    [data-scheme="dawn"], [data-scheme="holy"], [data-scheme="celestial"])
+    .partner-row__meta,
+:is([data-scheme="light"], [data-scheme="quest-log"], [data-scheme="sky"],
+    [data-scheme="dawn"], [data-scheme="holy"], [data-scheme="celestial"])
+    .taste-radar__title-prefix {
+    color: #64748b;
+}
+
+:is([data-scheme="light"], [data-scheme="quest-log"], [data-scheme="sky"],
+    [data-scheme="dawn"], [data-scheme="holy"], [data-scheme="celestial"])
+    .frequently-plays-with__title,
+:is([data-scheme="light"], [data-scheme="quest-log"], [data-scheme="sky"],
+    [data-scheme="dawn"], [data-scheme="holy"], [data-scheme="celestial"])
+    .taste-radar__title,
+:is([data-scheme="light"], [data-scheme="quest-log"], [data-scheme="sky"],
+    [data-scheme="dawn"], [data-scheme="holy"], [data-scheme="celestial"])
+    .partner-row__name {
+    color: #0f172a;
+}
+
+:is([data-scheme="light"], [data-scheme="quest-log"], [data-scheme="sky"],
+    [data-scheme="dawn"], [data-scheme="holy"], [data-scheme="celestial"])
+    .partner-row {
+    background: rgba(241, 245, 249, 0.6);
+    border-color: rgba(203, 213, 225, 0.3);
+}
+
+:is([data-scheme="light"], [data-scheme="quest-log"], [data-scheme="sky"],
+    [data-scheme="dawn"], [data-scheme="holy"], [data-scheme="celestial"])
+    .partner-row:hover {
+    background: rgba(226, 232, 240, 0.5);
+}

--- a/web/src/test/mocks/handlers.ts
+++ b/web/src/test/mocks/handlers.ts
@@ -117,4 +117,34 @@ export const handlers = [
     http.get(`${API_BASE}/users/:id/hearted-games`, () =>
         HttpResponse.json([]),
     ),
+
+    // User profile — taste profile (ROK-949). Returns a neutral empty
+    // profile so tests that incidentally render <TasteProfileSection>
+    // don't hit an MSW miss. Tests asserting specific dimensions can
+    // override with server.use().
+    http.get(`${API_BASE}/users/:id/taste-profile`, ({ params }) => {
+        const userId = Number(params.id);
+        return HttpResponse.json({
+            userId,
+            dimensions: {
+                co_op: 0, pvp: 0, battle_royale: 0, mmo: 0, moba: 0,
+                fighting: 0, shooter: 0, racing: 0, sports: 0, rpg: 0,
+                fantasy: 0, sci_fi: 0, adventure: 0, strategy: 0,
+                survival: 0, crafting: 0, automation: 0, sandbox: 0,
+                horror: 0, social: 0, roguelike: 0, puzzle: 0,
+                platformer: 0, stealth: 0,
+            },
+            intensityMetrics: {
+                intensity: 0, focus: 0, breadth: 0, consistency: 0,
+            },
+            archetype: 'Casual',
+            coPlayPartners: [],
+            computedAt: '2026-04-17T00:00:00.000Z',
+        });
+    }),
+
+    // User profile — similar players (ROK-949 companion endpoint).
+    http.get(`${API_BASE}/users/:id/similar-players`, () =>
+        HttpResponse.json({ similar: [] }),
+    ),
 ];


### PR DESCRIPTION
## Summary

- Adds a **Taste Profile** section to the user profile page: radar chart, archetype pill + hero title, intensity/focus/breadth badge, and "Frequently plays with" co-play partners (top 3 inline + "Show all" modal).
- Renders the player's **top 7 axes** dynamically from a pool of **24** (co_op, pvp, battle_royale, mmo, moba, fighting, shooter, racing, sports, rpg, fantasy, sci_fi, adventure, strategy, survival, crafting, automation, sandbox, horror, social, roguelike, puzzle, platformer, stealth). Different players get different radars.
- Backend axis matching is **tag-first** (Steam/ITAD tags) with IGDB IDs as fallback, plus **IDF rarity weighting** so specific sub-genres (Automation, Roguelike, Battle Royale) surface instead of being swamped by broad tags (Adventure).
- Intensity is a **60/30/10 blend** of current-week / rolling 4-week / all-time percentile rank.
- Per code review: extracted SIGNAL_WEIGHTS constants, tightened dimensions schema, batched aggregate-vectors loading (was N+1), consolidated weekly-intensity queries, added MSW default handler, extended radar `aria-label` to include intensity metrics.

## Linear
ROK-949 (parent epic ROK-947). Pre-existing Playwright flakes unrelated to this PR tracked in ROK-1070.

## Workspaces touched
- `packages/contract` — new `TASTE_PROFILE_AXIS_POOL` + strict dimensions schema
- `api/src/taste-profile/**` — axis mapping, vector + IDF helpers, batched aggregate-vectors pipeline, blended intensity rollup
- `web/src/pages/user-profile/**` — section, radar chart, pills, partners modal, helpers, CSS
- `web/src/hooks/use-taste-profile.ts`, `web/src/lib/api-client.ts`, `web/src/lib/api/users-api.ts`, `web/src/pages/user-profile-page.tsx`
- `scripts/smoke/user-profile-taste.smoke.spec.ts`

## Test plan

- [x] TDD Playwright smoke committed first (5 failing → 10 passing desktop + mobile)
- [x] Unit tests added: 15 taste-vector, 9 intensity-rollup, 5 topAxes helper + schema coverage
- [x] CI passes: build + TypeScript + lint + all 2796 web Vitest + 44 api taste-profile Jest
- [x] Integration tests: `taste-profile.integration.spec.ts` PASS (pre-existing backup-test flake flagged separately)
- [x] Operator tested locally and approved
- [x] Code review passed (APPROVED, 11 tech-debt items applied in review commit)
- [x] Playwright smoke — 10/10 on desktop + mobile for ROK-949's suite
- [x] DB regenerated end-to-end; admin profile renders sensible top-7

🤖 Generated with [Claude Code](https://claude.com/claude-code)