### PR TITLE
chore: batch 2026-04-17 (ROK-1056, ROK-1059)

### DIFF
--- a/api/src/common/testing/cross-suite-state.integration.spec.ts
+++ b/api/src/common/testing/cross-suite-state.integration.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * Regression: cross-suite in-memory state is cleared by truncateAllTables.
+ *
+ * ROK-1059 — full-suite local runs were flaking with 401 on authenticated
+ * POSTs issued right after `loginAsAdmin`. Root cause: `jwt_block:<userId>`
+ * entries written by earlier files (via `TokenBlocklistService.blockUser`
+ * during role changes / deletes) stayed in the module-level mock Redis
+ * store. When the fresh admin's id collided with one of those stale keys,
+ * `JwtStrategy.validate` rejected the just-issued token.
+ *
+ * `truncateAllTables` must now clear both the auth-user cache and the
+ * `jwt_block:*` keys from the mock Redis store — the one authoritative
+ * "reset module state" entry point between suites.
+ */
+import { getTestApp, type TestApp } from './test-app';
+import { truncateAllTables, loginAsAdmin } from './integration-helpers';
+import {
+  getCachedAuthUser,
+  setCachedAuthUser,
+} from '../../auth/auth-user-cache';
+import { TokenBlocklistService } from '../../auth/token-blocklist.service';
+
+function describeCrossSuiteState() {
+  let testApp: TestApp;
+
+  beforeAll(async () => {
+    testApp = await getTestApp();
+  });
+
+  afterEach(async () => {
+    testApp.seed = await truncateAllTables(testApp.db);
+  });
+
+  it('clears jwt_block:* keys so a fresh admin token is accepted after truncate', async () => {
+    const blocklist = testApp.app.get(TokenBlocklistService);
+    // Simulate an earlier suite blocking the currently-seeded admin.
+    await blocklist.blockUser(testApp.seed.adminUser.id);
+    const storeBefore = testApp.redisMock.store;
+    expect(
+      [...storeBefore.keys()].some((k) => k.startsWith('jwt_block:')),
+    ).toBe(true);
+
+    // Truncate + re-seed — this is what every suite's afterEach does.
+    testApp.seed = await truncateAllTables(testApp.db);
+
+    const storeAfter = testApp.redisMock.store;
+    expect(
+      [...storeAfter.keys()].filter((k) => k.startsWith('jwt_block:')),
+    ).toEqual([]);
+
+    // The canonical failure mode: login + authenticated request must 200,
+    // not 401, right after truncate.
+    const token = await loginAsAdmin(testApp.request, testApp.seed);
+    const res = await testApp.request
+      .get('/events/my-dashboard')
+      .set('Authorization', `Bearer ${token}`);
+    expect(res.status).toBe(200);
+  });
+
+  it('clears the auth-user cache so stale role/discordId data does not leak', async () => {
+    const staleId = 999_999;
+    setCachedAuthUser(staleId, { role: 'member', discordId: 'stale' });
+    expect(getCachedAuthUser(staleId)).not.toBeNull();
+
+    testApp.seed = await truncateAllTables(testApp.db);
+
+    expect(getCachedAuthUser(staleId)).toBeNull();
+  });
+}
+
+describe('Cross-suite state reset (integration)', () =>
+  describeCrossSuiteState());

--- a/api/src/common/testing/integration-helpers.ts
+++ b/api/src/common/testing/integration-helpers.ts
@@ -10,6 +10,8 @@ import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import * as supertest from 'supertest';
 import type TestAgent from 'supertest/lib/agent';
 import * as schema from '../../drizzle/schema';
+import { clearAuthUserCache } from '../../auth/auth-user-cache';
+import { INSTANCE_KEY, type TestApp } from './test-app';
 
 export interface SeededData {
   adminUser: typeof schema.users.$inferSelect;
@@ -110,8 +112,33 @@ export async function truncateAllTables(
     );
   }
 
+  // Reset cross-suite in-memory state that can otherwise leak between files
+  // during a full integration run (ROK-1059). The mock Redis store and the
+  // auth-user cache are module-level singletons held alive by the TestApp
+  // singleton on `process`. Without clearing them here, a `jwt_block:<userId>`
+  // entry written by an earlier suite can silently invalidate tokens issued
+  // to the freshly re-seeded admin (whose new id may collide with a stale key).
+  clearAuthUserCache();
+  clearJwtBlockKeysFromMockRedis();
+
   // Re-seed baseline data
   return seedBaseline(db);
