### PR TITLE
ROK-1054: fix: Steam link listener always DMs confirmation

### DIFF
--- a/api/src/admin/demo-test.controller.spec.ts
+++ b/api/src/admin/demo-test.controller.spec.ts
@@ -30,6 +30,7 @@ function createMockService() {
     setEventTimesForTest: jest.fn().mockResolvedValue({ success: true }),
     clearGameTimeConfirmationForTest: jest.fn().mockResolvedValue(undefined),
     setAutoHeartPrefForTest: jest.fn().mockResolvedValue(undefined),
+    getGameForTest: jest.fn(),
   };
 }
 
@@ -177,6 +178,29 @@ describe('DemoTestController — new test utility endpoints', () => {
         enabled: 'yes',
       }),
     ).rejects.toThrow(/Validation failed/);
+  });
+
+  it('getGame returns game name and id (ROK-1054)', async () => {
+    mockService.getGameForTest.mockResolvedValueOnce({
+      id: 8363,
+      name: 'Test WoW',
+    });
+    const result = await controller.getGameForTest({ id: 8363 });
+    expect(result).toEqual({ id: 8363, name: 'Test WoW' });
+    expect(mockService.getGameForTest).toHaveBeenCalledWith(8363);
+  });
+
+  it('getGame returns 404 when game not found', async () => {
+    mockService.getGameForTest.mockResolvedValueOnce(null);
+    await expect(controller.getGameForTest({ id: 99999 })).rejects.toThrow(
+      /Game not found/,
+    );
+  });
+
+  it('getGame rejects invalid id', async () => {
+    await expect(controller.getGameForTest({ id: -1 })).rejects.toThrow(
+      /Validation failed/,
+    );
   });
 
   it('clearGameTimeConfirmation delegates to service (ROK-999)', async () => {

--- a/api/src/admin/demo-test.controller.spec.ts
+++ b/api/src/admin/demo-test.controller.spec.ts
@@ -29,6 +29,7 @@ function createMockService() {
     pauseReconciliationForTest: jest.fn().mockResolvedValue({ success: true }),
     setEventTimesForTest: jest.fn().mockResolvedValue({ success: true }),
     clearGameTimeConfirmationForTest: jest.fn().mockResolvedValue(undefined),
+    setAutoHeartPrefForTest: jest.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -138,6 +139,42 @@ describe('DemoTestController — new test utility endpoints', () => {
         eventId: 1,
         startTime: 'not-a-date',
         endTime: '2026-04-01T02:00:00Z',
+      }),
+    ).rejects.toThrow(/Validation failed/);
+  });
+
+  it('setAutoHeartPref delegates to service (ROK-1054)', async () => {
+    const result = await controller.setAutoHeartPrefForTest({
+      userId: 7,
+      enabled: true,
+    });
+    expect(result).toEqual({ success: true });
+    expect(mockService.setAutoHeartPrefForTest).toHaveBeenCalledWith(7, true);
+  });
+
+  it('setAutoHeartPref accepts enabled=false', async () => {
+    const result = await controller.setAutoHeartPrefForTest({
+      userId: 12,
+      enabled: false,
+    });
+    expect(result).toEqual({ success: true });
+    expect(mockService.setAutoHeartPrefForTest).toHaveBeenCalledWith(12, false);
+  });
+
+  it('setAutoHeartPref rejects invalid userId', async () => {
+    await expect(
+      controller.setAutoHeartPrefForTest({
+        userId: -1,
+        enabled: true,
+      }),
+    ).rejects.toThrow(/Validation failed/);
+  });
+
+  it('setAutoHeartPref rejects non-boolean enabled', async () => {
+    await expect(
+      controller.setAutoHeartPrefForTest({
+        userId: 1,
+        enabled: 'yes',
       }),
     ).rejects.toThrow(/Validation failed/);
   });

