### PR TITLE
ROK-1063: feat: lineup title & description

### DIFF
--- a/api/src/activity-log/activity-log.integration.spec.ts
+++ b/api/src/activity-log/activity-log.integration.spec.ts
@@ -49,7 +49,7 @@ function describeActivityLog() {
       const createRes = await testApp.request
         .post('/lineups')
         .set('Authorization', `Bearer ${adminToken}`)
-        .send({});
+        .send({ title: 'Activity Log Test' });
 
       const lineupId = createRes.body.id as number;
       const res = await testApp.request
@@ -74,7 +74,7 @@ function describeActivityLog() {
       const createRes = await testApp.request
         .post('/lineups')
         .set('Authorization', `Bearer ${adminToken}`)
-        .send({});
+        .send({ title: 'Activity Log Test' });
       const lineupId = createRes.body.id as number;
 
       await testApp.request
@@ -104,7 +104,7 @@ function describeActivityLog() {
       const createRes = await testApp.request
         .post('/lineups')
         .set('Authorization', `Bearer ${adminToken}`)
-        .send({});
+        .send({ title: 'Activity Log Test' });
       const lineupId = createRes.body.id as number;
 
       await testApp.request
@@ -124,7 +124,7 @@ function describeActivityLog() {
       const createRes = await testApp.request
         .post('/lineups')
         .set('Authorization', `Bearer ${adminToken}`)
-        .send({});
+        .send({ title: 'Activity Log Test' });
       const lineupId = createRes.body.id as number;
 
       await testApp.request

--- a/api/src/drizzle/migrations/0122_lineup_title_description.sql
+++ b/api/src/drizzle/migrations/0122_lineup_title_description.sql
@@ -1,0 +1,16 @@
+-- ROK-1063 — feat: lineup title & description
+--
+-- Adds `title` (VARCHAR(100) NOT NULL) and `description` (TEXT NULL) to
+-- community_lineups. Existing rows (dev/staging — no prod data) are
+-- backfilled with `Lineup — {Month YYYY}` based on created_at before the
+-- NOT NULL constraint is applied.
+--
+-- Hand-edited after drizzle-kit generate to include the backfill step
+-- (codegen emits the column as NOT NULL directly, which would fail on
+-- any table that already has rows).
+ALTER TABLE "community_lineups" ADD COLUMN "title" varchar(100);--> statement-breakpoint
+ALTER TABLE "community_lineups" ADD COLUMN "description" text;--> statement-breakpoint
+UPDATE "community_lineups"
+  SET "title" = 'Lineup — ' || to_char("created_at", 'FMMonth YYYY')
+  WHERE "title" IS NULL;--> statement-breakpoint
+ALTER TABLE "community_lineups" ALTER COLUMN "title" SET NOT NULL;

--- a/api/src/drizzle/migrations/0123_lineup_created_embed_refs.sql
+++ b/api/src/drizzle/migrations/0123_lineup_created_embed_refs.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "community_lineups" ADD COLUMN "discord_created_channel_id" text;--> statement-breakpoint
+ALTER TABLE "community_lineups" ADD COLUMN "discord_created_message_id" text;

--- a/api/src/drizzle/migrations/meta/0122_snapshot.json
+++ b/api/src/drizzle/migrations/meta/0122_snapshot.json
@@ -1,0 +1,6745 @@
+{
+  "id": "de40f36f-f68f-4f1a-aba2-24eed256117c",
+  "prevId": "0652cbfc-666f-4b37-836e-244db74db491",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_id": {
+          "name": "steam_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_avatar_url": {
+          "name": "custom_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_time_confirmed_at": {
+          "name": "game_time_confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_discord_id_unique": {
+          "name": "users_discord_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_id"
+          ]
+        },
+        "users_steam_id_unique": {
+          "name": "users_steam_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "steam_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "display_name_length": {
+          "name": "display_name_length",
+          "value": "\"users\".\"display_name\" IS NULL OR (LENGTH(\"users\".\"display_name\") >= 2 AND LENGTH(\"users\".\"display_name\") <= 30)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "tsrange",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_config": {
+          "name": "slot_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_attendees": {
+          "name": "max_attendees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_unbench": {
+          "name": "auto_unbench",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "recurrence_group_id": {
+          "name": "recurrence_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_rule": {
+          "name": "recurrence_rule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_instances": {
+          "name": "content_instances",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_15min": {
+          "name": "reminder_15min",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_1hour": {
+          "name": "reminder_1hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_24hour": {
+          "name": "reminder_24hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_ad_hoc": {
+          "name": "is_ad_hoc",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ad_hoc_status": {
+          "name": "ad_hoc_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_binding_id": {
+          "name": "channel_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_scheduled_event_id": {
+          "name": "discord_scheduled_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extended_until": {
+          "name": "extended_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_channel_override": {
+          "name": "notification_channel_override",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rescheduling_poll_id": {
+          "name": "rescheduling_poll_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_events_creator_id": {
+          "name": "idx_events_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_game_id": {
+          "name": "idx_events_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_ad_hoc_binding": {
+          "name": "idx_events_ad_hoc_binding",
+          "columns": [
+            {
+              "expression": "channel_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_ad_hoc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_recurrence_group_id": {
+          "name": "idx_events_recurrence_group_id",
+          "columns": [
+            {
+              "expression": "recurrence_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_cancelled_at": {
+          "name": "idx_events_cancelled_at",
+          "columns": [
+            {
+              "expression": "cancelled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_discord_scheduled_event_id": {
+          "name": "idx_events_discord_scheduled_event_id",
+          "columns": [
+            {
+              "expression": "discord_scheduled_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_game_id_games_id_fk": {
+          "name": "events_game_id_games_id_fk",
+          "tableFrom": "events",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_creator_id_users_id_fk": {
+          "name": "events_creator_id_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_channel_binding_id_channel_bindings_id_fk": {
+          "name": "events_channel_binding_id_channel_bindings_id_fk",
+          "tableFrom": "events",
+          "tableTo": "channel_bindings",
+          "columnsFrom": [
+            "channel_binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_types": {
+      "name": "event_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_player_cap": {
+          "name": "default_player_cap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_duration_minutes": {
+          "name": "default_duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_composition": {
+          "name": "requires_composition",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_event_types_game_id": {
+          "name": "idx_event_types_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_types_game_id_games_id_fk": {
+          "name": "event_types_game_id_games_id_fk",
+          "tableFrom": "event_types",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_types_game_slug_unique": {
+          "name": "event_types_game_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "game_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "igdb_id": {
+          "name": "igdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregated_rating": {
+          "name": "aggregated_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "popularity": {
+          "name": "popularity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_modes": {
+          "name": "game_modes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "themes": {
+          "name": "themes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "platforms": {
+          "name": "platforms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "screenshots": {
+          "name": "screenshots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "videos": {
+          "name": "videos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "first_release_date": {
+          "name": "first_release_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_count": {
+          "name": "player_count",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitch_game_id": {
+          "name": "twitch_game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_app_id": {
+          "name": "steam_app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crossplay": {
+          "name": "crossplay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color_hex": {
+          "name": "color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_roles": {
+          "name": "has_roles",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_specs": {
+          "name": "has_specs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "itad_game_id": {
+          "name": "itad_game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_boxart_url": {
+          "name": "itad_boxart_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_tags": {
+          "name": "itad_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "max_characters_per_user": {
+          "name": "max_characters_per_user",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "api_namespace_prefix": {
+          "name": "api_namespace_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_current_price": {
+          "name": "itad_current_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_current_cut": {
+          "name": "itad_current_cut",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_current_shop": {
+          "name": "itad_current_shop",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_current_url": {
+          "name": "itad_current_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_lowest_price": {
+          "name": "itad_lowest_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_lowest_cut": {
+          "name": "itad_lowest_cut",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_price_updated_at": {
+          "name": "itad_price_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "early_access": {
+          "name": "early_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "igdb_enrichment_status": {
+          "name": "igdb_enrichment_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "igdb_enrichment_retry_count": {
+          "name": "igdb_enrichment_retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "games_igdb_id_unique": {
+          "name": "games_igdb_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "igdb_id"
+          ]
+        },
+        "games_slug_unique": {
+          "name": "games_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "games_itad_game_id_unique": {
+          "name": "games_itad_game_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "itad_game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_signups": {
+      "name": "event_signups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_avatar_hash": {
+          "name": "discord_avatar_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation_status": {
+          "name": "confirmation_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'signed_up'"
+        },
+        "preferred_roles": {
+          "name": "preferred_roles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attendance_status": {
+          "name": "attendance_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attendance_recorded_at": {
+          "name": "attendance_recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roached_out_at": {
+          "name": "roached_out_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_up_at": {
+          "name": "signed_up_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_event_signups_event_id": {
+          "name": "idx_event_signups_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_signups_discord_user_id": {
+          "name": "idx_event_signups_discord_user_id",
+          "columns": [
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_signups_user_id": {
+          "name": "idx_event_signups_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_signups_event_id_status": {
+          "name": "idx_event_signups_event_id_status",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_signups_event_id_events_id_fk": {
+          "name": "event_signups_event_id_events_id_fk",
+          "tableFrom": "event_signups",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_signups_user_id_users_id_fk": {
+          "name": "event_signups_user_id_users_id_fk",
+          "tableFrom": "event_signups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_signups_character_id_characters_id_fk": {
+          "name": "event_signups_character_id_characters_id_fk",
+          "tableFrom": "event_signups",
+          "tableTo": "characters",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_user": {
+          "name": "unique_event_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id"
+          ]
+        },
+        "unique_event_discord_user": {
+          "name": "unique_event_discord_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "discord_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_or_discord": {
+          "name": "user_or_discord",
+          "value": "\"event_signups\".\"user_id\" IS NOT NULL OR \"event_signups\".\"discord_user_id\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.characters": {
+      "name": "characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "realm": {
+          "name": "realm",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class": {
+          "name": "class",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_override": {
+          "name": "role_override",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_main": {
+          "name": "is_main",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "item_level": {
+          "name": "item_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "render_url": {
+          "name": "render_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "race": {
+          "name": "race",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faction": {
+          "name": "faction",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_url": {
+          "name": "profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_variant": {
+          "name": "game_variant",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "equipment": {
+          "name": "equipment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "talents": {
+          "name": "talents",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_one_main_per_game": {
+          "name": "idx_one_main_per_game",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"characters\".\"is_main\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_characters_user_id": {
+          "name": "idx_characters_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_characters_user_id_name": {
+          "name": "idx_characters_user_id_name",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "characters_user_id_users_id_fk": {
+          "name": "characters_user_id_users_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "characters_game_id_games_id_fk": {
+          "name": "characters_game_id_games_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_game_character": {
+          "name": "unique_user_game_character",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id",
+            "name",
+            "realm"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.local_credentials": {
+      "name": "local_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "local_credentials_user_id_users_id_fk": {
+          "name": "local_credentials_user_id_users_id_fk",
+          "tableFrom": "local_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "local_credentials_email_unique": {
+          "name": "local_credentials_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.availability": {
+      "name": "availability",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_range": {
+          "name": "time_range",
+          "type": "tsrange",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_availability_user_id": {
+          "name": "idx_availability_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "availability_user_id_users_id_fk": {
+          "name": "availability_user_id_users_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "availability_game_id_games_id_fk": {
+          "name": "availability_game_id_games_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "availability_source_event_id_events_id_fk": {
+          "name": "availability_source_event_id_events_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "events",
+          "columnsFrom": [
+            "source_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roster_assignments": {
+      "name": "roster_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signup_id": {
+          "name": "signup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "is_override": {
+          "name": "is_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_roster_assignments_event_id": {
+          "name": "idx_roster_assignments_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_roster_assignments_signup_id": {
+          "name": "idx_roster_assignments_signup_id",
+          "columns": [
+            {
+              "expression": "signup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roster_assignments_event_id_events_id_fk": {
+          "name": "roster_assignments_event_id_events_id_fk",
+          "tableFrom": "roster_assignments",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "roster_assignments_signup_id_event_signups_id_fk": {
+          "name": "roster_assignments_signup_id_event_signups_id_fk",
+          "tableFrom": "roster_assignments",
+          "tableTo": "event_signups",
+          "columnsFrom": [
+            "signup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_signup": {
+          "name": "unique_event_signup",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "signup_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_settings_key_unique": {
+          "name": "app_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_expires_at": {
+          "name": "idx_notifications_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_preferences": {
+      "name": "user_notification_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_prefs": {
+          "name": "channel_prefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"slot_vacated\":{\"inApp\":true,\"push\":true,\"discord\":true},\"event_reminder\":{\"inApp\":true,\"push\":true,\"discord\":true},\"new_event\":{\"inApp\":true,\"push\":true,\"discord\":true},\"subscribed_game\":{\"inApp\":true,\"push\":true,\"discord\":true},\"achievement_unlocked\":{\"inApp\":true,\"push\":false,\"discord\":false},\"level_up\":{\"inApp\":true,\"push\":false,\"discord\":false},\"missed_event_nudge\":{\"inApp\":true,\"push\":true,\"discord\":true},\"event_rescheduled\":{\"inApp\":true,\"push\":true,\"discord\":true},\"bench_promoted\":{\"inApp\":true,\"push\":true,\"discord\":true},\"event_cancelled\":{\"inApp\":true,\"push\":true,\"discord\":true},\"roster_reassigned\":{\"inApp\":true,\"push\":true,\"discord\":true},\"tentative_displaced\":{\"inApp\":true,\"push\":true,\"discord\":true},\"member_returned\":{\"inApp\":true,\"push\":true,\"discord\":true},\"recruitment_reminder\":{\"inApp\":true,\"push\":true,\"discord\":true},\"role_gap_alert\":{\"inApp\":true,\"push\":true,\"discord\":true},\"lineup_steam_nudge\":{\"inApp\":true,\"push\":false,\"discord\":true},\"community_lineup\":{\"inApp\":true,\"push\":true,\"discord\":true},\"system\":{\"inApp\":true,\"push\":false,\"discord\":false}}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_preferences_user_id_users_id_fk": {
+          "name": "user_notification_preferences_user_id_users_id_fk",
+          "tableFrom": "user_notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_preference_key": {
+          "name": "unique_user_preference_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_time_templates": {
+      "name": "game_time_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_hour": {
+          "name": "start_hour",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_time_templates_user_id_idx": {
+          "name": "game_time_templates_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_time_templates_user_id_users_id_fk": {
+          "name": "game_time_templates_user_id_users_id_fk",
+          "tableFrom": "game_time_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_game_time_slot": {
+          "name": "unique_user_game_time_slot",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "day_of_week",
+            "start_hour"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_time_absences": {
+      "name": "game_time_absences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_time_absences_user_id_idx": {
+          "name": "game_time_absences_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_time_absences_user_id_users_id_fk": {
+          "name": "game_time_absences_user_id_users_id_fk",
+          "tableFrom": "game_time_absences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_time_overrides": {
+      "name": "game_time_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hour": {
+          "name": "hour",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_time_overrides_user_id_idx": {
+          "name": "game_time_overrides_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_time_overrides_user_id_users_id_fk": {
+          "name": "game_time_overrides_user_id_users_id_fk",
+          "tableFrom": "game_time_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_override_date_hour": {
+          "name": "unique_user_override_date_hour",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "date",
+            "hour"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_interests": {
+      "name": "game_interests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "playtime_forever": {
+          "name": "playtime_forever",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playtime_2weeks": {
+          "name": "playtime_2weeks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_game_interests_game_id": {
+          "name": "idx_game_interests_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_interests_user_id_users_id_fk": {
+          "name": "game_interests_user_id_users_id_fk",
+          "tableFrom": "game_interests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_interests_game_id_games_id_fk": {
+          "name": "game_interests_game_id_games_id_fk",
+          "tableFrom": "game_interests",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_user_game_interest_source": {
+          "name": "uq_user_game_interest_source",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id",
+            "source"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_reminders_sent": {
+      "name": "event_reminders_sent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reminder_type": {
+          "name": "reminder_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_reminders_sent_event_id_events_id_fk": {
+          "name": "event_reminders_sent_event_id_events_id_fk",
+          "tableFrom": "event_reminders_sent",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_reminders_sent_user_id_users_id_fk": {
+          "name": "event_reminders_sent_user_id_users_id_fk",
+          "tableFrom": "event_reminders_sent",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_user_reminder": {
+          "name": "unique_event_user_reminder",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id",
+            "reminder_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_templates": {
+      "name": "event_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_templates_user_id_users_id_fk": {
+          "name": "event_templates_user_id_users_id_fk",
+          "tableFrom": "event_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plugins": {
+      "name": "plugins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config_json": {
+          "name": "config_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plugins_slug_unique": {
+          "name": "plugins_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_user_id_users_id_fk": {
+          "name": "feedback_user_id_users_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pug_slots": {
+      "name": "pug_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_avatar_hash": {
+          "name": "discord_avatar_hash",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class": {
+          "name": "class",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "server_invite_url": {
+          "name": "server_invite_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_event_pug": {
+          "name": "unique_event_pug",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pug_slots\".\"discord_username\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_invite_code": {
+          "name": "unique_invite_code",
+          "columns": [
+            {
+              "expression": "invite_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pug_slots\".\"invite_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pug_slots_event_id_events_id_fk": {
+          "name": "pug_slots_event_id_events_id_fk",
+          "tableFrom": "pug_slots",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pug_slots_claimed_by_user_id_users_id_fk": {
+          "name": "pug_slots_claimed_by_user_id_users_id_fk",
+          "tableFrom": "pug_slots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "claimed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pug_slots_created_by_users_id_fk": {
+          "name": "pug_slots_created_by_users_id_fk",
+          "tableFrom": "pug_slots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cron_jobs": {
+      "name": "cron_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_slug": {
+          "name": "plugin_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Other'"
+        },
+        "paused": {
+          "name": "paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cron_jobs_name_unique": {
+          "name": "cron_jobs_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cron_job_executions": {
+      "name": "cron_job_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cron_job_id": {
+          "name": "cron_job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cron_job_executions_job_started_idx": {
+          "name": "cron_job_executions_job_started_idx",
+          "columns": [
+            {
+              "expression": "cron_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cron_job_executions_cron_job_id_cron_jobs_id_fk": {
+          "name": "cron_job_executions_cron_job_id_cron_jobs_id_fk",
+          "tableFrom": "cron_job_executions",
+          "tableTo": "cron_jobs",
+          "columnsFrom": [
+            "cron_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_event_messages": {
+      "name": "discord_event_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embed_state": {
+          "name": "embed_state",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'posted'"
+        },
+        "bump_message_id": {
+          "name": "bump_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_discord_event_messages_event": {
+          "name": "idx_discord_event_messages_event",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_discord_event_messages_message": {
+          "name": "idx_discord_event_messages_message",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_event_messages_event_id_events_id_fk": {
+          "name": "discord_event_messages_event_id_events_id_fk",
+          "tableFrom": "discord_event_messages",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_channel_message": {
+          "name": "unique_event_channel_message",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "channel_id",
+            "message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_bindings": {
+      "name": "channel_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding_purpose": {
+          "name": "binding_purpose",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_group_id": {
+          "name": "recurrence_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_bindings_guild_channel_series_unique": {
+          "name": "channel_bindings_guild_channel_series_unique",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurrence_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_bindings_guild": {
+          "name": "idx_channel_bindings_guild",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_bindings_game": {
+          "name": "idx_channel_bindings_game",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_bindings_recurrence_group": {
+          "name": "idx_channel_bindings_recurrence_group",
+          "columns": [
+            {
+              "expression": "recurrence_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_bindings_game_id_games_id_fk": {
+          "name": "channel_bindings_game_id_games_id_fk",
+          "tableFrom": "channel_bindings",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_event_reminders_sent": {
+      "name": "post_event_reminders_sent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pug_slot_id": {
+          "name": "pug_slot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_event_reminders_sent_event_id_events_id_fk": {
+          "name": "post_event_reminders_sent_event_id_events_id_fk",
+          "tableFrom": "post_event_reminders_sent",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_event_reminders_sent_pug_slot_id_pug_slots_id_fk": {
+          "name": "post_event_reminders_sent_pug_slot_id_pug_slots_id_fk",
+          "tableFrom": "post_event_reminders_sent",
+          "tableTo": "pug_slots",
+          "columnsFrom": [
+            "pug_slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_post_event_pug_reminder": {
+          "name": "unique_post_event_pug_reminder",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "pug_slot_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_plans": {
+      "name": "event_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slot_config": {
+          "name": "slot_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_attendees": {
+          "name": "max_attendees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_unbench": {
+          "name": "auto_unbench",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_options": {
+          "name": "poll_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_duration_hours": {
+          "name": "poll_duration_hours",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_mode": {
+          "name": "poll_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "poll_round": {
+          "name": "poll_round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "poll_channel_id": {
+          "name": "poll_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_message_id": {
+          "name": "poll_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "winning_option": {
+          "name": "winning_option",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_event_id": {
+          "name": "created_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_instances": {
+          "name": "content_instances",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_15min": {
+          "name": "reminder_15min",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_1hour": {
+          "name": "reminder_1hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_24hour": {
+          "name": "reminder_24hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "poll_started_at": {
+          "name": "poll_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_ends_at": {
+          "name": "poll_ends_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_event_plans_creator_id": {
+          "name": "idx_event_plans_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_plans_status": {
+          "name": "idx_event_plans_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_plans_creator_id_users_id_fk": {
+          "name": "event_plans_creator_id_users_id_fk",
+          "tableFrom": "event_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_plans_game_id_games_id_fk": {
+          "name": "event_plans_game_id_games_id_fk",
+          "tableFrom": "event_plans",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "event_plans_created_event_id_events_id_fk": {
+          "name": "event_plans_created_event_id_events_id_fk",
+          "tableFrom": "event_plans",
+          "tableTo": "events",
+          "columnsFrom": [
+            "created_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_dungeon_quests": {
+      "name": "wow_classic_dungeon_quests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dungeon_instance_id": {
+          "name": "dungeon_instance_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quest_level": {
+          "name": "quest_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_level": {
+          "name": "required_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expansion": {
+          "name": "expansion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quest_giver_npc": {
+          "name": "quest_giver_npc",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quest_giver_zone": {
+          "name": "quest_giver_zone",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_quest_id": {
+          "name": "prev_quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_quest_id": {
+          "name": "next_quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewards_json": {
+          "name": "rewards_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objectives": {
+          "name": "objectives",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_restriction": {
+          "name": "class_restriction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "race_restriction": {
+          "name": "race_restriction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_inside_dungeon": {
+          "name": "starts_inside_dungeon",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sharable": {
+          "name": "sharable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reward_xp": {
+          "name": "reward_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_gold": {
+          "name": "reward_gold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_type": {
+          "name": "reward_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wow_classic_dungeon_quests_quest_id_unique": {
+          "name": "wow_classic_dungeon_quests_quest_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "quest_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_boss_loot": {
+      "name": "wow_classic_boss_loot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "boss_id": {
+          "name": "boss_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot": {
+          "name": "slot",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality": {
+          "name": "quality",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_level": {
+          "name": "item_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drop_rate": {
+          "name": "drop_rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expansion": {
+          "name": "expansion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_restrictions": {
+          "name": "class_restrictions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_subclass": {
+          "name": "item_subclass",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wow_classic_boss_loot_boss_id_wow_classic_bosses_id_fk": {
+          "name": "wow_classic_boss_loot_boss_id_wow_classic_bosses_id_fk",
+          "tableFrom": "wow_classic_boss_loot",
+          "tableTo": "wow_classic_bosses",
+          "columnsFrom": [
+            "boss_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_loot_boss_item_expansion": {
+          "name": "uq_loot_boss_item_expansion",
+          "nullsNotDistinct": false,
+          "columns": [
+            "boss_id",
+            "item_id",
+            "expansion"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_bosses": {
+      "name": "wow_classic_bosses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expansion": {
+          "name": "expansion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sod_modified": {
+          "name": "sod_modified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_boss_instance_name_expansion": {
+          "name": "uq_boss_instance_name_expansion",
+          "nullsNotDistinct": false,
+          "columns": [
+            "instance_id",
+            "name",
+            "expansion"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_quest_progress": {
+      "name": "wow_classic_quest_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picked_up": {
+          "name": "picked_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wow_classic_quest_progress_event_id_events_id_fk": {
+          "name": "wow_classic_quest_progress_event_id_events_id_fk",
+          "tableFrom": "wow_classic_quest_progress",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wow_classic_quest_progress_user_id_users_id_fk": {
+          "name": "wow_classic_quest_progress_user_id_users_id_fk",
+          "tableFrom": "wow_classic_quest_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_quest_progress_event_user_quest": {
+          "name": "uq_quest_progress_event_user_quest",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id",
+            "quest_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_activity_sessions": {
+      "name": "game_activity_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_activity_name": {
+          "name": "discord_activity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "game_activity_sessions_user_game_started_idx": {
+          "name": "game_activity_sessions_user_game_started_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "game_activity_sessions_game_started_idx": {
+          "name": "game_activity_sessions_game_started_idx",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_activity_sessions_user_id_users_id_fk": {
+          "name": "game_activity_sessions_user_id_users_id_fk",
+          "tableFrom": "game_activity_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_activity_sessions_game_id_games_id_fk": {
+          "name": "game_activity_sessions_game_id_games_id_fk",
+          "tableFrom": "game_activity_sessions",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_activity_rollups": {
+      "name": "game_activity_rollups",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period": {
+          "name": "period",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_seconds": {
+          "name": "total_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "game_activity_rollups_game_period_start_idx": {
+          "name": "game_activity_rollups_game_period_start_idx",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_activity_rollups_user_id_users_id_fk": {
+          "name": "game_activity_rollups_user_id_users_id_fk",
+          "tableFrom": "game_activity_rollups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_activity_rollups_game_id_games_id_fk": {
+          "name": "game_activity_rollups_game_id_games_id_fk",
+          "tableFrom": "game_activity_rollups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "game_activity_rollups_user_game_period_unique": {
+          "name": "game_activity_rollups_user_game_period_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id",
+            "period",
+            "period_start"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_game_mappings": {
+      "name": "discord_game_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "discord_activity_name": {
+          "name": "discord_activity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "discord_game_mappings_game_id_games_id_fk": {
+          "name": "discord_game_mappings_game_id_games_id_fk",
+          "tableFrom": "discord_game_mappings",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_game_mappings_discord_activity_name_unique": {
+          "name": "discord_game_mappings_discord_activity_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_activity_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ad_hoc_participants": {
+      "name": "ad_hoc_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_avatar_hash": {
+          "name": "discord_avatar_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_duration_seconds": {
+          "name": "total_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "ad_hoc_participants_event_discord_user_unique": {
+          "name": "ad_hoc_participants_event_discord_user_unique",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ad_hoc_participants_event": {
+          "name": "idx_ad_hoc_participants_event",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ad_hoc_participants_user": {
+          "name": "idx_ad_hoc_participants_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ad_hoc_participants_event_id_events_id_fk": {
+          "name": "ad_hoc_participants_event_id_events_id_fk",
+          "tableFrom": "ad_hoc_participants",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ad_hoc_participants_user_id_users_id_fk": {
+          "name": "ad_hoc_participants_user_id_users_id_fk",
+          "tableFrom": "ad_hoc_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_interest_suppressions": {
+      "name": "game_interest_suppressions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suppressed_at": {
+          "name": "suppressed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_interest_suppressions_user_id_users_id_fk": {
+          "name": "game_interest_suppressions_user_id_users_id_fk",
+          "tableFrom": "game_interest_suppressions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_interest_suppressions_game_id_games_id_fk": {
+          "name": "game_interest_suppressions_game_id_games_id_fk",
+          "tableFrom": "game_interest_suppressions",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_user_game_suppression": {
+          "name": "uq_user_game_suppression",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_voice_sessions": {
+      "name": "event_voice_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_join_at": {
+          "name": "first_join_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_leave_at": {
+          "name": "last_leave_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_duration_sec": {
+          "name": "total_duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "segments": {
+          "name": "segments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "event_voice_sessions_event_discord_user_unique": {
+          "name": "event_voice_sessions_event_discord_user_unique",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_voice_sessions_event": {
+          "name": "idx_event_voice_sessions_event",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_voice_sessions_event_id_events_id_fk": {
+          "name": "event_voice_sessions_event_id_events_id_fk",
+          "tableFrom": "event_voice_sessions",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_voice_sessions_user_id_users_id_fk": {
+          "name": "event_voice_sessions_user_id_users_id_fk",
+          "tableFrom": "event_voice_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrichments": {
+      "name": "enrichments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enricher_key": {
+          "name": "enricher_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_enrichments_entity": {
+          "name": "idx_enrichments_entity",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_entity_enricher": {
+          "name": "unique_entity_enricher",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "enricher_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_request_logs": {
+      "name": "ai_request_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "feature": {
+          "name": "feature",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ai_request_logs_created_at": {
+          "name": "idx_ai_request_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_request_logs_feature_created_at": {
+          "name": "idx_ai_request_logs_feature_created_at",
+          "columns": [
+            {
+              "expression": "feature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_request_logs_user_id_users_id_fk": {
+          "name": "ai_request_logs_user_id_users_id_fk",
+          "tableFrom": "ai_request_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_entries": {
+      "name": "community_lineup_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nominated_by": {
+          "name": "nominated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carried_over_from": {
+          "name": "carried_over_from",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_entries_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_entries_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_entries",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_entries_game_id_games_id_fk": {
+          "name": "community_lineup_entries_game_id_games_id_fk",
+          "tableFrom": "community_lineup_entries",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_entries_nominated_by_users_id_fk": {
+          "name": "community_lineup_entries_nominated_by_users_id_fk",
+          "tableFrom": "community_lineup_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "nominated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_entries_carried_over_from_community_lineups_id_fk": {
+          "name": "community_lineup_entries_carried_over_from_community_lineups_id_fk",
+          "tableFrom": "community_lineup_entries",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "carried_over_from"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lineup_entry_game": {
+          "name": "uq_lineup_entry_game",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineup_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_votes": {
+      "name": "community_lineup_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_votes_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_votes_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_votes",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_votes_user_id_users_id_fk": {
+          "name": "community_lineup_votes_user_id_users_id_fk",
+          "tableFrom": "community_lineup_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_votes_game_id_games_id_fk": {
+          "name": "community_lineup_votes_game_id_games_id_fk",
+          "tableFrom": "community_lineup_votes",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lineup_vote_user_game": {
+          "name": "uq_lineup_vote_user_game",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineup_id",
+            "user_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineups": {
+      "name": "community_lineups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'building'"
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_game_id": {
+          "name": "decided_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_event_id": {
+          "name": "linked_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voting_deadline": {
+          "name": "voting_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase_deadline": {
+          "name": "phase_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase_duration_override": {
+          "name": "phase_duration_override",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_threshold": {
+          "name": "match_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 35
+        },
+        "max_votes_per_player": {
+          "name": "max_votes_per_player",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "default_tiebreaker_mode": {
+          "name": "default_tiebreaker_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_tiebreaker_id": {
+          "name": "active_tiebreaker_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineups_decided_game_id_games_id_fk": {
+          "name": "community_lineups_decided_game_id_games_id_fk",
+          "tableFrom": "community_lineups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "decided_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_lineups_linked_event_id_events_id_fk": {
+          "name": "community_lineups_linked_event_id_events_id_fk",
+          "tableFrom": "community_lineups",
+          "tableTo": "events",
+          "columnsFrom": [
+            "linked_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_lineups_created_by_users_id_fk": {
+          "name": "community_lineups_created_by_users_id_fk",
+          "tableFrom": "community_lineups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_tiebreaker_bracket_matchups": {
+      "name": "community_lineup_tiebreaker_bracket_matchups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tiebreaker_id": {
+          "name": "tiebreaker_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_a_id": {
+          "name": "game_a_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_b_id": {
+          "name": "game_b_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "winner_game_id": {
+          "name": "winner_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bye": {
+          "name": "is_bye",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_tiebreaker_bracket_matchups_tiebreaker_id_community_lineup_tiebreakers_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_matchups_tiebreaker_id_community_lineup_tiebreakers_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_matchups",
+          "tableTo": "community_lineup_tiebreakers",
+          "columnsFrom": [
+            "tiebreaker_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_matchups_game_a_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_matchups_game_a_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_matchups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_matchups_game_b_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_matchups_game_b_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_matchups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_matchups_winner_game_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_matchups_winner_game_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_matchups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "winner_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_tiebreaker_matchup_round_pos": {
+          "name": "uq_tiebreaker_matchup_round_pos",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tiebreaker_id",
+            "round",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_tiebreaker_bracket_votes": {
+      "name": "community_lineup_tiebreaker_bracket_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "matchup_id": {
+          "name": "matchup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_tiebreaker_bracket_votes_matchup_id_community_lineup_tiebreaker_bracket_matchups_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_votes_matchup_id_community_lineup_tiebreaker_bracket_matchups_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_votes",
+          "tableTo": "community_lineup_tiebreaker_bracket_matchups",
+          "columnsFrom": [
+            "matchup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_votes_user_id_users_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_votes_user_id_users_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_votes_game_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_votes_game_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_votes",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_tiebreaker_bracket_vote": {
+          "name": "uq_tiebreaker_bracket_vote",
+          "nullsNotDistinct": false,
+          "columns": [
+            "matchup_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_tiebreaker_vetoes": {
+      "name": "community_lineup_tiebreaker_vetoes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tiebreaker_id": {
+          "name": "tiebreaker_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revealed": {
+          "name": "revealed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_tiebreaker_vetoes_tiebreaker_id_community_lineup_tiebreakers_id_fk": {
+          "name": "community_lineup_tiebreaker_vetoes_tiebreaker_id_community_lineup_tiebreakers_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_vetoes",
+          "tableTo": "community_lineup_tiebreakers",
+          "columnsFrom": [
+            "tiebreaker_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_vetoes_user_id_users_id_fk": {
+          "name": "community_lineup_tiebreaker_vetoes_user_id_users_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_vetoes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_vetoes_game_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_vetoes_game_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_vetoes",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_tiebreaker_veto_user": {
+          "name": "uq_tiebreaker_veto_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tiebreaker_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_tiebreakers": {
+      "name": "community_lineup_tiebreakers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "tied_game_ids": {
+          "name": "tied_game_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_vote_count": {
+          "name": "original_vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "winner_game_id": {
+          "name": "winner_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round_deadline": {
+          "name": "round_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_tiebreakers_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_tiebreakers_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_tiebreakers",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreakers_winner_game_id_games_id_fk": {
+          "name": "community_lineup_tiebreakers_winner_game_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreakers",
+          "tableTo": "games",
+          "columnsFrom": [
+            "winner_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_match_members": {
+      "name": "community_lineup_match_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_match_members_match_id_community_lineup_matches_id_fk": {
+          "name": "community_lineup_match_members_match_id_community_lineup_matches_id_fk",
+          "tableFrom": "community_lineup_match_members",
+          "tableTo": "community_lineup_matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_match_members_user_id_users_id_fk": {
+          "name": "community_lineup_match_members_user_id_users_id_fk",
+          "tableFrom": "community_lineup_match_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_match_member_user": {
+          "name": "uq_match_member_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_matches": {
+      "name": "community_lineup_matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'suggested'"
+        },
+        "threshold_met": {
+          "name": "threshold_met",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "vote_percentage": {
+          "name": "vote_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fit_type": {
+          "name": "fit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_event_id": {
+          "name": "linked_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_message_id": {
+          "name": "embed_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_channel_id": {
+          "name": "embed_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_vote_threshold": {
+          "name": "min_vote_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threshold_notified_at": {
+          "name": "threshold_notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_matches_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_matches_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_matches",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_matches_game_id_games_id_fk": {
+          "name": "community_lineup_matches_game_id_games_id_fk",
+          "tableFrom": "community_lineup_matches",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_matches_linked_event_id_events_id_fk": {
+          "name": "community_lineup_matches_linked_event_id_events_id_fk",
+          "tableFrom": "community_lineup_matches",
+          "tableTo": "events",
+          "columnsFrom": [
+            "linked_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lineup_match_game": {
+          "name": "uq_lineup_match_game",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineup_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_schedule_slots": {
+      "name": "community_lineup_schedule_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_time": {
+          "name": "proposed_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overlap_score": {
+          "name": "overlap_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_by": {
+          "name": "suggested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_schedule_slots_match_id_community_lineup_matches_id_fk": {
+          "name": "community_lineup_schedule_slots_match_id_community_lineup_matches_id_fk",
+          "tableFrom": "community_lineup_schedule_slots",
+          "tableTo": "community_lineup_matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_schedule_votes": {
+      "name": "community_lineup_schedule_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slot_id": {
+          "name": "slot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_schedule_votes_slot_id_community_lineup_schedule_slots_id_fk": {
+          "name": "community_lineup_schedule_votes_slot_id_community_lineup_schedule_slots_id_fk",
+          "tableFrom": "community_lineup_schedule_votes",
+          "tableTo": "community_lineup_schedule_slots",
+          "columnsFrom": [
+            "slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_schedule_votes_user_id_users_id_fk": {
+          "name": "community_lineup_schedule_votes_user_id_users_id_fk",
+          "tableFrom": "community_lineup_schedule_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_schedule_vote_user": {
+          "name": "uq_schedule_vote_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slot_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_activity_log_entity": {
+          "name": "idx_activity_log_entity",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_actor_id_users_id_fk": {
+          "name": "activity_log_actor_id_users_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_dedup": {
+      "name": "notification_dedup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_notification_dedup_key": {
+          "name": "uq_notification_dedup_key",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_dedup_expires_at": {
+          "name": "idx_notification_dedup_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consumed_intent_tokens": {
+      "name": "consumed_intent_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_consumed_intent_tokens_consumed_at": {
+          "name": "idx_consumed_intent_tokens_consumed_at",
+          "columns": [
+            {
+              "expression": "consumed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "consumed_intent_tokens_token_hash_unique": {
+          "name": "consumed_intent_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_taste_vectors": {
+      "name": "player_taste_vectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vector": {
+          "name": "vector",
+          "type": "vector(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intensity_metrics": {
+          "name": "intensity_metrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archetype": {
+          "name": "archetype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "signal_hash": {
+          "name": "signal_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "player_taste_vectors_computed_at_idx": {
+          "name": "player_taste_vectors_computed_at_idx",
+          "columns": [
+            {
+              "expression": "computed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "player_taste_vectors_user_id_users_id_fk": {
+          "name": "player_taste_vectors_user_id_users_id_fk",
+          "tableFrom": "player_taste_vectors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "player_taste_vectors_user_id_unique": {
+          "name": "player_taste_vectors_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_intensity_snapshots": {
+      "name": "player_intensity_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_start": {
+          "name": "week_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_hours": {
+          "name": "total_hours",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_breakdown": {
+          "name": "game_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unique_games": {
+          "name": "unique_games",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longest_session_hours": {
+          "name": "longest_session_hours",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longest_session_game_id": {
+          "name": "longest_session_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "player_intensity_snapshots_week_start_idx": {
+          "name": "player_intensity_snapshots_week_start_idx",
+          "columns": [
+            {
+              "expression": "week_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "player_intensity_snapshots_user_id_users_id_fk": {
+          "name": "player_intensity_snapshots_user_id_users_id_fk",
+          "tableFrom": "player_intensity_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "player_intensity_snapshots_longest_session_game_id_games_id_fk": {
+          "name": "player_intensity_snapshots_longest_session_game_id_games_id_fk",
+          "tableFrom": "player_intensity_snapshots",
+          "tableTo": "games",
+          "columnsFrom": [
+            "longest_session_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_player_intensity_user_week": {
+          "name": "uq_player_intensity_user_week",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "week_start"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_co_play": {
+      "name": "player_co_play",
+      "schema": "",
+      "columns": {
+        "user_id_a": {
+          "name": "user_id_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id_b": {
+          "name": "user_id_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_minutes": {
+          "name": "total_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_played_at": {
+          "name": "last_played_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "games_played": {
+          "name": "games_played",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "player_co_play_user_id_a_users_id_fk": {
+          "name": "player_co_play_user_id_a_users_id_fk",
+          "tableFrom": "player_co_play",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id_a"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "player_co_play_user_id_b_users_id_fk": {
+          "name": "player_co_play_user_id_b_users_id_fk",
+          "tableFrom": "player_co_play",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id_b"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "player_co_play_user_id_a_user_id_b_pk": {
+          "name": "player_co_play_user_id_a_user_id_b_pk",
+          "columns": [
+            "user_id_a",
+            "user_id_b"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_player_co_play_canonical_order": {
+          "name": "chk_player_co_play_canonical_order",
+          "value": "\"player_co_play\".\"user_id_a\" < \"player_co_play\".\"user_id_b\""
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/src/drizzle/migrations/meta/0123_snapshot.json
+++ b/api/src/drizzle/migrations/meta/0123_snapshot.json
@@ -1,0 +1,6757 @@
+{
+  "id": "fb88d6ca-e0f6-4b0e-8c2c-0099ac2067f3",
+  "prevId": "de40f36f-f68f-4f1a-aba2-24eed256117c",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_id": {
+          "name": "steam_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_avatar_url": {
+          "name": "custom_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_time_confirmed_at": {
+          "name": "game_time_confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_discord_id_unique": {
+          "name": "users_discord_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_id"
+          ]
+        },
+        "users_steam_id_unique": {
+          "name": "users_steam_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "steam_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "display_name_length": {
+          "name": "display_name_length",
+          "value": "\"users\".\"display_name\" IS NULL OR (LENGTH(\"users\".\"display_name\") >= 2 AND LENGTH(\"users\".\"display_name\") <= 30)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "tsrange",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_config": {
+          "name": "slot_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_attendees": {
+          "name": "max_attendees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_unbench": {
+          "name": "auto_unbench",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "recurrence_group_id": {
+          "name": "recurrence_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_rule": {
+          "name": "recurrence_rule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_instances": {
+          "name": "content_instances",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_15min": {
+          "name": "reminder_15min",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_1hour": {
+          "name": "reminder_1hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_24hour": {
+          "name": "reminder_24hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_ad_hoc": {
+          "name": "is_ad_hoc",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ad_hoc_status": {
+          "name": "ad_hoc_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_binding_id": {
+          "name": "channel_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_scheduled_event_id": {
+          "name": "discord_scheduled_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extended_until": {
+          "name": "extended_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_channel_override": {
+          "name": "notification_channel_override",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rescheduling_poll_id": {
+          "name": "rescheduling_poll_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_events_creator_id": {
+          "name": "idx_events_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_game_id": {
+          "name": "idx_events_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_ad_hoc_binding": {
+          "name": "idx_events_ad_hoc_binding",
+          "columns": [
+            {
+              "expression": "channel_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_ad_hoc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_recurrence_group_id": {
+          "name": "idx_events_recurrence_group_id",
+          "columns": [
+            {
+              "expression": "recurrence_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_cancelled_at": {
+          "name": "idx_events_cancelled_at",
+          "columns": [
+            {
+              "expression": "cancelled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_discord_scheduled_event_id": {
+          "name": "idx_events_discord_scheduled_event_id",
+          "columns": [
+            {
+              "expression": "discord_scheduled_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_game_id_games_id_fk": {
+          "name": "events_game_id_games_id_fk",
+          "tableFrom": "events",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_creator_id_users_id_fk": {
+          "name": "events_creator_id_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_channel_binding_id_channel_bindings_id_fk": {
+          "name": "events_channel_binding_id_channel_bindings_id_fk",
+          "tableFrom": "events",
+          "tableTo": "channel_bindings",
+          "columnsFrom": [
+            "channel_binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_types": {
+      "name": "event_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_player_cap": {
+          "name": "default_player_cap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_duration_minutes": {
+          "name": "default_duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_composition": {
+          "name": "requires_composition",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_event_types_game_id": {
+          "name": "idx_event_types_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_types_game_id_games_id_fk": {
+          "name": "event_types_game_id_games_id_fk",
+          "tableFrom": "event_types",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_types_game_slug_unique": {
+          "name": "event_types_game_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "game_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "igdb_id": {
+          "name": "igdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregated_rating": {
+          "name": "aggregated_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "popularity": {
+          "name": "popularity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_modes": {
+          "name": "game_modes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "themes": {
+          "name": "themes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "platforms": {
+          "name": "platforms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "screenshots": {
+          "name": "screenshots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "videos": {
+          "name": "videos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "first_release_date": {
+          "name": "first_release_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_count": {
+          "name": "player_count",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitch_game_id": {
+          "name": "twitch_game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_app_id": {
+          "name": "steam_app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crossplay": {
+          "name": "crossplay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color_hex": {
+          "name": "color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_roles": {
+          "name": "has_roles",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_specs": {
+          "name": "has_specs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "itad_game_id": {
+          "name": "itad_game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_boxart_url": {
+          "name": "itad_boxart_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_tags": {
+          "name": "itad_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "max_characters_per_user": {
+          "name": "max_characters_per_user",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "api_namespace_prefix": {
+          "name": "api_namespace_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_current_price": {
+          "name": "itad_current_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_current_cut": {
+          "name": "itad_current_cut",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_current_shop": {
+          "name": "itad_current_shop",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_current_url": {
+          "name": "itad_current_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_lowest_price": {
+          "name": "itad_lowest_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_lowest_cut": {
+          "name": "itad_lowest_cut",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_price_updated_at": {
+          "name": "itad_price_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "early_access": {
+          "name": "early_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "igdb_enrichment_status": {
+          "name": "igdb_enrichment_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "igdb_enrichment_retry_count": {
+          "name": "igdb_enrichment_retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "games_igdb_id_unique": {
+          "name": "games_igdb_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "igdb_id"
+          ]
+        },
+        "games_slug_unique": {
+          "name": "games_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "games_itad_game_id_unique": {
+          "name": "games_itad_game_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "itad_game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_signups": {
+      "name": "event_signups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_avatar_hash": {
+          "name": "discord_avatar_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation_status": {
+          "name": "confirmation_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'signed_up'"
+        },
+        "preferred_roles": {
+          "name": "preferred_roles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attendance_status": {
+          "name": "attendance_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attendance_recorded_at": {
+          "name": "attendance_recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roached_out_at": {
+          "name": "roached_out_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_up_at": {
+          "name": "signed_up_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_event_signups_event_id": {
+          "name": "idx_event_signups_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_signups_discord_user_id": {
+          "name": "idx_event_signups_discord_user_id",
+          "columns": [
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_signups_user_id": {
+          "name": "idx_event_signups_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_signups_event_id_status": {
+          "name": "idx_event_signups_event_id_status",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_signups_event_id_events_id_fk": {
+          "name": "event_signups_event_id_events_id_fk",
+          "tableFrom": "event_signups",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_signups_user_id_users_id_fk": {
+          "name": "event_signups_user_id_users_id_fk",
+          "tableFrom": "event_signups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_signups_character_id_characters_id_fk": {
+          "name": "event_signups_character_id_characters_id_fk",
+          "tableFrom": "event_signups",
+          "tableTo": "characters",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_user": {
+          "name": "unique_event_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id"
+          ]
+        },
+        "unique_event_discord_user": {
+          "name": "unique_event_discord_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "discord_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_or_discord": {
+          "name": "user_or_discord",
+          "value": "\"event_signups\".\"user_id\" IS NOT NULL OR \"event_signups\".\"discord_user_id\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.characters": {
+      "name": "characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "realm": {
+          "name": "realm",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class": {
+          "name": "class",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_override": {
+          "name": "role_override",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_main": {
+          "name": "is_main",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "item_level": {
+          "name": "item_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "render_url": {
+          "name": "render_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "race": {
+          "name": "race",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faction": {
+          "name": "faction",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_url": {
+          "name": "profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_variant": {
+          "name": "game_variant",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "equipment": {
+          "name": "equipment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "talents": {
+          "name": "talents",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_one_main_per_game": {
+          "name": "idx_one_main_per_game",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"characters\".\"is_main\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_characters_user_id": {
+          "name": "idx_characters_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_characters_user_id_name": {
+          "name": "idx_characters_user_id_name",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "characters_user_id_users_id_fk": {
+          "name": "characters_user_id_users_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "characters_game_id_games_id_fk": {
+          "name": "characters_game_id_games_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_game_character": {
+          "name": "unique_user_game_character",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id",
+            "name",
+            "realm"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.local_credentials": {
+      "name": "local_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "local_credentials_user_id_users_id_fk": {
+          "name": "local_credentials_user_id_users_id_fk",
+          "tableFrom": "local_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "local_credentials_email_unique": {
+          "name": "local_credentials_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.availability": {
+      "name": "availability",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_range": {
+          "name": "time_range",
+          "type": "tsrange",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_availability_user_id": {
+          "name": "idx_availability_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "availability_user_id_users_id_fk": {
+          "name": "availability_user_id_users_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "availability_game_id_games_id_fk": {
+          "name": "availability_game_id_games_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "availability_source_event_id_events_id_fk": {
+          "name": "availability_source_event_id_events_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "events",
+          "columnsFrom": [
+            "source_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roster_assignments": {
+      "name": "roster_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signup_id": {
+          "name": "signup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "is_override": {
+          "name": "is_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_roster_assignments_event_id": {
+          "name": "idx_roster_assignments_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_roster_assignments_signup_id": {
+          "name": "idx_roster_assignments_signup_id",
+          "columns": [
+            {
+              "expression": "signup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roster_assignments_event_id_events_id_fk": {
+          "name": "roster_assignments_event_id_events_id_fk",
+          "tableFrom": "roster_assignments",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "roster_assignments_signup_id_event_signups_id_fk": {
+          "name": "roster_assignments_signup_id_event_signups_id_fk",
+          "tableFrom": "roster_assignments",
+          "tableTo": "event_signups",
+          "columnsFrom": [
+            "signup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_signup": {
+          "name": "unique_event_signup",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "signup_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_settings_key_unique": {
+          "name": "app_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_expires_at": {
+          "name": "idx_notifications_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_preferences": {
+      "name": "user_notification_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_prefs": {
+          "name": "channel_prefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"slot_vacated\":{\"inApp\":true,\"push\":true,\"discord\":true},\"event_reminder\":{\"inApp\":true,\"push\":true,\"discord\":true},\"new_event\":{\"inApp\":true,\"push\":true,\"discord\":true},\"subscribed_game\":{\"inApp\":true,\"push\":true,\"discord\":true},\"achievement_unlocked\":{\"inApp\":true,\"push\":false,\"discord\":false},\"level_up\":{\"inApp\":true,\"push\":false,\"discord\":false},\"missed_event_nudge\":{\"inApp\":true,\"push\":true,\"discord\":true},\"event_rescheduled\":{\"inApp\":true,\"push\":true,\"discord\":true},\"bench_promoted\":{\"inApp\":true,\"push\":true,\"discord\":true},\"event_cancelled\":{\"inApp\":true,\"push\":true,\"discord\":true},\"roster_reassigned\":{\"inApp\":true,\"push\":true,\"discord\":true},\"tentative_displaced\":{\"inApp\":true,\"push\":true,\"discord\":true},\"member_returned\":{\"inApp\":true,\"push\":true,\"discord\":true},\"recruitment_reminder\":{\"inApp\":true,\"push\":true,\"discord\":true},\"role_gap_alert\":{\"inApp\":true,\"push\":true,\"discord\":true},\"lineup_steam_nudge\":{\"inApp\":true,\"push\":false,\"discord\":true},\"community_lineup\":{\"inApp\":true,\"push\":true,\"discord\":true},\"system\":{\"inApp\":true,\"push\":false,\"discord\":false}}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_preferences_user_id_users_id_fk": {
+          "name": "user_notification_preferences_user_id_users_id_fk",
+          "tableFrom": "user_notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_preference_key": {
+          "name": "unique_user_preference_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_time_templates": {
+      "name": "game_time_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_hour": {
+          "name": "start_hour",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_time_templates_user_id_idx": {
+          "name": "game_time_templates_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_time_templates_user_id_users_id_fk": {
+          "name": "game_time_templates_user_id_users_id_fk",
+          "tableFrom": "game_time_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_game_time_slot": {
+          "name": "unique_user_game_time_slot",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "day_of_week",
+            "start_hour"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_time_absences": {
+      "name": "game_time_absences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_time_absences_user_id_idx": {
+          "name": "game_time_absences_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_time_absences_user_id_users_id_fk": {
+          "name": "game_time_absences_user_id_users_id_fk",
+          "tableFrom": "game_time_absences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_time_overrides": {
+      "name": "game_time_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hour": {
+          "name": "hour",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_time_overrides_user_id_idx": {
+          "name": "game_time_overrides_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_time_overrides_user_id_users_id_fk": {
+          "name": "game_time_overrides_user_id_users_id_fk",
+          "tableFrom": "game_time_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_override_date_hour": {
+          "name": "unique_user_override_date_hour",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "date",
+            "hour"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_interests": {
+      "name": "game_interests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "playtime_forever": {
+          "name": "playtime_forever",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playtime_2weeks": {
+          "name": "playtime_2weeks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_game_interests_game_id": {
+          "name": "idx_game_interests_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_interests_user_id_users_id_fk": {
+          "name": "game_interests_user_id_users_id_fk",
+          "tableFrom": "game_interests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_interests_game_id_games_id_fk": {
+          "name": "game_interests_game_id_games_id_fk",
+          "tableFrom": "game_interests",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_user_game_interest_source": {
+          "name": "uq_user_game_interest_source",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id",
+            "source"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_reminders_sent": {
+      "name": "event_reminders_sent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reminder_type": {
+          "name": "reminder_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_reminders_sent_event_id_events_id_fk": {
+          "name": "event_reminders_sent_event_id_events_id_fk",
+          "tableFrom": "event_reminders_sent",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_reminders_sent_user_id_users_id_fk": {
+          "name": "event_reminders_sent_user_id_users_id_fk",
+          "tableFrom": "event_reminders_sent",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_user_reminder": {
+          "name": "unique_event_user_reminder",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id",
+            "reminder_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_templates": {
+      "name": "event_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_templates_user_id_users_id_fk": {
+          "name": "event_templates_user_id_users_id_fk",
+          "tableFrom": "event_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plugins": {
+      "name": "plugins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config_json": {
+          "name": "config_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plugins_slug_unique": {
+          "name": "plugins_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_user_id_users_id_fk": {
+          "name": "feedback_user_id_users_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pug_slots": {
+      "name": "pug_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_avatar_hash": {
+          "name": "discord_avatar_hash",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class": {
+          "name": "class",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "server_invite_url": {
+          "name": "server_invite_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_event_pug": {
+          "name": "unique_event_pug",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pug_slots\".\"discord_username\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_invite_code": {
+          "name": "unique_invite_code",
+          "columns": [
+            {
+              "expression": "invite_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pug_slots\".\"invite_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pug_slots_event_id_events_id_fk": {
+          "name": "pug_slots_event_id_events_id_fk",
+          "tableFrom": "pug_slots",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pug_slots_claimed_by_user_id_users_id_fk": {
+          "name": "pug_slots_claimed_by_user_id_users_id_fk",
+          "tableFrom": "pug_slots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "claimed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pug_slots_created_by_users_id_fk": {
+          "name": "pug_slots_created_by_users_id_fk",
+          "tableFrom": "pug_slots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cron_jobs": {
+      "name": "cron_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_slug": {
+          "name": "plugin_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Other'"
+        },
+        "paused": {
+          "name": "paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cron_jobs_name_unique": {
+          "name": "cron_jobs_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cron_job_executions": {
+      "name": "cron_job_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cron_job_id": {
+          "name": "cron_job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cron_job_executions_job_started_idx": {
+          "name": "cron_job_executions_job_started_idx",
+          "columns": [
+            {
+              "expression": "cron_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cron_job_executions_cron_job_id_cron_jobs_id_fk": {
+          "name": "cron_job_executions_cron_job_id_cron_jobs_id_fk",
+          "tableFrom": "cron_job_executions",
+          "tableTo": "cron_jobs",
+          "columnsFrom": [
+            "cron_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_event_messages": {
+      "name": "discord_event_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embed_state": {
+          "name": "embed_state",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'posted'"
+        },
+        "bump_message_id": {
+          "name": "bump_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_discord_event_messages_event": {
+          "name": "idx_discord_event_messages_event",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_discord_event_messages_message": {
+          "name": "idx_discord_event_messages_message",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_event_messages_event_id_events_id_fk": {
+          "name": "discord_event_messages_event_id_events_id_fk",
+          "tableFrom": "discord_event_messages",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_channel_message": {
+          "name": "unique_event_channel_message",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "channel_id",
+            "message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_bindings": {
+      "name": "channel_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding_purpose": {
+          "name": "binding_purpose",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_group_id": {
+          "name": "recurrence_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_bindings_guild_channel_series_unique": {
+          "name": "channel_bindings_guild_channel_series_unique",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurrence_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_bindings_guild": {
+          "name": "idx_channel_bindings_guild",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_bindings_game": {
+          "name": "idx_channel_bindings_game",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_bindings_recurrence_group": {
+          "name": "idx_channel_bindings_recurrence_group",
+          "columns": [
+            {
+              "expression": "recurrence_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_bindings_game_id_games_id_fk": {
+          "name": "channel_bindings_game_id_games_id_fk",
+          "tableFrom": "channel_bindings",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_event_reminders_sent": {
+      "name": "post_event_reminders_sent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pug_slot_id": {
+          "name": "pug_slot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_event_reminders_sent_event_id_events_id_fk": {
+          "name": "post_event_reminders_sent_event_id_events_id_fk",
+          "tableFrom": "post_event_reminders_sent",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_event_reminders_sent_pug_slot_id_pug_slots_id_fk": {
+          "name": "post_event_reminders_sent_pug_slot_id_pug_slots_id_fk",
+          "tableFrom": "post_event_reminders_sent",
+          "tableTo": "pug_slots",
+          "columnsFrom": [
+            "pug_slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_post_event_pug_reminder": {
+          "name": "unique_post_event_pug_reminder",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "pug_slot_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_plans": {
+      "name": "event_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slot_config": {
+          "name": "slot_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_attendees": {
+          "name": "max_attendees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_unbench": {
+          "name": "auto_unbench",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_options": {
+          "name": "poll_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_duration_hours": {
+          "name": "poll_duration_hours",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_mode": {
+          "name": "poll_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "poll_round": {
+          "name": "poll_round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "poll_channel_id": {
+          "name": "poll_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_message_id": {
+          "name": "poll_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "winning_option": {
+          "name": "winning_option",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_event_id": {
+          "name": "created_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_instances": {
+          "name": "content_instances",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_15min": {
+          "name": "reminder_15min",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_1hour": {
+          "name": "reminder_1hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_24hour": {
+          "name": "reminder_24hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "poll_started_at": {
+          "name": "poll_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_ends_at": {
+          "name": "poll_ends_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_event_plans_creator_id": {
+          "name": "idx_event_plans_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_plans_status": {
+          "name": "idx_event_plans_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_plans_creator_id_users_id_fk": {
+          "name": "event_plans_creator_id_users_id_fk",
+          "tableFrom": "event_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_plans_game_id_games_id_fk": {
+          "name": "event_plans_game_id_games_id_fk",
+          "tableFrom": "event_plans",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "event_plans_created_event_id_events_id_fk": {
+          "name": "event_plans_created_event_id_events_id_fk",
+          "tableFrom": "event_plans",
+          "tableTo": "events",
+          "columnsFrom": [
+            "created_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_dungeon_quests": {
+      "name": "wow_classic_dungeon_quests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dungeon_instance_id": {
+          "name": "dungeon_instance_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quest_level": {
+          "name": "quest_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_level": {
+          "name": "required_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expansion": {
+          "name": "expansion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quest_giver_npc": {
+          "name": "quest_giver_npc",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quest_giver_zone": {
+          "name": "quest_giver_zone",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_quest_id": {
+          "name": "prev_quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_quest_id": {
+          "name": "next_quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewards_json": {
+          "name": "rewards_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objectives": {
+          "name": "objectives",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_restriction": {
+          "name": "class_restriction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "race_restriction": {
+          "name": "race_restriction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_inside_dungeon": {
+          "name": "starts_inside_dungeon",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sharable": {
+          "name": "sharable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reward_xp": {
+          "name": "reward_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_gold": {
+          "name": "reward_gold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_type": {
+          "name": "reward_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wow_classic_dungeon_quests_quest_id_unique": {
+          "name": "wow_classic_dungeon_quests_quest_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "quest_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_boss_loot": {
+      "name": "wow_classic_boss_loot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "boss_id": {
+          "name": "boss_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot": {
+          "name": "slot",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality": {
+          "name": "quality",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_level": {
+          "name": "item_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drop_rate": {
+          "name": "drop_rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expansion": {
+          "name": "expansion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_restrictions": {
+          "name": "class_restrictions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_subclass": {
+          "name": "item_subclass",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wow_classic_boss_loot_boss_id_wow_classic_bosses_id_fk": {
+          "name": "wow_classic_boss_loot_boss_id_wow_classic_bosses_id_fk",
+          "tableFrom": "wow_classic_boss_loot",
+          "tableTo": "wow_classic_bosses",
+          "columnsFrom": [
+            "boss_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_loot_boss_item_expansion": {
+          "name": "uq_loot_boss_item_expansion",
+          "nullsNotDistinct": false,
+          "columns": [
+            "boss_id",
+            "item_id",
+            "expansion"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_bosses": {
+      "name": "wow_classic_bosses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expansion": {
+          "name": "expansion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sod_modified": {
+          "name": "sod_modified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_boss_instance_name_expansion": {
+          "name": "uq_boss_instance_name_expansion",
+          "nullsNotDistinct": false,
+          "columns": [
+            "instance_id",
+            "name",
+            "expansion"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_quest_progress": {
+      "name": "wow_classic_quest_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picked_up": {
+          "name": "picked_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wow_classic_quest_progress_event_id_events_id_fk": {
+          "name": "wow_classic_quest_progress_event_id_events_id_fk",
+          "tableFrom": "wow_classic_quest_progress",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wow_classic_quest_progress_user_id_users_id_fk": {
+          "name": "wow_classic_quest_progress_user_id_users_id_fk",
+          "tableFrom": "wow_classic_quest_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_quest_progress_event_user_quest": {
+          "name": "uq_quest_progress_event_user_quest",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id",
+            "quest_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_activity_sessions": {
+      "name": "game_activity_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_activity_name": {
+          "name": "discord_activity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "game_activity_sessions_user_game_started_idx": {
+          "name": "game_activity_sessions_user_game_started_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "game_activity_sessions_game_started_idx": {
+          "name": "game_activity_sessions_game_started_idx",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_activity_sessions_user_id_users_id_fk": {
+          "name": "game_activity_sessions_user_id_users_id_fk",
+          "tableFrom": "game_activity_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_activity_sessions_game_id_games_id_fk": {
+          "name": "game_activity_sessions_game_id_games_id_fk",
+          "tableFrom": "game_activity_sessions",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_activity_rollups": {
+      "name": "game_activity_rollups",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period": {
+          "name": "period",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_seconds": {
+          "name": "total_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "game_activity_rollups_game_period_start_idx": {
+          "name": "game_activity_rollups_game_period_start_idx",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_activity_rollups_user_id_users_id_fk": {
+          "name": "game_activity_rollups_user_id_users_id_fk",
+          "tableFrom": "game_activity_rollups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_activity_rollups_game_id_games_id_fk": {
+          "name": "game_activity_rollups_game_id_games_id_fk",
+          "tableFrom": "game_activity_rollups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "game_activity_rollups_user_game_period_unique": {
+          "name": "game_activity_rollups_user_game_period_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id",
+            "period",
+            "period_start"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_game_mappings": {
+      "name": "discord_game_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "discord_activity_name": {
+          "name": "discord_activity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "discord_game_mappings_game_id_games_id_fk": {
+          "name": "discord_game_mappings_game_id_games_id_fk",
+          "tableFrom": "discord_game_mappings",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_game_mappings_discord_activity_name_unique": {
+          "name": "discord_game_mappings_discord_activity_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_activity_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ad_hoc_participants": {
+      "name": "ad_hoc_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_avatar_hash": {
+          "name": "discord_avatar_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_duration_seconds": {
+          "name": "total_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "ad_hoc_participants_event_discord_user_unique": {
+          "name": "ad_hoc_participants_event_discord_user_unique",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ad_hoc_participants_event": {
+          "name": "idx_ad_hoc_participants_event",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ad_hoc_participants_user": {
+          "name": "idx_ad_hoc_participants_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ad_hoc_participants_event_id_events_id_fk": {
+          "name": "ad_hoc_participants_event_id_events_id_fk",
+          "tableFrom": "ad_hoc_participants",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ad_hoc_participants_user_id_users_id_fk": {
+          "name": "ad_hoc_participants_user_id_users_id_fk",
+          "tableFrom": "ad_hoc_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_interest_suppressions": {
+      "name": "game_interest_suppressions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suppressed_at": {
+          "name": "suppressed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_interest_suppressions_user_id_users_id_fk": {
+          "name": "game_interest_suppressions_user_id_users_id_fk",
+          "tableFrom": "game_interest_suppressions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_interest_suppressions_game_id_games_id_fk": {
+          "name": "game_interest_suppressions_game_id_games_id_fk",
+          "tableFrom": "game_interest_suppressions",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_user_game_suppression": {
+          "name": "uq_user_game_suppression",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_voice_sessions": {
+      "name": "event_voice_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_join_at": {
+          "name": "first_join_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_leave_at": {
+          "name": "last_leave_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_duration_sec": {
+          "name": "total_duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "segments": {
+          "name": "segments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "event_voice_sessions_event_discord_user_unique": {
+          "name": "event_voice_sessions_event_discord_user_unique",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_voice_sessions_event": {
+          "name": "idx_event_voice_sessions_event",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_voice_sessions_event_id_events_id_fk": {
+          "name": "event_voice_sessions_event_id_events_id_fk",
+          "tableFrom": "event_voice_sessions",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_voice_sessions_user_id_users_id_fk": {
+          "name": "event_voice_sessions_user_id_users_id_fk",
+          "tableFrom": "event_voice_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrichments": {
+      "name": "enrichments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enricher_key": {
+          "name": "enricher_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_enrichments_entity": {
+          "name": "idx_enrichments_entity",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_entity_enricher": {
+          "name": "unique_entity_enricher",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "enricher_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_request_logs": {
+      "name": "ai_request_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "feature": {
+          "name": "feature",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ai_request_logs_created_at": {
+          "name": "idx_ai_request_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_request_logs_feature_created_at": {
+          "name": "idx_ai_request_logs_feature_created_at",
+          "columns": [
+            {
+              "expression": "feature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_request_logs_user_id_users_id_fk": {
+          "name": "ai_request_logs_user_id_users_id_fk",
+          "tableFrom": "ai_request_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_entries": {
+      "name": "community_lineup_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nominated_by": {
+          "name": "nominated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carried_over_from": {
+          "name": "carried_over_from",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_entries_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_entries_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_entries",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_entries_game_id_games_id_fk": {
+          "name": "community_lineup_entries_game_id_games_id_fk",
+          "tableFrom": "community_lineup_entries",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_entries_nominated_by_users_id_fk": {
+          "name": "community_lineup_entries_nominated_by_users_id_fk",
+          "tableFrom": "community_lineup_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "nominated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_entries_carried_over_from_community_lineups_id_fk": {
+          "name": "community_lineup_entries_carried_over_from_community_lineups_id_fk",
+          "tableFrom": "community_lineup_entries",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "carried_over_from"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lineup_entry_game": {
+          "name": "uq_lineup_entry_game",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineup_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_votes": {
+      "name": "community_lineup_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_votes_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_votes_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_votes",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_votes_user_id_users_id_fk": {
+          "name": "community_lineup_votes_user_id_users_id_fk",
+          "tableFrom": "community_lineup_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_votes_game_id_games_id_fk": {
+          "name": "community_lineup_votes_game_id_games_id_fk",
+          "tableFrom": "community_lineup_votes",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lineup_vote_user_game": {
+          "name": "uq_lineup_vote_user_game",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineup_id",
+            "user_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineups": {
+      "name": "community_lineups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'building'"
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_game_id": {
+          "name": "decided_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_event_id": {
+          "name": "linked_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voting_deadline": {
+          "name": "voting_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase_deadline": {
+          "name": "phase_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase_duration_override": {
+          "name": "phase_duration_override",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_threshold": {
+          "name": "match_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 35
+        },
+        "max_votes_per_player": {
+          "name": "max_votes_per_player",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "default_tiebreaker_mode": {
+          "name": "default_tiebreaker_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_tiebreaker_id": {
+          "name": "active_tiebreaker_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_created_channel_id": {
+          "name": "discord_created_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_created_message_id": {
+          "name": "discord_created_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineups_decided_game_id_games_id_fk": {
+          "name": "community_lineups_decided_game_id_games_id_fk",
+          "tableFrom": "community_lineups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "decided_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_lineups_linked_event_id_events_id_fk": {
+          "name": "community_lineups_linked_event_id_events_id_fk",
+          "tableFrom": "community_lineups",
+          "tableTo": "events",
+          "columnsFrom": [
+            "linked_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_lineups_created_by_users_id_fk": {
+          "name": "community_lineups_created_by_users_id_fk",
+          "tableFrom": "community_lineups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_tiebreaker_bracket_matchups": {
+      "name": "community_lineup_tiebreaker_bracket_matchups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tiebreaker_id": {
+          "name": "tiebreaker_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_a_id": {
+          "name": "game_a_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_b_id": {
+          "name": "game_b_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "winner_game_id": {
+          "name": "winner_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bye": {
+          "name": "is_bye",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_tiebreaker_bracket_matchups_tiebreaker_id_community_lineup_tiebreakers_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_matchups_tiebreaker_id_community_lineup_tiebreakers_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_matchups",
+          "tableTo": "community_lineup_tiebreakers",
+          "columnsFrom": [
+            "tiebreaker_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_matchups_game_a_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_matchups_game_a_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_matchups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_matchups_game_b_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_matchups_game_b_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_matchups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_matchups_winner_game_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_matchups_winner_game_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_matchups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "winner_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_tiebreaker_matchup_round_pos": {
+          "name": "uq_tiebreaker_matchup_round_pos",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tiebreaker_id",
+            "round",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_tiebreaker_bracket_votes": {
+      "name": "community_lineup_tiebreaker_bracket_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "matchup_id": {
+          "name": "matchup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_tiebreaker_bracket_votes_matchup_id_community_lineup_tiebreaker_bracket_matchups_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_votes_matchup_id_community_lineup_tiebreaker_bracket_matchups_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_votes",
+          "tableTo": "community_lineup_tiebreaker_bracket_matchups",
+          "columnsFrom": [
+            "matchup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_votes_user_id_users_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_votes_user_id_users_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_votes_game_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_votes_game_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_votes",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_tiebreaker_bracket_vote": {
+          "name": "uq_tiebreaker_bracket_vote",
+          "nullsNotDistinct": false,
+          "columns": [
+            "matchup_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_tiebreaker_vetoes": {
+      "name": "community_lineup_tiebreaker_vetoes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tiebreaker_id": {
+          "name": "tiebreaker_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revealed": {
+          "name": "revealed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_tiebreaker_vetoes_tiebreaker_id_community_lineup_tiebreakers_id_fk": {
+          "name": "community_lineup_tiebreaker_vetoes_tiebreaker_id_community_lineup_tiebreakers_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_vetoes",
+          "tableTo": "community_lineup_tiebreakers",
+          "columnsFrom": [
+            "tiebreaker_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_vetoes_user_id_users_id_fk": {
+          "name": "community_lineup_tiebreaker_vetoes_user_id_users_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_vetoes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_vetoes_game_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_vetoes_game_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_vetoes",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_tiebreaker_veto_user": {
+          "name": "uq_tiebreaker_veto_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tiebreaker_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_tiebreakers": {
+      "name": "community_lineup_tiebreakers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "tied_game_ids": {
+          "name": "tied_game_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_vote_count": {
+          "name": "original_vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "winner_game_id": {
+          "name": "winner_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round_deadline": {
+          "name": "round_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_tiebreakers_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_tiebreakers_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_tiebreakers",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreakers_winner_game_id_games_id_fk": {
+          "name": "community_lineup_tiebreakers_winner_game_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreakers",
+          "tableTo": "games",
+          "columnsFrom": [
+            "winner_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_match_members": {
+      "name": "community_lineup_match_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_match_members_match_id_community_lineup_matches_id_fk": {
+          "name": "community_lineup_match_members_match_id_community_lineup_matches_id_fk",
+          "tableFrom": "community_lineup_match_members",
+          "tableTo": "community_lineup_matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_match_members_user_id_users_id_fk": {
+          "name": "community_lineup_match_members_user_id_users_id_fk",
+          "tableFrom": "community_lineup_match_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_match_member_user": {
+          "name": "uq_match_member_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_matches": {
+      "name": "community_lineup_matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'suggested'"
+        },
+        "threshold_met": {
+          "name": "threshold_met",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "vote_percentage": {
+          "name": "vote_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fit_type": {
+          "name": "fit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_event_id": {
+          "name": "linked_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_message_id": {
+          "name": "embed_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_channel_id": {
+          "name": "embed_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_vote_threshold": {
+          "name": "min_vote_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threshold_notified_at": {
+          "name": "threshold_notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_matches_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_matches_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_matches",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_matches_game_id_games_id_fk": {
+          "name": "community_lineup_matches_game_id_games_id_fk",
+          "tableFrom": "community_lineup_matches",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_matches_linked_event_id_events_id_fk": {
+          "name": "community_lineup_matches_linked_event_id_events_id_fk",
+          "tableFrom": "community_lineup_matches",
+          "tableTo": "events",
+          "columnsFrom": [
+            "linked_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lineup_match_game": {
+          "name": "uq_lineup_match_game",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineup_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_schedule_slots": {
+      "name": "community_lineup_schedule_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_time": {
+          "name": "proposed_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overlap_score": {
+          "name": "overlap_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_by": {
+          "name": "suggested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_schedule_slots_match_id_community_lineup_matches_id_fk": {
+          "name": "community_lineup_schedule_slots_match_id_community_lineup_matches_id_fk",
+          "tableFrom": "community_lineup_schedule_slots",
+          "tableTo": "community_lineup_matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_schedule_votes": {
+      "name": "community_lineup_schedule_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slot_id": {
+          "name": "slot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_schedule_votes_slot_id_community_lineup_schedule_slots_id_fk": {
+          "name": "community_lineup_schedule_votes_slot_id_community_lineup_schedule_slots_id_fk",
+          "tableFrom": "community_lineup_schedule_votes",
+          "tableTo": "community_lineup_schedule_slots",
+          "columnsFrom": [
+            "slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_schedule_votes_user_id_users_id_fk": {
+          "name": "community_lineup_schedule_votes_user_id_users_id_fk",
+          "tableFrom": "community_lineup_schedule_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_schedule_vote_user": {
+          "name": "uq_schedule_vote_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slot_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_activity_log_entity": {
+          "name": "idx_activity_log_entity",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_actor_id_users_id_fk": {
+          "name": "activity_log_actor_id_users_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_dedup": {
+      "name": "notification_dedup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_notification_dedup_key": {
+          "name": "uq_notification_dedup_key",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_dedup_expires_at": {
+          "name": "idx_notification_dedup_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consumed_intent_tokens": {
+      "name": "consumed_intent_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_consumed_intent_tokens_consumed_at": {
+          "name": "idx_consumed_intent_tokens_consumed_at",
+          "columns": [
+            {
+              "expression": "consumed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "consumed_intent_tokens_token_hash_unique": {
+          "name": "consumed_intent_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_taste_vectors": {
+      "name": "player_taste_vectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vector": {
+          "name": "vector",
+          "type": "vector(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intensity_metrics": {
+          "name": "intensity_metrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archetype": {
+          "name": "archetype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "signal_hash": {
+          "name": "signal_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "player_taste_vectors_computed_at_idx": {
+          "name": "player_taste_vectors_computed_at_idx",
+          "columns": [
+            {
+              "expression": "computed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "player_taste_vectors_user_id_users_id_fk": {
+          "name": "player_taste_vectors_user_id_users_id_fk",
+          "tableFrom": "player_taste_vectors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "player_taste_vectors_user_id_unique": {
+          "name": "player_taste_vectors_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_intensity_snapshots": {
+      "name": "player_intensity_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_start": {
+          "name": "week_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_hours": {
+          "name": "total_hours",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_breakdown": {
+          "name": "game_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unique_games": {
+          "name": "unique_games",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longest_session_hours": {
+          "name": "longest_session_hours",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longest_session_game_id": {
+          "name": "longest_session_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "player_intensity_snapshots_week_start_idx": {
+          "name": "player_intensity_snapshots_week_start_idx",
+          "columns": [
+            {
+              "expression": "week_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "player_intensity_snapshots_user_id_users_id_fk": {
+          "name": "player_intensity_snapshots_user_id_users_id_fk",
+          "tableFrom": "player_intensity_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "player_intensity_snapshots_longest_session_game_id_games_id_fk": {
+          "name": "player_intensity_snapshots_longest_session_game_id_games_id_fk",
+          "tableFrom": "player_intensity_snapshots",
+          "tableTo": "games",
+          "columnsFrom": [
+            "longest_session_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_player_intensity_user_week": {
+          "name": "uq_player_intensity_user_week",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "week_start"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_co_play": {
+      "name": "player_co_play",
+      "schema": "",
+      "columns": {
+        "user_id_a": {
+          "name": "user_id_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id_b": {
+          "name": "user_id_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_minutes": {
+          "name": "total_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_played_at": {
+          "name": "last_played_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "games_played": {
+          "name": "games_played",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "player_co_play_user_id_a_users_id_fk": {
+          "name": "player_co_play_user_id_a_users_id_fk",
+          "tableFrom": "player_co_play",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id_a"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "player_co_play_user_id_b_users_id_fk": {
+          "name": "player_co_play_user_id_b_users_id_fk",
+          "tableFrom": "player_co_play",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id_b"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "player_co_play_user_id_a_user_id_b_pk": {
+          "name": "player_co_play_user_id_a_user_id_b_pk",
+          "columns": [
+            "user_id_a",
+            "user_id_b"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_player_co_play_canonical_order": {
+          "name": "chk_player_co_play_canonical_order",
+          "value": "\"player_co_play\".\"user_id_a\" < \"player_co_play\".\"user_id_b\""
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/src/drizzle/migrations/meta/_journal.json
+++ b/api/src/drizzle/migrations/meta/_journal.json
@@ -862,6 +862,13 @@
       "when": 1776486584799,
       "tag": "0122_lineup_title_description",
       "breakpoints": true
+    },
+    {
+      "idx": 123,
+      "version": "7",
+      "when": 1776536897783,
+      "tag": "0123_lineup_created_embed_refs",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/drizzle/migrations/meta/_journal.json
+++ b/api/src/drizzle/migrations/meta/_journal.json
@@ -855,6 +855,13 @@
       "when": 1775949515716,
       "tag": "0121_player_taste_profile",
       "breakpoints": true
+    },
+    {
+      "idx": 122,
+      "version": "7",
+      "when": 1776486584799,
+      "tag": "0122_lineup_title_description",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/drizzle/schema/community-lineups.ts
+++ b/api/src/drizzle/schema/community-lineups.ts
@@ -7,6 +7,7 @@ import {
   smallint,
   unique,
   jsonb,
+  varchar,
 } from 'drizzle-orm/pg-core';
 import { users } from './users';
 import { games } from './games';
@@ -22,6 +23,10 @@ export type LineupStatus = 'building' | 'voting' | 'decided' | 'archived';
  */
 export const communityLineups = pgTable('community_lineups', {
   id: serial('id').primaryKey(),
+  /** Operator-authored title shown everywhere the lineup appears (ROK-1063). */
+  title: varchar('title', { length: 100 }).notNull(),
+  /** Optional operator-authored markdown description (ROK-1063). */
+  description: text('description'),
   status: text('status', {
     enum: ['building', 'voting', 'decided', 'archived'],
   })

--- a/api/src/drizzle/schema/community-lineups.ts
+++ b/api/src/drizzle/schema/community-lineups.ts
@@ -56,6 +56,10 @@ export const communityLineups = pgTable('community_lineups', {
   }),
   /** Active tiebreaker FK (ROK-938). Null when no tiebreaker is active. */
   activeTiebreakerId: integer('active_tiebreaker_id'),
+  /** Discord channel ID of the creation embed (ROK-1063, for edit-in-place). */
+  discordCreatedChannelId: text('discord_created_channel_id'),
+  /** Discord message ID of the creation embed (ROK-1063, for edit-in-place). */
+  discordCreatedMessageId: text('discord_created_message_id'),
   createdAt: timestamp('created_at').defaultNow().notNull(),
   updatedAt: timestamp('updated_at').defaultNow().notNull(),
 });

--- a/api/src/lineups/common-ground.integration.spec.ts
+++ b/api/src/lineups/common-ground.integration.spec.ts
@@ -58,7 +58,7 @@ function describeCommonGround() {
     const res = await testApp.request
       .post('/lineups')
       .set('Authorization', `Bearer ${adminToken}`)
-      .send({});
+      .send({ title: 'Common Ground Test' });
     if (res.status !== 201) {
       throw new Error(
         `createBuildingLineup failed: ${res.status} ${JSON.stringify(res.body)}`,

--- a/api/src/lineups/lineup-notification-channel.helpers.ts
+++ b/api/src/lineups/lineup-notification-channel.helpers.ts
@@ -2,8 +2,35 @@
  * Resolves the Discord channel for lineup embeds (ROK-932).
  * Falls back from dedicated lineup channel to announcement channel.
  */
+import { eq } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from '../drizzle/schema';
 import { SETTING_KEYS } from '../drizzle/schema';
 import type { SettingsService } from '../settings/settings.service';
+
+type Db = PostgresJsDatabase<typeof schema>;
+
+/** Lineup metadata pulled from the DB for embed context (ROK-1063). */
+export interface LineupMeta {
+  title?: string;
+  description?: string | null;
+}
+
+/** Load title + description for a lineup (ROK-1063). */
+export async function loadLineupMeta(
+  db: Db,
+  lineupId: number,
+): Promise<LineupMeta> {
+  const [row] = await db
+    .select({
+      title: schema.communityLineups.title,
+      description: schema.communityLineups.description,
+    })
+    .from(schema.communityLineups)
+    .where(eq(schema.communityLineups.id, lineupId))
+    .limit(1);
+  return { title: row?.title, description: row?.description ?? null };
+}
 
 /**
  * Resolve the channel ID for posting lineup embeds.

--- a/api/src/lineups/lineup-notification-dm-batch.helpers.ts
+++ b/api/src/lineups/lineup-notification-dm-batch.helpers.ts
@@ -1,0 +1,74 @@
+/**
+ * DM fan-out helpers extracted from LineupNotificationService (ROK-1063).
+ * Keeps lineup-notification.service.ts under the per-file line budget.
+ */
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from '../drizzle/schema';
+import type { NotificationService } from '../notifications/notification.service';
+import type { NotificationDedupService } from '../notifications/notification-dedup.service';
+import type { LineupInfo, MatchInfo } from './lineup-notification.service';
+import {
+  sendVotingDM,
+  sendSchedulingDM,
+  sendEventCreatedDM,
+} from './lineup-notification-dm.helpers';
+import {
+  findDiscordLinkedMembers,
+  findMatchMemberUsers,
+} from './lineup-notification-targets.helpers';
+
+type Db = PostgresJsDatabase<typeof schema>;
+
+/** Fan-out voting-open DMs to all Discord-linked members. */
+export async function fanOutVotingDMs(
+  db: Db,
+  notificationService: NotificationService,
+  dedupService: NotificationDedupService,
+  lineup: LineupInfo,
+  gameCount: number,
+): Promise<void> {
+  const members = await findDiscordLinkedMembers(db);
+  for (const member of members) {
+    await sendVotingDM(
+      notificationService,
+      dedupService,
+      lineup,
+      member,
+      gameCount,
+    );
+  }
+}
+
+/** Fan-out scheduling DMs to all members of a match. */
+export async function fanOutSchedulingDMs(
+  db: Db,
+  notificationService: NotificationService,
+  dedupService: NotificationDedupService,
+  match: MatchInfo,
+): Promise<void> {
+  const members = await findMatchMemberUsers(db, match.id);
+  for (const m of members) {
+    await sendSchedulingDM(notificationService, dedupService, match, m);
+  }
+}
+
+/** Fan-out event-created DMs to prefetched match members. */
+export async function fanOutEventCreatedDMs(
+  notificationService: NotificationService,
+  dedupService: NotificationDedupService,
+  match: MatchInfo,
+  eventDate: Date,
+  eventId: number | undefined,
+  members: Awaited<ReturnType<typeof findMatchMemberUsers>>,
+): Promise<void> {
+  for (const member of members) {
+    await sendEventCreatedDM(
+      notificationService,
+      dedupService,
+      match,
+      member,
+      eventDate,
+      eventId,
+    );
+  }
+}

--- a/api/src/lineups/lineup-notification-dms.helpers.ts
+++ b/api/src/lineups/lineup-notification-dms.helpers.ts
@@ -1,0 +1,113 @@
+/**
+ * DM builders for Community Lineup notifications (ROK-932, extracted in ROK-1063).
+ * Keeps lineup-notification.service.ts under the 300-line ESLint limit.
+ */
+import type { NotificationService } from '../notifications/notification.service';
+import type { NotificationDedupService } from '../notifications/notification-dedup.service';
+import { DEDUP_TTL } from './lineup-notification.constants';
+
+/** Send a deduped DM via the notification service. */
+export async function sendDedupedDM(
+  dedupService: NotificationDedupService,
+  notificationService: NotificationService,
+  dedupKey: string,
+  payload: Parameters<NotificationService['create']>[0],
+): Promise<void> {
+  if (await dedupService.checkAndMarkSent(dedupKey, DEDUP_TTL)) return;
+  await notificationService.create(payload);
+}
+
+/** Build the match-member DM (AC-6). */
+export async function dispatchMatchMemberDM(
+  dedupService: NotificationDedupService,
+  notificationService: NotificationService,
+  args: {
+    matchId: number;
+    userId: number;
+    gameName: string;
+    coPlayers: string[];
+    lineupId: number;
+  },
+): Promise<void> {
+  const coList = args.coPlayers.length
+    ? args.coPlayers.join(', ')
+    : 'your group';
+  await sendDedupedDM(
+    dedupService,
+    notificationService,
+    `lineup-match-dm:${args.matchId}:${args.userId}`,
+    {
+      userId: args.userId,
+      type: 'community_lineup',
+      title: `You're matched for ${args.gameName}!`,
+      message: `You're in a match for ${args.gameName} with ${coList}. Schedule a time!`,
+      payload: {
+        subtype: 'lineup_match_member',
+        matchId: args.matchId,
+        lineupId: args.lineupId,
+        gameName: args.gameName,
+      },
+    },
+  );
+}
+
+/** Build the rally-interest DM (AC-7). */
+export async function dispatchRallyInterestDM(
+  dedupService: NotificationDedupService,
+  notificationService: NotificationService,
+  args: {
+    matchId: number;
+    userId: number;
+    gameName: string;
+    lineupId: number;
+  },
+): Promise<void> {
+  await sendDedupedDM(
+    dedupService,
+    notificationService,
+    `lineup-rally-dm:${args.matchId}:${args.userId}`,
+    {
+      userId: args.userId,
+      type: 'community_lineup',
+      title: `${args.gameName} needs more interest!`,
+      message: `${args.gameName} almost has enough players. Join the match!`,
+      payload: {
+        subtype: 'lineup_rally_interest',
+        matchId: args.matchId,
+        lineupId: args.lineupId,
+        gameName: args.gameName,
+      },
+    },
+  );
+}
+
+/** Build the nomination-removed DM (AC-16). */
+export async function dispatchNominationRemovedDM(
+  dedupService: NotificationDedupService,
+  notificationService: NotificationService,
+  args: {
+    lineupId: number;
+    gameId: number;
+    gameName: string;
+    userId: number;
+    operatorName: string;
+  },
+): Promise<void> {
+  await sendDedupedDM(
+    dedupService,
+    notificationService,
+    `lineup-removed-dm:${args.lineupId}:${args.gameId}:${args.userId}`,
+    {
+      userId: args.userId,
+      type: 'community_lineup',
+      title: 'Nomination removed',
+      message: `Your nomination ${args.gameName} was removed by ${args.operatorName}.`,
+      payload: {
+        subtype: 'lineup_nomination_removed',
+        lineupId: args.lineupId,
+        gameId: args.gameId,
+        gameName: args.gameName,
+      },
+    },
+  );
+}

--- a/api/src/lineups/lineup-notification-embed-chrome.helpers.ts
+++ b/api/src/lineups/lineup-notification-embed-chrome.helpers.ts
@@ -1,0 +1,82 @@
+/**
+ * Shared chrome helpers for Community Lineup Discord embeds (ROK-932).
+ * Extracted from lineup-notification-embed.helpers.ts in ROK-1063 to keep
+ * both files under the 300-line ESLint limit.
+ */
+import {
+  EmbedBuilder,
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+} from 'discord.js';
+import type {
+  EmbedContext,
+  LineupPhase,
+} from './lineup-notification-embed.helpers';
+
+/** Convert a Date to Discord relative timestamp: `<t:UNIX:R>`. */
+export function discordTs(date: Date, style: 'R' | 'f' | 'F' = 'R'): string {
+  return `<t:${Math.floor(date.getTime() / 1000)}:${style}>`;
+}
+
+/** Build a link button pointing at the lineup page with a custom label. */
+export function ctaButton(
+  ctx: EmbedContext,
+  label: string,
+): ActionRowBuilder<ButtonBuilder> {
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setLabel(label)
+      .setStyle(ButtonStyle.Link)
+      .setURL(`${ctx.baseUrl}/community-lineup/${ctx.lineupId}`),
+  );
+}
+
+const PHASE_LABELS: [LineupPhase, string][] = [
+  ['nominations', 'Nominations'],
+  ['voting', 'Voting'],
+  ['decided', 'Scheduling'],
+];
+
+/** Build a breadcrumb with completed phases struck through. */
+function phaseBreadcrumb(current: LineupPhase): string {
+  const idx = PHASE_LABELS.findIndex(([k]) => k === current);
+  return PHASE_LABELS.map(([key, name], i) => {
+    if (i < idx) return `\u2705 ${name}`;
+    if (key === current) return `\u{1F539} **${name}**`;
+    return `\u2796 ${name}`;
+  }).join('  \u203A  ');
+}
+
+/**
+ * Resolve the embed title: prepend the operator-authored lineup title to the
+ * phase headline when present, otherwise fall back to the legacy default
+ * ("Community Lineup — <headline>") (ROK-1063).
+ */
+export function resolveEmbedTitle(
+  ctx: EmbedContext,
+  emoji: string,
+  headline: string,
+): string {
+  const base = ctx.lineupTitle?.trim() || 'Community Lineup';
+  return `${emoji} ${base} — ${headline}`;
+}
+
+/** Apply shared author + phase breadcrumb + footer to an embed. */
+export function applyChrome(
+  embed: EmbedBuilder,
+  ctx: EmbedContext,
+  label: string,
+): void {
+  embed
+    .setAuthor({ name: ctx.communityName || 'Raid Ledger' })
+    .addFields({
+      name: '\u200B',
+      value: phaseBreadcrumb(ctx.phase),
+      inline: false,
+    })
+    .setFooter({
+      text: `${ctx.communityName || 'Raid Ledger'} \u00B7 ${label}`,
+    })
+    .setTimestamp();
+}

--- a/api/src/lineups/lineup-notification-embed.helpers.ts
+++ b/api/src/lineups/lineup-notification-embed.helpers.ts
@@ -372,7 +372,9 @@ export function buildTiebreakerStartedEmbed(
   const descIntro = ctx.lineupDescription ? `${ctx.lineupDescription}\n\n` : '';
 
   const embed = new EmbedBuilder()
-    .setTitle(resolveEmbedTitle(ctx, '\u2694\u{FE0F}', 'Tiebreaker Round Started'))
+    .setTitle(
+      resolveEmbedTitle(ctx, '\u2694\u{FE0F}', 'Tiebreaker Round Started'),
+    )
     .setDescription(
       descIntro +
         `It's a tie! A ${mode} tiebreaker is now running. ${modeBlurb}` +

--- a/api/src/lineups/lineup-notification-embed.helpers.ts
+++ b/api/src/lineups/lineup-notification-embed.helpers.ts
@@ -10,6 +10,12 @@ import {
   ButtonStyle,
 } from 'discord.js';
 import { EMBED_COLORS } from '../discord-bot/discord-bot.constants';
+import {
+  discordTs,
+  ctaButton,
+  resolveEmbedTitle,
+  applyChrome,
+} from './lineup-notification-embed-chrome.helpers';
 
 /** Lineup phase for breadcrumb rendering. */
 export type LineupPhase = 'nominations' | 'voting' | 'decided';
@@ -48,69 +54,6 @@ export interface MatchSummary {
 export interface EmbedWithRow {
   embed: EmbedBuilder;
   row: ActionRowBuilder<ButtonBuilder>;
-}
-
-/** Convert a Date to Discord relative timestamp: `<t:UNIX:R>`. */
-function discordTs(date: Date, style: 'R' | 'f' | 'F' = 'R'): string {
-  return `<t:${Math.floor(date.getTime() / 1000)}:${style}>`;
-}
-
-/** Build a link button pointing at the lineup page with a custom label. */
-function ctaButton(
-  ctx: EmbedContext,
-  label: string,
-): ActionRowBuilder<ButtonBuilder> {
-  return new ActionRowBuilder<ButtonBuilder>().addComponents(
-    new ButtonBuilder()
-      .setLabel(label)
-      .setStyle(ButtonStyle.Link)
-      .setURL(`${ctx.baseUrl}/community-lineup/${ctx.lineupId}`),
-  );
-}
-
-const PHASE_LABELS: [LineupPhase, string][] = [
-  ['nominations', 'Nominations'],
-  ['voting', 'Voting'],
-  ['decided', 'Scheduling'],
-];
-
-/** Build a breadcrumb with completed phases struck through. */
-function phaseBreadcrumb(current: LineupPhase): string {
-  const idx = PHASE_LABELS.findIndex(([k]) => k === current);
-  return PHASE_LABELS.map(([key, name], i) => {
-    if (i < idx) return `\u2705 ${name}`;
-    if (key === current) return `\u{1F539} **${name}**`;
-    return `\u2796 ${name}`;
-  }).join('  \u203A  ');
-}
-
-/**
- * Resolve the embed title: prepend the operator-authored lineup title to the
- * phase headline when present, otherwise fall back to the legacy default
- * ("Community Lineup — <headline>") (ROK-1063).
- */
-function resolveEmbedTitle(
-  ctx: EmbedContext,
-  emoji: string,
-  headline: string,
-): string {
-  const base = ctx.lineupTitle?.trim() || 'Community Lineup';
-  return `${emoji} ${base} — ${headline}`;
-}
-
-/** Apply shared author + phase breadcrumb + footer to an embed. */
-function applyChrome(embed: EmbedBuilder, ctx: EmbedContext, label: string) {
-  embed
-    .setAuthor({ name: ctx.communityName || 'Raid Ledger' })
-    .addFields({
-      name: '\u200B',
-      value: phaseBreadcrumb(ctx.phase),
-      inline: false,
-    })
-    .setFooter({
-      text: `${ctx.communityName || 'Raid Ledger'} \u00B7 ${label}`,
-    })
-    .setTimestamp();
 }
 
 // ─── Channel Embeds ──────────────────────────────────────────

--- a/api/src/lineups/lineup-notification-embed.helpers.ts
+++ b/api/src/lineups/lineup-notification-embed.helpers.ts
@@ -20,6 +20,10 @@ export interface EmbedContext {
   lineupId: number;
   communityName: string;
   phase: LineupPhase;
+  /** Operator-authored lineup title (ROK-1063). Falls back to default when missing. */
+  lineupTitle?: string;
+  /** Operator-authored markdown description (ROK-1063). */
+  lineupDescription?: string | null;
 }
 
 /** Nomination entry for milestone embeds. */
@@ -80,6 +84,20 @@ function phaseBreadcrumb(current: LineupPhase): string {
   }).join('  \u203A  ');
 }
 
+/**
+ * Resolve the embed title: prepend the operator-authored lineup title to the
+ * phase headline when present, otherwise fall back to the legacy default
+ * ("Community Lineup — <headline>") (ROK-1063).
+ */
+function resolveEmbedTitle(
+  ctx: EmbedContext,
+  emoji: string,
+  headline: string,
+): string {
+  const base = ctx.lineupTitle?.trim() || 'Community Lineup';
+  return `${emoji} ${base} — ${headline}`;
+}
+
 /** Apply shared author + phase breadcrumb + footer to an embed. */
 function applyChrome(embed: EmbedBuilder, ctx: EmbedContext, label: string) {
   embed
@@ -105,11 +123,13 @@ export function buildCreatedEmbed(
   const deadline = targetDate
     ? `\n\n\u{1F4C5} **Target play date:** ${discordTs(targetDate)}`
     : '';
+  const descIntro = ctx.lineupDescription ? `${ctx.lineupDescription}\n\n` : '';
 
   const embed = new EmbedBuilder()
-    .setTitle('\u{1F3B2} Community Lineup — Nominations Open!')
+    .setTitle(resolveEmbedTitle(ctx, '\u{1F3B2}', 'Nominations Open!'))
     .setDescription(
-      'A new **Community Lineup** has started! Suggest games now; voting ' +
+      descIntro +
+        'A new **Community Lineup** has started! Suggest games now; voting ' +
         'opens automatically once nominations close. Phases advance on ' +
         'their own as each deadline passes:' +
         '\n\n' +
@@ -173,10 +193,12 @@ export function buildVotingOpenEmbed(
     ? `\n\n\u23F0 **Voting closes:** ${discordTs(deadline)}`
     : '';
 
+  const descIntro = ctx.lineupDescription ? `${ctx.lineupDescription}\n\n` : '';
   const embed = new EmbedBuilder()
-    .setTitle('\u{1F5F3}\u{FE0F} Vote on the Community Lineup!')
+    .setTitle(resolveEmbedTitle(ctx, '\u{1F5F3}\u{FE0F}', 'Voting Open!'))
     .setDescription(
-      'Nominations are closed — voting is now open. Pick the games you ' +
+      descIntro +
+        'Nominations are closed — voting is now open. Pick the games you ' +
         'most want to play; each member gets a limited number of votes, ' +
         'so choose wisely.' +
         deadlineStr,
@@ -208,10 +230,12 @@ export function buildDecidedEmbed(
   const scheduling = matches.filter((m) => m.thresholdMet);
   const rally = matches.filter((m) => !m.thresholdMet);
 
+  const descIntro = ctx.lineupDescription ? `${ctx.lineupDescription}\n\n` : '';
   const embed = new EmbedBuilder()
-    .setTitle('\u{1F3AF} Community Lineup — Results Are In!')
+    .setTitle(resolveEmbedTitle(ctx, '\u{1F3AF}', 'Results Are In!'))
     .setDescription(
-      'Voting is closed. Games that hit the vote threshold are ' +
+      descIntro +
+        'Voting is closed. Games that hit the vote threshold are ' +
         '**ready to schedule** — pick a time and play. Games still short ' +
         'on votes can rally more players and join the schedule.',
     )
@@ -345,11 +369,13 @@ export function buildTiebreakerStartedEmbed(
     ? `\n\n\u23F0 **Closes** ${discordTs(deadline)}`
     : '';
   const cta = mode === 'veto' ? 'Cast Your Vetoes' : 'Vote in Bracket';
+  const descIntro = ctx.lineupDescription ? `${ctx.lineupDescription}\n\n` : '';
 
   const embed = new EmbedBuilder()
-    .setTitle('\u2694\u{FE0F} Tiebreaker Round Started')
+    .setTitle(resolveEmbedTitle(ctx, '\u2694\u{FE0F}', 'Tiebreaker Round Started'))
     .setDescription(
-      `It's a tie! A ${mode} tiebreaker is now running. ${modeBlurb}` +
+      descIntro +
+        `It's a tie! A ${mode} tiebreaker is now running. ${modeBlurb}` +
         deadlineStr,
     )
     .setColor(EMBED_COLORS.ANNOUNCEMENT);

--- a/api/src/lineups/lineup-notification-refresh.helpers.ts
+++ b/api/src/lineups/lineup-notification-refresh.helpers.ts
@@ -1,0 +1,81 @@
+/**
+ * Persistence + in-place refresh helpers for the lineup-created embed (ROK-1063).
+ * Extracted from lineup-notification.service.ts to keep the service under the
+ * 300-line ESLint limit.
+ */
+import type { Logger } from '@nestjs/common';
+import type { EmbedBuilder, ActionRowBuilder, ButtonBuilder } from 'discord.js';
+import { eq } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from '../drizzle/schema';
+import type { DiscordBotClientService } from '../discord-bot/discord-bot-client.service';
+
+type Db = PostgresJsDatabase<typeof schema>;
+
+/** Stored Discord reference for the lineup-created embed. */
+export interface CreatedEmbedRef {
+  channelId: string;
+  messageId: string;
+  targetDate: Date | null;
+}
+
+/** Persist the channel/message IDs of the lineup-created embed. */
+export async function persistCreatedEmbedRef(
+  db: Db,
+  lineupId: number,
+  channelId: string,
+  messageId: string,
+): Promise<void> {
+  await db
+    .update(schema.communityLineups)
+    .set({
+      discordCreatedChannelId: channelId,
+      discordCreatedMessageId: messageId,
+    })
+    .where(eq(schema.communityLineups.id, lineupId));
+}
+
+/** Load the stored creation-embed ref (null if not posted or channel missing). */
+export async function loadCreatedEmbedRef(
+  db: Db,
+  lineupId: number,
+): Promise<CreatedEmbedRef | null> {
+  const [row] = await db
+    .select({
+      channelId: schema.communityLineups.discordCreatedChannelId,
+      messageId: schema.communityLineups.discordCreatedMessageId,
+      targetDate: schema.communityLineups.targetDate,
+    })
+    .from(schema.communityLineups)
+    .where(eq(schema.communityLineups.id, lineupId))
+    .limit(1);
+  if (!row?.channelId || !row?.messageId) return null;
+  return {
+    channelId: row.channelId,
+    messageId: row.messageId,
+    targetDate: row.targetDate ?? null,
+  };
+}
+
+/**
+ * Edit a stored creation-embed in place.
+ * Swallows Discord errors so the caller's flow is unaffected.
+ */
+export async function editCreatedEmbedSafe(
+  botClient: DiscordBotClientService,
+  logger: Logger,
+  lineupId: number,
+  ref: CreatedEmbedRef,
+  embed: EmbedBuilder,
+  row: ActionRowBuilder<ButtonBuilder>,
+): Promise<void> {
+  try {
+    await botClient.editEmbed(ref.channelId, ref.messageId, embed, row);
+  } catch (err) {
+    logger.warn(
+      `Failed to edit lineup-created embed for lineup ${lineupId}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+}

--- a/api/src/lineups/lineup-notification.service.spec.ts
+++ b/api/src/lineups/lineup-notification.service.spec.ts
@@ -26,6 +26,11 @@ function makeMockDb() {
         }),
       }),
     }),
+    update: jest.fn().mockReturnValue({
+      set: jest.fn().mockReturnValue({
+        where: jest.fn().mockResolvedValue(undefined),
+      }),
+    }),
   };
 }
 
@@ -185,6 +190,114 @@ describe('LineupNotificationService', () => {
       await service.notifyLineupCreated(makeLineup());
 
       expect(mockBotClient.sendEmbed).not.toHaveBeenCalled();
+    });
+
+    it('persists Discord channel/message IDs after posting (ROK-1063)', async () => {
+      mockBotClient.sendEmbed.mockResolvedValueOnce({ id: 'msg-created-42' });
+      mockSettingsService.get.mockResolvedValue('chan-lineup');
+
+      await service.notifyLineupCreated(makeLineup(99));
+
+      expect(mockDb.update).toHaveBeenCalledTimes(1);
+      const setCall = mockDb.update.mock.results[0].value.set.mock.calls[0][0];
+      expect(setCall).toMatchObject({
+        discordCreatedChannelId: 'chan-lineup',
+        discordCreatedMessageId: 'msg-created-42',
+      });
+    });
+
+    it('skips persisting message ID when no channel is configured', async () => {
+      mockSettingsService.get.mockResolvedValue(null);
+      mockSettingsService.getDiscordBotDefaultChannel.mockResolvedValue(null);
+
+      await service.notifyLineupCreated(makeLineup());
+
+      expect(mockDb.update).not.toHaveBeenCalled();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // ROK-1063: Embed refresh after metadata edit
+  // -----------------------------------------------------------------------
+  describe('refreshCreatedEmbed (ROK-1063)', () => {
+    it('edits the stored Discord message in place when refs exist', async () => {
+      mockBotClient.editEmbed = jest.fn().mockResolvedValue({ id: 'msg-1' });
+      mockDb.select = jest.fn().mockReturnValue({
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockReturnValue({
+            limit: jest.fn().mockResolvedValue([
+              {
+                channelId: 'chan-edit',
+                messageId: 'msg-edit-77',
+                targetDate: null,
+              },
+            ]),
+          }),
+        }),
+      });
+      mockSettingsService.get.mockResolvedValue('chan-edit');
+
+      await service.refreshCreatedEmbed({
+        id: 99,
+        title: 'New Title',
+        description: 'New desc',
+      });
+
+      expect(mockBotClient.editEmbed).toHaveBeenCalledTimes(1);
+      const [channelArg, messageArg] = mockBotClient.editEmbed.mock.calls[0];
+      expect(channelArg).toBe('chan-edit');
+      expect(messageArg).toBe('msg-edit-77');
+    });
+
+    it('is a no-op when the lineup has no stored Discord message ref', async () => {
+      mockBotClient.editEmbed = jest.fn();
+      mockDb.select = jest.fn().mockReturnValue({
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockReturnValue({
+            limit: jest
+              .fn()
+              .mockResolvedValue([
+                { channelId: null, messageId: null, targetDate: null },
+              ]),
+          }),
+        }),
+      });
+
+      await service.refreshCreatedEmbed({
+        id: 99,
+        title: 'X',
+        description: null,
+      });
+
+      expect(mockBotClient.editEmbed).not.toHaveBeenCalled();
+    });
+
+    it('swallows edit errors so metadata update still succeeds', async () => {
+      mockBotClient.editEmbed = jest
+        .fn()
+        .mockRejectedValue(new Error('Unknown Message'));
+      mockDb.select = jest.fn().mockReturnValue({
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockReturnValue({
+            limit: jest.fn().mockResolvedValue([
+              {
+                channelId: 'c1',
+                messageId: 'm1',
+                targetDate: null,
+              },
+            ]),
+          }),
+        }),
+      });
+      mockSettingsService.get.mockResolvedValue('c1');
+
+      await expect(
+        service.refreshCreatedEmbed({
+          id: 99,
+          title: 'X',
+          description: null,
+        }),
+      ).resolves.toBeUndefined();
     });
   });
 

--- a/api/src/lineups/lineup-notification.service.spec.ts
+++ b/api/src/lineups/lineup-notification.service.spec.ts
@@ -45,6 +45,7 @@ function makeMockDedupService() {
 function makeMockBotClient() {
   return {
     sendEmbed: jest.fn().mockResolvedValue({ id: 'msg-1' }),
+    editEmbed: jest.fn().mockResolvedValue({ id: 'msg-1' }),
     isConnected: jest.fn().mockReturnValue(true),
   };
 }
@@ -196,7 +197,7 @@ describe('LineupNotificationService', () => {
       mockBotClient.sendEmbed.mockResolvedValueOnce({ id: 'msg-created-42' });
       mockSettingsService.get.mockResolvedValue('chan-lineup');
 
-      await service.notifyLineupCreated(makeLineup(99));
+      await service.notifyLineupCreated(makeLineup({ id: 99 }));
 
       expect(mockDb.update).toHaveBeenCalledTimes(1);
       const setCall = mockDb.update.mock.results[0].value.set.mock.calls[0][0];

--- a/api/src/lineups/lineup-notification.service.ts
+++ b/api/src/lineups/lineup-notification.service.ts
@@ -11,9 +11,13 @@ import { NotificationService } from '../notifications/notification.service';
 import { NotificationDedupService } from '../notifications/notification-dedup.service';
 import { DiscordBotClientService } from '../discord-bot/discord-bot-client.service';
 import { SettingsService } from '../settings/settings.service';
-import { resolveLineupChannel } from './lineup-notification-channel.helpers';
+import {
+  resolveLineupChannel,
+  loadLineupMeta,
+} from './lineup-notification-channel.helpers';
 import type {
   EmbedContext,
+  EmbedWithRow,
   NominationEntry,
   LineupPhase,
 } from './lineup-notification-embed.helpers';
@@ -26,12 +30,11 @@ import {
   buildEventCreatedEmbed,
 } from './lineup-notification-embed.helpers';
 import {
-  sendVotingDM,
-  sendSchedulingDM,
-  sendEventCreatedDM,
-} from './lineup-notification-dm.helpers';
+  fanOutVotingDMs,
+  fanOutSchedulingDMs,
+  fanOutEventCreatedDMs,
+} from './lineup-notification-dm-batch.helpers';
 import {
-  findDiscordLinkedMembers,
   findMatchMemberUsers,
   hasExistingPollEmbed,
 } from './lineup-notification-targets.helpers';
@@ -40,6 +43,10 @@ import { DEDUP_TTL } from './lineup-notification.constants';
 /** Shape of a lineup passed to notification methods. */
 export interface LineupInfo {
   id: number;
+  /** Operator-authored title surfaced in every embed (ROK-1063). */
+  title?: string;
+  /** Operator-authored markdown description (ROK-1063). */
+  description?: string | null;
   targetDate?: Date;
   votingDeadline?: Date;
   phaseDeadline?: Date | null;
@@ -73,28 +80,34 @@ export class LineupNotificationService {
   private async resolveCtx(
     lineupId: number,
     phase: LineupPhase,
+    overrides?: { title?: string; description?: string | null },
   ): Promise<EmbedContext> {
     const baseUrl = (await this.settingsService.getClientUrl()) ?? '';
     const community = await this.settingsService.get('community_name');
+    const meta = overrides?.title
+      ? overrides
+      : await loadLineupMeta(this.db, lineupId);
     return {
       baseUrl,
       lineupId,
       communityName: community ?? 'Raid Ledger',
       phase,
+      lineupTitle: meta.title,
+      lineupDescription: meta.description ?? null,
     };
   }
 
   /** AC-1: Post channel embed when lineup is created. */
   async notifyLineupCreated(lineup: LineupInfo): Promise<void> {
-    const key = `lineup-created:${lineup.id}`;
-    if (await this.dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
-
-    const channelId = await resolveLineupChannel(this.settingsService);
-    if (!channelId) return;
-
-    const ctx = await this.resolveCtx(lineup.id, 'nominations');
-    const { embed, row } = buildCreatedEmbed(ctx, lineup.targetDate);
-    await this.botClient.sendEmbed(channelId, embed, row);
+    const ctx = await this.resolveCtx(lineup.id, 'nominations', {
+      title: lineup.title,
+      description: lineup.description ?? null,
+    });
+    await this.postChannelEmbed(
+      `lineup-created:${lineup.id}`,
+      () => buildCreatedEmbed(ctx, lineup.targetDate),
+      ctx,
+    );
   }
 
   /** AC-2: Post channel embed at nomination milestones (25/50/100%). */
@@ -103,15 +116,12 @@ export class LineupNotificationService {
     threshold: number,
     entries: NominationEntry[],
   ): Promise<void> {
-    const key = `lineup-milestone:${lineupId}:${threshold}`;
-    if (await this.dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
-
-    const channelId = await resolveLineupChannel(this.settingsService);
-    if (!channelId) return;
-
     const ctx = await this.resolveCtx(lineupId, 'nominations');
-    const { embed, row } = buildMilestoneEmbed(ctx, threshold, entries);
-    await this.botClient.sendEmbed(channelId, embed, row);
+    await this.postChannelEmbed(
+      `lineup-milestone:${lineupId}:${threshold}`,
+      () => buildMilestoneEmbed(ctx, threshold, entries),
+      ctx,
+    );
   }
 
   /** AC-3: Post channel embed + DMs when voting opens. */
@@ -128,16 +138,12 @@ export class LineupNotificationService {
     lineupId: number,
     matches: MatchInfo[],
   ): Promise<void> {
-    const key = `lineup-decided:${lineupId}`;
-    if (await this.dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
-
-    const channelId = await resolveLineupChannel(this.settingsService);
-    if (channelId) {
-      const ctx = await this.resolveCtx(lineupId, 'decided');
-      const { embed, row } = buildDecidedEmbed(ctx, matches);
-      await this.botClient.sendEmbed(channelId, embed, row);
-    }
-
+    const ctx = await this.resolveCtx(lineupId, 'decided');
+    await this.postChannelEmbed(
+      `lineup-decided:${lineupId}`,
+      () => buildDecidedEmbed(ctx, matches),
+      ctx,
+    );
     await this.sendMatchMemberDMs(lineupId, matches);
   }
 
@@ -167,21 +173,13 @@ export class LineupNotificationService {
     coPlayers: string[],
     lineupId: number,
   ): Promise<void> {
-    const key = `lineup-match-dm:${matchId}:${userId}`;
-    if (await this.dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
-
-    const coPlayerList = coPlayers.length ? coPlayers.join(', ') : 'your group';
-    await this.notificationService.create({
+    const coList = coPlayers.length ? coPlayers.join(', ') : 'your group';
+    await this.sendDedupedDM(`lineup-match-dm:${matchId}:${userId}`, {
       userId,
       type: 'community_lineup',
       title: `You're matched for ${gameName}!`,
-      message: `You're in a match for ${gameName} with ${coPlayerList}. Schedule a time!`,
-      payload: {
-        subtype: 'lineup_match_member',
-        matchId,
-        lineupId,
-        gameName,
-      },
+      message: `You're in a match for ${gameName} with ${coList}. Schedule a time!`,
+      payload: { subtype: 'lineup_match_member', matchId, lineupId, gameName },
     });
   }
 
@@ -192,10 +190,7 @@ export class LineupNotificationService {
     gameName: string,
     lineupId: number,
   ): Promise<void> {
-    const key = `lineup-rally-dm:${matchId}:${userId}`;
-    if (await this.dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
-
-    await this.notificationService.create({
+    await this.sendDedupedDM(`lineup-rally-dm:${matchId}:${userId}`, {
       userId,
       type: 'community_lineup',
       title: `${gameName} needs more interest!`,
@@ -209,18 +204,24 @@ export class LineupNotificationService {
     });
   }
 
+  /** Send a deduped DM via the notification service (ROK-1063 refactor). */
+  private async sendDedupedDM(
+    dedupKey: string,
+    payload: Parameters<NotificationService['create']>[0],
+  ): Promise<void> {
+    if (await this.dedupService.checkAndMarkSent(dedupKey, DEDUP_TTL)) return;
+    await this.notificationService.create(payload);
+  }
+
   /** AC-8: Post per-match channel embed + DMs when scheduling opens. */
   async notifySchedulingOpen(match: MatchInfo): Promise<void> {
     await this.postSchedulingChannelEmbed(match);
-    const members = await findMatchMemberUsers(this.db, match.id);
-    for (const m of members) {
-      await sendSchedulingDM(
-        this.notificationService,
-        this.dedupService,
-        match,
-        m,
-      );
-    }
+    await fanOutSchedulingDMs(
+      this.db,
+      this.notificationService,
+      this.dedupService,
+      match,
+    );
   }
 
   /** AC-10: Post channel embed + DMs when event is created. */
@@ -232,7 +233,14 @@ export class LineupNotificationService {
     const members = await findMatchMemberUsers(this.db, match.id);
     const names = members.map((m) => m.displayName);
     await this.postEventCreatedChannelEmbed(match, eventDate, eventId, names);
-    await this.sendEventCreatedDMs(match, eventDate, eventId, members);
+    await fanOutEventCreatedDMs(
+      this.notificationService,
+      this.dedupService,
+      match,
+      eventDate,
+      eventId,
+      members,
+    );
   }
 
   /** AC-16: DM to nominator when operator removes their nomination. */
@@ -243,21 +251,37 @@ export class LineupNotificationService {
     userId: number,
     operatorName: string,
   ): Promise<void> {
-    const key = `lineup-removed-dm:${lineupId}:${gameId}:${userId}`;
-    if (await this.dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
-
-    await this.notificationService.create({
-      userId,
-      type: 'community_lineup',
-      title: 'Nomination removed',
-      message: `Your nomination ${gameName} was removed by ${operatorName}.`,
-      payload: {
-        subtype: 'lineup_nomination_removed',
-        lineupId,
-        gameId,
-        gameName,
+    await this.sendDedupedDM(
+      `lineup-removed-dm:${lineupId}:${gameId}:${userId}`,
+      {
+        userId,
+        type: 'community_lineup',
+        title: 'Nomination removed',
+        message: `Your nomination ${gameName} was removed by ${operatorName}.`,
+        payload: {
+          subtype: 'lineup_nomination_removed',
+          lineupId,
+          gameId,
+          gameName,
+        },
       },
-    });
+    );
+  }
+
+  /** Dedup + resolve channel + post an embed (ROK-1063 refactor). */
+  private async postChannelEmbed(
+    dedupKey: string,
+    build: (
+      ctx: EmbedContext,
+    ) => Promise<EmbedWithRow | null> | EmbedWithRow | null,
+    ctx: EmbedContext,
+  ): Promise<void> {
+    if (await this.dedupService.checkAndMarkSent(dedupKey, DEDUP_TTL)) return;
+    const channelId = await resolveLineupChannel(this.settingsService);
+    if (!channelId) return;
+    const result = await build(ctx);
+    if (!result) return;
+    await this.botClient.sendEmbed(channelId, result.embed, result.row);
   }
 
   /** Post the voting-open channel embed. */
@@ -265,34 +289,25 @@ export class LineupNotificationService {
     lineup: LineupInfo,
     games: { id: number; name: string }[],
   ): Promise<void> {
-    const key = `lineup-voting:${lineup.id}`;
-    if (await this.dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
-
-    const channelId = await resolveLineupChannel(this.settingsService);
-    if (!channelId) return;
-
     const ctx = await this.resolveCtx(lineup.id, 'voting');
-    const { embed, row } = buildVotingOpenEmbed(
+    await this.postChannelEmbed(
+      `lineup-voting:${lineup.id}`,
+      () => buildVotingOpenEmbed(ctx, games, lineup.votingDeadline),
       ctx,
-      games,
-      lineup.votingDeadline,
     );
-    await this.botClient.sendEmbed(channelId, embed, row);
   }
 
   /** Post the scheduling-open channel embed for a match. */
   private async postSchedulingChannelEmbed(match: MatchInfo): Promise<void> {
-    const key = `lineup-scheduling:${match.id}`;
-    if (await this.dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
-
-    const channelId = await resolveLineupChannel(this.settingsService);
-    if (!channelId) return;
-
-    if (await hasExistingPollEmbed(this.db, match.id)) return;
-
     const ctx = await this.resolveCtx(match.lineupId, 'decided');
-    const { embed, row } = buildSchedulingEmbed(ctx, match.gameName, match.id);
-    await this.botClient.sendEmbed(channelId, embed, row);
+    await this.postChannelEmbed(
+      `lineup-scheduling:${match.id}`,
+      async () => {
+        if (await hasExistingPollEmbed(this.db, match.id)) return null;
+        return buildSchedulingEmbed(ctx, match.gameName, match.id);
+      },
+      ctx,
+    );
   }
 
   /** Post the event-created channel embed. */
@@ -302,22 +317,20 @@ export class LineupNotificationService {
     eventId: number | undefined,
     memberNames: string[],
   ): Promise<void> {
-    const key = `lineup-event:${match.id}`;
-    if (await this.dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
-
-    const channelId = await resolveLineupChannel(this.settingsService);
-    if (!channelId) return;
-
     const ctx = await this.resolveCtx(match.lineupId, 'decided');
-    const { embed, row } = buildEventCreatedEmbed(
+    await this.postChannelEmbed(
+      `lineup-event:${match.id}`,
+      () =>
+        buildEventCreatedEmbed(
+          ctx,
+          match.gameName,
+          match.gameId,
+          eventDate,
+          eventId,
+          memberNames,
+        ),
       ctx,
-      match.gameName,
-      match.gameId,
-      eventDate,
-      eventId,
-      memberNames,
     );
-    await this.botClient.sendEmbed(channelId, embed, row);
   }
 
   /** Send voting-open DMs to all Discord-linked members. */
@@ -325,34 +338,12 @@ export class LineupNotificationService {
     lineup: LineupInfo,
     gameCount: number,
   ): Promise<void> {
-    const members = await findDiscordLinkedMembers(this.db);
-    for (const member of members) {
-      await sendVotingDM(
-        this.notificationService,
-        this.dedupService,
-        lineup,
-        member,
-        gameCount,
-      );
-    }
-  }
-
-  /** Send event-created DMs to prefetched match members. */
-  private async sendEventCreatedDMs(
-    match: MatchInfo,
-    eventDate: Date,
-    eventId: number | undefined,
-    members: Awaited<ReturnType<typeof findMatchMemberUsers>>,
-  ): Promise<void> {
-    for (const member of members) {
-      await sendEventCreatedDM(
-        this.notificationService,
-        this.dedupService,
-        match,
-        member,
-        eventDate,
-        eventId,
-      );
-    }
+    await fanOutVotingDMs(
+      this.db,
+      this.notificationService,
+      this.dedupService,
+      lineup,
+      gameCount,
+    );
   }
 }

--- a/api/src/lineups/lineup-notification.service.ts
+++ b/api/src/lineups/lineup-notification.service.ts
@@ -5,6 +5,7 @@
  */
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { eq } from 'drizzle-orm';
 import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
 import * as schema from '../drizzle/schema';
 import { NotificationService } from '../notifications/notification.service';
@@ -103,11 +104,57 @@ export class LineupNotificationService {
       title: lineup.title,
       description: lineup.description ?? null,
     });
-    await this.postChannelEmbed(
+    const sent = await this.postChannelEmbed(
       `lineup-created:${lineup.id}`,
       () => buildCreatedEmbed(ctx, lineup.targetDate),
       ctx,
     );
+    if (sent) {
+      await this.db
+        .update(schema.communityLineups)
+        .set({
+          discordCreatedChannelId: sent.channelId,
+          discordCreatedMessageId: sent.messageId,
+        })
+        .where(eq(schema.communityLineups.id, lineup.id));
+    }
+  }
+
+  /**
+   * Refresh the lineup-created embed after metadata edit (ROK-1063).
+   * Edits the original Discord message in place with the new title/description.
+   * Silent no-op if no stored message ref (e.g. channel not configured at creation).
+   */
+  async refreshCreatedEmbed(lineup: LineupInfo): Promise<void> {
+    const [row] = await this.db
+      .select({
+        channelId: schema.communityLineups.discordCreatedChannelId,
+        messageId: schema.communityLineups.discordCreatedMessageId,
+        targetDate: schema.communityLineups.targetDate,
+      })
+      .from(schema.communityLineups)
+      .where(eq(schema.communityLineups.id, lineup.id))
+      .limit(1);
+    if (!row?.channelId || !row?.messageId) return;
+    const ctx = await this.resolveCtx(lineup.id, 'nominations', {
+      title: lineup.title,
+      description: lineup.description ?? null,
+    });
+    const built = buildCreatedEmbed(ctx, row.targetDate ?? undefined);
+    try {
+      await this.botClient.editEmbed(
+        row.channelId,
+        row.messageId,
+        built.embed,
+        built.row,
+      );
+    } catch (err) {
+      this.logger.warn(
+        `Failed to edit lineup-created embed for lineup ${lineup.id}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
   }
 
   /** AC-2: Post channel embed at nomination milestones (25/50/100%). */
@@ -275,13 +322,19 @@ export class LineupNotificationService {
       ctx: EmbedContext,
     ) => Promise<EmbedWithRow | null> | EmbedWithRow | null,
     ctx: EmbedContext,
-  ): Promise<void> {
-    if (await this.dedupService.checkAndMarkSent(dedupKey, DEDUP_TTL)) return;
+  ): Promise<{ channelId: string; messageId: string } | null> {
+    if (await this.dedupService.checkAndMarkSent(dedupKey, DEDUP_TTL))
+      return null;
     const channelId = await resolveLineupChannel(this.settingsService);
-    if (!channelId) return;
+    if (!channelId) return null;
     const result = await build(ctx);
-    if (!result) return;
-    await this.botClient.sendEmbed(channelId, result.embed, result.row);
+    if (!result) return null;
+    const sent = await this.botClient.sendEmbed(
+      channelId,
+      result.embed,
+      result.row,
+    );
+    return { channelId, messageId: sent.id };
   }
 
   /** Post the voting-open channel embed. */

--- a/api/src/lineups/lineup-notification.service.ts
+++ b/api/src/lineups/lineup-notification.service.ts
@@ -5,9 +5,18 @@
  */
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
-import { eq } from 'drizzle-orm';
 import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
 import * as schema from '../drizzle/schema';
+import {
+  persistCreatedEmbedRef,
+  loadCreatedEmbedRef,
+  editCreatedEmbedSafe,
+} from './lineup-notification-refresh.helpers';
+import {
+  dispatchMatchMemberDM,
+  dispatchRallyInterestDM,
+  dispatchNominationRemovedDM,
+} from './lineup-notification-dms.helpers';
 import { NotificationService } from '../notifications/notification.service';
 import { NotificationDedupService } from '../notifications/notification-dedup.service';
 import { DiscordBotClientService } from '../discord-bot/discord-bot-client.service';
@@ -110,13 +119,12 @@ export class LineupNotificationService {
       ctx,
     );
     if (sent) {
-      await this.db
-        .update(schema.communityLineups)
-        .set({
-          discordCreatedChannelId: sent.channelId,
-          discordCreatedMessageId: sent.messageId,
-        })
-        .where(eq(schema.communityLineups.id, lineup.id));
+      await persistCreatedEmbedRef(
+        this.db,
+        lineup.id,
+        sent.channelId,
+        sent.messageId,
+      );
     }
   }
 
@@ -126,35 +134,21 @@ export class LineupNotificationService {
    * Silent no-op if no stored message ref (e.g. channel not configured at creation).
    */
   async refreshCreatedEmbed(lineup: LineupInfo): Promise<void> {
-    const [row] = await this.db
-      .select({
-        channelId: schema.communityLineups.discordCreatedChannelId,
-        messageId: schema.communityLineups.discordCreatedMessageId,
-        targetDate: schema.communityLineups.targetDate,
-      })
-      .from(schema.communityLineups)
-      .where(eq(schema.communityLineups.id, lineup.id))
-      .limit(1);
-    if (!row?.channelId || !row?.messageId) return;
+    const ref = await loadCreatedEmbedRef(this.db, lineup.id);
+    if (!ref) return;
     const ctx = await this.resolveCtx(lineup.id, 'nominations', {
       title: lineup.title,
       description: lineup.description ?? null,
     });
-    const built = buildCreatedEmbed(ctx, row.targetDate ?? undefined);
-    try {
-      await this.botClient.editEmbed(
-        row.channelId,
-        row.messageId,
-        built.embed,
-        built.row,
-      );
-    } catch (err) {
-      this.logger.warn(
-        `Failed to edit lineup-created embed for lineup ${lineup.id}: ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      );
-    }
+    const built = buildCreatedEmbed(ctx, ref.targetDate ?? undefined);
+    await editCreatedEmbedSafe(
+      this.botClient,
+      this.logger,
+      lineup.id,
+      ref,
+      built.embed,
+      built.row,
+    );
   }
 
   /** AC-2: Post channel embed at nomination milestones (25/50/100%). */
@@ -176,8 +170,19 @@ export class LineupNotificationService {
     lineup: LineupInfo,
     games: { id: number; name: string }[],
   ): Promise<void> {
-    await this.postVotingChannelEmbed(lineup, games);
-    await this.sendVotingDMs(lineup, games.length);
+    const ctx = await this.resolveCtx(lineup.id, 'voting');
+    await this.postChannelEmbed(
+      `lineup-voting:${lineup.id}`,
+      () => buildVotingOpenEmbed(ctx, games, lineup.votingDeadline),
+      ctx,
+    );
+    await fanOutVotingDMs(
+      this.db,
+      this.notificationService,
+      this.dedupService,
+      lineup,
+      games.length,
+    );
   }
 
   /** AC-5: Post combined tier embed + per-member DMs when matches are found. */
@@ -220,13 +225,12 @@ export class LineupNotificationService {
     coPlayers: string[],
     lineupId: number,
   ): Promise<void> {
-    const coList = coPlayers.length ? coPlayers.join(', ') : 'your group';
-    await this.sendDedupedDM(`lineup-match-dm:${matchId}:${userId}`, {
+    await dispatchMatchMemberDM(this.dedupService, this.notificationService, {
+      matchId,
       userId,
-      type: 'community_lineup',
-      title: `You're matched for ${gameName}!`,
-      message: `You're in a match for ${gameName} with ${coList}. Schedule a time!`,
-      payload: { subtype: 'lineup_match_member', matchId, lineupId, gameName },
+      gameName,
+      coPlayers,
+      lineupId,
     });
   }
 
@@ -237,32 +241,25 @@ export class LineupNotificationService {
     gameName: string,
     lineupId: number,
   ): Promise<void> {
-    await this.sendDedupedDM(`lineup-rally-dm:${matchId}:${userId}`, {
+    await dispatchRallyInterestDM(this.dedupService, this.notificationService, {
+      matchId,
       userId,
-      type: 'community_lineup',
-      title: `${gameName} needs more interest!`,
-      message: `${gameName} almost has enough players. Join the match!`,
-      payload: {
-        subtype: 'lineup_rally_interest',
-        matchId,
-        lineupId,
-        gameName,
-      },
+      gameName,
+      lineupId,
     });
-  }
-
-  /** Send a deduped DM via the notification service (ROK-1063 refactor). */
-  private async sendDedupedDM(
-    dedupKey: string,
-    payload: Parameters<NotificationService['create']>[0],
-  ): Promise<void> {
-    if (await this.dedupService.checkAndMarkSent(dedupKey, DEDUP_TTL)) return;
-    await this.notificationService.create(payload);
   }
 
   /** AC-8: Post per-match channel embed + DMs when scheduling opens. */
   async notifySchedulingOpen(match: MatchInfo): Promise<void> {
-    await this.postSchedulingChannelEmbed(match);
+    const ctx = await this.resolveCtx(match.lineupId, 'decided');
+    await this.postChannelEmbed(
+      `lineup-scheduling:${match.id}`,
+      async () => {
+        if (await hasExistingPollEmbed(this.db, match.id)) return null;
+        return buildSchedulingEmbed(ctx, match.gameName, match.id);
+      },
+      ctx,
+    );
     await fanOutSchedulingDMs(
       this.db,
       this.notificationService,
@@ -278,8 +275,20 @@ export class LineupNotificationService {
     eventId?: number,
   ): Promise<void> {
     const members = await findMatchMemberUsers(this.db, match.id);
-    const names = members.map((m) => m.displayName);
-    await this.postEventCreatedChannelEmbed(match, eventDate, eventId, names);
+    const ctx = await this.resolveCtx(match.lineupId, 'decided');
+    await this.postChannelEmbed(
+      `lineup-event:${match.id}`,
+      () =>
+        buildEventCreatedEmbed(
+          ctx,
+          match.gameName,
+          match.gameId,
+          eventDate,
+          eventId,
+          members.map((m) => m.displayName),
+        ),
+      ctx,
+    );
     await fanOutEventCreatedDMs(
       this.notificationService,
       this.dedupService,
@@ -298,20 +307,10 @@ export class LineupNotificationService {
     userId: number,
     operatorName: string,
   ): Promise<void> {
-    await this.sendDedupedDM(
-      `lineup-removed-dm:${lineupId}:${gameId}:${userId}`,
-      {
-        userId,
-        type: 'community_lineup',
-        title: 'Nomination removed',
-        message: `Your nomination ${gameName} was removed by ${operatorName}.`,
-        payload: {
-          subtype: 'lineup_nomination_removed',
-          lineupId,
-          gameId,
-          gameName,
-        },
-      },
+    await dispatchNominationRemovedDM(
+      this.dedupService,
+      this.notificationService,
+      { lineupId, gameId, gameName, userId, operatorName },
     );
   }
 
@@ -335,68 +334,5 @@ export class LineupNotificationService {
       result.row,
     );
     return { channelId, messageId: sent.id };
-  }
-
-  /** Post the voting-open channel embed. */
-  private async postVotingChannelEmbed(
-    lineup: LineupInfo,
-    games: { id: number; name: string }[],
-  ): Promise<void> {
-    const ctx = await this.resolveCtx(lineup.id, 'voting');
-    await this.postChannelEmbed(
-      `lineup-voting:${lineup.id}`,
-      () => buildVotingOpenEmbed(ctx, games, lineup.votingDeadline),
-      ctx,
-    );
-  }
-
-  /** Post the scheduling-open channel embed for a match. */
-  private async postSchedulingChannelEmbed(match: MatchInfo): Promise<void> {
-    const ctx = await this.resolveCtx(match.lineupId, 'decided');
-    await this.postChannelEmbed(
-      `lineup-scheduling:${match.id}`,
-      async () => {
-        if (await hasExistingPollEmbed(this.db, match.id)) return null;
-        return buildSchedulingEmbed(ctx, match.gameName, match.id);
-      },
-      ctx,
-    );
-  }
-
-  /** Post the event-created channel embed. */
-  private async postEventCreatedChannelEmbed(
-    match: MatchInfo,
-    eventDate: Date,
-    eventId: number | undefined,
-    memberNames: string[],
-  ): Promise<void> {
-    const ctx = await this.resolveCtx(match.lineupId, 'decided');
-    await this.postChannelEmbed(
-      `lineup-event:${match.id}`,
-      () =>
-        buildEventCreatedEmbed(
-          ctx,
-          match.gameName,
-          match.gameId,
-          eventDate,
-          eventId,
-          memberNames,
-        ),
-      ctx,
-    );
-  }
-
-  /** Send voting-open DMs to all Discord-linked members. */
-  private async sendVotingDMs(
-    lineup: LineupInfo,
-    gameCount: number,
-  ): Promise<void> {
-    await fanOutVotingDMs(
-      this.db,
-      this.notificationService,
-      this.dedupService,
-      lineup,
-      gameCount,
-    );
   }
 }

--- a/api/src/lineups/lineup-phase-scheduling.integration.spec.ts
+++ b/api/src/lineups/lineup-phase-scheduling.integration.spec.ts
@@ -43,7 +43,7 @@ function describePhaseScheduling() {
     return testApp.request
       .post('/lineups')
       .set('Authorization', `Bearer ${token}`)
-      .send(durations);
+      .send({ title: 'Phase Scheduling Test', ...durations });
   }
 
   // ── POST /lineups with duration params ──────────────────────
@@ -76,7 +76,7 @@ function describePhaseScheduling() {
       const res = await testApp.request
         .post('/lineups')
         .set('Authorization', `Bearer ${adminToken}`)
-        .send({});
+        .send({ title: 'Phase Scheduling Default' });
 
       expect(res.status).toBe(201);
       // Without explicit durations, admin defaults (48h building) are applied

--- a/api/src/lineups/lineups-banner.helpers.spec.ts
+++ b/api/src/lineups/lineups-banner.helpers.spec.ts
@@ -9,6 +9,8 @@ const NOW = new Date('2026-03-22T20:00:00Z');
 
 const mockLineup = {
   id: 1,
+  title: 'Test Lineup',
+  description: null as string | null,
   status: 'building' as const,
   targetDate: NOW,
   decidedGameId: null as number | null,

--- a/api/src/lineups/lineups-banner.helpers.ts
+++ b/api/src/lineups/lineups-banner.helpers.ts
@@ -33,6 +33,8 @@ interface BannerEntry {
 /** Lineup shape used by buildBannerResponse. */
 interface BannerLineup {
   id: number;
+  title: string;
+  description: string | null;
   status: string;
   targetDate: Date | null;
   phaseDeadline?: Date | null;
@@ -114,6 +116,8 @@ export function buildBannerResponse(
 
   return {
     id: lineup.id,
+    title: lineup.title,
+    description: lineup.description ?? null,
     status: lineup.status as LineupBannerResponseDto['status'],
     targetDate: lineup.targetDate?.toISOString?.() ?? null,
     phaseDeadline: lineup.phaseDeadline?.toISOString?.() ?? null,

--- a/api/src/lineups/lineups-lifecycle.helpers.ts
+++ b/api/src/lineups/lineups-lifecycle.helpers.ts
@@ -46,6 +46,8 @@ export function insertLineup(
     return tx
       .insert(schema.communityLineups)
       .values({
+        title: dto.title,
+        description: dto.description ?? null,
         createdBy: userId,
         targetDate: dto.targetDate ? new Date(dto.targetDate) : null,
         phaseDeadline,

--- a/api/src/lineups/lineups-match-actions.helpers.ts
+++ b/api/src/lineups/lineups-match-actions.helpers.ts
@@ -1,0 +1,42 @@
+/**
+ * Thin wrappers around match actions (bandwagon/advance) + scheduling hook.
+ * Extracted from lineups.service.ts in ROK-1063 to keep the service under
+ * the 300-line ESLint limit.
+ */
+import type { Logger } from '@nestjs/common';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import type { BandwagonJoinResponseDto } from '@raid-ledger/contract';
+import * as schema from '../drizzle/schema';
+import type { LineupNotificationService } from './lineup-notification.service';
+import {
+  executeBandwagonJoin,
+  advanceMatch as advanceMatchHelper,
+} from './lineups-bandwagon.helpers';
+import { fireSchedulingOpen } from './lineups-notify-hooks.helpers';
+
+type Db = PostgresJsDatabase<typeof schema>;
+
+export async function runBandwagonJoin(
+  db: Db,
+  notifications: LineupNotificationService,
+  logger: Logger,
+  lineupId: number,
+  matchId: number,
+  userId: number,
+): Promise<BandwagonJoinResponseDto> {
+  const result = await executeBandwagonJoin(db, lineupId, matchId, userId);
+  if (result.promoted) fireSchedulingOpen(notifications, logger, db, matchId);
+  return result;
+}
+
+export async function runAdvanceMatch(
+  db: Db,
+  notifications: LineupNotificationService,
+  logger: Logger,
+  lineupId: number,
+  matchId: number,
+): Promise<{ promoted: boolean }> {
+  const result = await advanceMatchHelper(db, lineupId, matchId);
+  if (result.promoted) fireSchedulingOpen(notifications, logger, db, matchId);
+  return result;
+}

--- a/api/src/lineups/lineups-matches.integration.spec.ts
+++ b/api/src/lineups/lineups-matches.integration.spec.ts
@@ -99,7 +99,7 @@ async function buildDecidedLineup(opts: {
   const createRes = await testApp.request
     .post('/lineups')
     .set('Authorization', `Bearer ${opts.token}`)
-    .send({ matchThreshold: opts.matchThreshold ?? 35 });
+    .send({ title: 'Matches Test', matchThreshold: opts.matchThreshold ?? 35 });
   const lineupId = createRes.body.id as number;
 
   // Add entries for each game
@@ -421,7 +421,7 @@ function describeJoin() {
     const createRes = await testApp.request
       .post('/lineups')
       .set('Authorization', `Bearer ${adminToken}`)
-      .send({});
+      .send({ title: 'Matches Test' });
     const lineupId = createRes.body.id as number;
 
     const member = await loginAsMember('early-joiner');
@@ -629,7 +629,7 @@ function describeCarryover() {
     const newRes = await testApp.request
       .post('/lineups')
       .set('Authorization', `Bearer ${adminToken}`)
-      .send({});
+      .send({ title: 'Matches Test' });
 
     expect(newRes.status).toBe(201);
     const newLineupId = newRes.body.id as number;

--- a/api/src/lineups/lineups-metadata.helpers.ts
+++ b/api/src/lineups/lineups-metadata.helpers.ts
@@ -5,13 +5,20 @@
 import {
   ConflictException,
   ForbiddenException,
+  Logger,
   NotFoundException,
 } from '@nestjs/common';
 import { eq } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
-import type { UpdateLineupMetadataDto } from '@raid-ledger/contract';
+import type {
+  LineupDetailResponseDto,
+  UpdateLineupMetadataDto,
+} from '@raid-ledger/contract';
 import * as schema from '../drizzle/schema';
 import { findLineupById } from './lineups-query.helpers';
+import { buildDetailResponse } from './lineups-response.helpers';
+import type { LineupNotificationService } from './lineup-notification.service';
+import { fireLineupMetadataRefresh } from './lineups-notify-hooks.helpers';
 import type { CallerIdentity } from './lineups.service';
 
 type Db = PostgresJsDatabase<typeof schema>;
@@ -49,4 +56,26 @@ export async function authorizeAndPersistMetadata(
     .update(schema.communityLineups)
     .set(values)
     .where(eq(schema.communityLineups.id, id));
+}
+
+/**
+ * High-level metadata update: authorise, persist, fire notification refresh,
+ * and return the fresh detail payload.
+ */
+export async function runMetadataUpdate(
+  db: Db,
+  lineupNotifications: LineupNotificationService,
+  logger: Logger,
+  id: number,
+  dto: UpdateLineupMetadataDto,
+  caller: CallerIdentity,
+): Promise<LineupDetailResponseDto> {
+  await authorizeAndPersistMetadata(db, id, dto, caller);
+  const detail = await buildDetailResponse(db, id, caller.id);
+  fireLineupMetadataRefresh(lineupNotifications, logger, {
+    id: detail.id,
+    title: detail.title,
+    description: detail.description,
+  });
+  return detail;
 }

--- a/api/src/lineups/lineups-metadata.helpers.ts
+++ b/api/src/lineups/lineups-metadata.helpers.ts
@@ -1,0 +1,52 @@
+/**
+ * Metadata update helpers for community lineups (ROK-1063).
+ * Keeps lineups.service.ts under the 300-line file limit.
+ */
+import {
+  ConflictException,
+  ForbiddenException,
+  NotFoundException,
+} from '@nestjs/common';
+import { eq } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import type { UpdateLineupMetadataDto } from '@raid-ledger/contract';
+import * as schema from '../drizzle/schema';
+import { findLineupById } from './lineups-query.helpers';
+import type { CallerIdentity } from './lineups.service';
+
+type Db = PostgresJsDatabase<typeof schema>;
+
+/**
+ * Authorise a metadata update and persist the change (ROK-1063).
+ *
+ * - Throws NotFoundException when the lineup does not exist.
+ * - Throws ConflictException (409) when the lineup is archived.
+ * - Throws ForbiddenException (403) when the caller is not admin/operator
+ *   and is not the original creator.
+ *
+ * Always bumps `updated_at` to match other lineup updates.
+ */
+export async function authorizeAndPersistMetadata(
+  db: Db,
+  id: number,
+  dto: UpdateLineupMetadataDto,
+  caller: CallerIdentity,
+): Promise<void> {
+  const [lineup] = await findLineupById(db, id);
+  if (!lineup) throw new NotFoundException('Lineup not found');
+  if (lineup.status === 'archived') {
+    throw new ConflictException('Cannot edit an archived lineup');
+  }
+  const isPrivileged = caller.role === 'admin' || caller.role === 'operator';
+  if (!isPrivileged && lineup.createdBy !== caller.id) {
+    throw new ForbiddenException('Not allowed to edit this lineup');
+  }
+
+  const values: Record<string, unknown> = { updatedAt: new Date() };
+  if (dto.title !== undefined) values.title = dto.title;
+  if (dto.description !== undefined) values.description = dto.description;
+  await db
+    .update(schema.communityLineups)
+    .set(values)
+    .where(eq(schema.communityLineups.id, id));
+}

--- a/api/src/lineups/lineups-metadata.integration.spec.ts
+++ b/api/src/lineups/lineups-metadata.integration.spec.ts
@@ -1,0 +1,238 @@
+/**
+ * ROK-1063 — feat: lineup title & description
+ *
+ * Failing TDD integration tests that cover the acceptance criteria for the
+ * new `title` + `description` fields on community lineups and the new
+ * `PATCH /lineups/:id/metadata` endpoint.
+ *
+ * These tests intentionally fail against the current codebase — they
+ * describe the target behavior for the dev agent to implement.
+ */
+import { eq } from 'drizzle-orm';
+import { getTestApp, type TestApp } from '../common/testing/test-app';
+import {
+  truncateAllTables,
+  loginAsAdmin,
+} from '../common/testing/integration-helpers';
+import * as schema from '../drizzle/schema';
+
+function describeLineupMetadata() {
+  let testApp: TestApp;
+  let adminToken: string;
+
+  beforeAll(async () => {
+    testApp = await getTestApp();
+    adminToken = await loginAsAdmin(testApp.request, testApp.seed);
+  });
+
+  afterEach(async () => {
+    testApp.seed = await truncateAllTables(testApp.db);
+    adminToken = await loginAsAdmin(testApp.request, testApp.seed);
+  });
+
+  async function loginAsMember(): Promise<{ token: string; userId: number }> {
+    const bcrypt = await import('bcrypt');
+    const hash = await bcrypt.hash('MemberPass1!', 4);
+    const [user] = await testApp.db
+      .insert(schema.users)
+      .values({
+        discordId: 'local:member@test.local',
+        username: 'member',
+        role: 'member',
+      })
+      .returning();
+    await testApp.db.insert(schema.localCredentials).values({
+      email: 'member@test.local',
+      passwordHash: hash,
+      userId: user.id,
+    });
+    const res = await testApp.request
+      .post('/auth/local')
+      .send({ email: 'member@test.local', password: 'MemberPass1!' });
+    return { token: res.body.access_token as string, userId: user.id };
+  }
+
+  async function createLineup(token: string, body: Record<string, unknown>) {
+    return testApp.request
+      .post('/lineups')
+      .set('Authorization', `Bearer ${token}`)
+      .send(body);
+  }
+
+  // ── POST /lineups — title validation ─────────────────────────
+
+  function describeCreateValidation() {
+    it('should reject blank title with 400', async () => {
+      const res = await createLineup(adminToken, { title: '' });
+      expect(res.status).toBe(400);
+    });
+
+    it('should reject 101-char title with 400', async () => {
+      const res = await createLineup(adminToken, {
+        title: 'a'.repeat(101),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('should reject >500 char description with 400', async () => {
+      const res = await createLineup(adminToken, {
+        title: 'Friday Night Raid',
+        description: 'd'.repeat(501),
+      });
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 201 with title + description echoed back', async () => {
+      const res = await createLineup(adminToken, {
+        title: 'Friday Night Raid',
+        description: 'Weekly community pick — vote for your favorite!',
+      });
+
+      expect(res.status).toBe(201);
+      expect(res.body).toMatchObject({
+        title: 'Friday Night Raid',
+        description: 'Weekly community pick — vote for your favorite!',
+      });
+    });
+
+    it('should accept missing description (optional)', async () => {
+      const res = await createLineup(adminToken, {
+        title: 'Spring Lineup',
+      });
+      expect(res.status).toBe(201);
+      expect(res.body.title).toBe('Spring Lineup');
+      // Description is optional — null or undefined both acceptable
+      expect(res.body.description ?? null).toBeNull();
+    });
+  }
+  describe('POST /lineups — title & description', describeCreateValidation);
+
+  // ── PATCH /lineups/:id/metadata ──────────────────────────────
+
+  function describePatchMetadata() {
+    async function createForUpdate() {
+      const res = await createLineup(adminToken, {
+        title: 'Initial Title',
+        description: 'Initial description',
+      });
+      return res.body.id as number;
+    }
+
+    it('should return 200 and updated title/description for admin', async () => {
+      const id = await createForUpdate();
+      const res = await testApp.request
+        .patch(`/lineups/${id}/metadata`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({
+          title: 'Renamed Lineup',
+          description: 'Updated description',
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        title: 'Renamed Lineup',
+        description: 'Updated description',
+      });
+    });
+
+    it('should allow description to be cleared to null', async () => {
+      const id = await createForUpdate();
+      const res = await testApp.request
+        .patch(`/lineups/${id}/metadata`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ title: 'Kept Title', description: null });
+
+      expect(res.status).toBe(200);
+      expect(res.body.description).toBeNull();
+    });
+
+    it('should reject blank title with 400', async () => {
+      const id = await createForUpdate();
+      const res = await testApp.request
+        .patch(`/lineups/${id}/metadata`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ title: '' });
+      expect(res.status).toBe(400);
+    });
+
+    it('should reject 101-char title with 400', async () => {
+      const id = await createForUpdate();
+      const res = await testApp.request
+        .patch(`/lineups/${id}/metadata`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ title: 'z'.repeat(101) });
+      expect(res.status).toBe(400);
+    });
+
+    it('should reject >500 char description with 400', async () => {
+      const id = await createForUpdate();
+      const res = await testApp.request
+        .patch(`/lineups/${id}/metadata`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ description: 'd'.repeat(501) });
+      expect(res.status).toBe(400);
+    });
+
+    it('should return 409 when lineup is archived', async () => {
+      const id = await createForUpdate();
+      // Force lineup to archived state directly — avoids needing entries/games
+      await testApp.db
+        .update(schema.communityLineups)
+        .set({ status: 'archived' })
+        .where(eq(schema.communityLineups.id, id));
+
+      const res = await testApp.request
+        .patch(`/lineups/${id}/metadata`)
+        .set('Authorization', `Bearer ${adminToken}`)
+        .send({ title: 'Too Late' });
+
+      expect(res.status).toBe(409);
+    });
+
+    it('should return 403 for non-creator member', async () => {
+      const id = await createForUpdate();
+      const { token: memberToken } = await loginAsMember();
+
+      const res = await testApp.request
+        .patch(`/lineups/${id}/metadata`)
+        .set('Authorization', `Bearer ${memberToken}`)
+        .send({ title: 'Hijack' });
+
+      expect(res.status).toBe(403);
+    });
+
+    it('should return 401 when unauthenticated', async () => {
+      const id = await createForUpdate();
+      const res = await testApp.request
+        .patch(`/lineups/${id}/metadata`)
+        .send({ title: 'No auth' });
+      expect(res.status).toBe(401);
+    });
+  }
+  describe('PATCH /lineups/:id/metadata', describePatchMetadata);
+
+  // ── GET /lineups/:id — response shape ────────────────────────
+
+  function describeDetailShape() {
+    it('should include title + description on detail response', async () => {
+      const createRes = await createLineup(adminToken, {
+        title: 'Detail Shape Lineup',
+        description: 'Body copy shown in modal',
+      });
+      const id = createRes.body.id as number;
+
+      const res = await testApp.request
+        .get(`/lineups/${id}`)
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({
+        title: 'Detail Shape Lineup',
+        description: 'Body copy shown in modal',
+      });
+    });
+  }
+  describe('GET /lineups/:id — title & description shape', describeDetailShape);
+}
+
+describe('Lineup metadata (integration, ROK-1063)', describeLineupMetadata);

--- a/api/src/lineups/lineups-notify-hooks.helpers.ts
+++ b/api/src/lineups/lineups-notify-hooks.helpers.ts
@@ -35,6 +35,20 @@ export function fireLineupCreated(
   svc.notifyLineupCreated(lineup).catch(logError(logger, 'lineup-created'));
 }
 
+/**
+ * Fire an in-place embed refresh after metadata edit (ROK-1063).
+ * No-op when the lineup has no stored Discord message reference.
+ */
+export function fireLineupMetadataRefresh(
+  svc: LineupNotificationService,
+  logger: Logger,
+  lineup: LineupInfo,
+): void {
+  svc
+    .refreshCreatedEmbed(lineup)
+    .catch(logError(logger, 'lineup-metadata-refresh'));
+}
+
 /** Check and fire nomination milestone notification. */
 export function fireNominationMilestone(
   svc: LineupNotificationService,

--- a/api/src/lineups/lineups-response.helpers.ts
+++ b/api/src/lineups/lineups-response.helpers.ts
@@ -82,6 +82,8 @@ function mapLineupCore(
 ) {
   return {
     id: lineup.id,
+    title: lineup.title,
+    description: lineup.description ?? null,
     status: lineup.status,
     targetDate: lineup.targetDate?.toISOString() ?? null,
     decidedGameId: lineup.decidedGameId,

--- a/api/src/lineups/lineups-transition.helpers.ts
+++ b/api/src/lineups/lineups-transition.helpers.ts
@@ -1,0 +1,88 @@
+/**
+ * Status transition helpers extracted from lineups.service.ts (ROK-1063).
+ * Keeps the service under the 300-line ESLint limit.
+ */
+import { Logger, NotFoundException } from '@nestjs/common';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import type {
+  LineupDetailResponseDto,
+  UpdateLineupStatusDto,
+} from '@raid-ledger/contract';
+import * as schema from '../drizzle/schema';
+import type { LineupStatus } from '../drizzle/schema';
+import type { ActivityLogService } from '../activity-log/activity-log.service';
+import type { SettingsService } from '../settings/settings.service';
+import type { LineupPhaseQueueService } from './queue/lineup-phase.queue';
+import { guardTiebreakerOnTransition } from './tiebreaker/tiebreaker-detect.helpers';
+import type { LineupNotificationService } from './lineup-notification.service';
+import { findLineupById, validateDecidedGame } from './lineups-query.helpers';
+import {
+  applyStatusUpdate,
+  runMatchingAlgorithm,
+  validateTransition,
+} from './lineups-lifecycle.helpers';
+import { buildDetailResponse } from './lineups-response.helpers';
+import { logTransition } from './lineups-activity.helpers';
+import {
+  fireVotingOpen,
+  fireDecidedNotifications,
+} from './lineups-notify-hooks.helpers';
+
+type Db = PostgresJsDatabase<typeof schema>;
+
+export interface TransitionDeps {
+  db: Db;
+  activityLog: ActivityLogService;
+  settings: SettingsService;
+  phaseQueue: LineupPhaseQueueService;
+  lineupNotifications: LineupNotificationService;
+  logger: Logger;
+}
+
+/** Orchestrate a lineup status transition with validation, update, and hooks. */
+export async function runStatusTransition(
+  deps: TransitionDeps,
+  id: number,
+  dto: UpdateLineupStatusDto,
+): Promise<LineupDetailResponseDto> {
+  const [lineup] = await findLineupById(deps.db, id);
+  if (!lineup) throw new NotFoundException('Lineup not found');
+
+  validateTransition(lineup.status as LineupStatus, dto);
+  if (dto.status === 'decided' && dto.decidedGameId) {
+    await validateDecidedGame(deps.db, id, dto.decidedGameId);
+  }
+
+  await guardTiebreakerOnTransition(deps.db, id, lineup.status, dto);
+  await applyStatusUpdate(
+    deps.db,
+    deps.settings,
+    deps.phaseQueue,
+    id,
+    dto,
+    lineup,
+  );
+  if (dto.status === 'decided') {
+    await runMatchingAlgorithm(deps.db, id, deps.logger);
+  }
+  await logTransition(deps.db, deps.activityLog, id, dto);
+
+  if (dto.status === 'voting') {
+    fireVotingOpen(
+      deps.lineupNotifications,
+      deps.logger,
+      deps.db,
+      id,
+      lineup.phaseDeadline,
+    );
+  }
+  if (dto.status === 'decided') {
+    fireDecidedNotifications(
+      deps.lineupNotifications,
+      deps.logger,
+      deps.db,
+      id,
+    );
+  }
+  return buildDetailResponse(deps.db, id);
+}

--- a/api/src/lineups/lineups-voting.integration.spec.ts
+++ b/api/src/lineups/lineups-voting.integration.spec.ts
@@ -62,7 +62,7 @@ function describeVoting() {
     return testApp.request
       .post('/lineups')
       .set('Authorization', `Bearer ${token}`)
-      .send(extra);
+      .send({ title: 'Voting Test', ...extra });
   }
 
   async function addEntry(lineupId: number, gameId: number, userId: number) {

--- a/api/src/lineups/lineups.controller.ts
+++ b/api/src/lineups/lineups.controller.ts
@@ -19,6 +19,7 @@ import { RolesGuard } from '../auth/roles.guard';
 import { Roles } from '../auth/roles.decorator';
 import {
   CreateLineupSchema,
+  UpdateLineupMetadataSchema,
   UpdateLineupStatusSchema,
   CommonGroundQuerySchema,
   NominateGameSchema,
@@ -151,6 +152,26 @@ export class LineupsController {
       throw new BadRequestException(parsed.error.flatten().fieldErrors);
     }
     return this.lineupsService.transitionStatus(id, parsed.data);
+  }
+
+  /**
+   * PATCH /lineups/:id/metadata — update title/description (ROK-1063).
+   * Allowed for admin/operator or the original creator.
+   */
+  @Patch(':id/metadata')
+  async updateMetadata(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() body: unknown,
+    @Req() req: AuthRequest,
+  ): Promise<LineupDetailResponseDto> {
+    const parsed = UpdateLineupMetadataSchema.safeParse(body);
+    if (!parsed.success) {
+      throw new BadRequestException(parsed.error.flatten().fieldErrors);
+    }
+    return this.lineupsService.updateMetadata(id, parsed.data, {
+      id: req.user.id,
+      role: req.user.role,
+    });
   }
 
   /** GET /lineups/:id/matches — grouped matches for decided view (ROK-937). */

--- a/api/src/lineups/lineups.integration.spec.ts
+++ b/api/src/lineups/lineups.integration.spec.ts
@@ -75,7 +75,7 @@ function describeLineups() {
     return testApp.request
       .post('/lineups')
       .set('Authorization', `Bearer ${token}`)
-      .send({});
+      .send({ title: 'Lineup Test' });
   }
 
   async function addEntry(lineupId: number, gameId: number, userId: number) {
@@ -105,7 +105,10 @@ function describeLineups() {
       const res = await testApp.request
         .post('/lineups')
         .set('Authorization', `Bearer ${adminToken}`)
-        .send({ targetDate: '2026-04-15T00:00:00Z' });
+        .send({
+          title: 'Target Date Test',
+          targetDate: '2026-04-15T00:00:00Z',
+        });
 
       expect(res.status).toBe(201);
       expect(res.body.targetDate).toBeTruthy();

--- a/api/src/lineups/lineups.service.spec.ts
+++ b/api/src/lineups/lineups.service.spec.ts
@@ -42,6 +42,8 @@ const NOW = new Date('2026-03-22T20:00:00Z');
 
 const mockLineup = {
   id: 1,
+  title: 'Test Lineup',
+  description: null as string | null,
   status: 'building',
   targetDate: null as Date | null,
   decidedGameId: null as number | null,
@@ -216,7 +218,7 @@ function describeLineupsService() {
       mockInsert([{ ...mockLineup, id: 1 }]);
       mockBuildDetail();
 
-      const result = await service.create({}, 10);
+      const result = await service.create({ title: 'Test Lineup' }, 10);
 
       expect(result.id).toBe(1);
       expect(result.status).toBe('building');
@@ -226,7 +228,9 @@ function describeLineupsService() {
     it('should throw ConflictException when active lineup exists', async () => {
       mockSelects(makeSelectChain({ limitResult: [{ id: 99 }] }));
 
-      await expect(service.create({}, 10)).rejects.toThrow(ConflictException);
+      await expect(
+        service.create({ title: 'Test Lineup' }, 10),
+      ).rejects.toThrow(ConflictException);
       expect(mockDb.insert).not.toHaveBeenCalled();
     });
 
@@ -236,7 +240,10 @@ function describeLineupsService() {
       mockInsert([{ ...mockLineup, targetDate: new Date(targetDate) }]);
       mockBuildDetail({ ...mockLineup, targetDate: new Date(targetDate) });
 
-      const result = await service.create({ targetDate }, 10);
+      const result = await service.create(
+        { title: 'Test Lineup', targetDate },
+        10,
+      );
 
       expect(result.targetDate).toBe(new Date(targetDate).toISOString());
     });

--- a/api/src/lineups/lineups.service.ts
+++ b/api/src/lineups/lineups.service.ts
@@ -20,12 +20,10 @@ import type {
 } from '@raid-ledger/contract';
 import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
 import * as schema from '../drizzle/schema';
-import type { LineupStatus } from '../drizzle/schema';
 import { ActivityLogService } from '../activity-log/activity-log.service';
 import { SettingsService } from '../settings/settings.service';
 import { LineupPhaseQueueService } from './queue/lineup-phase.queue';
 import { LineupSteamNudgeService } from './lineup-steam-nudge.service';
-import { guardTiebreakerOnTransition } from './tiebreaker/tiebreaker-detect.helpers';
 import { LineupNotificationService } from './lineup-notification.service';
 import {
   findActiveLineup,
@@ -33,14 +31,8 @@ import {
   findBuildingLineup,
   findNominatedGameIds,
   countDistinctNominators,
-  validateDecidedGame,
 } from './lineups-query.helpers';
-import {
-  insertLineup,
-  applyStatusUpdate,
-  runMatchingAlgorithm,
-  validateTransition,
-} from './lineups-lifecycle.helpers';
+import { insertLineup } from './lineups-lifecycle.helpers';
 import { buildDetailResponse } from './lineups-response.helpers';
 import { buildCommonGroundResponse } from './common-ground-query.helpers';
 import { findBannerLineup, buildBannerData } from './lineups-banner.helpers';
@@ -59,23 +51,20 @@ import {
   buildOverrides,
   computeInitialDeadline,
 } from './lineups-phase.helpers';
-import { logTransition, logNomination } from './lineups-activity.helpers';
+import { logNomination } from './lineups-activity.helpers';
 import { toggleVote as toggleVoteHelper } from './lineups-voting.helpers';
 import { buildGroupedMatchesResponse } from './lineups-match-response.helpers';
-import {
-  executeBandwagonJoin,
-  advanceMatch as advanceMatchHelper,
-} from './lineups-bandwagon.helpers';
 import { carryOverFromLastDecided } from './lineups-carryover.helpers';
-import { authorizeAndPersistMetadata } from './lineups-metadata.helpers';
+import { runMetadataUpdate } from './lineups-metadata.helpers';
+import { runStatusTransition } from './lineups-transition.helpers';
+import {
+  runBandwagonJoin,
+  runAdvanceMatch,
+} from './lineups-match-actions.helpers';
 import {
   fireLineupCreated,
-  fireLineupMetadataRefresh,
   fireNominationMilestone,
-  fireVotingOpen,
-  fireDecidedNotifications,
   fireNominationRemoved,
-  fireSchedulingOpen,
 } from './lineups-notify-hooks.helpers';
 
 /** Caller identity for authorization checks. */
@@ -171,52 +160,22 @@ export class LineupsService {
   }
 
   /** Transition a lineup to a new status. */
-  async transitionStatus(
+  transitionStatus(
     id: number,
     dto: UpdateLineupStatusDto,
   ): Promise<LineupDetailResponseDto> {
-    const [lineup] = await findLineupById(this.db, id);
-    if (!lineup) throw new NotFoundException('Lineup not found');
-
-    validateTransition(lineup.status as LineupStatus, dto);
-    if (dto.status === 'decided' && dto.decidedGameId) {
-      await validateDecidedGame(this.db, id, dto.decidedGameId);
-    }
-
-    // Tiebreaker gate: block ties, override winner, or reset (ROK-938)
-    await guardTiebreakerOnTransition(this.db, id, lineup.status, dto);
-
-    await applyStatusUpdate(
-      this.db,
-      this.settings,
-      this.phaseQueue,
+    return runStatusTransition(
+      {
+        db: this.db,
+        activityLog: this.activityLog,
+        settings: this.settings,
+        phaseQueue: this.phaseQueue,
+        lineupNotifications: this.lineupNotifications,
+        logger: this.logger,
+      },
       id,
       dto,
-      lineup,
     );
-    if (dto.status === 'decided') {
-      await runMatchingAlgorithm(this.db, id, this.logger);
-    }
-    await logTransition(this.db, this.activityLog, id, dto);
-
-    if (dto.status === 'voting') {
-      fireVotingOpen(
-        this.lineupNotifications,
-        this.logger,
-        this.db,
-        id,
-        lineup.phaseDeadline,
-      );
-    }
-    if (dto.status === 'decided') {
-      fireDecidedNotifications(
-        this.lineupNotifications,
-        this.logger,
-        this.db,
-        id,
-      );
-    }
-    return buildDetailResponse(this.db, id);
   }
 
   /** Get Common Ground games — ownership overlap. */
@@ -305,34 +264,33 @@ export class LineupsService {
   }
 
   /** Bandwagon join a match (ROK-937). */
-  async bandwagonJoin(
+  bandwagonJoin(
     lineupId: number,
     matchId: number,
     userId: number,
   ): Promise<BandwagonJoinResponseDto> {
-    const result = await executeBandwagonJoin(
+    return runBandwagonJoin(
       this.db,
+      this.lineupNotifications,
+      this.logger,
       lineupId,
       matchId,
       userId,
     );
-    this.firePromoted(result.promoted, matchId);
-    return result;
   }
 
   /** Advance a suggested match to scheduling (ROK-937). */
-  async advanceMatch(
+  advanceMatch(
     lineupId: number,
     matchId: number,
   ): Promise<{ promoted: boolean }> {
-    const result = await advanceMatchHelper(this.db, lineupId, matchId);
-    this.firePromoted(result.promoted, matchId);
-    return result;
-  }
-
-  private firePromoted(promoted: boolean, matchId: number): void {
-    if (!promoted) return;
-    fireSchedulingOpen(this.lineupNotifications, this.logger, this.db, matchId);
+    return runAdvanceMatch(
+      this.db,
+      this.lineupNotifications,
+      this.logger,
+      lineupId,
+      matchId,
+    );
   }
 
   /** Update a lineup's title and/or description (ROK-1063). */
@@ -341,13 +299,13 @@ export class LineupsService {
     dto: UpdateLineupMetadataDto,
     caller: CallerIdentity,
   ): Promise<LineupDetailResponseDto> {
-    await authorizeAndPersistMetadata(this.db, id, dto, caller);
-    const detail = await buildDetailResponse(this.db, id, caller.id);
-    fireLineupMetadataRefresh(this.lineupNotifications, this.logger, {
-      id: detail.id,
-      title: detail.title,
-      description: detail.description,
-    });
-    return detail;
+    return runMetadataUpdate(
+      this.db,
+      this.lineupNotifications,
+      this.logger,
+      id,
+      dto,
+      caller,
+    );
   }
 }

--- a/api/src/lineups/lineups.service.ts
+++ b/api/src/lineups/lineups.service.ts
@@ -15,6 +15,7 @@ import type {
   LineupBannerResponseDto,
   LineupDetailResponseDto,
   NominateGameDto,
+  UpdateLineupMetadataDto,
   UpdateLineupStatusDto,
 } from '@raid-ledger/contract';
 import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
@@ -66,6 +67,7 @@ import {
   advanceMatch as advanceMatchHelper,
 } from './lineups-bandwagon.helpers';
 import { carryOverFromLastDecided } from './lineups-carryover.helpers';
+import { authorizeAndPersistMetadata } from './lineups-metadata.helpers';
 import {
   fireLineupCreated,
   fireNominationMilestone,
@@ -119,6 +121,8 @@ export class LineupsService {
 
     fireLineupCreated(this.lineupNotifications, this.logger, {
       id: row.id,
+      title: row.title,
+      description: row.description ?? null,
       targetDate: dto.targetDate ? new Date(dto.targetDate) : undefined,
     });
 
@@ -311,14 +315,7 @@ export class LineupsService {
       matchId,
       userId,
     );
-    if (result.promoted) {
-      fireSchedulingOpen(
-        this.lineupNotifications,
-        this.logger,
-        this.db,
-        matchId,
-      );
-    }
+    this.firePromoted(result.promoted, matchId);
     return result;
   }
 
@@ -328,14 +325,22 @@ export class LineupsService {
     matchId: number,
   ): Promise<{ promoted: boolean }> {
     const result = await advanceMatchHelper(this.db, lineupId, matchId);
-    if (result.promoted) {
-      fireSchedulingOpen(
-        this.lineupNotifications,
-        this.logger,
-        this.db,
-        matchId,
-      );
-    }
+    this.firePromoted(result.promoted, matchId);
     return result;
+  }
+
+  private firePromoted(promoted: boolean, matchId: number): void {
+    if (!promoted) return;
+    fireSchedulingOpen(this.lineupNotifications, this.logger, this.db, matchId);
+  }
+
+  /** Update a lineup's title and/or description (ROK-1063). */
+  async updateMetadata(
+    id: number,
+    dto: UpdateLineupMetadataDto,
+    caller: CallerIdentity,
+  ): Promise<LineupDetailResponseDto> {
+    await authorizeAndPersistMetadata(this.db, id, dto, caller);
+    return buildDetailResponse(this.db, id, caller.id);
   }
 }

--- a/api/src/lineups/lineups.service.ts
+++ b/api/src/lineups/lineups.service.ts
@@ -70,6 +70,7 @@ import { carryOverFromLastDecided } from './lineups-carryover.helpers';
 import { authorizeAndPersistMetadata } from './lineups-metadata.helpers';
 import {
   fireLineupCreated,
+  fireLineupMetadataRefresh,
   fireNominationMilestone,
   fireVotingOpen,
   fireDecidedNotifications,
@@ -341,6 +342,12 @@ export class LineupsService {
     caller: CallerIdentity,
   ): Promise<LineupDetailResponseDto> {
     await authorizeAndPersistMetadata(this.db, id, dto, caller);
-    return buildDetailResponse(this.db, id, caller.id);
+    const detail = await buildDetailResponse(this.db, id, caller.id);
+    fireLineupMetadataRefresh(this.lineupNotifications, this.logger, {
+      id: detail.id,
+      title: detail.title,
+      description: detail.description,
+    });
+    return detail;
   }
 }

--- a/api/src/lineups/standalone-poll/standalone-poll-query.helpers.ts
+++ b/api/src/lineups/standalone-poll/standalone-poll-query.helpers.ts
@@ -61,6 +61,10 @@ export async function insertDecidedLineup(
   const [row] = await db
     .insert(schema.communityLineups)
     .values({
+      // Synthetic title — this lineup row is only a storage vehicle for a
+      // standalone scheduling poll and is hidden from lineup queries by
+      // `phaseDurationOverride.standalone`. Not surfaced in any UI.
+      title: 'Standalone Scheduling Poll',
       status: 'decided',
       createdBy: userId,
       linkedEventId: linkedEventId ?? null,

--- a/packages/contract/src/lineup.schema.ts
+++ b/packages/contract/src/lineup.schema.ts
@@ -24,8 +24,12 @@ export type LineupStatusDto = z.infer<typeof LineupStatusSchema>;
 // Request Schemas
 // ============================================================
 
-/** Create a new lineup. */
+/** Create a new lineup (ROK-1063: title required, description optional markdown). */
 export const CreateLineupSchema = z.object({
+    /** Operator-authored title (1-100 chars, ROK-1063). */
+    title: z.string().trim().min(1).max(100),
+    /** Optional operator-authored markdown description (<=500 chars, ROK-1063). */
+    description: z.string().max(500).nullable().optional(),
     targetDate: z.string().datetime({ offset: true }).nullable().optional(),
     /** Hours for the building phase (1-720, default from admin settings). */
     buildingDurationHours: z.number().int().min(1).max(720).optional(),
@@ -42,6 +46,23 @@ export const CreateLineupSchema = z.object({
 });
 
 export type CreateLineupDto = z.infer<typeof CreateLineupSchema>;
+
+/**
+ * Update a lineup's title and/or description (ROK-1063).
+ * Title, when provided, must be 1-100 chars (trimmed non-empty).
+ * Description may be null to clear.
+ */
+export const UpdateLineupMetadataSchema = z
+    .object({
+        title: z.string().trim().min(1).max(100).optional(),
+        description: z.string().max(500).nullable().optional(),
+    })
+    .refine(
+        (data) => data.title !== undefined || data.description !== undefined,
+        { message: 'At least one of title or description must be provided' },
+    );
+
+export type UpdateLineupMetadataDto = z.infer<typeof UpdateLineupMetadataSchema>;
 
 /** Transition a lineup to a new status with optional context fields. */
 export const UpdateLineupStatusSchema = z.object({
@@ -100,6 +121,10 @@ export type LineupEntryResponseDto = z.infer<typeof LineupEntryResponseSchema>;
 /** Full lineup detail including entries and vote tallies. */
 export const LineupDetailResponseSchema = z.object({
     id: z.number(),
+    /** Operator-authored title shown in H1 / embeds (ROK-1063). */
+    title: z.string(),
+    /** Operator-authored markdown description (ROK-1063). */
+    description: z.string().nullable(),
     status: LineupStatusSchema,
     targetDate: z.string().nullable(),
     decidedGameId: z.number().nullable(),
@@ -142,6 +167,10 @@ const LineupBannerEntrySchema = z.object({
 /** Lightweight banner data for the Games page hero. */
 export const LineupBannerResponseSchema = z.object({
     id: z.number(),
+    /** Operator-authored title (ROK-1063). */
+    title: z.string(),
+    /** Operator-authored markdown description (ROK-1063). */
+    description: z.string().nullable(),
     status: LineupStatusSchema,
     targetDate: z.string().nullable(),
     phaseDeadline: z.string().nullable(),

--- a/scripts/smoke/community-lineup.smoke.spec.ts
+++ b/scripts/smoke/community-lineup.smoke.spec.ts
@@ -69,6 +69,7 @@ async function ensureActiveLineupInBuildingPhase(token: string): Promise<number>
         await archiveLineup(token, banner.id);
     }
     const lineup = (await apiPost(token, '/lineups', {
+        title: 'Smoke Lineup',
         targetDate: new Date(Date.now() + 7 * 86_400_000).toISOString(),
         buildingDurationHours: 720,
         votingDurationHours: 720,
@@ -99,6 +100,7 @@ test.beforeAll(async () => {
 
     // Create a fresh lineup in building phase with long durations (ROK-1007)
     const lineup = (await apiPost(adminToken, '/lineups', {
+        title: 'Smoke Lineup',
         targetDate: new Date(Date.now() + 7 * 86_400_000).toISOString(),
         buildingDurationHours: 720,
         votingDurationHours: 720,
@@ -131,11 +133,13 @@ test.describe('Community Lineup banner on Games page', () => {
         await expect(page.getByText('COMMUNITY LINEUP')).toBeVisible({ timeout: 15_000 });
     });
 
-    test('banner shows question heading and vote link', async ({ page }) => {
+    test('banner shows per-lineup title heading and vote link (ROK-1063)', async ({ page }) => {
         await page.goto('/games');
 
-        const heading = page.getByText('What are we playing this week?');
-        await expect(heading).toBeVisible({ timeout: 15_000 });
+        await expect(page.getByText('COMMUNITY LINEUP')).toBeVisible({ timeout: 15_000 });
+        // Per-lineup H2 title (falls back to backfilled "Lineup — <Month YYYY>")
+        const heading = page.locator('h2').filter({ hasText: /Lineup|Community/i }).first();
+        await expect(heading).toBeVisible({ timeout: 5_000 });
 
         const viewLink = page.getByRole('link', { name: /View Lineup/i });
         await expect(viewLink).toBeVisible({ timeout: 5_000 });
@@ -258,7 +262,7 @@ test.describe('Community Lineup detail page', () => {
 
         // Header shows "Community Lineup" title
         await expect(
-            page.getByRole('heading', { name: 'Community Lineup' }),
+            page.getByRole('heading', { level: 1, name: /Smoke Lineup|Lineup — / }),
         ).toBeVisible({ timeout: 15_000 });
 
         // Status badge shows one of the valid statuses
@@ -276,7 +280,7 @@ test.describe('Community Lineup detail page', () => {
 
         await page.goto(`/community-lineup/${lineupId}`);
         await expect(
-            page.getByRole('heading', { name: 'Community Lineup' }),
+            page.getByRole('heading', { level: 1, name: /Smoke Lineup|Lineup — / }),
         ).toBeVisible({ timeout: 15_000 });
 
         // Phase breadcrumb shows "Nominating" in the header
@@ -289,7 +293,7 @@ test.describe('Community Lineup detail page', () => {
     test('activity timeline section is present', async ({ page }) => {
         await page.goto(`/community-lineup/${lineupId}`);
         await expect(
-            page.getByRole('heading', { name: 'Community Lineup' }),
+            page.getByRole('heading', { level: 1, name: /Smoke Lineup|Lineup — / }),
         ).toBeVisible({ timeout: 15_000 });
 
         // Activity heading -- the timeline may have entries from lineup creation
@@ -304,7 +308,7 @@ test.describe('Community Lineup detail page', () => {
     test('shows nomination grid or empty state', async ({ page }) => {
         await page.goto(`/community-lineup/${lineupId}`);
         await expect(
-            page.getByRole('heading', { name: 'Community Lineup' }),
+            page.getByRole('heading', { level: 1, name: /Smoke Lineup|Lineup — / }),
         ).toBeVisible({ timeout: 15_000 });
 
         // Either "Nominated Games" heading (has entries) or empty state text
@@ -328,7 +332,7 @@ test.describe('Community Lineup detail page', () => {
         await page.waitForURL(/\/community-lineup\/\d+/, { timeout: 10_000 });
 
         await expect(
-            page.getByRole('heading', { name: 'Community Lineup' }),
+            page.getByRole('heading', { level: 1, name: /Smoke Lineup|Lineup — / }),
         ).toBeVisible({ timeout: 10_000 });
 
         // Click back button (aria-label="Go back")
@@ -355,7 +359,7 @@ test.describe('Community Lineup responsive layout', () => {
 
         await page.goto(`/community-lineup/${lineupId}`);
         await expect(
-            page.getByRole('heading', { name: 'Community Lineup' }),
+            page.getByRole('heading', { level: 1, name: /Smoke Lineup|Lineup — / }),
         ).toBeVisible({ timeout: 15_000 });
 
         // If there are nominated games, the grid container uses sm:grid-cols-2
@@ -377,7 +381,7 @@ test.describe('Community Lineup responsive layout', () => {
 
         await page.goto(`/community-lineup/${lineupId}`);
         await expect(
-            page.getByRole('heading', { name: 'Community Lineup' }),
+            page.getByRole('heading', { level: 1, name: /Smoke Lineup|Lineup — / }),
         ).toBeVisible({ timeout: 15_000 });
 
         const nominatedHeading = page.getByRole('heading', { name: 'Nominated Games' });
@@ -429,6 +433,7 @@ test.describe('Voting phase', () => {
             if (banner.status !== 'building') {
                 await archiveLineup(adminToken, banner.id);
                 const created = (await apiPost(adminToken, '/lineups', {
+                    title: 'Smoke Lineup',
                     targetDate: new Date(Date.now() + 7 * 86_400_000).toISOString(),
                     buildingDurationHours: 720,
                     votingDurationHours: 720,
@@ -441,6 +446,7 @@ test.describe('Voting phase', () => {
         } else {
             // No active lineup -- create one
             const created = (await apiPost(adminToken, '/lineups', {
+                title: 'Smoke Lineup',
                 targetDate: new Date(Date.now() + 7 * 86_400_000).toISOString(),
                 buildingDurationHours: 720,
                 votingDurationHours: 720,

--- a/scripts/smoke/lineup-creation.smoke.spec.ts
+++ b/scripts/smoke/lineup-creation.smoke.spec.ts
@@ -93,6 +93,7 @@ async function ensureActiveLineup(
             Authorization: `Bearer ${token}`,
         },
         body: JSON.stringify({
+            title: 'Smoke Lineup',
             buildingDurationHours: 720,
             votingDurationHours: 720,
             decidedDurationHours: 720,
@@ -150,7 +151,7 @@ test.describe('Start Lineup button on Games page', () => {
                     'Content-Type': 'application/json',
                     Authorization: `Bearer ${adminToken}`,
                 },
-                body: JSON.stringify({}),
+                body: JSON.stringify({ title: 'Smoke Lineup' }),
             });
             expect(createRes.ok).toBe(true);
         }
@@ -259,7 +260,7 @@ test.describe('Lineup creation modal', () => {
         }
 
         await expect(
-            page.getByRole('heading', { name: 'Community Lineup' }),
+            page.getByRole('heading', { level: 1, name: /Smoke Lineup|Lineup — / }),
         ).toBeVisible({ timeout: 10_000 });
     });
 });
@@ -333,7 +334,7 @@ test.describe('Phase breadcrumb transitions', () => {
             lineupId = await ensureActiveLineup(adminToken);
             await page.goto(`/community-lineup/${lineupId}`);
             await expect(
-                page.getByRole('heading', { name: 'Community Lineup' }),
+                page.getByRole('heading', { level: 1, name: /Smoke Lineup|Lineup — / }),
             ).toBeVisible({ timeout: 5_000 });
             // "Voting" should be a clickable button (next phase from building)
             const votingBtn = page.getByRole('button', { name: 'Voting' });
@@ -346,7 +347,7 @@ test.describe('Phase breadcrumb transitions', () => {
             lineupId = await ensureActiveLineup(adminToken);
             await page.goto(`/community-lineup/${lineupId}`);
             await expect(
-                page.getByRole('heading', { name: 'Community Lineup' }),
+                page.getByRole('heading', { level: 1, name: /Smoke Lineup|Lineup — / }),
             ).toBeVisible({ timeout: 5_000 });
 
             // First click — shows "Advance?"
@@ -371,7 +372,7 @@ test.describe('Phase breadcrumb transitions', () => {
 
             await page.goto(`/community-lineup/${lineupId}`);
             await expect(
-                page.getByRole('heading', { name: 'Community Lineup' }),
+                page.getByRole('heading', { level: 1, name: /Smoke Lineup|Lineup — / }),
             ).toBeVisible({ timeout: 5_000 });
 
             // "Nominating" should be a clickable button (previous phase from voting)

--- a/scripts/smoke/lineup-decided.smoke.spec.ts
+++ b/scripts/smoke/lineup-decided.smoke.spec.ts
@@ -111,6 +111,7 @@ async function createDecidedLineupWithMatches(token: string): Promise<{
     // Create lineup with a lower match threshold to maximise match generation
     // Use 720h durations to prevent BullMQ auto-transitions (ROK-1007)
     const createRes = await apiPost(token, '/lineups', {
+        title: 'Smoke Lineup',
         buildingDurationHours: 720,
         votingDurationHours: 720,
         decidedDurationHours: 720,

--- a/scripts/smoke/lineup-phase-breadcrumb.smoke.spec.ts
+++ b/scripts/smoke/lineup-phase-breadcrumb.smoke.spec.ts
@@ -70,6 +70,7 @@ async function ensureActiveLineup(token: string): Promise<number> {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
         body: JSON.stringify({
+            title: 'Smoke Lineup',
             buildingDurationHours: 720,
             votingDurationHours: 720,
             decidedDurationHours: 720,
@@ -112,7 +113,7 @@ async function ensureLineupInPhase(token: string, targetPhase: string): Promise<
 async function gotoLineupDetail(page: ReturnType<typeof test.info>['_test'] extends never ? never : Parameters<Parameters<typeof test>[1]>[0]['page'], lineupId: number) {
     await page.goto(`/community-lineup/${lineupId}`);
     await expect(
-        page.getByRole('heading', { name: 'Community Lineup' }),
+        page.getByRole('heading', { level: 1, name: /Smoke Lineup|Lineup — / }),
     ).toBeVisible({ timeout: 10_000 });
 }
 

--- a/scripts/smoke/lineup-tiebreaker.smoke.spec.ts
+++ b/scripts/smoke/lineup-tiebreaker.smoke.spec.ts
@@ -117,6 +117,7 @@ async function createVotingLineupWithTiebreaker(
     const gameIds = await fetchGameIds(token, 4);
 
     const createRes = (await apiPost(token, '/lineups', {
+        title: 'Smoke Lineup',
         buildingDurationHours: 720,
         votingDurationHours: 720,
         decidedDurationHours: 720,
@@ -176,6 +177,7 @@ test.describe('Tiebreaker prompt modal', () => {
         gameIds = await fetchGameIds(adminToken, 4);
 
         const createRes = (await apiPost(adminToken, '/lineups', {
+            title: 'Smoke Lineup',
             buildingDurationHours: 720,
             votingDurationHours: 720,
             decidedDurationHours: 720,

--- a/scripts/smoke/lineup-votes-per-player.smoke.spec.ts
+++ b/scripts/smoke/lineup-votes-per-player.smoke.spec.ts
@@ -85,6 +85,7 @@ async function createVotingLineupWithVotesPerPlayer(
     const gameIds = await fetchGameIds(token, 3);
 
     const createRes = await apiPost(token, '/lineups', {
+        title: 'Smoke Lineup',
         buildingDurationHours: 720,
         votingDurationHours: 720,
         decidedDurationHours: 720,

--- a/scripts/smoke/paste-nominate.smoke.spec.ts
+++ b/scripts/smoke/paste-nominate.smoke.spec.ts
@@ -42,6 +42,7 @@ async function ensureBuildingLineup(token: string): Promise<number> {
         await archiveLineup(token, banner.id);
     }
     const lineup = (await apiPost(token, '/lineups', {
+        title: 'Smoke Lineup',
         targetDate: new Date(Date.now() + 7 * 86_400_000).toISOString(),
     })) as { id?: number };
     if (lineup?.id) return lineup.id;
@@ -114,7 +115,7 @@ test.describe('Paste Steam URL opens NominateModal (AC1, AC2, AC7)', () => {
     test('pasting Steam URL opens modal in preview state', async ({ page }) => {
         await page.goto(`/community-lineup/${lineupId}`);
         await expect(
-            page.getByRole('heading', { name: 'Community Lineup' }),
+            page.getByRole('heading', { level: 1, name: /Smoke Lineup|Lineup — / }),
         ).toBeVisible({ timeout: 15_000 });
 
         await dispatchPaste(page, STEAM_URL);
@@ -133,7 +134,7 @@ test.describe('Paste Steam URL opens NominateModal (AC1, AC2, AC7)', () => {
     test('preview state shows game name and cover art or placeholder', async ({ page }) => {
         await page.goto(`/community-lineup/${lineupId}`);
         await expect(
-            page.getByRole('heading', { name: 'Community Lineup' }),
+            page.getByRole('heading', { level: 1, name: /Smoke Lineup|Lineup — / }),
         ).toBeVisible({ timeout: 15_000 });
 
         await dispatchPaste(page, STEAM_URL);
@@ -164,7 +165,7 @@ test.describe('Unknown game shows toast (AC3)', () => {
     test('toast "Game not found in library" appears for unknown Steam app ID', async ({ page }) => {
         await page.goto(`/community-lineup/${lineupId}`);
         await expect(
-            page.getByRole('heading', { name: 'Community Lineup' }),
+            page.getByRole('heading', { level: 1, name: /Smoke Lineup|Lineup — / }),
         ).toBeVisible({ timeout: 15_000 });
 
         await dispatchPaste(page, UNKNOWN_STEAM_URL);
@@ -197,7 +198,7 @@ test.describe('Input focus suppresses detection (AC4)', () => {
 
         await page.goto(`/community-lineup/${lineupId}`);
         await expect(
-            page.getByRole('heading', { name: 'Community Lineup' }),
+            page.getByRole('heading', { level: 1, name: /Smoke Lineup|Lineup — / }),
         ).toBeVisible({ timeout: 15_000 });
 
         // Open NominateModal manually to get an input on the page
@@ -245,7 +246,7 @@ test.describe('Non-Steam URLs ignored (AC5)', () => {
     test('pasting a non-Steam URL does not open modal or show toast', async ({ page }) => {
         await page.goto(`/community-lineup/${lineupId}`);
         await expect(
-            page.getByRole('heading', { name: 'Community Lineup' }),
+            page.getByRole('heading', { level: 1, name: /Smoke Lineup|Lineup — / }),
         ).toBeVisible({ timeout: 15_000 });
 
         await dispatchPaste(page, 'https://www.example.com/some/page');
@@ -260,7 +261,7 @@ test.describe('Non-Steam URLs ignored (AC5)', () => {
     test('pasting plain text does not trigger detection', async ({ page }) => {
         await page.goto(`/community-lineup/${lineupId}`);
         await expect(
-            page.getByRole('heading', { name: 'Community Lineup' }),
+            page.getByRole('heading', { level: 1, name: /Smoke Lineup|Lineup — / }),
         ).toBeVisible({ timeout: 15_000 });
 
         await dispatchPaste(page, 'just some random text with no URL');
@@ -286,6 +287,7 @@ test.describe('Paste disabled in non-building phases (AC6)', () => {
         }
 
         const created = (await apiPost(adminToken, '/lineups', {
+            title: 'Smoke Lineup',
             targetDate: new Date(Date.now() + 7 * 86_400_000).toISOString(),
         })) as { id: number };
         votingLineupId = created.id;
@@ -307,7 +309,7 @@ test.describe('Paste disabled in non-building phases (AC6)', () => {
 
         // Wait for the page to fully load (heading visible, no error)
         await expect(
-            page.getByRole('heading', { name: 'Community Lineup' }),
+            page.getByRole('heading', { level: 1, name: /Smoke Lineup|Lineup — / }),
         ).toBeVisible({ timeout: 15_000 });
 
         await dispatchPaste(page, STEAM_URL);

--- a/scripts/smoke/scheduling-poll.smoke.spec.ts
+++ b/scripts/smoke/scheduling-poll.smoke.spec.ts
@@ -69,6 +69,7 @@ async function createSchedulingLineupWithMatch(token: string): Promise<{
 
     // Create lineup with a low match threshold to maximize match generation
     const createRes = await apiPost(token, '/lineups', {
+        title: 'Smoke Lineup',
         buildingDurationHours: 24,
         votingDurationHours: 48,
         decidedDurationHours: 24,

--- a/tools/test-bot/src/smoke/run.ts
+++ b/tools/test-bot/src/smoke/run.ts
@@ -24,6 +24,7 @@ import { cdpSlashCommandTests } from './tests/cdp-slash-commands.test.js';
 import { cdpSteamInterestTests } from './tests/cdp-steam-interest.test.js';
 import { scheduledEventCompletionTests } from './tests/scheduled-event-completion.test.js';
 import { aiChatTests } from './tests/ai-chat.test.js';
+import { lineupTitleTests } from './tests/lineup-title.test.js';
 
 /** Build a TestResult from a test, status, and timing info. */
 function buildResult(
@@ -137,6 +138,7 @@ function collectTests(filterCat?: string): SmokeTest[] {
     ...cdpSteamInterestTests,
     ...scheduledEventCompletionTests,
     ...aiChatTests,
+    ...lineupTitleTests,
   ].filter((t) => !filterCat || t.category === filterCat);
 }
 

--- a/tools/test-bot/src/smoke/tests/lineup-title.test.ts
+++ b/tools/test-bot/src/smoke/tests/lineup-title.test.ts
@@ -1,0 +1,106 @@
+/**
+ * ROK-1063 — lineup title & description Discord smoke test.
+ *
+ * Creates a lineup with a known title and description via the API, then
+ * polls the default notification channel for the "Community Lineup —
+ * Nominations Open!" embed. Asserts the lineup's title appears in the
+ * embed (author/header context) and the description appears in the body.
+ *
+ * This test is intentionally failing until ROK-1063 ships — embeds
+ * currently render a static "Community Lineup" header regardless of the
+ * lineup's stored title.
+ */
+import { pollForEmbed } from '../../helpers/polling.js';
+import { awaitProcessing } from '../fixtures.js';
+import type { SmokeTest, TestContext } from '../types.js';
+import type { ApiClient } from '../api.js';
+
+interface LineupPayload {
+  id: number;
+  title?: string;
+  description?: string | null;
+  [k: string]: unknown;
+}
+
+async function archiveAllLineups(api: ApiClient): Promise<void> {
+  // Best effort — if an active lineup exists, archive it so we can create a new one.
+  try {
+    const active = await api.get<{ id: number }>('/lineups/active');
+    if (active?.id) {
+      await api
+        .patch(`/lineups/${active.id}/status`, { status: 'archived' })
+        .catch(() => null);
+    }
+  } catch {
+    // No active lineup — nothing to archive.
+  }
+}
+
+async function deleteLineup(api: ApiClient, id: number): Promise<void> {
+  await api.delete(`/lineups/${id}`).catch(() => {
+    // Fallback: archive so the next test can create a fresh lineup.
+    return api
+      .patch(`/lineups/${id}/status`, { status: 'archived' })
+      .catch(() => null);
+  });
+}
+
+const lineupTitleInEmbed: SmokeTest = {
+  name: 'Lineup embed shows per-lineup title + description (ROK-1063)',
+  category: 'embed',
+  async run(ctx: TestContext) {
+    await archiveAllLineups(ctx.api);
+
+    const title = `Smoke Lineup ${Date.now()}`;
+    const description =
+      'Smoke-test description — vote for your favorite pick!';
+
+    const lineup = await ctx.api.post<LineupPayload>('/lineups', {
+      title,
+      description,
+    });
+
+    try {
+      await awaitProcessing(ctx.api);
+
+      // Wait for the "created" embed to appear with the custom title.
+      const msg = await pollForEmbed(
+        ctx.defaultChannelId,
+        (m) =>
+          m.embeds.some((e) => {
+            const haystack = [
+              e.title ?? '',
+              e.description ?? '',
+              e.footer ?? '',
+              ...e.fields.map((f) => `${f.name} ${f.value}`),
+            ].join(' ');
+            return haystack.includes(title);
+          }),
+        ctx.config.timeoutMs,
+      );
+
+      const embed = msg.embeds[0];
+      const haystack = [
+        embed.title ?? '',
+        embed.description ?? '',
+        embed.footer ?? '',
+        ...embed.fields.map((f) => `${f.name} ${f.value}`),
+      ].join(' ');
+
+      if (!haystack.includes(title)) {
+        throw new Error(
+          `Expected lineup title "${title}" in embed, got: ${haystack.slice(0, 500)}`,
+        );
+      }
+      if (!haystack.includes(description)) {
+        throw new Error(
+          `Expected lineup description "${description}" in embed, got: ${haystack.slice(0, 500)}`,
+        );
+      }
+    } finally {
+      await deleteLineup(ctx.api, lineup.id);
+    }
+  },
+};
+
+export const lineupTitleTests: SmokeTest[] = [lineupTitleInEmbed];

--- a/web/src/components/lineups/CommonGroundFilters.tsx
+++ b/web/src/components/lineups/CommonGroundFilters.tsx
@@ -97,7 +97,7 @@ export function CommonGroundFilters({ filters, onChange, availableTags, search, 
     );
 
     return (
-        <div style={{ display: 'grid', gridTemplateColumns: '160px 1fr 1fr 1fr', gap: 16, alignItems: 'center' }}>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-[160px_1fr_1fr_1fr] gap-3 sm:gap-4 items-center">
             <input
                 type="text"
                 value={search}

--- a/web/src/components/lineups/LineupBanner.test.tsx
+++ b/web/src/components/lineups/LineupBanner.test.tsx
@@ -64,10 +64,10 @@ describe('LineupBanner — populated state', () => {
         expect(screen.getByText('COMMUNITY LINEUP')).toBeInTheDocument();
     });
 
-    it('renders the lineup question heading', () => {
-        mockHookReturn(createMockBanner());
+    it('renders the lineup title heading (ROK-1063)', () => {
+        mockHookReturn(createMockBanner({ title: 'Spring Kickoff' }));
         renderWithProviders(<LineupBanner />);
-        expect(screen.getByText(/what are we playing/i)).toBeInTheDocument();
+        expect(screen.getByText('Spring Kickoff')).toBeInTheDocument();
     });
 
     it('renders the lineup status badge', () => {

--- a/web/src/components/lineups/LineupBanner.title.test.tsx
+++ b/web/src/components/lineups/LineupBanner.title.test.tsx
@@ -1,0 +1,52 @@
+/**
+ * ROK-1063 — failing TDD tests for the LineupBanner title.
+ *
+ * The banner must show the lineup's stored `title` prominently so
+ * members can tell lineups apart at a glance.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test/render-helpers';
+import { createMockBanner } from '../../test/lineup-factories';
+import { LineupBanner } from './LineupBanner';
+
+vi.mock('../../hooks/use-lineups', () => ({
+    useLineupBanner: vi.fn(),
+}));
+
+vi.mock('./NominateModal', () => ({
+    NominateModal: () => null,
+}));
+
+vi.mock('../../hooks/use-auth', () => ({
+    useAuth: () => ({ user: null }),
+    isOperatorOrAdmin: () => false,
+}));
+
+import { useLineupBanner } from '../../hooks/use-lineups';
+
+const mockUseLineupBanner = vi.mocked(useLineupBanner);
+
+function mockBannerWithTitle(title: string) {
+    const data = createMockBanner();
+    const withTitle = { ...data, title } as typeof data & { title: string };
+    mockUseLineupBanner.mockReturnValue({
+        data: withTitle,
+        isLoading: false,
+        isSuccess: true,
+        isError: false,
+        error: null,
+        isFetching: false,
+    } as unknown as ReturnType<typeof useLineupBanner>);
+}
+
+describe('LineupBanner — title (ROK-1063)', () => {
+    it('renders the lineup title prominently in the banner', () => {
+        mockBannerWithTitle('Summer Kick-off Raid');
+        renderWithProviders(<LineupBanner />);
+
+        expect(
+            screen.getByText(/Summer Kick-off Raid/),
+        ).toBeInTheDocument();
+    });
+});

--- a/web/src/components/lineups/LineupBanner.tsx
+++ b/web/src/components/lineups/LineupBanner.tsx
@@ -51,12 +51,12 @@ function StatusBar({ targetDate, phaseDeadline, status }: {
     );
 }
 
-/** Heading row with question and status badge. */
+/** Heading row with per-lineup title and status badge (ROK-1063). */
 function BannerHeading({ banner }: { banner: LineupBannerResponseDto }): JSX.Element {
     return (
         <div className="flex items-center gap-3 mb-1">
-            <h2 className="text-lg font-bold text-foreground">
-                What are we playing this week?
+            <h2 className="text-lg font-bold text-foreground truncate" title={banner.title}>
+                {banner.title}
             </h2>
             <LineupStatusBadge status={banner.status} />
             {banner.tiebreakerActive && <TiebreakerBadge />}

--- a/web/src/components/lineups/LineupDetailHeader.test.tsx
+++ b/web/src/components/lineups/LineupDetailHeader.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * ROK-1063 — failing TDD tests for the lineup detail header.
+ *
+ * The H1 must render the lineup's stored `title` (NOT the static
+ * "Community Lineup" string). When a description is present, it must
+ * render below the heading.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test/render-helpers';
+import { createMockLineupDetail } from '../../test/lineup-factories';
+import { LineupDetailHeader } from './LineupDetailHeader';
+
+vi.mock('../../hooks/use-lineups', () => ({
+    useTransitionLineupStatus: () => ({
+        mutate: vi.fn(),
+        isPending: false,
+    }),
+}));
+
+vi.mock('../../hooks/use-auth', () => ({
+    useAuth: () => ({ user: null }),
+    isOperatorOrAdmin: () => false,
+}));
+
+// Provide a type cast so test factory overrides for title/description work
+// even before the contract types are updated.
+type DetailOverrides = Partial<
+    ReturnType<typeof createMockLineupDetail> & {
+        title: string;
+        description: string | null;
+    }
+>;
+
+function buildDetail(overrides: DetailOverrides) {
+    return createMockLineupDetail(
+        overrides as Parameters<typeof createMockLineupDetail>[0],
+    ) as ReturnType<typeof createMockLineupDetail> & {
+        title: string;
+        description: string | null;
+    };
+}
+
+describe('LineupDetailHeader — title (ROK-1063)', () => {
+    it('renders the lineup title as the H1 heading', () => {
+        const lineup = buildDetail({ title: 'Spring Raid Picks' });
+        renderWithProviders(<LineupDetailHeader lineup={lineup} />);
+
+        const heading = screen.getByRole('heading', { level: 1 });
+        expect(heading).toHaveTextContent('Spring Raid Picks');
+    });
+
+    it('does NOT render the hardcoded "Community Lineup" string as H1', () => {
+        const lineup = buildDetail({ title: 'Winter Picks' });
+        renderWithProviders(<LineupDetailHeader lineup={lineup} />);
+
+        const heading = screen.getByRole('heading', { level: 1 });
+        expect(heading.textContent ?? '').not.toMatch(/community lineup/i);
+    });
+});
+
+describe('LineupDetailHeader — description (ROK-1063)', () => {
+    it('renders description text below the heading when present', () => {
+        const lineup = buildDetail({
+            title: 'Any title',
+            description: 'Community-picked games for this Friday.',
+        });
+        renderWithProviders(<LineupDetailHeader lineup={lineup} />);
+
+        expect(
+            screen.getByText(/Community-picked games for this Friday\./),
+        ).toBeInTheDocument();
+    });
+});

--- a/web/src/components/lineups/LineupDetailHeader.tsx
+++ b/web/src/components/lineups/LineupDetailHeader.tsx
@@ -89,7 +89,7 @@ function PhaseBreadcrumb({ lineup, onTiebreakerIntercept }: {
   }
 
   return (
-    <div className="flex items-center gap-1 text-sm">
+    <div className="flex items-center flex-wrap gap-x-1 gap-y-0.5 text-sm">
       {PHASES.map((p, i) => {
         const isCurrent = i === currentIdx;
         const isClickable = canOperate && (i === currentIdx + 1 || i === currentIdx - 1);
@@ -156,10 +156,13 @@ function EditButton({ onClick }: { onClick: () => void }): JSX.Element {
     <button
       type="button"
       onClick={onClick}
-      className="text-xs text-muted hover:text-foreground px-2 py-1 rounded border border-edge/50 hover:bg-overlay/50 transition-colors"
+      className="inline-flex items-center gap-1 text-xs text-muted hover:text-foreground px-2.5 py-1.5 rounded border border-edge/50 hover:bg-overlay/50 active:bg-overlay transition-colors flex-shrink-0 whitespace-nowrap min-h-[32px]"
       aria-label="Edit lineup metadata"
     >
-      Edit
+      <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
+      </svg>
+      <span className="hidden sm:inline">Edit</span>
     </button>
   );
 }
@@ -179,27 +182,38 @@ export function LineupDetailHeader({ lineup, onTiebreakerIntercept }: Props): JS
 
   return (
     <div className="border-b border-edge pb-4 mb-4 w-full">
-      <div className="flex items-center justify-between mb-1">
-        <div className="flex items-center gap-3 min-w-0">
-          <button
-            onClick={() => navigate(-1)}
-            className="text-muted hover:text-foreground transition"
-            aria-label="Go back"
-          >
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
-            </svg>
-          </button>
-          <h1 className="text-lg font-display font-bold tracking-wide truncate" title={lineup.title}>
-            {lineup.title}
-          </h1>
+      {/* Row 1: back + title + edit (always single row, title truncates) */}
+      <div className="flex items-center gap-3 min-w-0 mb-2 md:mb-1">
+        <button
+          onClick={() => navigate(-1)}
+          className="text-muted hover:text-foreground transition flex-shrink-0"
+          aria-label="Go back"
+        >
+          <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
+          </svg>
+        </button>
+        <h1 className="text-lg font-display font-bold tracking-wide truncate flex-1 min-w-0" title={lineup.title}>
+          {lineup.title}
+        </h1>
+        {/* Desktop-only inline badge + breadcrumb after title */}
+        <div className="hidden md:flex items-center gap-3 flex-shrink-0">
           <LineupStatusBadge status={lineup.status} />
           {canEdit && <EditButton onClick={() => setEditOpen(true)} />}
-        </div>
-        <div className="flex items-center gap-2">
           <PhaseBreadcrumb lineup={lineup} onTiebreakerIntercept={onTiebreakerIntercept} />
           <PhaseCircle status={lineup.status} />
         </div>
+        {/* Mobile-only edit button on the same row as title */}
+        {canEdit && (
+          <div className="md:hidden flex-shrink-0">
+            <EditButton onClick={() => setEditOpen(true)} />
+          </div>
+        )}
+      </div>
+      {/* Row 2 (mobile only): breadcrumb + circle (badge already shown as current phase in breadcrumb) */}
+      <div className="md:hidden flex items-center gap-2 flex-wrap mb-2 ml-8">
+        <PhaseBreadcrumb lineup={lineup} onTiebreakerIntercept={onTiebreakerIntercept} />
+        <PhaseCircle status={lineup.status} />
       </div>
       {lineup.description && (
         <div className="ml-8 mb-2">

--- a/web/src/components/lineups/LineupDetailHeader.tsx
+++ b/web/src/components/lineups/LineupDetailHeader.tsx
@@ -182,7 +182,7 @@ export function LineupDetailHeader({ lineup, onTiebreakerIntercept }: Props): JS
 
   return (
     <div className="border-b border-edge pb-4 mb-4 w-full">
-      {/* Row 1: back + title + edit (always single row, title truncates) */}
+      {/* Row 1: back + title + badge + edit + (desktop-only: breadcrumb + circle) */}
       <div className="flex items-center gap-3 min-w-0 mb-2 md:mb-1">
         <button
           onClick={() => navigate(-1)}
@@ -196,21 +196,15 @@ export function LineupDetailHeader({ lineup, onTiebreakerIntercept }: Props): JS
         <h1 className="text-lg font-display font-bold tracking-wide truncate flex-1 min-w-0" title={lineup.title}>
           {lineup.title}
         </h1>
-        {/* Desktop-only inline badge + breadcrumb after title */}
+        <LineupStatusBadge status={lineup.status} />
+        {canEdit && <EditButton onClick={() => setEditOpen(true)} />}
+        {/* Desktop-only inline breadcrumb + circle after edit */}
         <div className="hidden md:flex items-center gap-3 flex-shrink-0">
-          <LineupStatusBadge status={lineup.status} />
-          {canEdit && <EditButton onClick={() => setEditOpen(true)} />}
           <PhaseBreadcrumb lineup={lineup} onTiebreakerIntercept={onTiebreakerIntercept} />
           <PhaseCircle status={lineup.status} />
         </div>
-        {/* Mobile-only edit button on the same row as title */}
-        {canEdit && (
-          <div className="md:hidden flex-shrink-0">
-            <EditButton onClick={() => setEditOpen(true)} />
-          </div>
-        )}
       </div>
-      {/* Row 2 (mobile only): breadcrumb + circle (badge already shown as current phase in breadcrumb) */}
+      {/* Row 2 (mobile only): breadcrumb + circle */}
       <div className="md:hidden flex items-center gap-2 flex-wrap mb-2 ml-8">
         <PhaseBreadcrumb lineup={lineup} onTiebreakerIntercept={onTiebreakerIntercept} />
         <PhaseCircle status={lineup.status} />

--- a/web/src/components/lineups/LineupDetailHeader.tsx
+++ b/web/src/components/lineups/LineupDetailHeader.tsx
@@ -8,6 +8,8 @@ import { PhaseCountdown } from './phase-countdown';
 import { PHASES, PHASE_LABELS } from './lineup-phases';
 import { toast } from '../../lib/toast';
 import { UnlinkedSteamCount } from './UnlinkedSteamCount';
+import { MarkdownText } from '../ui/markdown-text';
+import { EditLineupMetadataModal } from './edit-lineup-metadata-modal';
 
 interface Props {
   lineup: LineupDetailResponseDto;
@@ -149,13 +151,36 @@ function PhaseContextInfo({ lineup }: { lineup: LineupDetailResponseDto }): JSX.
   return null;
 }
 
+function EditButton({ onClick }: { onClick: () => void }): JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="text-xs text-muted hover:text-foreground px-2 py-1 rounded border border-edge/50 hover:bg-overlay/50 transition-colors"
+      aria-label="Edit lineup metadata"
+    >
+      Edit
+    </button>
+  );
+}
+
+function useCanEdit(lineup: LineupDetailResponseDto): boolean {
+  const { user } = useAuth();
+  if (lineup.status === 'archived') return false;
+  if (!user) return false;
+  if (isOperatorOrAdmin(user)) return true;
+  return user.id === lineup.createdBy.id;
+}
+
 export function LineupDetailHeader({ lineup, onTiebreakerIntercept }: Props): JSX.Element {
   const navigate = useNavigate();
+  const [editOpen, setEditOpen] = useState(false);
+  const canEdit = useCanEdit(lineup);
 
   return (
     <div className="border-b border-edge pb-4 mb-4 w-full">
       <div className="flex items-center justify-between mb-1">
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 min-w-0">
           <button
             onClick={() => navigate(-1)}
             className="text-muted hover:text-foreground transition"
@@ -165,14 +190,22 @@ export function LineupDetailHeader({ lineup, onTiebreakerIntercept }: Props): JS
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
             </svg>
           </button>
-          <h1 className="text-lg font-display font-bold tracking-wide">Community Lineup</h1>
+          <h1 className="text-lg font-display font-bold tracking-wide truncate" title={lineup.title}>
+            {lineup.title}
+          </h1>
           <LineupStatusBadge status={lineup.status} />
+          {canEdit && <EditButton onClick={() => setEditOpen(true)} />}
         </div>
         <div className="flex items-center gap-2">
           <PhaseBreadcrumb lineup={lineup} onTiebreakerIntercept={onTiebreakerIntercept} />
           <PhaseCircle status={lineup.status} />
         </div>
       </div>
+      {lineup.description && (
+        <div className="ml-8 mb-2">
+          <MarkdownText text={lineup.description} />
+        </div>
+      )}
       <div className="flex items-center justify-between ml-8">
         <div className="flex items-center gap-2 flex-wrap text-sm">
           <span className="text-muted">Started by {lineup.createdBy.displayName}</span>
@@ -183,6 +216,14 @@ export function LineupDetailHeader({ lineup, onTiebreakerIntercept }: Props): JS
           <PhaseCountdown phaseDeadline={lineup.phaseDeadline} phaseStartedAt={lineup.updatedAt} status={lineup.status} compact />
         )}
       </div>
+      {editOpen && (
+        <EditLineupMetadataModal
+          lineupId={lineup.id}
+          initialTitle={lineup.title}
+          initialDescription={lineup.description}
+          onClose={() => setEditOpen(false)}
+        />
+      )}
     </div>
   );
 }

--- a/web/src/components/lineups/edit-lineup-metadata-modal.tsx
+++ b/web/src/components/lineups/edit-lineup-metadata-modal.tsx
@@ -1,0 +1,118 @@
+/**
+ * Edit lineup title + description (ROK-1063).
+ * Opens from LineupDetailHeader "Edit" button. Same validation as creation.
+ */
+import { useState, type JSX } from 'react';
+import { Modal } from '../ui/modal';
+import { useUpdateLineupMetadata } from '../../hooks/use-lineups';
+import { toast } from '../../lib/toast';
+
+interface Props {
+    lineupId: number;
+    initialTitle: string;
+    initialDescription: string | null;
+    onClose: () => void;
+}
+
+const DESCRIPTION_MAX = 500;
+
+function TitleField({ value, onChange }: {
+    value: string;
+    onChange: (v: string) => void;
+}): JSX.Element {
+    return (
+        <div>
+            <label htmlFor="edit-lineup-title" className="block text-sm font-medium text-secondary mb-1">
+                Title <span className="text-rose-400">*</span>
+            </label>
+            <input
+                id="edit-lineup-title"
+                type="text"
+                required
+                maxLength={100}
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                className="w-full px-3 py-2 text-sm bg-panel border border-edge rounded-lg text-foreground focus:outline-none focus:ring-2 focus:ring-emerald-500/50"
+            />
+        </div>
+    );
+}
+
+function DescriptionField({ value, onChange }: {
+    value: string;
+    onChange: (v: string) => void;
+}): JSX.Element {
+    return (
+        <div>
+            <div className="flex items-center justify-between mb-1">
+                <label htmlFor="edit-lineup-description" className="block text-sm font-medium text-secondary">
+                    Description
+                </label>
+                <span className="text-xs text-muted tabular-nums">
+                    {value.length} / {DESCRIPTION_MAX}
+                </span>
+            </div>
+            <textarea
+                id="edit-lineup-description"
+                rows={4}
+                maxLength={DESCRIPTION_MAX}
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                className="w-full px-3 py-2 text-sm bg-panel border border-edge rounded-lg text-foreground focus:outline-none focus:ring-2 focus:ring-emerald-500/50"
+            />
+        </div>
+    );
+}
+
+export function EditLineupMetadataModal({ lineupId, initialTitle, initialDescription, onClose }: Props): JSX.Element {
+    const [title, setTitle] = useState(initialTitle);
+    const [description, setDescription] = useState(initialDescription ?? '');
+    const update = useUpdateLineupMetadata();
+
+    async function handleSave() {
+        const trimmed = title.trim();
+        if (!trimmed) {
+            toast.error('Title is required');
+            return;
+        }
+        try {
+            await update.mutateAsync({
+                lineupId,
+                body: {
+                    title: trimmed,
+                    description: description.trim() === '' ? null : description,
+                },
+            });
+            toast.success('Lineup updated');
+            onClose();
+        } catch (err) {
+            toast.error(err instanceof Error ? err.message : 'Failed to update lineup');
+        }
+    }
+
+    return (
+        <Modal isOpen={true} onClose={onClose} title="Edit Lineup">
+            <div className="space-y-4">
+                <TitleField value={title} onChange={setTitle} />
+                <DescriptionField value={description} onChange={setDescription} />
+                <div className="flex justify-end gap-3 pt-2">
+                    <button
+                        type="button"
+                        onClick={onClose}
+                        className="px-4 py-2 text-sm font-medium text-secondary bg-panel border border-edge rounded-lg hover:bg-overlay transition-colors"
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        type="button"
+                        onClick={() => void handleSave()}
+                        disabled={update.isPending || title.trim() === ''}
+                        className="px-4 py-2 text-sm font-medium bg-emerald-600 text-white rounded-lg hover:bg-emerald-500 transition-colors disabled:opacity-50"
+                    >
+                        {update.isPending ? 'Saving...' : 'Save'}
+                    </button>
+                </div>
+            </div>
+        </Modal>
+    );
+}

--- a/web/src/components/lineups/edit-lineup-metadata-modal.tsx
+++ b/web/src/components/lineups/edit-lineup-metadata-modal.tsx
@@ -58,7 +58,8 @@ function DescriptionField({ value, onChange }: {
                 maxLength={DESCRIPTION_MAX}
                 value={value}
                 onChange={(e) => onChange(e.target.value)}
-                className="w-full px-3 py-2 text-sm bg-panel border border-edge rounded-lg text-foreground focus:outline-none focus:ring-2 focus:ring-emerald-500/50"
+                placeholder="Optional markdown — **bold**, *italic*, `code`, [link](https://example.com)"
+                className="w-full px-3 py-2 text-sm bg-panel border border-edge rounded-lg text-foreground placeholder:text-dim focus:outline-none focus:ring-2 focus:ring-emerald-500/50"
             />
         </div>
     );

--- a/web/src/components/lineups/start-lineup-modal.test.tsx
+++ b/web/src/components/lineups/start-lineup-modal.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * ROK-1063 — failing TDD tests for the StartLineupModal.
+ *
+ * Validates the new title + description fields on the "Start Community
+ * Lineup" modal:
+ *   - Title input is rendered, required, and pre-filled with
+ *     `Lineup — <current month year>` (no zero padding).
+ *   - Description textarea is rendered with a character counter that
+ *     updates as the user types and caps at 500.
+ *   - Submission without a title is blocked (mutation not called,
+ *     inline error shown).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../../test/render-helpers';
+import { StartLineupModal } from './start-lineup-modal';
+
+vi.mock('../../hooks/use-lineups', () => ({
+    useCreateLineup: vi.fn(),
+}));
+
+vi.mock('../../hooks/admin/use-lineup-settings', () => ({
+    useLineupSettings: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual<typeof import('react-router-dom')>(
+        'react-router-dom',
+    );
+    return { ...actual, useNavigate: () => vi.fn() };
+});
+
+import { useCreateLineup } from '../../hooks/use-lineups';
+import { useLineupSettings } from '../../hooks/admin/use-lineup-settings';
+
+const mutateAsync = vi.fn();
+
+function currentMonthYear(): string {
+    const now = new Date();
+    const month = now.toLocaleString('en-US', { month: 'long' });
+    return `${month} ${now.getFullYear()}`;
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mutateAsync.mockResolvedValue({ id: 42 });
+    vi.mocked(useCreateLineup).mockReturnValue({
+        mutateAsync,
+        isPending: false,
+        isError: false,
+        error: null,
+    } as unknown as ReturnType<typeof useCreateLineup>);
+    vi.mocked(useLineupSettings).mockReturnValue({
+        lineupDefaults: {
+            data: {
+                buildingDurationHours: 48,
+                votingDurationHours: 24,
+                decidedDurationHours: 168,
+            },
+            isLoading: false,
+        },
+        updateDefaults: {},
+    } as unknown as ReturnType<typeof useLineupSettings>);
+});
+
+describe('StartLineupModal — title field', () => {
+    it('renders a title input prefilled with "Lineup — <Month YYYY>"', () => {
+        renderWithProviders(
+            <StartLineupModal isOpen={true} onClose={vi.fn()} />,
+        );
+        const titleInput = screen.getByLabelText(/title/i) as HTMLInputElement;
+        expect(titleInput).toBeInTheDocument();
+        expect(titleInput.value).toBe(`Lineup — ${currentMonthYear()}`);
+    });
+
+    it('marks the title input as required', () => {
+        renderWithProviders(
+            <StartLineupModal isOpen={true} onClose={vi.fn()} />,
+        );
+        const titleInput = screen.getByLabelText(/title/i) as HTMLInputElement;
+        expect(titleInput).toBeRequired();
+    });
+
+    it('blocks submission when title is cleared', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(
+            <StartLineupModal isOpen={true} onClose={vi.fn()} />,
+        );
+        const titleInput = screen.getByLabelText(/title/i) as HTMLInputElement;
+        await user.clear(titleInput);
+
+        const createBtn = screen.getByRole('button', { name: /create lineup/i });
+        await user.click(createBtn);
+
+        expect(mutateAsync).not.toHaveBeenCalled();
+    });
+});
+
+describe('StartLineupModal — description field', () => {
+    it('renders a description textarea', () => {
+        renderWithProviders(
+            <StartLineupModal isOpen={true} onClose={vi.fn()} />,
+        );
+        expect(screen.getByLabelText(/description/i)).toBeInTheDocument();
+    });
+
+    it('shows a 500-character counter that updates as the user types', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(
+            <StartLineupModal isOpen={true} onClose={vi.fn()} />,
+        );
+        // Initial counter: 0 / 500
+        expect(screen.getByText(/0\s*\/\s*500/)).toBeInTheDocument();
+
+        const textarea = screen.getByLabelText(/description/i);
+        await user.type(textarea, 'Hello world');
+
+        // After typing 11 chars, counter reflects "11 / 500"
+        expect(screen.getByText(/11\s*\/\s*500/)).toBeInTheDocument();
+    });
+});
+
+describe('StartLineupModal — submits title + description', () => {
+    it('passes title and description to useCreateLineup.mutateAsync', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(
+            <StartLineupModal isOpen={true} onClose={vi.fn()} />,
+        );
+
+        const titleInput = screen.getByLabelText(/title/i);
+        await user.clear(titleInput);
+        await user.type(titleInput, 'Co-op Night');
+
+        const textarea = screen.getByLabelText(/description/i);
+        await user.type(textarea, 'Casual co-op picks');
+
+        await user.click(
+            screen.getByRole('button', { name: /create lineup/i }),
+        );
+
+        expect(mutateAsync).toHaveBeenCalledTimes(1);
+        expect(mutateAsync.mock.calls[0][0]).toMatchObject({
+            title: 'Co-op Night',
+            description: 'Casual co-op picks',
+        });
+    });
+});

--- a/web/src/components/lineups/start-lineup-modal.tsx
+++ b/web/src/components/lineups/start-lineup-modal.tsx
@@ -1,5 +1,6 @@
 /**
- * Start Lineup modal with configurable duration fields (ROK-946).
+ * Start Lineup modal with configurable duration fields (ROK-946)
+ * and per-lineup title + description (ROK-1063).
  */
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -12,6 +13,14 @@ interface Props {
   isOpen: boolean;
   onClose: () => void;
 }
+
+function defaultTitle(): string {
+  const now = new Date();
+  const month = now.toLocaleString('en-US', { month: 'long' });
+  return `Lineup — ${month} ${now.getFullYear()}`;
+}
+
+const DESCRIPTION_MAX = 500;
 
 function useDurationState() {
   const { lineupDefaults } = useLineupSettings();
@@ -133,14 +142,106 @@ function ThresholdSlider({ value, onChange }: {
   );
 }
 
+function TitleField({ value, onChange }: {
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div>
+      <label htmlFor="lineup-title" className="block text-sm font-medium text-secondary mb-1">
+        Title <span className="text-rose-400">*</span>
+      </label>
+      <input
+        id="lineup-title"
+        type="text"
+        required
+        maxLength={100}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Lineup — April 2026"
+        className="w-full px-3 py-2 text-sm bg-panel border border-edge rounded-lg text-foreground placeholder:text-dim focus:outline-none focus:ring-2 focus:ring-emerald-500/50"
+      />
+    </div>
+  );
+}
+
+function DescriptionField({ value, onChange }: {
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <div>
+      <div className="flex items-center justify-between mb-1">
+        <label htmlFor="lineup-description" className="block text-sm font-medium text-secondary">
+          Description
+        </label>
+        <span className="text-xs text-muted tabular-nums">
+          {value.length} / {DESCRIPTION_MAX}
+        </span>
+      </div>
+      <textarea
+        id="lineup-description"
+        rows={3}
+        maxLength={DESCRIPTION_MAX}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder="Optional markdown — bold, italic, links, line breaks"
+        className="w-full px-3 py-2 text-sm bg-panel border border-edge rounded-lg text-foreground placeholder:text-dim focus:outline-none focus:ring-2 focus:ring-emerald-500/50"
+      />
+    </div>
+  );
+}
+
+function TiebreakerPicker({ value, onChange }: {
+  value: 'bracket' | 'veto' | null;
+  onChange: (v: 'bracket' | 'veto' | null) => void;
+}) {
+  const opts: ReadonlyArray<readonly [('bracket' | 'veto' | null), string]> = [
+    ['bracket', 'Bracket'],
+    ['veto', 'Veto'],
+    [null, 'None'],
+  ];
+  return (
+    <div className="border-t border-edge/30 pt-4">
+      <label className="text-sm font-medium text-secondary">Tiebreaker Mode</label>
+      <p className="text-xs text-muted mb-2">Used when voting produces tied games at deadline.</p>
+      <div className="flex gap-2">
+        {opts.map(([val, label]) => (
+          <button
+            key={String(val)}
+            type="button"
+            onClick={() => onChange(val)}
+            className={`flex-1 px-3 py-2 text-sm font-medium rounded-lg border transition-colors ${
+              value === val
+                ? 'bg-emerald-600/20 border-emerald-500/50 text-emerald-400'
+                : 'bg-panel border-edge text-muted hover:text-foreground'
+            }`}
+          >
+            {label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 export function StartLineupModal({ isOpen, onClose }: Props) {
   const navigate = useNavigate();
   const createLineup = useCreateLineup();
   const durations = useDurationState();
+  const [title, setTitle] = useState<string>(defaultTitle);
+  const [description, setDescription] = useState<string>('');
 
   async function handleSubmit() {
+    const trimmed = title.trim();
+    if (!trimmed) {
+      toast.error('Title is required');
+      return;
+    }
     try {
       const result = await createLineup.mutateAsync({
+        title: trimmed,
+        description: description.trim() === '' ? null : description,
         buildingDurationHours: durations.building,
         votingDurationHours: durations.voting,
         matchThreshold: durations.matchThreshold,
@@ -157,6 +258,8 @@ export function StartLineupModal({ isOpen, onClose }: Props) {
   return (
     <Modal isOpen={isOpen} onClose={onClose} title="Start Community Lineup">
       <div className="space-y-4">
+        <TitleField value={title} onChange={setTitle} />
+        <DescriptionField value={description} onChange={setDescription} />
         <p className="text-sm text-muted">
           Configure the duration for each phase. The lineup will automatically
           advance through phases when time expires.
@@ -185,26 +288,10 @@ export function StartLineupModal({ isOpen, onClose }: Props) {
           value={durations.votesPerPlayer}
           onChange={durations.setVotesPerPlayer}
         />
-        <div className="border-t border-edge/30 pt-4">
-          <label className="text-sm font-medium text-secondary">Tiebreaker Mode</label>
-          <p className="text-xs text-muted mb-2">Used when voting produces tied games at deadline.</p>
-          <div className="flex gap-2">
-            {([['bracket', 'Bracket'], ['veto', 'Veto'], [null, 'None']] as const).map(([val, label]) => (
-              <button
-                key={String(val)}
-                type="button"
-                onClick={() => durations.setTiebreakerMode(val as 'bracket' | 'veto' | null)}
-                className={`flex-1 px-3 py-2 text-sm font-medium rounded-lg border transition-colors ${
-                  durations.tiebreakerMode === val
-                    ? 'bg-emerald-600/20 border-emerald-500/50 text-emerald-400'
-                    : 'bg-panel border-edge text-muted hover:text-foreground'
-                }`}
-              >
-                {label}
-              </button>
-            ))}
-          </div>
-        </div>
+        <TiebreakerPicker
+          value={durations.tiebreakerMode}
+          onChange={durations.setTiebreakerMode}
+        />
         <div className="flex justify-end gap-3 pt-2">
           <button
             type="button"
@@ -216,7 +303,7 @@ export function StartLineupModal({ isOpen, onClose }: Props) {
           <button
             type="button"
             onClick={() => void handleSubmit()}
-            disabled={createLineup.isPending}
+            disabled={createLineup.isPending || title.trim() === ''}
             className="px-4 py-2 text-sm font-medium bg-emerald-600 text-white rounded-lg hover:bg-emerald-500 transition-colors disabled:opacity-50"
           >
             {createLineup.isPending ? 'Creating...' : 'Create Lineup'}

--- a/web/src/components/lineups/start-lineup-modal.tsx
+++ b/web/src/components/lineups/start-lineup-modal.tsx
@@ -185,7 +185,7 @@ function DescriptionField({ value, onChange }: {
         maxLength={DESCRIPTION_MAX}
         value={value}
         onChange={(e) => onChange(e.target.value)}
-        placeholder="Optional markdown — bold, italic, links, line breaks"
+        placeholder="Optional markdown — **bold**, *italic*, `code`, [link](https://example.com)"
         className="w-full px-3 py-2 text-sm bg-panel border border-edge rounded-lg text-foreground placeholder:text-dim focus:outline-none focus:ring-2 focus:ring-emerald-500/50"
       />
     </div>

--- a/web/src/components/lineups/tiebreaker/TiebreakerPromptModal.tsx
+++ b/web/src/components/lineups/tiebreaker/TiebreakerPromptModal.tsx
@@ -9,6 +9,8 @@ import { useStartTiebreaker, useDismissTiebreaker } from '../../../hooks/use-tie
 
 interface Props {
     lineupId: number;
+    /** Lineup title used in heading context (ROK-1063). */
+    lineupTitle?: string;
     tiebreaker: TiebreakerDetailDto | null;
     onClose: () => void;
 }
@@ -22,11 +24,12 @@ function TiedGameItem({ name }: { name: string }): JSX.Element {
     );
 }
 
-export function TiebreakerPromptModal({ lineupId, tiebreaker, onClose }: Props): JSX.Element {
+export function TiebreakerPromptModal({ lineupId, lineupTitle, tiebreaker, onClose }: Props): JSX.Element {
     const startMutation = useStartTiebreaker();
     const dismissMutation = useDismissTiebreaker();
 
     const tiedGames = tiebreaker?.matchups?.map((m) => m.gameA.gameName) ?? [];
+    const heading = lineupTitle ? `Games tied in ${lineupTitle}` : 'Games are tied!';
 
     function handleStart(mode: 'bracket' | 'veto') {
         startMutation.mutate(
@@ -46,7 +49,7 @@ export function TiebreakerPromptModal({ lineupId, tiebreaker, onClose }: Props):
         >
             <div className="bg-surface border border-edge rounded-xl p-6 max-w-md w-full mx-4 shadow-xl">
                 <h2 className="text-lg font-bold text-foreground mb-2">
-                    Games are tied!
+                    {heading}
                 </h2>
                 <p className="text-sm text-muted mb-4">
                     Multiple games have the same number of votes. Choose a tiebreaker mode to resolve the tie.

--- a/web/src/components/ui/markdown-text.tsx
+++ b/web/src/components/ui/markdown-text.tsx
@@ -1,0 +1,88 @@
+import type { JSX } from 'react';
+
+interface Props {
+    text: string;
+    className?: string;
+}
+
+type Token =
+    | { kind: 'text'; value: string }
+    | { kind: 'bold'; value: string }
+    | { kind: 'italic'; value: string }
+    | { kind: 'code'; value: string }
+    | { kind: 'link'; text: string; href: string };
+
+const PATTERN =
+    /(\*\*[^*\n]+\*\*)|(\*[^*\n]+\*)|(`[^`\n]+`)|(\[[^\]\n]+\]\([^)\n]+\))/g;
+
+function parseInline(line: string): Token[] {
+    const tokens: Token[] = [];
+    let lastIdx = 0;
+    for (const match of line.matchAll(PATTERN)) {
+        const [raw] = match;
+        const idx = match.index ?? 0;
+        if (idx > lastIdx) tokens.push({ kind: 'text', value: line.slice(lastIdx, idx) });
+        if (raw.startsWith('**')) tokens.push({ kind: 'bold', value: raw.slice(2, -2) });
+        else if (raw.startsWith('`')) tokens.push({ kind: 'code', value: raw.slice(1, -1) });
+        else if (raw.startsWith('[')) {
+            const closeBracket = raw.indexOf('](');
+            const text = raw.slice(1, closeBracket);
+            const href = raw.slice(closeBracket + 2, -1);
+            if (/^https?:\/\//.test(href) || href.startsWith('/')) {
+                tokens.push({ kind: 'link', text, href });
+            } else {
+                tokens.push({ kind: 'text', value: raw });
+            }
+        } else tokens.push({ kind: 'italic', value: raw.slice(1, -1) });
+        lastIdx = idx + raw.length;
+    }
+    if (lastIdx < line.length) tokens.push({ kind: 'text', value: line.slice(lastIdx) });
+    return tokens;
+}
+
+function renderToken(token: Token, i: number): JSX.Element | string {
+    switch (token.kind) {
+        case 'bold':
+            return <strong key={i}>{token.value}</strong>;
+        case 'italic':
+            return <em key={i}>{token.value}</em>;
+        case 'code':
+            return (
+                <code key={i} className="px-1 rounded bg-surface/60 text-xs">
+                    {token.value}
+                </code>
+            );
+        case 'link':
+            return (
+                <a
+                    key={i}
+                    href={token.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-emerald-400 hover:underline"
+                >
+                    {token.text}
+                </a>
+            );
+        default:
+            return token.value;
+    }
+}
+
+/**
+ * Minimal markdown renderer (ROK-1063).
+ * Supports: **bold**, *italic*, `code`, [link](url), line breaks.
+ * Raw HTML is NOT rendered — only the allow-listed inline tokens above.
+ */
+export function MarkdownText({ text, className }: Props): JSX.Element {
+    const lines = text.split(/\r?\n/);
+    return (
+        <div className={className}>
+            {lines.map((line, li) => (
+                <p key={li} className="text-sm text-muted whitespace-pre-wrap">
+                    {parseInline(line).map((tok, ti) => renderToken(tok, ti))}
+                </p>
+            ))}
+        </div>
+    );
+}

--- a/web/src/hooks/use-lineups.ts
+++ b/web/src/hooks/use-lineups.ts
@@ -19,8 +19,12 @@ import {
   createLineup,
   transitionLineupStatus,
   toggleVote,
+  updateLineupMetadata,
 } from '../lib/api-client';
-import type { CreateLineupParams } from '../lib/api/lineups-api';
+import type {
+  CreateLineupParams,
+  UpdateLineupMetadataParams,
+} from '../lib/api/lineups-api';
 
 /** Query key for the active lineup. */
 const ACTIVE_LINEUP_KEY = ['lineups', 'active'] as const;
@@ -135,6 +139,22 @@ export function useToggleVote() {
     { lineupId: number; gameId: number }
   >({
     mutationFn: ({ lineupId, gameId }) => toggleVote(lineupId, gameId),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: [...LINEUPS_PREFIX] });
+    },
+  });
+}
+
+/** Hook for updating lineup title/description (ROK-1063). */
+export function useUpdateLineupMetadata() {
+  const qc = useQueryClient();
+
+  return useMutation<
+    LineupDetailResponseDto,
+    Error,
+    { lineupId: number; body: UpdateLineupMetadataParams }
+  >({
+    mutationFn: ({ lineupId, body }) => updateLineupMetadata(lineupId, body),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: [...LINEUPS_PREFIX] });
     },

--- a/web/src/lib/api-client.ts
+++ b/web/src/lib/api-client.ts
@@ -167,7 +167,11 @@ export {
 } from './api/analytics-api';
 
 // Lineups (ROK-934, ROK-935)
-export type { CommonGroundParams, CreateLineupParams } from './api/lineups-api';
+export type {
+    CommonGroundParams,
+    CreateLineupParams,
+    UpdateLineupMetadataParams,
+} from './api/lineups-api';
 export {
     getActiveLineup,
     getCommonGround,
@@ -178,6 +182,7 @@ export {
     createLineup,
     transitionLineupStatus,
     toggleVote,
+    updateLineupMetadata,
 } from './api/lineups-api';
 
 // Activity Log (ROK-930)

--- a/web/src/lib/api/lineups-api.ts
+++ b/web/src/lib/api/lineups-api.ts
@@ -67,6 +67,10 @@ export async function removeNomination(lineupId: number, gameId: number): Promis
 
 /** Parameters for creating a lineup. */
 export interface CreateLineupParams {
+  /** Operator-authored title (required, 1-100 chars, ROK-1063). */
+  title: string;
+  /** Optional markdown description (<=500 chars, ROK-1063). */
+  description?: string | null;
   targetDate?: string | null;
   buildingDurationHours?: number;
   votingDurationHours?: number;
@@ -78,11 +82,28 @@ export interface CreateLineupParams {
 
 /** Create a new lineup with optional duration params. */
 export async function createLineup(
-  params: CreateLineupParams = {},
+  params: CreateLineupParams,
 ): Promise<LineupDetailResponseDto> {
   return fetchApi('/lineups', {
     method: 'POST',
     body: JSON.stringify(params),
+  });
+}
+
+/** Parameters for updating lineup metadata (ROK-1063). */
+export interface UpdateLineupMetadataParams {
+  title?: string;
+  description?: string | null;
+}
+
+/** Update a lineup's title and/or description (ROK-1063). */
+export async function updateLineupMetadata(
+  lineupId: number,
+  body: UpdateLineupMetadataParams,
+): Promise<LineupDetailResponseDto> {
+  return fetchApi(`/lineups/${lineupId}/metadata`, {
+    method: 'PATCH',
+    body: JSON.stringify(body),
   });
 }
 

--- a/web/src/pages/lineup-detail-page.tsx
+++ b/web/src/pages/lineup-detail-page.tsx
@@ -132,6 +132,7 @@ export function LineupDetailPage(): JSX.Element {
       {showPrompt && (
         <TiebreakerPromptModal
           lineupId={lineup.id}
+          lineupTitle={lineup.title}
           tiebreaker={tiebreaker ?? null}
           onClose={() => { setPromptDismissed(true); setTiebreakerPromptOpen(false); }}
         />

--- a/web/src/pages/lineup-detail-page.tsx
+++ b/web/src/pages/lineup-detail-page.tsx
@@ -69,7 +69,7 @@ export function LineupDetailPage(): JSX.Element {
 
   return (
     <div className="max-w-4xl mx-auto px-4 py-4">
-      <div className="flex items-start justify-between gap-4 mb-4">
+      <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-3 mb-4">
         <LineupDetailHeader lineup={lineup} onTiebreakerIntercept={() => {
           setPromptDismissed(false);
           setTiebreakerPromptOpen(true);
@@ -78,7 +78,7 @@ export function LineupDetailPage(): JSX.Element {
           <button
             type="button"
             onClick={() => setModalOpen(true)}
-            className="mt-1 px-4 py-2 text-sm font-medium bg-emerald-600 text-white rounded-lg hover:bg-emerald-500 transition-colors flex-shrink-0"
+            className="sm:mt-1 px-4 py-2 text-sm font-medium bg-emerald-600 text-white rounded-lg hover:bg-emerald-500 transition-colors flex-shrink-0 w-full sm:w-auto"
           >
             Nominate
           </button>

--- a/web/src/test/lineup-factories.ts
+++ b/web/src/test/lineup-factories.ts
@@ -14,6 +14,8 @@ export function createMockBanner(
 ): LineupBannerResponseDto {
     return {
         id: 1,
+        title: 'Test Lineup',
+        description: null,
         status: 'building',
         targetDate: '2026-03-28',
         entryCount: 3,
@@ -25,7 +27,7 @@ export function createMockBanner(
             { gameId: 2, gameName: 'Elden Ring', gameCoverUrl: '/cover2.jpg', ownerCount: 4, voteCount: 2 },
         ],
         ...overrides,
-    };
+    } as LineupBannerResponseDto;
 }
 
 /** Create a mock lineup entry response. */
@@ -60,6 +62,8 @@ export function createMockLineupDetail(
 ): LineupDetailResponseDto {
     return {
         id: 1,
+        title: 'Test Lineup',
+        description: null,
         status: 'building',
         targetDate: '2026-03-28',
         decidedGameId: null,
@@ -74,5 +78,5 @@ export function createMockLineupDetail(
         createdAt: '2026-03-20T00:00:00Z',
         updatedAt: '2026-03-20T00:00:00Z',
         ...overrides,
-    };
+    } as LineupDetailResponseDto;
 }


### PR DESCRIPTION
## Summary
- Adds per-lineup **title** (VARCHAR(100) NOT NULL, required 1–100 chars) and **description** (TEXT NULL, markdown ≤500 chars) so members can tell lineups apart in-app and in Discord.
- New `PATCH /lineups/:id/metadata` endpoint (creator or operator/admin) with 409 on archived, 403 on non-creator member.
- Discord creation embed **refreshes in place** on edit — verified end-to-end via Discord CDP (same message, "(edited)" marker).
- Zero new web dependencies — minimal markdown renderer supports bold/italic/code/links.
- Mobile layout fixes: responsive CommonGroundFilters grid, wrapping phase breadcrumb, full-width Nominate button, icon+text edit button.

## Linear
ROK-1063

## Migrations
- `0122_lineup_title_description.sql` — adds columns, backfills `Lineup — {FMMonth YYYY}` from `created_at`, then `SET NOT NULL`.
- `0123_lineup_created_embed_refs.sql` — adds `discord_created_channel_id` + `discord_created_message_id` for in-place embed edits.

## Key decisions
- **Duplicate title policy:** server is permissive; existing one-active-lineup invariant makes collision a non-issue.
- **Markdown renderer:** ~90-line inline whitelist (no new deps). Only **bold**, *italic*, \`code\`, and links to http(s)/relative paths are rendered; raw HTML is escaped.
- **Embed refresh scope:** creation embed only (the one that carries the title + description as per spec). Other phase embeds refresh naturally when that phase fires.

## Test plan
- [x] Build + TypeScript + Lint + Unit tests + Integration tests + Coverage (both api + web) — all green via \`validate-ci.sh --full\`
- [x] Migration validation (container + drizzle-kit migrate)
- [x] Playwright desktop + mobile (413 passed, 0 failed)
- [x] 14 new integration tests for POST/PATCH /metadata + GET shape
- [x] 10 new web unit tests (title prefill, counter, H1 replacement, markdown render, banner title)
- [x] 3 new unit tests for \`refreshCreatedEmbed\` (messageId persisted, in-place edit, error swallowing)
- [x] Smoke test registered (\`lineup-title.test.ts\`)
- [x] Code review passed (auto-fixed 2 tsc errors in spec file; 6 tech debt items logged)
- [x] **End-to-end Discord CDP verification:** created lineup via API, embed posted with original title, PATCHed metadata, embed updated in place with "(edited)" marker

## Tech debt (follow-up)
Reviewer logged 6 items — file-size refactors for `lineup-notification.service.ts`, `lineups.service.ts`, `lineup-notification-embed.helpers.ts`; minor markdown href validation hardening; migration locale consideration; archived-vs-authz check ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)