+}
+
+/**
+ * Delete all `jwt_block:*` entries from the in-memory Redis mock backing the
+ * current TestApp singleton. No-op when no TestApp is registered yet (which
+ * happens during the very first truncate before the mock is created).
+ */
+function clearJwtBlockKeysFromMockRedis(): void {
+  const instance = (process as unknown as Record<string, TestApp | null>)[
+    INSTANCE_KEY
+  ];
+  const store = instance?.redisMock?.store;
+  if (!store) return;
+  for (const key of [...store.keys()]) {
+    if (key.startsWith('jwt_block:')) store.delete(key);
+  }
 }
 
 /**

--- a/api/src/common/testing/test-app.ts
+++ b/api/src/common/testing/test-app.ts
@@ -75,9 +75,12 @@ function mockRedisIncr(store: Map<string, string>) {
   };
 }
 
-/** In-memory Redis mock that satisfies the interface used by the app. */
-function createRedisMock() {
-  const store = new Map<string, string>();
+export interface RedisMockHandle {
+  client: ReturnType<typeof buildRedisMockClient>;
+  store: Map<string, string>;
+}
+
+function buildRedisMockClient(store: Map<string, string>) {
   return {
     get: (key: string) => Promise.resolve(store.get(key) ?? null),
     set: mockRedisSet(store),
@@ -96,8 +99,14 @@ function createRedisMock() {
     quit: () => Promise.resolve('OK'),
     disconnect: () => undefined,
     status: 'ready',
-    duplicate: () => createRedisMock(),
+    duplicate: () => buildRedisMockClient(store),
   };
+}
+
+/** In-memory Redis mock whose backing store is exposed for cross-suite reset. */
+function createRedisMock(): RedisMockHandle {
+  const store = new Map<string, string>();
+  return { client: buildRedisMockClient(store), store };
 }
 
 export interface TestApp {
@@ -107,6 +116,9 @@ export interface TestApp {
   seed: SeededData;
   /** Only set when running locally via Testcontainers; null in CI. */
   container: StartedPostgreSqlContainer | null;
+  /** Handle to the in-memory Redis mock. Exposed so truncateAllTables can
+   * clear cross-suite state (e.g. jwt_block:* keys) without call-site changes. */
+  redisMock: RedisMockHandle;
 }
 
 /**
@@ -116,7 +128,7 @@ export interface TestApp {
  * The `process` object IS shared across VM contexts in the same
  * Node.js process, making it a reliable cross-file singleton store.
  */
-const INSTANCE_KEY = '__raid_ledger_test_app';
+export const INSTANCE_KEY = '__raid_ledger_test_app';
 
 function getInstance(): TestApp | null {
   return (
@@ -177,20 +189,25 @@ export async function getTestApp(): Promise<TestApp> {
   if (cached) return cached;
   const { connectionString, container } = await provisionDatabase();
   const db = await setupDatabase(connectionString);
+  const redisMock = createRedisMock();
+  // Register the mock BEFORE seeding so truncateAllTables can reset it
+  // via the process-level singleton during its first (pre-app-init) call.
+  const preInstance: Partial<TestApp> = { db, redisMock };
+  setInstance(preInstance as TestApp);
   const seed = await truncateAllTables(db);
   setTestEnvVars(connectionString);
   const moduleRef = await Test.createTestingModule({ imports: [AppModule] })
     .overrideProvider(DrizzleAsyncProvider)
     .useValue(db)
     .overrideProvider(REDIS_CLIENT)
-    .useValue(createRedisMock())
+    .useValue(redisMock.client)
     .compile();
   const app = moduleRef.createNestApplication();
   await app.init();
   const request = supertest.default(
     app.getHttpServer() as import('http').Server,
   );
-  const testApp: TestApp = { app, request, db, seed, container };
+  const testApp: TestApp = { app, request, db, seed, container, redisMock };
   setInstance(testApp);
   return testApp;
 }

--- a/web/src/components/features/game-time/GameTimeWidget.tsx
+++ b/web/src/components/features/game-time/GameTimeWidget.tsx
@@ -7,7 +7,7 @@ import type { GameTimePreviewBlock } from './GameTimeGrid';
 import type { GameTimeEventBlock } from '@raid-ledger/contract';
 import { EventBlockPopover } from './EventBlockPopover';
 import { AttendeeAvatars } from '../../calendar/AttendeeAvatars';
-import { checkGameTimeOverlap } from './game-time-overlap.utils';
+import { checkGameTimeOverlap, walkEventHours } from './game-time-overlap.utils';
 
 interface AttendeePreview {
     id: number;
@@ -46,18 +46,12 @@ function computeSmartHourRange(startTime: string, endTime: string): [number, num
 }
 
 function collectDayHours(startTime: string, endTime: string): Map<number, number[]> {
-    const start = new Date(startTime);
-    const end = new Date(endTime);
-    const cursor = new Date(start);
-    cursor.setMinutes(0, 0, 0);
-    if (cursor < start) cursor.setHours(cursor.getHours() + 1);
     const dayHours = new Map<number, number[]>();
-    while (cursor < end) {
-        const hours = dayHours.get(cursor.getDay()) ?? [];
-        hours.push(cursor.getHours());
-        dayHours.set(cursor.getDay(), hours);
-        cursor.setHours(cursor.getHours() + 1);
-    }
+    walkEventHours(startTime, endTime, (dayOfWeek, hour) => {
+        const hours = dayHours.get(dayOfWeek) ?? [];
+        hours.push(hour);
+        dayHours.set(dayOfWeek, hours);
+    });
     return dayHours;
 }
 

--- a/web/src/components/features/game-time/game-time-overlap.utils.test.ts
+++ b/web/src/components/features/game-time/game-time-overlap.utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { checkGameTimeOverlap } from './game-time-overlap.utils';
+import { checkGameTimeOverlap, walkEventHours } from './game-time-overlap.utils';
 
 /**
  * ROK-1039 — `checkGameTimeOverlap` must use Sunday-first dayOfWeek convention
@@ -171,5 +171,103 @@ describe('checkGameTimeOverlap — edge cases', () => {
         const endTime = localISO(1, 19, 45);   // Monday 19:45
 
         expect(checkGameTimeOverlap(slots, startTime, endTime)).toBe(true);
+    });
+});
+
+/**
+ * ROK-1056 — walkEventHours is the shared cursor iterator used by both
+ * checkGameTimeOverlap and GameTimeWidget.collectDayHours. These tests lock
+ * the iterator's contract so either caller can rely on identical behavior.
+ */
+function collectVisits(startTime: string, endTime: string): Array<[number, number]> {
+    const visits: Array<[number, number]> = [];
+    walkEventHours(startTime, endTime, (dayOfWeek, hour) => {
+        visits.push([dayOfWeek, hour]);
+    });
+    return visits;
+}
+
+describe('walkEventHours — iterator contract', () => {
+    it('visits every whole hour between start and end', () => {
+        const visits = collectVisits(localISO(1, 19), localISO(1, 22));
+        expect(visits).toEqual([[1, 19], [1, 20], [1, 21]]);
+    });
+
+    it('floors sub-hour start to the next whole hour', () => {
+        // 19:30 → first whole hour inside [start, end) is 20:00
+        const visits = collectVisits(localISO(1, 19, 30), localISO(1, 21));
+        expect(visits).toEqual([[1, 20]]);
+    });
+
+    it('visits the start hour when start is exactly on the hour', () => {
+        const visits = collectVisits(localISO(1, 19), localISO(1, 19, 45));
+        expect(visits).toEqual([[1, 19]]);
+    });
+
+    it('does not visit the end hour when end is exactly on the hour', () => {
+        const visits = collectVisits(localISO(1, 19), localISO(1, 20));
+        expect(visits).toEqual([[1, 19]]);
+    });
+
+    it('crosses midnight and updates dayOfWeek', () => {
+        const visits = collectVisits(localISO(5, 23), localISO(6, 2));
+        expect(visits).toEqual([[5, 23], [6, 0], [6, 1]]);
+    });
+
+    it('yields nothing when end <= start', () => {
+        expect(collectVisits(localISO(1, 19), localISO(1, 19))).toEqual([]);
+        expect(collectVisits(localISO(1, 20), localISO(1, 19))).toEqual([]);
+    });
+
+    it('yields nothing when the range is entirely inside a single sub-hour window', () => {
+        // 19:15 → 19:45 has no whole-hour boundary inside [start, end)
+        expect(collectVisits(localISO(1, 19, 15), localISO(1, 19, 45))).toEqual([]);
+    });
+});
+
+/**
+ * ROK-1056 — DST boundary sanity. We don't pin the test timezone, so instead
+ * of asserting exact hour numbers (which depend on host TZ), we assert that
+ * checkGameTimeOverlap agrees with walkEventHours across the boundary: for
+ * every hour the walker visits, a slot marked available at that (day, hour)
+ * must produce an overlap, and the absence of matching slots must not.
+ *
+ * 2026-03-08 is US spring-forward, 2026-11-01 is US fall-back. JS's
+ * setHours(getHours()+1) is DST-aware, so on spring-forward the skipped
+ * wall-clock hour is never visited, and on fall-back the repeated wall-clock
+ * hour is visited once per occurrence.
+ */
+describe('checkGameTimeOverlap — DST boundary consistency (ROK-1056)', () => {
+    it('spring-forward Sunday 2026-03-08: overlap answer matches walker visits', () => {
+        // 2026-03-08 is a Sunday (dayOffset 0 from 2026-03-08). Anchor directly.
+        const start = new Date(2026, 2, 8, 1, 0, 0, 0).toISOString();   // Sun 01:00 local
+        const end = new Date(2026, 2, 8, 4, 0, 0, 0).toISOString();     // Sun 04:00 local
+        const visits = collectVisits(start, end);
+
+        expect(visits.length).toBeGreaterThan(0);
+        // Every visited (day, hour) with a matching available slot produces overlap.
+        for (const [dayOfWeek, hour] of visits) {
+            const slots: Slot[] = [{ dayOfWeek, hour, status: 'available' }];
+            expect(checkGameTimeOverlap(slots, start, end)).toBe(true);
+        }
+        // A slot at an hour the walker did not visit must not produce overlap.
+        const visitedKeys = new Set(visits.map(([d, h]) => `${d}:${h}`));
+        const unvisitedHour = [0, 1, 2, 3, 4, 5].find((h) => !visitedKeys.has(`${visits[0][0]}:${h}`));
+        if (unvisitedHour !== undefined) {
+            const slots: Slot[] = [{ dayOfWeek: visits[0][0], hour: unvisitedHour, status: 'available' }];
+            expect(checkGameTimeOverlap(slots, start, end)).toBe(false);
+        }
+    });
+
+    it('fall-back Sunday 2026-11-01: overlap answer matches walker visits', () => {
+        const start = new Date(2026, 10, 1, 1, 0, 0, 0).toISOString();  // Sun 01:00 local
+        const end = new Date(2026, 10, 1, 3, 0, 0, 0).toISOString();    // Sun 03:00 local
+        const visits = collectVisits(start, end);
+
+        expect(visits.length).toBeGreaterThan(0);
+        for (const [dayOfWeek, hour] of visits) {
+            const slots: Slot[] = [{ dayOfWeek, hour, status: 'available' }];
+            expect(checkGameTimeOverlap(slots, start, end)).toBe(true);
+        }
     });
 });

--- a/web/src/components/features/game-time/game-time-overlap.utils.ts
+++ b/web/src/components/features/game-time/game-time-overlap.utils.ts
@@ -1,3 +1,35 @@
+import type { GameTimeSlot } from '@raid-ledger/contract';
+
+/**
+ * Walks the event [startTime, endTime) range hour-by-hour, invoking `visit`
+ * with the local `dayOfWeek` (0=Sun..6=Sat) and `hour` at each step.
+ *
+ * The cursor floors to the start hour and only advances when it sits strictly
+ * before the start (sub-hour starts skip the partial hour). Using
+ * `setHours(getHours() + 1)` makes the walk DST-aware: on spring-forward the
+ * skipped wall-clock hour is never visited; on fall-back the repeated hour is
+ * visited once per wall-clock occurrence.
+ *
+ * @param startTime - Event start as ISO string
+ * @param endTime - Event end as ISO string
+ * @param visit - Invoked per covered hour with `(dayOfWeek, hour)`
+ */
+export function walkEventHours(
+    startTime: string,
+    endTime: string,
+    visit: (dayOfWeek: number, hour: number) => void,
+): void {
+    const start = new Date(startTime);
+    const end = new Date(endTime);
+    const cursor = new Date(start);
+    cursor.setMinutes(0, 0, 0);
+    if (cursor < start) cursor.setHours(cursor.getHours() + 1);
+    while (cursor < end) {
+        visit(cursor.getDay(), cursor.getHours());
+        cursor.setHours(cursor.getHours() + 1);
+    }
+}
+
 /**
  * Returns true if any hour covered by the event matches an "available" slot
  * in the user's weekly game-time template.
@@ -7,10 +39,8 @@
  * to Sunday-first before sending to the client (see
  * `api/src/users/game-time.service.ts`), so no day conversion is needed here.
  *
- * The cursor is floored to the event's start hour and advances one hour at a
- * time until the event end; any hour that lands on an available slot counts
- * as an overlap. A slot counts as "available" when `status === 'available'`
- * or `status` is absent.
+ * A slot counts as "available" when `status === 'available'` or `status` is
+ * absent.
  *
  * @param slots - User's weekly game-time template slots (Sunday-first)
  * @param startTime - Event start as ISO string
@@ -18,7 +48,7 @@
  * @returns true when the event intersects at least one available slot
  */
 export function checkGameTimeOverlap(
-    slots: Array<{ dayOfWeek: number; hour: number; status?: string }>,
+    slots: Pick<GameTimeSlot, 'dayOfWeek' | 'hour' | 'status'>[],
     startTime: string,
     endTime: string,
 ): boolean {
@@ -28,14 +58,10 @@ export function checkGameTimeOverlap(
             .filter((s) => s.status === 'available' || !s.status)
             .map((s) => `${s.dayOfWeek}:${s.hour}`),
     );
-    const start = new Date(startTime);
-    const end = new Date(endTime);
-    const cursor = new Date(start);
-    cursor.setMinutes(0, 0, 0);
-    if (cursor < start) cursor.setHours(cursor.getHours() + 1);
-    while (cursor < end) {
-        if (templateSet.has(`${cursor.getDay()}:${cursor.getHours()}`)) return true;
-        cursor.setHours(cursor.getHours() + 1);
-    }
-    return false;
+    let found = false;
+    walkEventHours(startTime, endTime, (dayOfWeek, hour) => {
+        if (found) return;
+        if (templateSet.has(`${dayOfWeek}:${hour}`)) found = true;
+    });
+    return found;
 }


### PR DESCRIPTION
## Summary

Batch of 2 tech-debt stories — all low-risk, test-infra and refactor only.

- **ROK-1056** (Tech Debt, Events) — game-time overlap util: tighten param type to contract `GameTimeSlot`, add DST spring-forward + fall-back tests, extract shared `walkEventHours` cursor iterator consumed by both `checkGameTimeOverlap` and `GameTimeWidget.collectDayHours`.
- **ROK-1059** (Tech Debt, Testing Infra) — root-caused local-only integration flake (events-dashboard 401 after `truncateAllTables`): in-memory singleton leak where `auth-user-cache.ts` Map + mock Redis `jwt_block:*` keys persisted across test files. `truncateAllTables` now clears both after re-seed. Added `cross-suite-state.integration.spec.ts` regression test. No production auth code touched.

## Validation

| Gate | Result |
|---|---|
| Per-story code review | PASS (both APPROVED) |
| Test gap analysis | PASS |
| Build / TypeScript / Lint (api + web) | PASS (0 errors) |
| Unit tests (api) | PASS — 385 suites / 5313 tests |
| Unit tests (web) | PASS — 218 files / 2843 tests |
| Integration tests (api, full suite) | PASS — 50 suites / 645 tests |
| Playwright smoke | PASS — 466 passed, 0 failed |

## Stories

| Story | Label | Reviewer verdict |
|-------|-------|------------------|
| ROK-1056 | Tech Debt (Events) | APPROVED |
| ROK-1059 | Tech Debt (Testing Infra) | APPROVED |

🤖 Generated with [Claude Code](https://claude.com/claude-code)