--- a/api/src/admin/demo-test.controller.ts
+++ b/api/src/admin/demo-test.controller.ts
@@ -9,6 +9,7 @@ import {
   HttpCode,
   HttpStatus,
   BadRequestException,
+  NotFoundException,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { SkipThrottle } from '@nestjs/throttler';
@@ -27,6 +28,7 @@ import {
   InjectVoiceSessionSchema,
   AwaitProcessingSchema,
   SetSteamAppIdSchema,
+  GetGameSchema,
   ClearGameInterestSchema,
   CreateTestSignupSchema,
   SetEventTimesSchema,
@@ -283,6 +285,16 @@ export class DemoTestController {
       parsed.steamAppId,
     );
     return { success: true };
+  }
+
+  /** Fetch a game by id — DEMO_MODE only (ROK-1054 smoke test). */
+  @Post('get-game')
+  @HttpCode(HttpStatus.OK)
+  async getGameForTest(@Body() body: unknown) {
+    const { id } = this.parseBody(GetGameSchema, body);
+    const game = await this.demoTestService.getGameForTest(id);
+    if (!game) throw new NotFoundException('Game not found');
+    return game;
   }
 
   /** Set autoHeartSteamUrls preference for a user — DEMO_MODE only (ROK-1054). */

--- a/api/src/admin/demo-test.controller.ts
+++ b/api/src/admin/demo-test.controller.ts
@@ -31,6 +31,7 @@ import {
   CreateTestSignupSchema,
   SetEventTimesSchema,
   CancelLineupPhaseJobsSchema,
+  SetAutoHeartPrefSchema,
 } from './demo-test.schemas';
 
 /**
@@ -280,6 +281,20 @@ export class DemoTestController {
     await this.demoTestService.setSteamAppIdForTest(
       parsed.gameId,
       parsed.steamAppId,
+    );
+    return { success: true };
+  }
+
+  /** Set autoHeartSteamUrls preference for a user — DEMO_MODE only (ROK-1054). */
+  @Post('set-auto-heart-pref')
+  @HttpCode(HttpStatus.OK)
+  async setAutoHeartPrefForTest(
+    @Body() body: unknown,
+  ): Promise<{ success: boolean }> {
+    const parsed = this.parseBody(SetAutoHeartPrefSchema, body);
+    await this.demoTestService.setAutoHeartPrefForTest(
+      parsed.userId,
+      parsed.enabled,
     );
     return { success: true };
   }

--- a/api/src/admin/demo-test.schemas.ts
+++ b/api/src/admin/demo-test.schemas.ts
@@ -57,6 +57,10 @@ export const SetSteamAppIdSchema = z.object({
   steamAppId: z.number().int().positive(),
 });
 
+export const GetGameSchema = z.object({
+  id: z.number().int().positive(),
+});
+
 export const ClearGameInterestSchema = z.object({
   userId: z.number().int().positive(),
   gameId: z.number().int().positive(),

--- a/api/src/admin/demo-test.schemas.ts
+++ b/api/src/admin/demo-test.schemas.ts
@@ -62,6 +62,11 @@ export const ClearGameInterestSchema = z.object({
   gameId: z.number().int().positive(),
 });
 
+export const SetAutoHeartPrefSchema = z.object({
+  userId: z.number().int().positive(),
+  enabled: z.boolean(),
+});
+
 const VALID_STATUSES = ['signed_up', 'tentative', 'declined'] as const;
 
 export const CreateTestSignupSchema = z.object({

--- a/api/src/admin/demo-test.service.ts
+++ b/api/src/admin/demo-test.service.ts
@@ -319,6 +319,17 @@ export class DemoTestService {
       .where(eq(schema.games.id, gameId));
   }
 
+  /** Fetch a game by id (for smoke-test fixture setup) — DEMO_MODE only (ROK-1054). */
+  async getGameForTest(id: number) {
+    await this.assertDemoMode();
+    const rows = await this.db
+      .select({ id: schema.games.id, name: schema.games.name })
+      .from(schema.games)
+      .where(eq(schema.games.id, id))
+      .limit(1);
+    return rows[0] ?? null;
+  }
+
   /** Set the autoHeartSteamUrls preference for a user — DEMO_MODE only (ROK-1054). */
   async setAutoHeartPrefForTest(
     userId: number,

--- a/api/src/admin/demo-test.service.ts
+++ b/api/src/admin/demo-test.service.ts
@@ -29,6 +29,7 @@ import {
   triggerClassifyForTest as triggerClassify,
   type InjectVoiceSessionParams,
 } from './demo-test-voice.helpers';
+import { setAutoHeartSteamUrlsPref } from '../discord-bot/listeners/steam-link-interest.helpers';
 
 /**
  * Service for demo/test-only endpoints used by smoke tests.
@@ -316,6 +317,15 @@ export class DemoTestService {
       .update(schema.games)
       .set({ steamAppId })
       .where(eq(schema.games.id, gameId));
+  }
+
+  /** Set the autoHeartSteamUrls preference for a user — DEMO_MODE only (ROK-1054). */
+  async setAutoHeartPrefForTest(
+    userId: number,
+    enabled: boolean,
+  ): Promise<void> {
+    await this.assertDemoMode();
+    await setAutoHeartSteamUrlsPref(this.db, userId, enabled);
   }
 
   /** Clear game_time_confirmed_at for a user -- DEMO_MODE only (ROK-999). */

--- a/api/src/discord-bot/listeners/steam-link.listener.spec.ts
+++ b/api/src/discord-bot/listeners/steam-link.listener.spec.ts
@@ -327,7 +327,7 @@ function silentSkipTests() {
     expect(mockDmSend).not.toHaveBeenCalled();
   });
 
-  it('silently skips when user is already interested in the game', async () => {
+  it('does not send an interest prompt when user is already interested in the game', async () => {
     stubGameLookup({ id: 42, name: 'CS2', steamAppId: 730 });
     stubUserLookup({ id: 7, discordId: 'discord-user-1' });
     stubInterestCheck(true);
@@ -335,7 +335,17 @@ function silentSkipTests() {
     const msg = createMessage('https://store.steampowered.com/app/730/CS2/');
     await callHandleMessage(msg);
 
-    expect(mockDmSend).not.toHaveBeenCalled();
+    // ROK-1054: a confirmation DM IS sent (see dmConfirmationTests),
+    // but the interest prompt with buttons (components) is NOT sent.
+    const calls = mockDmSend.mock.calls;
+    const hasPromptWithComponents = calls.some(
+      (call) =>
+        Array.isArray((call[0] as Record<string, unknown>)?.components) &&
+        ((call[0] as { components: unknown[] }).components.length ?? 0) > 0,
+    );
+    expect(hasPromptWithComponents).toBe(false);
+    // Should not have inserted any new interest row either
+    expect(mockDb.insert).not.toHaveBeenCalled();
   });
 }
 

--- a/api/src/discord-bot/listeners/steam-link.listener.spec.ts
+++ b/api/src/discord-bot/listeners/steam-link.listener.spec.ts
@@ -167,6 +167,10 @@ describe('SteamLinkListener', () => {
     autoHeartTests();
   });
 
+  describe('message handling — DM confirmations (ROK-1054)', () => {
+    dmConfirmationTests();
+  });
+
   describe('button handlers', () => {
     buttonHandlerTests();
   });
@@ -422,6 +426,79 @@ function buttonHandlerTests() {
     await callHandleButtonInteraction(interaction);
 
     expect(interaction.update).toHaveBeenCalled();
+  });
+}
+
+function dmConfirmationTests() {
+  it('AC1: DMs the user when they post a Steam link for a game they already have hearted', async () => {
+    // Game exists, user linked, interest already present
+    stubGameLookup({ id: 42, name: 'Counter-Strike 2', steamAppId: 730 });
+    stubUserLookup({ id: 7, discordId: 'discord-user-1' });
+    stubInterestCheck(true);
+
+    const msg = createMessage('https://store.steampowered.com/app/730/CS2/');
+    await callHandleMessage(msg);
+
+    // Expect a DM confirmation that matches the spec copy
+    expect(mockDmSend).toHaveBeenCalledTimes(1);
+    expect(mockDmSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining(
+          'You already have **Counter-Strike 2** hearted',
+        ),
+      }),
+    );
+  });
+
+  it('AC2: DMs the user when auto-heart adds a game interest', async () => {
+    stubGameLookup({ id: 42, name: 'Counter-Strike 2', steamAppId: 730 });
+    stubUserLookup({ id: 7, discordId: 'discord-user-1' });
+    stubInterestCheck(false);
+    stubAutoHeartPref(true);
+
+    const msg = createMessage('https://store.steampowered.com/app/730/CS2/');
+    await callHandleMessage(msg);
+
+    // Auto-heart should still add the interest
+    expect(mockDb.insert).toHaveBeenCalled();
+    // And DM the user with an "Auto-hearted ..." confirmation
+    expect(mockDmSend).toHaveBeenCalledTimes(1);
+    expect(mockDmSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('Auto-hearted **Counter-Strike 2**'),
+      }),
+    );
+  });
+
+  it('AC3: swallows DM send errors (user has DMs disabled) and logs a warning', async () => {
+    stubGameLookup({ id: 42, name: 'Counter-Strike 2', steamAppId: 730 });
+    stubUserLookup({ id: 7, discordId: 'discord-user-1' });
+    // Trigger the already-hearted branch so we exercise the new DM send
+    stubInterestCheck(true);
+
+    // Simulate DM send failing (e.g. user has DMs disabled)
+    const dmError = new Error('Cannot send messages to this user');
+    mockDmSend.mockRejectedValueOnce(dmError);
+
+    // Spy on the listener's logger warn method
+    const warnSpy = jest
+      .spyOn(
+        (listener as unknown as { logger: { warn: jest.Mock } }).logger,
+        'warn',
+      )
+      .mockImplementation();
+
+    const msg = createMessage('https://store.steampowered.com/app/730/CS2/');
+
+    // Should NOT throw when DM send rejects
+    await expect(callHandleMessage(msg)).resolves.toBeUndefined();
+
+    // Should have attempted the DM once
+    expect(mockDmSend).toHaveBeenCalledTimes(1);
+    // Should have logged a warning instead of throwing
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
   });
 }
 

--- a/api/src/discord-bot/listeners/steam-link.listener.ts
+++ b/api/src/discord-bot/listeners/steam-link.listener.ts
@@ -153,20 +153,52 @@ export class SteamLinkListener {
     const user = await findLinkedRlUser(this.db, message.author.id);
     if (!user) return;
 
+    await this.dispatchInterestFlow(message, user.id, game);
+  }
+
+  /**
+   * Dispatch the post-lookup interest flow: already-hearted DM, auto-heart
+   * DM, or interactive prompt depending on existing state and preferences.
+   */
+  private async dispatchInterestFlow(
+    message: Message,
+    userId: number,
+    game: { id: number; name: string },
+  ): Promise<void> {
     const alreadyInterested = await hasExistingHeartInterest(
       this.db,
-      user.id,
+      userId,
       game.id,
     );
-    if (alreadyInterested) return;
+    if (alreadyInterested) {
+      await this.sendDmSafe(
+        message,
+        `You already have **${game.name}** hearted! 💜`,
+      );
+      return;
+    }
 
-    const autoHeart = await getAutoHeartSteamUrlsPref(this.db, user.id);
+    const autoHeart = await getAutoHeartSteamUrlsPref(this.db, userId);
     if (autoHeart) {
-      await addDiscordInterest(this.db, user.id, game.id);
+      await addDiscordInterest(this.db, userId, game.id);
+      await this.sendDmSafe(message, `Auto-hearted **${game.name}**! 💜`);
       return;
     }
 
     await this.sendInterestPrompt(message, game);
+  }
+
+  /**
+   * Send a plain-text DM to the message author, swallowing and logging
+   * failures (e.g. when the user has DMs disabled from server members).
+   */
+  private async sendDmSafe(message: Message, content: string): Promise<void> {
+    try {
+      const dm = await message.author.createDM();
+      await dm.send({ content });
+    } catch (err: unknown) {
+      this.logger.warn(`Failed to send Steam interest DM: ${String(err)}`);
+    }
   }
 
   /** Discover and add a game via ITAD when it's not in the DB. */

--- a/api/src/discord-bot/listeners/steam-link.listener.ts
+++ b/api/src/discord-bot/listeners/steam-link.listener.ts
@@ -197,7 +197,9 @@ export class SteamLinkListener {
       const dm = await message.author.createDM();
       await dm.send({ content });
     } catch (err: unknown) {
-      this.logger.warn(`Failed to send Steam interest DM: ${String(err)}`);
+      const detail =
+        err instanceof Error ? (err.stack ?? err.message) : String(err);
+      this.logger.warn(`Failed to send Steam interest DM: ${detail}`);
     }
   }
 

--- a/tools/test-bot/src/smoke/tests/cdp-steam-interest.test.ts
+++ b/tools/test-bot/src/smoke/tests/cdp-steam-interest.test.ts
@@ -76,6 +76,15 @@ function buildCdpSteamTests(): SmokeTest[] {
       steamAppId: TEST_STEAM_APP_ID,
     });
 
+    // Read the real game name from the DB — ctx.games[0].name is a synthetic
+    // `Game <id>` label (see setup.ts#buildDemoData). The listener reads the
+    // true name from Postgres so assertions must use the DB value.
+    const dbGame = await ctx.api.post<{ id: number; name: string }>(
+      '/admin/test/get-game',
+      { id: game.id },
+    );
+    const gameName = dbGame.name;
+
     // Get the logged-in user's Discord ID via CDP
     const discordId = await getLoggedInDiscordId(page);
     if (!discordId) {
@@ -97,7 +106,16 @@ function buildCdpSteamTests(): SmokeTest[] {
       gameId: game.id,
     });
 
-    return { gameName: game.name, discordId };
+    // Reset auto-heart preference so tests start from a known-clean baseline.
+    // A prior run (e.g. the AC2 auto-heart test) can otherwise leave
+    // autoHeartSteamUrls=true and make the interest-prompt test hit the
+    // auto-heart branch instead.
+    await ctx.api.post('/admin/test/set-auto-heart-pref', {
+      userId: ctx.testUserId,
+      enabled: false,
+    });
+
+    return { gameName, discordId };
   }
 
   /** Navigate to DMs and read the most recent DM message. */

--- a/tools/test-bot/src/smoke/tests/cdp-steam-interest.test.ts
+++ b/tools/test-bot/src/smoke/tests/cdp-steam-interest.test.ts
@@ -143,28 +143,44 @@ function buildCdpSteamTests(): SmokeTest[] {
     return '';
   }
 
+  /**
+   * Post a Steam URL in the test channel after ensuring the page is on the
+   * correct channel and any ephemeral messages are dismissed.
+   */
+  async function postSteamUrl(
+    ctx: TestContext,
+    p: import('playwright').Page,
+  ): Promise<void> {
+    const { typeMessage, navigateToChannel, dismissEphemeralMessages } =
+      await import('../cdp/discord-page.js');
+    await navigateToChannel(p, SMOKE.guildId, ctx.defaultChannelId);
+    await p.waitForTimeout(2000);
+    await dismissEphemeralMessages(p);
+    const url = `https://store.steampowered.com/app/${TEST_STEAM_APP_ID}/`;
+    await typeMessage(p, url);
+    // Give the bot time to process the message and dispatch a DM.
+    await p.waitForTimeout(5000);
+  }
+
+  /** Return to the default test channel for subsequent tests. */
+  async function returnToTestChannel(
+    ctx: TestContext,
+    p: import('playwright').Page,
+  ): Promise<void> {
+    const { navigateToChannel } = await import('../cdp/discord-page.js');
+    await navigateToChannel(p, SMOKE.guildId, ctx.defaultChannelId);
+    await p.waitForTimeout(1000);
+  }
+
   const tests: SmokeTest[] = [
     {
       name: 'CDP: Steam URL triggers DM interest prompt',
       category: 'cdp-command',
       async run(ctx) {
         const p = await getPage(ctx);
-        const { typeMessage, navigateToChannel, dismissEphemeralMessages } =
-          await import('../cdp/discord-page.js');
         const { gameName } = await setupFixtures(ctx, p);
-        // Re-navigate after the reload in getLoggedInDiscordId
-        await navigateToChannel(p, SMOKE.guildId, ctx.defaultChannelId);
-        await p.waitForTimeout(2000);
-        await dismissEphemeralMessages(p);
+        await postSteamUrl(ctx, p);
 
-        // Send the Steam URL in the channel
-        const url = `https://store.steampowered.com/app/${TEST_STEAM_APP_ID}/`;
-        await typeMessage(p, url);
-
-        // Wait for bot to process and send DM
-        await p.waitForTimeout(5000);
-
-        // Check for DM
         const dmText = await readLastDm(p, 15_000);
 
         if (!dmText) {
@@ -182,9 +198,90 @@ function buildCdpSteamTests(): SmokeTest[] {
           );
         }
 
-        // Navigate back to the test channel for subsequent tests
-        await navigateToChannel(p, SMOKE.guildId, ctx.defaultChannelId);
-        await p.waitForTimeout(1000);
+        await returnToTestChannel(ctx, p);
+      },
+    },
+    {
+      name: 'CDP: Steam URL on already-hearted game triggers "already hearted" DM',
+      category: 'cdp-command',
+      async run(ctx) {
+        const p = await getPage(ctx);
+        const { gameName } = await setupFixtures(ctx, p);
+
+        // Pre-heart the game so the listener takes the "already hearted" path.
+        const game = ctx.games[0];
+        if (!game) throw new Error('No games in test context');
+        await ctx.api.post('/admin/test/add-game-interest', {
+          userId: ctx.testUserId,
+          gameId: game.id,
+        });
+
+        await postSteamUrl(ctx, p);
+
+        const dmText = await readLastDm(p, 15_000);
+
+        if (!dmText) {
+          throw new Error(
+            `Expected "already hearted" DM for "${gameName}", got no DM from bot`,
+          );
+        }
+
+        const lc = dmText.toLowerCase();
+        const hasGameName = lc.includes(gameName.toLowerCase());
+        const hasAlreadyPhrase = lc.includes('already have');
+        if (!hasGameName || !hasAlreadyPhrase) {
+          throw new Error(
+            `DM content "${dmText}" missing expected markers ` +
+              `(gameName=${hasGameName}, alreadyHavePhrase=${hasAlreadyPhrase}) ` +
+              `for game "${gameName}"`,
+          );
+        }
+
+        await returnToTestChannel(ctx, p);
+      },
+    },
+    {
+      name: 'CDP: Steam URL with auto-heart enabled triggers "auto-hearted" DM',
+      category: 'cdp-command',
+      async run(ctx) {
+        const p = await getPage(ctx);
+        const { gameName } = await setupFixtures(ctx, p);
+
+        // Enable auto-heart preference so the listener hearts silently + DMs.
+        await ctx.api.post('/admin/test/set-auto-heart-pref', {
+          userId: ctx.testUserId,
+          enabled: true,
+        });
+
+        try {
+          await postSteamUrl(ctx, p);
+
+          const dmText = await readLastDm(p, 15_000);
+
+          if (!dmText) {
+            throw new Error(
+              `Expected "auto-hearted" DM for "${gameName}", got no DM from bot`,
+            );
+          }
+
+          const lc = dmText.toLowerCase();
+          const hasGameName = lc.includes(gameName.toLowerCase());
+          const hasAutoPhrase = lc.includes('auto-hearted');
+          if (!hasGameName || !hasAutoPhrase) {
+            throw new Error(
+              `DM content "${dmText}" missing expected markers ` +
+                `(gameName=${hasGameName}, autoHeartedPhrase=${hasAutoPhrase}) ` +
+                `for game "${gameName}"`,
+            );
+          }
+        } finally {
+          // Always disable the preference so it doesn't leak into later tests.
+          await ctx.api.post('/admin/test/set-auto-heart-pref', {
+            userId: ctx.testUserId,
+            enabled: false,
+          });
+          await returnToTestChannel(ctx, p);
+        }
       },
     },
   ];


### PR DESCRIPTION
## Summary

- `SteamLinkListener.processSingleAppId` no longer exits silently on the already-hearted or auto-heart paths. Both now send a DM to the user:
  - Already hearted → `"You already have **${game.name}** hearted! 💜"`
  - Auto-heart → `"Auto-hearted **${game.name}**! 💜"`
- DM sends wrapped in a new private `sendDmSafe` helper that catches errors and logs via `logger.warn` with the error stack preserved, so users with DMs disabled no longer crash the listener.
- Post-lookup branching extracted to a `dispatchInterestFlow` helper to stay under the 30-line/function ESLint limit.
- Existing prompt flow (new game, no auto-heart) unchanged.

## Test coverage

- **Unit (Jest):** 3 new failing-first tests in `steam-link.listener.spec.ts` covering AC1/AC2/AC3. Full api suite green (5319 tests).
- **CDP smoke (real Discord, real DB):** 2 new cases in `cdp-steam-interest.test.ts` exercising the already-hearted and auto-heart paths end-to-end. New admin test endpoints added to support fixtures: `POST /admin/test/set-auto-heart-pref`, `POST /admin/test/get-game`. `setupFixtures` now reads the real DB game name (previously synthetic) and resets auto-heart to `false` each run to prevent cross-test leaks.
- All 3 target CDP tests pass against local dev + Discord Electron with CDP.

## Linear

ROK-1054

Tech debt + flake follow-ups filed: ROK-1071, ROK-1072, ROK-1073, ROK-1074, ROK-1075.

## Test plan

- [x] Unit tests added/updated (3 new + 1 assertion tightened)
- [x] CI passes (build + lint + typecheck + api tests)
- [x] Operator tested locally (CDP smoke 3/3 green for this story's ACs)
- [x] Code review passed (APPROVED, no auto-fixes; TD-4 resolved inline with stack-preserving log)
- [x] Smoke tests passed (85/87 — 2 unrelated pre-existing flakes filed as ROK-1074, ROK-1075)