### PR TITLE
ROK-1081: feat: Discord paste-to-nominate — extend Steam link listener for active lineup

### DIFF
--- a/api/src/admin/admin.module.ts
+++ b/api/src/admin/admin.module.ts
@@ -17,6 +17,7 @@ import { AuthModule } from '../auth/auth.module';
 import { IgdbModule } from '../igdb/igdb.module';
 import { DemoDataService } from './demo-data.service';
 import { DemoTestService } from './demo-test.service';
+import { DemoTestLineupService } from './demo-test-lineup.service';
 import { SlashCommandTestService } from './slash-command-test.service';
 import { LineupsModule } from '../lineups/lineups.module';
 import { AiChatModule } from '../discord-bot/ai-chat/ai-chat.module';
@@ -46,6 +47,11 @@ import { AiChatTestController } from './ai-chat-test.controller';
     LineupSettingsController,
     OnboardingController,
   ],
-  providers: [DemoDataService, DemoTestService, SlashCommandTestService],
+  providers: [
+    DemoDataService,
+    DemoTestService,
+    DemoTestLineupService,
+    SlashCommandTestService,
+  ],
 })
 export class AdminModule {}

--- a/api/src/admin/demo-test-games.controller.spec.ts
+++ b/api/src/admin/demo-test-games.controller.spec.ts
@@ -1,6 +1,7 @@
 import { Test } from '@nestjs/testing';
 import { DemoTestGamesController } from './demo-test-games.controller';
 import { DemoTestService } from './demo-test.service';
+import { DemoTestLineupService } from './demo-test-lineup.service';
 import { LineupSteamNudgeService } from '../lineups/lineup-steam-nudge.service';
 
 function createMockService() {
@@ -14,19 +15,32 @@ function createMockService() {
   };
 }
 
+function createMockLineupService() {
+  return {
+    setAutoNominatePrefForTest: jest.fn().mockResolvedValue(undefined),
+    createBuildingLineupForTest: jest.fn().mockResolvedValue({ lineupId: 1 }),
+    nominateGameForTest: jest.fn().mockResolvedValue(undefined),
+    archiveLineupForTest: jest.fn().mockResolvedValue(undefined),
+    archiveActiveLineupForTest: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
 describe('DemoTestGamesController', () => {
   let controller: DemoTestGamesController;
   let mockService: ReturnType<typeof createMockService>;
+  let mockLineupService: ReturnType<typeof createMockLineupService>;
   let nudge: { nudgeUnlinkedMembers: jest.Mock };
 
   beforeEach(async () => {
     mockService = createMockService();
+    mockLineupService = createMockLineupService();
     nudge = { nudgeUnlinkedMembers: jest.fn().mockResolvedValue(undefined) };
 
     const module = await Test.createTestingModule({
       controllers: [DemoTestGamesController],
       providers: [
         { provide: DemoTestService, useValue: mockService },
+        { provide: DemoTestLineupService, useValue: mockLineupService },
         { provide: LineupSteamNudgeService, useValue: nudge },
       ],
     }).compile();

--- a/api/src/admin/demo-test-games.controller.ts
+++ b/api/src/admin/demo-test-games.controller.ts
@@ -11,6 +11,7 @@ import { AuthGuard } from '@nestjs/passport';
 import { SkipThrottle } from '@nestjs/throttler';
 import { AdminGuard } from '../auth/admin.guard';
 import { DemoTestService } from './demo-test.service';
+import { DemoTestLineupService } from './demo-test-lineup.service';
 import { LineupSteamNudgeService } from '../lineups/lineup-steam-nudge.service';
 import {
   AddGameInterestSchema,
@@ -19,6 +20,10 @@ import {
   ClearGameInterestSchema,
   SetAutoHeartPrefSchema,
   CancelLineupPhaseJobsSchema,
+  CreateBuildingLineupSchema,
+  NominateGameTestSchema,
+  ArchiveLineupSchema,
+  SetAutoNominatePrefSchema,
 } from './demo-test.schemas';
 import { parseDemoBody } from './demo-test.utils';
 
@@ -31,6 +36,7 @@ import { parseDemoBody } from './demo-test.utils';
 export class DemoTestGamesController {
   constructor(
     private readonly demoTestService: DemoTestService,
+    private readonly demoTestLineup: DemoTestLineupService,
     private readonly steamNudge: LineupSteamNudgeService,
   ) {}
 
@@ -121,5 +127,65 @@ export class DemoTestGamesController {
       parsed.lineupId,
     );
     return { success: true, removed };
+  }
+
+  /** Set autoNominateSteamUrls preference — DEMO_MODE only (ROK-1081). */
+  @Post('set-auto-nominate-pref')
+  @HttpCode(HttpStatus.OK)
+  async setAutoNominatePrefForTest(
+    @Body() body: unknown,
+  ): Promise<{ success: boolean }> {
+    const parsed = parseDemoBody(SetAutoNominatePrefSchema, body);
+    await this.demoTestLineup.setAutoNominatePrefForTest(
+      parsed.userId,
+      parsed.enabled,
+    );
+    return { success: true };
+  }
+
+  /** Create a building-phase lineup for smoke tests — DEMO_MODE only (ROK-1081). */
+  @Post('create-building-lineup')
+  @HttpCode(HttpStatus.OK)
+  async createBuildingLineupForTest(
+    @Body() body: unknown,
+  ): Promise<{ lineupId: number }> {
+    const parsed = parseDemoBody(CreateBuildingLineupSchema, body);
+    return this.demoTestLineup.createBuildingLineupForTest(
+      parsed.createdByUserId,
+    );
+  }
+
+  /** Insert a nomination directly — DEMO_MODE only (ROK-1081). */
+  @Post('nominate-game')
+  @HttpCode(HttpStatus.OK)
+  async nominateGameForTest(
+    @Body() body: unknown,
+  ): Promise<{ success: boolean }> {
+    const parsed = parseDemoBody(NominateGameTestSchema, body);
+    await this.demoTestLineup.nominateGameForTest(
+      parsed.lineupId,
+      parsed.gameId,
+      parsed.userId,
+    );
+    return { success: true };
+  }
+
+  /** Archive a specific lineup — DEMO_MODE only (ROK-1081). */
+  @Post('archive-lineup')
+  @HttpCode(HttpStatus.OK)
+  async archiveLineupForTest(
+    @Body() body: unknown,
+  ): Promise<{ success: boolean }> {
+    const parsed = parseDemoBody(ArchiveLineupSchema, body);
+    await this.demoTestLineup.archiveLineupForTest(parsed.lineupId);
+    return { success: true };
+  }
+
+  /** Archive any active lineup — DEMO_MODE only (ROK-1081). */
+  @Post('archive-active-lineup')
+  @HttpCode(HttpStatus.OK)
+  async archiveActiveLineupForTest(): Promise<{ success: boolean }> {
+    await this.demoTestLineup.archiveActiveLineupForTest();
+    return { success: true };
   }
 }

--- a/api/src/admin/demo-test-lineup.helpers.ts
+++ b/api/src/admin/demo-test-lineup.helpers.ts
@@ -1,0 +1,62 @@
+/**
+ * DEMO_MODE-only helpers for Community Lineup smoke-test fixtures (ROK-1081).
+ *
+ * Extracted from demo-test.service.ts to keep that file under the 300-line
+ * limit. These helpers perform raw DB writes intentionally — they must not
+ * pass through the normal LineupsService guards so tests can set up and
+ * tear down lineups regardless of status-transition rules.
+ */
+import { sql } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from '../drizzle/schema';
+
+type Db = PostgresJsDatabase<typeof schema>;
+
+/** Create a new community lineup in `building` status. */
+export async function createBuildingLineupForTest(
+  db: Db,
+  createdByUserId: number,
+): Promise<{ lineupId: number }> {
+  const [row] = await db
+    .insert(schema.communityLineups)
+    .values({
+      title: 'Smoke Test Lineup',
+      status: 'building',
+      createdBy: createdByUserId,
+    })
+    .returning({ id: schema.communityLineups.id });
+  return { lineupId: row.id };
+}
+
+/** Insert a lineup entry directly (bypasses service caps). Idempotent. */
+export async function nominateGameForTest(
+  db: Db,
+  lineupId: number,
+  gameId: number,
+  userId: number,
+): Promise<void> {
+  await db
+    .insert(schema.communityLineupEntries)
+    .values({ lineupId, gameId, nominatedBy: userId })
+    .onConflictDoNothing();
+}
+
+/** Archive a specific lineup. No-op when the lineup doesn't exist. */
+export async function archiveLineupForTest(
+  db: Db,
+  lineupId: number,
+): Promise<void> {
+  await db
+    .update(schema.communityLineups)
+    .set({ status: 'archived', updatedAt: new Date() })
+    .where(eq(schema.communityLineups.id, lineupId));
+}
+
+/** Archive any lineup currently in `building` or `voting` status. */
+export async function archiveActiveLineupForTest(db: Db): Promise<void> {
+  await db
+    .update(schema.communityLineups)
+    .set({ status: 'archived', updatedAt: new Date() })
+    .where(sql`${schema.communityLineups.status} IN ('building', 'voting')`);
+}

--- a/api/src/admin/demo-test-lineup.service.ts
+++ b/api/src/admin/demo-test-lineup.service.ts
@@ -1,0 +1,69 @@
+import { Injectable, Inject, ForbiddenException } from '@nestjs/common';
+import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from '../drizzle/schema';
+import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
+import { SettingsService } from '../settings/settings.service';
+import { setAutoNominateSteamUrlsPref } from '../discord-bot/listeners/steam-link-interest.helpers';
+import {
+  createBuildingLineupForTest,
+  nominateGameForTest,
+  archiveLineupForTest,
+  archiveActiveLineupForTest,
+} from './demo-test-lineup.helpers';
+
+/**
+ * DEMO_MODE-only lineup test service (ROK-1081).
+ * Split from DemoTestService to stay under the 300-line file limit.
+ */
+@Injectable()
+export class DemoTestLineupService {
+  constructor(
+    @Inject(DrizzleAsyncProvider)
+    private db: PostgresJsDatabase<typeof schema>,
+    private readonly settingsService: SettingsService,
+  ) {}
+
+  private async assertDemoMode(): Promise<void> {
+    if (process.env.DEMO_MODE !== 'true') {
+      throw new ForbiddenException('Only available in DEMO_MODE');
+    }
+    const demoMode = await this.settingsService.getDemoMode();
+    if (!demoMode) {
+      throw new ForbiddenException('Only available in DEMO_MODE');
+    }
+  }
+
+  async setAutoNominatePrefForTest(
+    userId: number,
+    enabled: boolean,
+  ): Promise<void> {
+    await this.assertDemoMode();
+    await setAutoNominateSteamUrlsPref(this.db, userId, enabled);
+  }
+
+  async createBuildingLineupForTest(
+    createdByUserId: number,
+  ): Promise<{ lineupId: number }> {
+    await this.assertDemoMode();
+    return createBuildingLineupForTest(this.db, createdByUserId);
+  }
+
+  async nominateGameForTest(
+    lineupId: number,
+    gameId: number,
+    userId: number,
+  ): Promise<void> {
+    await this.assertDemoMode();
+    await nominateGameForTest(this.db, lineupId, gameId, userId);
+  }
+
+  async archiveLineupForTest(lineupId: number): Promise<void> {
+    await this.assertDemoMode();
+    await archiveLineupForTest(this.db, lineupId);
+  }
+
+  async archiveActiveLineupForTest(): Promise<void> {
+    await this.assertDemoMode();
+    await archiveActiveLineupForTest(this.db);
+  }
+}

--- a/api/src/admin/demo-test.schemas.ts
+++ b/api/src/admin/demo-test.schemas.ts
@@ -71,6 +71,25 @@ export const SetAutoHeartPrefSchema = z.object({
   enabled: z.boolean(),
 });
 
+export const CreateBuildingLineupSchema = z.object({
+  createdByUserId: z.number().int().positive(),
+});
+
+export const NominateGameTestSchema = z.object({
+  lineupId: z.number().int().positive(),
+  gameId: z.number().int().positive(),
+  userId: z.number().int().positive(),
+});
+
+export const ArchiveLineupSchema = z.object({
+  lineupId: z.number().int().positive(),
+});
+
+export const SetAutoNominatePrefSchema = z.object({
+  userId: z.number().int().positive(),
+  enabled: z.boolean(),
+});
+
 const VALID_STATUSES = ['signed_up', 'tentative', 'declined'] as const;
 
 export const CreateTestSignupSchema = z.object({

--- a/api/src/discord-bot/discord-bot.constants.ts
+++ b/api/src/discord-bot/discord-bot.constants.ts
@@ -171,6 +171,18 @@ export const STEAM_INTEREST_BUTTON_IDS = {
   AUTO: 'steam_interest_auto',
 } as const;
 
+/**
+ * Custom IDs for Steam URL paste-to-nominate buttons (ROK-1081).
+ * Format: `{action}:{gameId}` -- e.g. `steam_nominate_nominate:42`.
+ * The active lineup is re-resolved on click so nothing is stale.
+ */
+export const STEAM_NOMINATE_BUTTON_IDS = {
+  NOMINATE: 'steam_nominate_nominate',
+  HEART: 'steam_nominate_heart',
+  AUTO: 'steam_nominate_auto',
+  DISMISS: 'steam_nominate_dismiss',
+} as const;
+
 export const SIGNUP_BUTTON_IDS = {
   SIGNUP: 'signup',
   TENTATIVE: 'tentative',

--- a/api/src/discord-bot/listeners/steam-link-interest.helpers.spec.ts
+++ b/api/src/discord-bot/listeners/steam-link-interest.helpers.spec.ts
@@ -16,6 +16,10 @@ import {
   getAutoHeartSteamUrlsPref,
   addDiscordInterest,
   setAutoHeartSteamUrlsPref,
+  findActiveBuildingLineup,
+  isGameNominated,
+  getAutoNominateSteamUrlsPref,
+  setAutoNominateSteamUrlsPref,
 } from './steam-link-interest.helpers';
 import {
   createDrizzleMock,
@@ -169,6 +173,99 @@ describe('setAutoHeartSteamUrlsPref', () => {
     mockDb.onConflictDoUpdate.mockResolvedValueOnce(undefined);
 
     await setAutoHeartSteamUrlsPref(mockDb as never, 7, true);
+
+    expect(mockDb.onConflictDoUpdate).toHaveBeenCalled();
+  });
+});
+
+// --- ROK-1081: paste-to-nominate helpers ---
+
+describe('findActiveBuildingLineup', () => {
+  it('returns the lineup when one is in building status', async () => {
+    mockDb.limit.mockResolvedValueOnce([{ id: 123 }]);
+
+    const result = await findActiveBuildingLineup(mockDb as never);
+
+    expect(result).toMatchObject({ id: expect.any(Number) });
+  });
+
+  it('returns null when no lineup is in building status', async () => {
+    mockDb.limit.mockResolvedValueOnce([]);
+
+    const result = await findActiveBuildingLineup(mockDb as never);
+
+    expect(result).toBeNull();
+  });
+});
+
+describe('isGameNominated', () => {
+  it('returns true when the game is already on the lineup entries', async () => {
+    mockDb.limit.mockResolvedValueOnce([{ id: 1 }]);
+
+    const result = await isGameNominated(mockDb as never, 123, 42);
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false when the game has not been nominated for the lineup', async () => {
+    mockDb.limit.mockResolvedValueOnce([]);
+
+    const result = await isGameNominated(mockDb as never, 123, 42);
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('getAutoNominateSteamUrlsPref', () => {
+  it('returns true when user has auto-nominate preference enabled', async () => {
+    mockDb.limit.mockResolvedValueOnce([
+      { key: 'autoNominateSteamUrls', value: true },
+    ]);
+
+    const result = await getAutoNominateSteamUrlsPref(mockDb as never, 7);
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false when preference row does not exist', async () => {
+    mockDb.limit.mockResolvedValueOnce([]);
+
+    const result = await getAutoNominateSteamUrlsPref(mockDb as never, 7);
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when preference value is explicitly false', async () => {
+    mockDb.limit.mockResolvedValueOnce([
+      { key: 'autoNominateSteamUrls', value: false },
+    ]);
+
+    const result = await getAutoNominateSteamUrlsPref(mockDb as never, 7);
+
+    expect(result).toBe(false);
+  });
+});
+
+describe('setAutoNominateSteamUrlsPref', () => {
+  it('upserts the autoNominateSteamUrls preference to true', async () => {
+    mockDb.onConflictDoUpdate.mockResolvedValueOnce(undefined);
+
+    await setAutoNominateSteamUrlsPref(mockDb as never, 7, true);
+
+    expect(mockDb.insert).toHaveBeenCalled();
+    expect(mockDb.values).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: 7,
+        key: 'autoNominateSteamUrls',
+        value: true,
+      }),
+    );
+  });
+
+  it('uses onConflictDoUpdate for upsert semantics', async () => {
+    mockDb.onConflictDoUpdate.mockResolvedValueOnce(undefined);
+
+    await setAutoNominateSteamUrlsPref(mockDb as never, 7, true);
 
     expect(mockDb.onConflictDoUpdate).toHaveBeenCalled();
   });

--- a/api/src/discord-bot/listeners/steam-link-interest.helpers.ts
+++ b/api/src/discord-bot/listeners/steam-link-interest.helpers.ts
@@ -5,7 +5,7 @@
  * game resolution by Steam app ID, user lookup by Discord ID,
  * existing interest checks, and preference management.
  */
-import { eq, and, inArray } from 'drizzle-orm';
+import { eq, and, desc, inArray } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import * as schema from '../../drizzle/schema';
 import {
@@ -165,4 +165,102 @@ export async function discoverGameBySteamAppId(
   const result = await discoverGameViaItad(steamAppId, deps);
   if (!result) return null;
   return findGameBySteamAppId(deps.db, steamAppId);
+}
+
+// --- ROK-1081: paste-to-nominate helpers ---
+
+/**
+ * Find the most recent Community Lineup currently in `building` status.
+ *
+ * Unlike `findActiveLineup` in lineups-query.helpers.ts, this helper is
+ * scoped strictly to `building` — a voting lineup does not accept new
+ * nominations, so the paste-to-nominate flow must not trigger for it.
+ *
+ * @param db - Drizzle database instance
+ * @returns Lineup id, or null if no building lineup exists
+ */
+export async function findActiveBuildingLineup(
+  db: Db,
+): Promise<{ id: number } | null> {
+  const [lineup] = await db
+    .select({ id: schema.communityLineups.id })
+    .from(schema.communityLineups)
+    .where(eq(schema.communityLineups.status, 'building'))
+    .orderBy(desc(schema.communityLineups.createdAt))
+    .limit(1);
+  return lineup ?? null;
+}
+
+/**
+ * Check whether a game is already nominated for a lineup.
+ *
+ * @param db - Drizzle database instance
+ * @param lineupId - Community lineup ID
+ * @param gameId - Game ID
+ * @returns true when a `community_lineup_entries` row exists
+ */
+export async function isGameNominated(
+  db: Db,
+  lineupId: number,
+  gameId: number,
+): Promise<boolean> {
+  const rows = await db
+    .select({ id: schema.communityLineupEntries.id })
+    .from(schema.communityLineupEntries)
+    .where(
+      and(
+        eq(schema.communityLineupEntries.lineupId, lineupId),
+        eq(schema.communityLineupEntries.gameId, gameId),
+      ),
+    )
+    .limit(1);
+  return rows.length > 0;
+}
+
+/**
+ * Check if a user has the auto-nominate Steam URLs preference enabled.
+ *
+ * @param db - Drizzle database instance
+ * @param userId - Raid Ledger user ID
+ * @returns true if autoNominateSteamUrls is enabled
+ */
+export async function getAutoNominateSteamUrlsPref(
+  db: Db,
+  userId: number,
+): Promise<boolean> {
+  const [pref] = await db
+    .select({
+      key: schema.userPreferences.key,
+      value: schema.userPreferences.value,
+    })
+    .from(schema.userPreferences)
+    .where(
+      and(
+        eq(schema.userPreferences.userId, userId),
+        eq(schema.userPreferences.key, 'autoNominateSteamUrls'),
+      ),
+    )
+    .limit(1);
+  return pref?.value === true;
+}
+
+/**
+ * Upsert the autoNominateSteamUrls user preference.
+ *
+ * @param db - Drizzle database instance
+ * @param userId - Raid Ledger user ID
+ * @param enabled - Whether auto-nominate is enabled
+ */
+export async function setAutoNominateSteamUrlsPref(
+  db: Db,
+  userId: number,
+  enabled: boolean,
+): Promise<void> {
+  await db
+    .insert(schema.userPreferences)
+    .values({ userId, key: 'autoNominateSteamUrls', value: enabled })
+    .onConflictDoUpdate({
+      target: [schema.userPreferences.userId, schema.userPreferences.key],
+      set: { value: enabled },
+    });
 }

--- a/api/src/discord-bot/listeners/steam-link.listener.interest-flow.ts
+++ b/api/src/discord-bot/listeners/steam-link.listener.interest-flow.ts
@@ -1,0 +1,102 @@
+/**
+ * Helpers for the Steam heart/interest flow (ROK-966).
+ *
+ * Extracted from steam-link.listener.ts to keep the listener under the
+ * 300-line limit. All helpers are pure or operate through the caller's
+ * Drizzle client.
+ */
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  type ButtonInteraction,
+} from 'discord.js';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from '../../drizzle/schema';
+import { STEAM_INTEREST_BUTTON_IDS } from '../discord-bot.constants';
+import {
+  addDiscordInterest,
+  findLinkedRlUser,
+  setAutoHeartSteamUrlsPref,
+} from './steam-link-interest.helpers';
+import { replaceDmWithText } from './steam-link.listener.nomination-flow';
+
+type Db = PostgresJsDatabase<typeof schema>;
+
+/** Build the 3-button heart interest prompt action row. */
+export function buildInterestButtonRow(
+  gameId: number,
+): ActionRowBuilder<ButtonBuilder> {
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`${STEAM_INTEREST_BUTTON_IDS.HEART}:${gameId}`)
+      .setLabel('Interested')
+      .setStyle(ButtonStyle.Success),
+    new ButtonBuilder()
+      .setCustomId(`${STEAM_INTEREST_BUTTON_IDS.DISMISS}:${gameId}`)
+      .setLabel('Not Interested')
+      .setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder()
+      .setCustomId(`${STEAM_INTEREST_BUTTON_IDS.AUTO}:${gameId}`)
+      .setLabel('Always Auto-Interest')
+      .setStyle(ButtonStyle.Primary),
+  );
+}
+
+/**
+ * Parse a `steam_interest_*` button custom ID into action + gameId.
+ * Returns null when the custom ID doesn't match the expected shape.
+ */
+export function parseSteamInterestButtonId(
+  customId: string,
+): { action: string; gameId: number } | null {
+  const parts = customId.split(':');
+  if (parts.length !== 2) return null;
+  const [action, gameIdStr] = parts;
+  const gameId = parseInt(gameIdStr, 10);
+  if (isNaN(gameId)) return null;
+  const validActions: string[] = [
+    STEAM_INTEREST_BUTTON_IDS.HEART,
+    STEAM_INTEREST_BUTTON_IDS.DISMISS,
+    STEAM_INTEREST_BUTTON_IDS.AUTO,
+  ];
+  if (!validActions.includes(action)) return null;
+  return { action, gameId };
+}
+
+/**
+ * Handle a heart-flow button click by updating the DM in place.
+ * Returns true when the click was handled (regardless of action).
+ */
+export async function handleInterestButtonClick(
+  db: Db,
+  interaction: ButtonInteraction,
+): Promise<boolean> {
+  const parsed = parseSteamInterestButtonId(interaction.customId);
+  if (!parsed) return false;
+
+  const { action, gameId } = parsed;
+  if (action === STEAM_INTEREST_BUTTON_IDS.DISMISS) {
+    await replaceDmWithText(interaction, 'Dismissed.');
+    return true;
+  }
+
+  const user = await findLinkedRlUser(db, interaction.user.id);
+  if (!user) {
+    await replaceDmWithText(interaction, 'Could not find your linked account.');
+    return true;
+  }
+
+  if (action === STEAM_INTEREST_BUTTON_IDS.HEART) {
+    await addDiscordInterest(db, user.id, gameId);
+    await replaceDmWithText(interaction, 'Marked as interested!');
+  } else if (action === STEAM_INTEREST_BUTTON_IDS.AUTO) {
+    await addDiscordInterest(db, user.id, gameId);
+    await setAutoHeartSteamUrlsPref(db, user.id, true);
+    await replaceDmWithText(
+      interaction,
+      'Auto-interest enabled for future Steam URLs!',
+    );
+  }
+  return true;
+}

--- a/api/src/discord-bot/listeners/steam-link.listener.nomination-flow.ts
+++ b/api/src/discord-bot/listeners/steam-link.listener.nomination-flow.ts
@@ -1,0 +1,246 @@
+/**
+ * Helpers for the Steam paste-to-nominate flow (ROK-1081).
+ *
+ * Extracted from steam-link.listener.ts so the listener stays under the
+ * 300-line limit. These are pure UI/DOM-building helpers plus a thin
+ * exception-to-DM translation layer around `LineupsService.nominate`.
+ */
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  type ButtonInteraction,
+} from 'discord.js';
+import { eq } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from '../../drizzle/schema';
+import { STEAM_NOMINATE_BUTTON_IDS } from '../discord-bot.constants';
+
+type Db = PostgresJsDatabase<typeof schema>;
+
+/**
+ * DM payload for the nomination prompt — a plain content + components
+ * shape accepted by both `dm.send()` and `interaction.update()`.
+ */
+export interface NominationPromptPayload {
+  content: string;
+  components: ActionRowBuilder<ButtonBuilder>[];
+}
+
+/** Prefix marking all steam_nominate_* custom IDs. */
+const STEAM_NOMINATE_PREFIX = 'steam_nominate_';
+
+/**
+ * Build the 4-button nomination prompt action row.
+ * Buttons: Nominate / Just Heart It / Always Auto-Nominate / Dismiss.
+ */
+export function buildNominationButtonRow(
+  gameId: number,
+): ActionRowBuilder<ButtonBuilder> {
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`${STEAM_NOMINATE_BUTTON_IDS.NOMINATE}:${gameId}`)
+      .setLabel('Nominate')
+      .setStyle(ButtonStyle.Success),
+    new ButtonBuilder()
+      .setCustomId(`${STEAM_NOMINATE_BUTTON_IDS.HEART}:${gameId}`)
+      .setLabel('Just Heart It')
+      .setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder()
+      .setCustomId(`${STEAM_NOMINATE_BUTTON_IDS.AUTO}:${gameId}`)
+      .setLabel('Always Auto-Nominate')
+      .setStyle(ButtonStyle.Primary),
+    new ButtonBuilder()
+      .setCustomId(`${STEAM_NOMINATE_BUTTON_IDS.DISMISS}:${gameId}`)
+      .setLabel('Dismiss')
+      .setStyle(ButtonStyle.Secondary),
+  );
+}
+
+/**
+ * Parse a steam_nominate_* button custom ID into action + gameId.
+ * Returns null for non-matching customIds.
+ */
+export function parseSteamNominateButtonId(
+  customId: string,
+): { action: string; gameId: number } | null {
+  if (!customId.startsWith(STEAM_NOMINATE_PREFIX)) return null;
+  const parts = customId.split(':');
+  if (parts.length !== 2) return null;
+  const [action, gameIdStr] = parts;
+  const gameId = parseInt(gameIdStr, 10);
+  if (isNaN(gameId)) return null;
+  const validActions: string[] = [
+    STEAM_NOMINATE_BUTTON_IDS.NOMINATE,
+    STEAM_NOMINATE_BUTTON_IDS.HEART,
+    STEAM_NOMINATE_BUTTON_IDS.AUTO,
+    STEAM_NOMINATE_BUTTON_IDS.DISMISS,
+  ];
+  if (!validActions.includes(action)) return null;
+  return { action, gameId };
+}
+
+/** Build the DM payload for the 4-button nomination prompt. */
+export function buildNominationPrompt(game: {
+  id: number;
+  name: string;
+}): NominationPromptPayload {
+  return {
+    content: `**${game.name}** — add to the current Community Lineup?`,
+    components: [buildNominationButtonRow(game.id)],
+  };
+}
+
+/**
+ * Translate an error from LineupsService.nominate into the user-facing
+ * DM copy prescribed by AC-6 and the button handler spec.
+ */
+export function translateNominateError(err: unknown, gameName: string): string {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (/Lineup has reached/i.test(msg)) return msg;
+  if (/not in building status/i.test(msg)) {
+    return 'Nominations have closed for the current lineup.';
+  }
+  if (/already nominated|uq_lineup_entry_game|duplicate/i.test(msg)) {
+    return `**${gameName}** is already nominated for the current lineup.`;
+  }
+  return `Could not nominate **${gameName}** right now. Please try again.`;
+}
+
+/**
+ * Interface the nomination flow needs from LineupsService.
+ * Keeps this module independent of the NestJS service class.
+ */
+export interface LineupsNominator {
+  nominate(
+    lineupId: number,
+    dto: { gameId: number; note?: string | null },
+    userId: number,
+  ): Promise<unknown>;
+}
+
+/**
+ * Call LineupsService.nominate and return either a success-copy string or
+ * a user-friendly error string. Never throws.
+ */
+export async function safeNominate(
+  nominator: LineupsNominator,
+  lineupId: number,
+  gameId: number,
+  gameName: string,
+  userId: number,
+  successCopy: string,
+): Promise<string> {
+  try {
+    await nominator.nominate(lineupId, { gameId }, userId);
+    return successCopy;
+  } catch (err: unknown) {
+    return translateNominateError(err, gameName);
+  }
+}
+
+/** Ask the button interaction helper to update the DM in place. */
+export async function replaceDmWithText(
+  interaction: ButtonInteraction,
+  content: string,
+): Promise<void> {
+  await interaction.update({ content, components: [] });
+}
+
+/** Fetch a game name by id. Falls back to "the game" on miss. */
+export async function lookupGameName(db: Db, gameId: number): Promise<string> {
+  const rows = await db
+    .select({ name: schema.games.name })
+    .from(schema.games)
+    .where(eq(schema.games.id, gameId))
+    .limit(1);
+  return rows[0]?.name ?? 'the game';
+}
+
+/** Build the success DM copy for the Nominate / Auto-Nominate buttons. */
+export function buildNominateSuccessCopy(
+  action: string,
+  gameName: string,
+): string {
+  if (action === STEAM_NOMINATE_BUTTON_IDS.AUTO) {
+    return 'Auto-nominate enabled for future Steam URLs!';
+  }
+  return `Nominated **${gameName}** to the lineup!`;
+}
+
+/**
+ * Deps for the nominate button handler: just the DB + optional service.
+ * Kept loose so the listener can pass itself through without coupling.
+ */
+export interface NominateButtonDeps {
+  db: Db;
+  lineupsService?: LineupsNominator;
+  findActiveBuildingLineupId(): Promise<number | null>;
+  addInterest(userId: number, gameId: number): Promise<void>;
+  findLinkedUser(discordId: string): Promise<{ id: number } | null>;
+  setAutoNominatePref(userId: number, enabled: boolean): Promise<void>;
+}
+
+/**
+ * Handle a nominate-flow button click by updating the DM in place.
+ * Returns true when the customId matched; false otherwise so the caller
+ * can fall back to the heart-flow handler.
+ */
+export async function handleNominateButtonClick(
+  deps: NominateButtonDeps,
+  interaction: ButtonInteraction,
+  action: string,
+  gameId: number,
+): Promise<void> {
+  if (action === STEAM_NOMINATE_BUTTON_IDS.DISMISS) {
+    await replaceDmWithText(interaction, 'Dismissed.');
+    return;
+  }
+  const user = await deps.findLinkedUser(interaction.user.id);
+  if (!user) {
+    await replaceDmWithText(interaction, 'Could not find your linked account.');
+    return;
+  }
+  if (action === STEAM_NOMINATE_BUTTON_IDS.HEART) {
+    await deps.addInterest(user.id, gameId);
+    await replaceDmWithText(interaction, 'Marked as interested!');
+    return;
+  }
+  await runNominateOnClick(deps, interaction, user.id, gameId, action);
+}
+
+/** Nominate path for the Nominate and Auto buttons. */
+async function runNominateOnClick(
+  deps: NominateButtonDeps,
+  interaction: ButtonInteraction,
+  userId: number,
+  gameId: number,
+  action: string,
+): Promise<void> {
+  const lineupId = await deps.findActiveBuildingLineupId();
+  if (lineupId === null) {
+    await replaceDmWithText(
+      interaction,
+      'Nominations have closed for the current lineup.',
+    );
+    return;
+  }
+  const gameName = await lookupGameName(deps.db, gameId);
+  if (action === STEAM_NOMINATE_BUTTON_IDS.AUTO) {
+    await deps.setAutoNominatePref(userId, true);
+  }
+  if (!deps.lineupsService) {
+    await replaceDmWithText(interaction, 'Nominations are not available.');
+    return;
+  }
+  try {
+    await deps.lineupsService.nominate(lineupId, { gameId }, userId);
+  } catch (err: unknown) {
+    await replaceDmWithText(interaction, translateNominateError(err, gameName));
+    return;
+  }
+  await replaceDmWithText(
+    interaction,
+    buildNominateSuccessCopy(action, gameName),
+  );
+}

--- a/api/src/discord-bot/listeners/steam-link.listener.nomination.spec.ts
+++ b/api/src/discord-bot/listeners/steam-link.listener.nomination.spec.ts
@@ -1,0 +1,361 @@
+/**
+ * TDD tests for steam-link.listener.ts — paste-to-nominate (ROK-1081).
+ *
+ * Extends the ROK-966 heart flow: when an active Community Lineup is in
+ * `building` status, pasting a Steam URL offers a 4-button nomination DM
+ * (Nominate / Just Heart It / Always Auto-Nominate / Dismiss) instead of
+ * the 3-button heart prompt.
+ *
+ * These tests MUST fail until the dev agent:
+ *   1. Adds `findActiveBuildingLineup`, `isGameNominated`,
+ *      `getAutoNominateSteamUrlsPref`, `setAutoNominateSteamUrlsPref` helpers
+ *   2. Accepts `LineupsService` as a constructor dependency
+ *   3. Dispatches the nomination flow when a building lineup exists
+ *   4. Adds `STEAM_NOMINATE_BUTTON_IDS` constants and button handlers
+ *
+ * Shared setup lives in ./steam-link.listener.spec-helpers.ts.
+ */
+import {
+  buildMockContext,
+  callHandleMessage,
+  callHandleButtonInteraction,
+  createMessage,
+  makeButtonInteraction,
+  stubGameLookup,
+  stubUserLookup,
+  stubBuildingLineup,
+  stubGameNominated,
+  stubAutoNominatePref,
+  type MockContext,
+} from './steam-link.listener.spec-helpers';
+
+let ctx: MockContext;
+
+beforeEach(() => {
+  ctx = buildMockContext();
+});
+
+describe('SteamLinkListener — nomination flow (ROK-1081)', () => {
+  describe('AC-1 active building lineup check', () => {
+    activeLineupTests();
+  });
+
+  describe('AC-3 already-nominated DM', () => {
+    alreadyNominatedTests();
+  });
+
+  describe('AC-4 nomination prompt DM', () => {
+    nominationPromptTests();
+  });
+
+  describe('AC-5 auto-nominate preference', () => {
+    autoNominateTests();
+  });
+
+  describe('AC-6 cap reached (auto-nominate)', () => {
+    nominationCapTests();
+  });
+
+  describe('button handlers — steam_nominate_*', () => {
+    buttonHandlerTests();
+  });
+});
+
+/**
+ * AC-1: when a building lineup is active the nomination flow runs (DM
+ * mentions Community Lineup); when no building lineup exists the existing
+ * heart flow runs unchanged (regression — ROK-966).
+ */
+function activeLineupTests() {
+  it('runs the nomination flow when a building lineup is active', async () => {
+    stubGameLookup(ctx, { id: 42, name: 'Counter-Strike 2', steamAppId: 730 });
+    stubUserLookup(ctx, { id: 7, discordId: 'discord-user-1' });
+    stubBuildingLineup(ctx, { id: 123 });
+    stubGameNominated(ctx, false);
+    stubAutoNominatePref(ctx, false);
+
+    const msg = createMessage(
+      ctx,
+      'https://store.steampowered.com/app/730/CS2/',
+    );
+    await callHandleMessage(ctx.listener, msg);
+
+    expect(ctx.mockDmSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('Community Lineup'),
+      }),
+    );
+  });
+
+  it('falls back to heart flow (no nomination copy) when no building lineup exists', async () => {
+    stubGameLookup(ctx, { id: 42, name: 'Counter-Strike 2', steamAppId: 730 });
+    stubUserLookup(ctx, { id: 7, discordId: 'discord-user-1' });
+    stubBuildingLineup(ctx, null);
+    // heart flow path: no existing interest, no auto-heart pref.
+    ctx.mockDb.limit.mockResolvedValueOnce([]); // hasExistingHeartInterest
+    ctx.mockDb.limit.mockResolvedValueOnce([]); // getAutoHeartSteamUrlsPref
+
+    const msg = createMessage(
+      ctx,
+      'https://store.steampowered.com/app/730/CS2/',
+    );
+    await callHandleMessage(ctx.listener, msg);
+
+    const call = ctx.mockDmSend.mock.calls[0]?.[0] as
+      | { content?: string }
+      | undefined;
+    const content = call?.content ?? '';
+    expect(content).not.toMatch(/Community Lineup/i);
+    expect(content).not.toMatch(/nominate/i);
+  });
+}
+
+/**
+ * AC-3: building lineup + game already nominated — DM tells the user the
+ * game is already nominated, with NO buttons.
+ */
+function alreadyNominatedTests() {
+  it('sends a DM with the already-nominated copy and no buttons', async () => {
+    stubGameLookup(ctx, { id: 42, name: 'Counter-Strike 2', steamAppId: 730 });
+    stubUserLookup(ctx, { id: 7, discordId: 'discord-user-1' });
+    stubBuildingLineup(ctx, { id: 123 });
+    stubGameNominated(ctx, true);
+
+    const msg = createMessage(
+      ctx,
+      'https://store.steampowered.com/app/730/CS2/',
+    );
+    await callHandleMessage(ctx.listener, msg);
+
+    expect(ctx.mockDmSend).toHaveBeenCalledTimes(1);
+    const call = ctx.mockDmSend.mock.calls[0]?.[0] as {
+      content?: string;
+      components?: unknown[];
+    };
+    expect(call?.content).toContain(
+      '**Counter-Strike 2** is already nominated for the current lineup.',
+    );
+    const hasComponents =
+      Array.isArray(call?.components) && (call?.components?.length ?? 0) > 0;
+    expect(hasComponents).toBe(false);
+    expect(ctx.mockLineupsService.nominate).not.toHaveBeenCalled();
+  });
+}
+
+/**
+ * AC-4: building lineup + unnominated game (no auto-nominate pref) — DM
+ * shows a 4-button nomination prompt with the Community Lineup copy.
+ */
+function nominationPromptTests() {
+  async function sendPromptMessage() {
+    stubGameLookup(ctx, { id: 42, name: 'Counter-Strike 2', steamAppId: 730 });
+    stubUserLookup(ctx, { id: 7, discordId: 'discord-user-1' });
+    stubBuildingLineup(ctx, { id: 123 });
+    stubGameNominated(ctx, false);
+    stubAutoNominatePref(ctx, false);
+
+    const msg = createMessage(
+      ctx,
+      'https://store.steampowered.com/app/730/CS2/',
+    );
+    await callHandleMessage(ctx.listener, msg);
+  }
+
+  it('DM copy asks to add the game to the current Community Lineup', async () => {
+    await sendPromptMessage();
+
+    expect(ctx.mockDmSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining(
+          '**Counter-Strike 2** — add to the current Community Lineup?',
+        ),
+      }),
+    );
+  });
+
+  it('DM includes an action row with exactly 4 buttons', async () => {
+    await sendPromptMessage();
+
+    const call = ctx.mockDmSend.mock.calls[0]?.[0] as {
+      components?: unknown[];
+    };
+    expect(Array.isArray(call?.components)).toBe(true);
+    const firstRow = call?.components?.[0] as {
+      components?: unknown[];
+      toJSON?: () => { components: unknown[] };
+    };
+    const buttons =
+      firstRow?.components ?? firstRow?.toJSON?.().components ?? [];
+    expect(buttons.length).toBe(4);
+  });
+
+  it('uses steam_nominate_* custom IDs for all four buttons', async () => {
+    await sendPromptMessage();
+
+    const call = ctx.mockDmSend.mock.calls[0]?.[0] as {
+      components?: unknown[];
+    };
+    const firstRow = call?.components?.[0] as {
+      components?: Array<Record<string, unknown>>;
+      toJSON?: () => { components: Array<Record<string, unknown>> };
+    };
+    const rawButtons =
+      firstRow?.components ?? firstRow?.toJSON?.().components ?? [];
+    const customIds = rawButtons.map((b) => {
+      const direct = (b?.data as { custom_id?: string } | undefined)
+        ?.custom_id;
+      const viaJson = (
+        b?.toJSON as (() => { custom_id?: string }) | undefined
+      )?.();
+      return direct ?? viaJson?.custom_id ?? '';
+    });
+    const joined = customIds.join(' ');
+    expect(joined).toContain('steam_nominate_nominate');
+    expect(joined).toContain('steam_nominate_heart');
+    expect(joined).toContain('steam_nominate_auto');
+    expect(joined).toContain('steam_nominate_dismiss');
+  });
+}
+
+/**
+ * AC-5: building lineup + autoNominateSteamUrls=true — directly nominates
+ * without a prompt and DMs a confirmation.
+ */
+function autoNominateTests() {
+  it('auto-nominates without prompt when preference is enabled', async () => {
+    stubGameLookup(ctx, { id: 42, name: 'Counter-Strike 2', steamAppId: 730 });
+    stubUserLookup(ctx, { id: 7, discordId: 'discord-user-1' });
+    stubBuildingLineup(ctx, { id: 123 });
+    stubGameNominated(ctx, false);
+    stubAutoNominatePref(ctx, true);
+
+    const msg = createMessage(
+      ctx,
+      'https://store.steampowered.com/app/730/CS2/',
+    );
+    await callHandleMessage(ctx.listener, msg);
+
+    expect(ctx.mockLineupsService.nominate).toHaveBeenCalled();
+    expect(ctx.mockDmSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining(
+          'Auto-nominated **Counter-Strike 2** to the current lineup!',
+        ),
+      }),
+    );
+    // No buttons on the auto-nominate confirmation DM.
+    const call = ctx.mockDmSend.mock.calls[0]?.[0] as {
+      components?: unknown[];
+    };
+    const hasComponents =
+      Array.isArray(call?.components) && (call?.components?.length ?? 0) > 0;
+    expect(hasComponents).toBe(false);
+  });
+}
+
+/**
+ * AC-6: auto-nominate enabled but nomination cap hit — DM surfaces the
+ * exact error message from the LineupsService rejection.
+ */
+function nominationCapTests() {
+  it('surfaces the cap error message from LineupsService in the DM', async () => {
+    stubGameLookup(ctx, { id: 42, name: 'Counter-Strike 2', steamAppId: 730 });
+    stubUserLookup(ctx, { id: 7, discordId: 'discord-user-1' });
+    stubBuildingLineup(ctx, { id: 123 });
+    stubGameNominated(ctx, false);
+    stubAutoNominatePref(ctx, true);
+    ctx.mockLineupsService.nominate.mockRejectedValueOnce(
+      new Error('Lineup has reached the 25-entry cap'),
+    );
+
+    const msg = createMessage(
+      ctx,
+      'https://store.steampowered.com/app/730/CS2/',
+    );
+    await callHandleMessage(ctx.listener, msg);
+
+    expect(ctx.mockDmSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining(
+          'Lineup has reached the 25-entry cap',
+        ),
+      }),
+    );
+  });
+}
+
+/** Button handler tests — all four steam_nominate_* button IDs. */
+function buttonHandlerTests() {
+  it('Nominate button calls LineupsService.nominate and updates in place', async () => {
+    stubUserLookup(ctx, { id: 7, discordId: 'discord-user-1' });
+    stubBuildingLineup(ctx, { id: 123 });
+
+    const interaction = makeButtonInteraction('steam_nominate_nominate:42');
+    await callHandleButtonInteraction(ctx.listener, interaction);
+
+    expect(ctx.mockLineupsService.nominate).toHaveBeenCalled();
+    expect(interaction.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('Nominated **'),
+        components: [],
+      }),
+    );
+  });
+
+  it('Just Heart It button calls addDiscordInterest and updates in place', async () => {
+    stubUserLookup(ctx, { id: 7, discordId: 'discord-user-1' });
+    ctx.mockDb.onConflictDoNothing.mockResolvedValueOnce(undefined);
+
+    const interaction = makeButtonInteraction('steam_nominate_heart:42');
+    await callHandleButtonInteraction(ctx.listener, interaction);
+
+    expect(ctx.mockDb.insert).toHaveBeenCalled();
+    expect(ctx.mockDb.values).toHaveBeenCalledWith(
+      expect.objectContaining({ source: 'discord' }),
+    );
+    expect(interaction.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: 'Marked as interested!',
+        components: [],
+      }),
+    );
+    expect(ctx.mockLineupsService.nominate).not.toHaveBeenCalled();
+  });
+
+  it('Always Auto-Nominate button sets pref + nominates and updates in place', async () => {
+    stubUserLookup(ctx, { id: 7, discordId: 'discord-user-1' });
+    stubBuildingLineup(ctx, { id: 123 });
+    ctx.mockDb.onConflictDoUpdate.mockResolvedValueOnce(undefined);
+
+    const interaction = makeButtonInteraction('steam_nominate_auto:42');
+    await callHandleButtonInteraction(ctx.listener, interaction);
+
+    const valuesCalls = ctx.mockDb.values.mock.calls;
+    const hasAutoNominatePref = valuesCalls.some(
+      (call: unknown[]) =>
+        (call[0] as Record<string, unknown>)?.key === 'autoNominateSteamUrls',
+    );
+    expect(hasAutoNominatePref).toBe(true);
+    expect(ctx.mockLineupsService.nominate).toHaveBeenCalled();
+    expect(interaction.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: 'Auto-nominate enabled for future Steam URLs!',
+        components: [],
+      }),
+    );
+  });
+
+  it('Dismiss button updates in place to "Dismissed." without side effects', async () => {
+    const interaction = makeButtonInteraction('steam_nominate_dismiss:42');
+    await callHandleButtonInteraction(ctx.listener, interaction);
+
+    expect(interaction.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: 'Dismissed.',
+        components: [],
+      }),
+    );
+    expect(ctx.mockLineupsService.nominate).not.toHaveBeenCalled();
+    expect(ctx.mockDb.insert).not.toHaveBeenCalled();
+  });
+}

--- a/api/src/discord-bot/listeners/steam-link.listener.nomination.spec.ts
+++ b/api/src/discord-bot/listeners/steam-link.listener.nomination.spec.ts
@@ -202,8 +202,7 @@ function nominationPromptTests() {
     const rawButtons =
       firstRow?.components ?? firstRow?.toJSON?.().components ?? [];
     const customIds = rawButtons.map((b) => {
-      const direct = (b?.data as { custom_id?: string } | undefined)
-        ?.custom_id;
+      const direct = (b?.data as { custom_id?: string } | undefined)?.custom_id;
       const viaJson = (
         b?.toJSON as (() => { custom_id?: string }) | undefined
       )?.();
@@ -276,9 +275,7 @@ function nominationCapTests() {
 
     expect(ctx.mockDmSend).toHaveBeenCalledWith(
       expect.objectContaining({
-        content: expect.stringContaining(
-          'Lineup has reached the 25-entry cap',
-        ),
+        content: expect.stringContaining('Lineup has reached the 25-entry cap'),
       }),
     );
   });

--- a/api/src/discord-bot/listeners/steam-link.listener.spec-helpers.ts
+++ b/api/src/discord-bot/listeners/steam-link.listener.spec-helpers.ts
@@ -1,0 +1,158 @@
+/**
+ * Shared test helpers for steam-link.listener.spec files.
+ *
+ * Extracted so the original ROK-966 spec (heart flow) and the new
+ * ROK-1081 nomination spec can share setup without exceeding the
+ * 750-line test file limit.
+ */
+import { SteamLinkListener } from './steam-link.listener';
+import { ChannelType } from 'discord.js';
+
+export interface MockContext {
+  listener: SteamLinkListener;
+  mockClientService: Record<string, jest.Mock>;
+  mockDb: Record<string, jest.Mock>;
+  mockLineupsService: { nominate: jest.Mock };
+  mockDmSend: jest.Mock;
+  messageIdCounter: { count: number };
+}
+
+/**
+ * Build a fresh mock context with listener, drizzle chain mock,
+ * a LineupsService stub, and a DM send jest.fn.
+ *
+ * The returned object's fields are mutable so individual tests can
+ * override behaviour (e.g. mockDb.limit.mockResolvedValueOnce(...)).
+ */
+export function buildMockContext(): MockContext {
+  const mockClientService = { getClient: jest.fn() };
+
+  const chain: Record<string, jest.Mock> = {};
+  chain.from = jest.fn().mockReturnValue(chain);
+  chain.where = jest.fn().mockReturnValue(chain);
+  chain.limit = jest.fn().mockResolvedValue([]);
+  chain.insert = jest.fn().mockReturnValue(chain);
+  chain.values = jest.fn().mockReturnValue(chain);
+  chain.onConflictDoNothing = jest.fn().mockResolvedValue(undefined);
+  chain.onConflictDoUpdate = jest.fn().mockResolvedValue(undefined);
+  chain.select = jest.fn().mockReturnValue(chain);
+  chain.orderBy = jest.fn().mockReturnValue(chain);
+
+  const mockLineupsService = {
+    nominate: jest.fn().mockResolvedValue(undefined),
+  };
+
+  const listener = new SteamLinkListener(
+    chain as never,
+    mockClientService as never,
+    undefined as never,
+    undefined as never,
+    undefined as never,
+    mockLineupsService as never,
+  );
+
+  return {
+    listener,
+    mockClientService,
+    mockDb: chain,
+    mockLineupsService,
+    mockDmSend: jest.fn().mockResolvedValue({ id: 'dm-1' }),
+    messageIdCounter: { count: 0 },
+  };
+}
+
+export function callHandleMessage(
+  listener: SteamLinkListener,
+  message: unknown,
+): Promise<void> {
+  return (
+    listener as unknown as { handleMessage: (m: unknown) => Promise<void> }
+  ).handleMessage(message);
+}
+
+export function callHandleButtonInteraction(
+  listener: SteamLinkListener,
+  interaction: unknown,
+): Promise<void> {
+  return (
+    listener as unknown as {
+      handleButtonInteraction: (i: unknown) => Promise<void>;
+    }
+  ).handleButtonInteraction(interaction);
+}
+
+/** Build a Discord message-like object for use in listener tests. */
+export function createMessage(
+  ctx: MockContext,
+  content: string,
+  overrides: Record<string, unknown> = {},
+) {
+  ctx.messageIdCounter.count += 1;
+  return {
+    id: `msg-${ctx.messageIdCounter.count}`,
+    content,
+    author: {
+      bot: false,
+      id: 'discord-user-1',
+      createDM: jest.fn().mockResolvedValue({ send: ctx.mockDmSend }),
+    },
+    guild: { id: 'guild-123' },
+    channel: { type: ChannelType.GuildText, id: 'chan-1' },
+    ...overrides,
+  };
+}
+
+/** Build a Discord button interaction mock. */
+export function makeButtonInteraction(
+  customId: string,
+  userId: string = 'discord-user-1',
+) {
+  const interaction = {
+    isButton: () => true,
+    customId,
+    user: { id: userId, username: 'TestUser' },
+    replied: false,
+    deferred: false,
+    deferUpdate: jest.fn().mockResolvedValue(undefined),
+    editReply: jest.fn().mockResolvedValue(undefined),
+    reply: jest.fn().mockImplementation(() => {
+      interaction.replied = true;
+      return Promise.resolve(undefined);
+    }),
+    update: jest.fn().mockResolvedValue(undefined),
+  };
+  return interaction;
+}
+
+// --- Stub helpers for sequential DB queries ---
+
+export function stubGameLookup(
+  ctx: MockContext,
+  game: { id: number; name: string; steamAppId: number } | null,
+) {
+  ctx.mockDb.limit.mockResolvedValueOnce(game ? [game] : []);
+}
+
+export function stubUserLookup(
+  ctx: MockContext,
+  user: { id: number; discordId: string } | null,
+) {
+  ctx.mockDb.limit.mockResolvedValueOnce(user ? [user] : []);
+}
+
+export function stubBuildingLineup(
+  ctx: MockContext,
+  lineup: { id: number } | null,
+) {
+  ctx.mockDb.limit.mockResolvedValueOnce(lineup ? [lineup] : []);
+}
+
+export function stubGameNominated(ctx: MockContext, nominated: boolean) {
+  ctx.mockDb.limit.mockResolvedValueOnce(nominated ? [{ id: 1 }] : []);
+}
+
+export function stubAutoNominatePref(ctx: MockContext, enabled: boolean) {
+  ctx.mockDb.limit.mockResolvedValueOnce(
+    enabled ? [{ key: 'autoNominateSteamUrls', value: true }] : [],
+  );
+}

--- a/api/src/discord-bot/listeners/steam-link.listener.spec-helpers.ts
+++ b/api/src/discord-bot/listeners/steam-link.listener.spec-helpers.ts
@@ -42,13 +42,17 @@ export function buildMockContext(): MockContext {
     nominate: jest.fn().mockResolvedValue(undefined),
   };
 
+  const mockModuleRef = {
+    get: jest.fn().mockReturnValue(mockLineupsService),
+  };
+
   const listener = new SteamLinkListener(
     chain as never,
     mockClientService as never,
     undefined as never,
     undefined as never,
     undefined as never,
-    mockLineupsService as never,
+    mockModuleRef as never,
   );
 
   return {

--- a/api/src/discord-bot/listeners/steam-link.listener.spec.ts
+++ b/api/src/discord-bot/listeners/steam-link.listener.spec.ts
@@ -137,6 +137,10 @@ function stubAutoHeartPref(enabled: boolean) {
   }
 }
 
+function stubNoBuildingLineup() {
+  mockDb.limit.mockResolvedValueOnce([]);
+}
+
 describe('SteamLinkListener', () => {
   beforeEach(() => {
     setupSteamLinkModule();
@@ -333,6 +337,7 @@ function silentSkipTests() {
   it('does not send an interest prompt when user is already interested in the game', async () => {
     stubGameLookup({ id: 42, name: 'CS2', steamAppId: 730 });
     stubUserLookup({ id: 7, discordId: 'discord-user-1' });
+    stubNoBuildingLineup();
     stubInterestCheck(true);
 
     const msg = createMessage('https://store.steampowered.com/app/730/CS2/');
@@ -356,6 +361,7 @@ function autoHeartTests() {
   it('auto-hearts without prompt when preference is enabled', async () => {
     stubGameLookup({ id: 42, name: 'CS2', steamAppId: 730 });
     stubUserLookup({ id: 7, discordId: 'discord-user-1' });
+    stubNoBuildingLineup();
     stubInterestCheck(false);
     stubAutoHeartPref(true);
 
@@ -447,6 +453,7 @@ function dmConfirmationTests() {
     // Game exists, user linked, interest already present
     stubGameLookup({ id: 42, name: 'Counter-Strike 2', steamAppId: 730 });
     stubUserLookup({ id: 7, discordId: 'discord-user-1' });
+    stubNoBuildingLineup();
     stubInterestCheck(true);
 
     const msg = createMessage('https://store.steampowered.com/app/730/CS2/');
@@ -466,6 +473,7 @@ function dmConfirmationTests() {
   it('AC2: DMs the user when auto-heart adds a game interest', async () => {
     stubGameLookup({ id: 42, name: 'Counter-Strike 2', steamAppId: 730 });
     stubUserLookup({ id: 7, discordId: 'discord-user-1' });
+    stubNoBuildingLineup();
     stubInterestCheck(false);
     stubAutoHeartPref(true);
 
@@ -486,6 +494,7 @@ function dmConfirmationTests() {
   it('AC3: swallows DM send errors (user has DMs disabled) and logs a warning', async () => {
     stubGameLookup({ id: 42, name: 'Counter-Strike 2', steamAppId: 730 });
     stubUserLookup({ id: 7, discordId: 'discord-user-1' });
+    stubNoBuildingLineup();
     // Trigger the already-hearted branch so we exercise the new DM send
     stubInterestCheck(true);
 
@@ -531,4 +540,3 @@ function rateLimitTests() {
     expect(mockDmSend).toHaveBeenCalledTimes(1);
   });
 }
-

--- a/api/src/discord-bot/listeners/steam-link.listener.spec.ts
+++ b/api/src/discord-bot/listeners/steam-link.listener.spec.ts
@@ -35,6 +35,7 @@ function setupSteamLinkModule() {
   chain.onConflictDoNothing = jest.fn().mockResolvedValue(undefined);
   chain.onConflictDoUpdate = jest.fn().mockResolvedValue(undefined);
   chain.select = jest.fn().mockReturnValue(chain);
+  chain.orderBy = jest.fn().mockReturnValue(chain);
   mockDb = chain;
 
   listener = new SteamLinkListener(
@@ -178,6 +179,8 @@ describe('SteamLinkListener', () => {
   describe('rate limiting / dedup', () => {
     rateLimitTests();
   });
+
+  // ROK-1081 nomination flow tests live in ./steam-link.listener.nomination.spec.ts
 });
 
 function botConnectedTests() {
@@ -528,3 +531,4 @@ function rateLimitTests() {
     expect(mockDmSend).toHaveBeenCalledTimes(1);
   });
 }
+

--- a/api/src/discord-bot/listeners/steam-link.listener.ts
+++ b/api/src/discord-bot/listeners/steam-link.listener.ts
@@ -1,20 +1,25 @@
 /**
  * Listener that detects Steam store URLs in Discord messages and prompts
- * users to mark interest in the game on Raid Ledger (ROK-966).
+ * users to heart the game (ROK-966) or nominate it to the current
+ * Community Lineup (ROK-1081).
  *
- * Three prompt options:
- * 1. "Interested" -- create game_interests row with source 'discord'
- * 2. "Not Interested" -- dismiss the ephemeral prompt
- * 3. "Always Auto-Interest" -- heart + set autoHeartSteamUrls preference
+ * Heart flow (no building lineup) — 3 buttons:
+ *   Interested / Not Interested / Always Auto-Interest
+ *
+ * Nomination flow (building lineup active) — 4 buttons:
+ *   Nominate / Just Heart It / Always Auto-Nominate / Dismiss
  */
-import { Injectable, Inject, Logger, Optional } from '@nestjs/common';
+import {
+  Injectable,
+  Inject,
+  Logger,
+  Optional,
+  forwardRef,
+} from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
 import {
   Events,
   ChannelType,
-  ActionRowBuilder,
-  ButtonBuilder,
-  ButtonStyle,
   type Message,
   type ButtonInteraction,
   type Interaction,
@@ -26,11 +31,9 @@ import { ItadService } from '../../itad/itad.service';
 import { IgdbService } from '../../igdb/igdb.service';
 import { SettingsService } from '../../settings/settings.service';
 import { SETTING_KEYS } from '../../drizzle/schema';
+import { LineupsService } from '../../lineups/lineups.service';
 import { DiscordBotClientService } from '../discord-bot-client.service';
-import {
-  DISCORD_BOT_EVENTS,
-  STEAM_INTEREST_BUTTON_IDS,
-} from '../discord-bot.constants';
+import { DISCORD_BOT_EVENTS } from '../discord-bot.constants';
 import { parseSteamAppIds } from './steam-link.helpers';
 import {
   findGameBySteamAppId,
@@ -38,18 +41,32 @@ import {
   hasExistingHeartInterest,
   getAutoHeartSteamUrlsPref,
   addDiscordInterest,
-  setAutoHeartSteamUrlsPref,
+  setAutoNominateSteamUrlsPref,
   discoverGameBySteamAppId,
+  findActiveBuildingLineup,
+  isGameNominated,
+  getAutoNominateSteamUrlsPref,
 } from './steam-link-interest.helpers';
+import {
+  buildInterestButtonRow,
+  handleInterestButtonClick,
+} from './steam-link.listener.interest-flow';
+import {
+  buildNominationPrompt,
+  handleNominateButtonClick,
+  parseSteamNominateButtonId,
+  safeNominate,
+} from './steam-link.listener.nomination-flow';
 
 /** Dedup TTL in milliseconds. */
 const DEDUP_TTL_MS = 30_000;
 
 type Db = PostgresJsDatabase<typeof schema>;
+type Game = { id: number; name: string; igdbId: number | null };
 
 /**
  * Detects Steam store URLs in Discord messages and prompts
- * the user to heart the game on Raid Ledger.
+ * the user to heart or nominate the game on Raid Ledger.
  */
 @Injectable()
 export class SteamLinkListener {
@@ -64,6 +81,9 @@ export class SteamLinkListener {
     @Optional() private readonly itadService: ItadService,
     @Optional() private readonly igdbService: IgdbService,
     private readonly settingsService: SettingsService,
+    @Optional()
+    @Inject(forwardRef(() => LineupsService))
+    private readonly lineupsService?: LineupsService,
   ) {
     this.startDedupCleanup();
   }
@@ -120,14 +140,6 @@ export class SteamLinkListener {
     const appIds = parseSteamAppIds(message.content);
     if (appIds.length === 0) return;
 
-    await this.processAppIds(appIds, message);
-  }
-
-  /** Process extracted app IDs: resolve, check, and prompt or auto-heart. */
-  private async processAppIds(
-    appIds: number[],
-    message: Message,
-  ): Promise<void> {
     for (const appId of appIds) {
       await this.processSingleAppId(appId, message);
     }
@@ -153,45 +165,90 @@ export class SteamLinkListener {
     const user = await findLinkedRlUser(this.db, message.author.id);
     if (!user) return;
 
-    await this.dispatchInterestFlow(message, user.id, game);
+    const buildingLineup = await findActiveBuildingLineup(this.db);
+    if (buildingLineup) {
+      await this.dispatchNominationFlow(
+        message,
+        user.id,
+        game,
+        buildingLineup.id,
+      );
+    } else {
+      await this.dispatchInterestFlow(message, user.id, game);
+    }
   }
 
-  /**
-   * Dispatch the post-lookup interest flow: already-hearted DM, auto-heart
-   * DM, or interactive prompt depending on existing state and preferences.
-   */
+  /** Heart flow (ROK-966) — 3-button prompt when no building lineup exists. */
   private async dispatchInterestFlow(
     message: Message,
     userId: number,
-    game: { id: number; name: string },
+    game: Game,
   ): Promise<void> {
-    const alreadyInterested = await hasExistingHeartInterest(
-      this.db,
-      userId,
-      game.id,
-    );
-    if (alreadyInterested) {
+    if (await hasExistingHeartInterest(this.db, userId, game.id)) {
       await this.sendDmSafe(
         message,
         `You already have **${game.name}** hearted! 💜`,
       );
       return;
     }
-
-    const autoHeart = await getAutoHeartSteamUrlsPref(this.db, userId);
-    if (autoHeart) {
+    if (await getAutoHeartSteamUrlsPref(this.db, userId)) {
       await addDiscordInterest(this.db, userId, game.id);
       await this.sendDmSafe(message, `Auto-hearted **${game.name}**! 💜`);
       return;
     }
-
-    await this.sendInterestPrompt(message, game);
+    const row = buildInterestButtonRow(game.id);
+    const dm = await message.author.createDM();
+    await dm.send({
+      content: `Interested in **${game.name}** on Raid Ledger?`,
+      components: [row],
+    });
   }
 
-  /**
-   * Send a plain-text DM to the message author, swallowing and logging
-   * failures (e.g. when the user has DMs disabled from server members).
-   */
+  /** Nomination flow (ROK-1081) — 4-button prompt when a building lineup is active. */
+  private async dispatchNominationFlow(
+    message: Message,
+    userId: number,
+    game: Game,
+    lineupId: number,
+  ): Promise<void> {
+    if (await isGameNominated(this.db, lineupId, game.id)) {
+      await this.sendDmSafe(
+        message,
+        `**${game.name}** is already nominated for the current lineup.`,
+      );
+      return;
+    }
+    if (await getAutoNominateSteamUrlsPref(this.db, userId)) {
+      await this.autoNominate(message, userId, game, lineupId);
+      return;
+    }
+    const dm = await message.author.createDM();
+    await dm.send(buildNominationPrompt(game));
+  }
+
+  /** Auto-nominate path: call LineupsService and DM the result. */
+  private async autoNominate(
+    message: Message,
+    userId: number,
+    game: Game,
+    lineupId: number,
+  ): Promise<void> {
+    if (!this.lineupsService) {
+      await this.sendDmSafe(message, 'Auto-nominate is not available.');
+      return;
+    }
+    const copy = await safeNominate(
+      this.lineupsService,
+      lineupId,
+      game.id,
+      game.name,
+      userId,
+      `Auto-nominated **${game.name}** to the current lineup!`,
+    );
+    await this.sendDmSafe(message, copy);
+  }
+
+  /** Send a plain-text DM, swallowing and logging failures. */
   private async sendDmSafe(message: Message, content: string): Promise<void> {
     try {
       const dm = await message.author.createDM();
@@ -204,9 +261,7 @@ export class SteamLinkListener {
   }
 
   /** Discover and add a game via ITAD when it's not in the DB. */
-  private async discoverGame(
-    appId: number,
-  ): Promise<{ id: number; name: string; igdbId: number | null } | null> {
+  private async discoverGame(appId: number): Promise<Game | null> {
     if (!this.itadService) return null;
     const adultFilter =
       (await this.settingsService.get(SETTING_KEYS.IGDB_FILTER_ADULT)) ===
@@ -221,127 +276,43 @@ export class SteamLinkListener {
     );
   }
 
-  /** Send the interest prompt as a DM to the message author. */
-  private async sendInterestPrompt(
-    message: Message,
-    game: { id: number; name: string },
-  ): Promise<void> {
-    const row = buildButtonRow(game.id);
-    const dm = await message.author.createDM();
-    await dm.send({
-      content: `Interested in **${game.name}** on Raid Ledger?`,
-      components: [row],
-    });
-  }
-
-  /** Handle a button interaction from the interest prompt. */
+  /** Route button interactions to the heart or nominate handler. */
   private async handleButtonInteraction(
     interaction: ButtonInteraction,
   ): Promise<void> {
-    const parsed = parseSteamButtonId(interaction.customId);
-    if (!parsed) return;
-
-    const { action, gameId } = parsed;
-    const user = await findLinkedRlUser(this.db, interaction.user.id);
-
-    if (action === STEAM_INTEREST_BUTTON_IDS.DISMISS) {
-      await this.handleDismissButton(interaction);
+    const nom = parseSteamNominateButtonId(interaction.customId);
+    if (nom) {
+      await handleNominateButtonClick(
+        this.buildNominateDeps(),
+        interaction,
+        nom.action,
+        nom.gameId,
+      );
       return;
     }
-
-    if (!user) {
-      await interaction.update({
-        content: 'Could not find your linked account.',
-        components: [],
-      });
-      return;
-    }
-
-    if (action === STEAM_INTEREST_BUTTON_IDS.HEART) {
-      await this.handleHeartButton(interaction, user.id, gameId);
-    } else if (action === STEAM_INTEREST_BUTTON_IDS.AUTO) {
-      await this.handleAutoButton(interaction, user.id, gameId);
-    }
+    await handleInterestButtonClick(this.db, interaction);
   }
 
-  /** Handle the "Interested" button click. */
-  private async handleHeartButton(
-    interaction: ButtonInteraction,
-    userId: number,
-    gameId: number,
-  ): Promise<void> {
-    await addDiscordInterest(this.db, userId, gameId);
-    await interaction.update({
-      content: 'Marked as interested!',
-      components: [],
-    });
-  }
-
-  /** Handle the "Not Interested" button click. */
-  private async handleDismissButton(
-    interaction: ButtonInteraction,
-  ): Promise<void> {
-    await interaction.update({ content: 'Dismissed.', components: [] });
-  }
-
-  /** Handle the "Always Auto-Interest" button click. */
-  private async handleAutoButton(
-    interaction: ButtonInteraction,
-    userId: number,
-    gameId: number,
-  ): Promise<void> {
-    await addDiscordInterest(this.db, userId, gameId);
-    await setAutoHeartSteamUrlsPref(this.db, userId, true);
-    await interaction.update({
-      content: 'Auto-interest enabled for future Steam URLs!',
-      components: [],
-    });
+  /** Build the deps object for the nomination button click handler. */
+  private buildNominateDeps() {
+    return {
+      db: this.db,
+      lineupsService: this.lineupsService,
+      findActiveBuildingLineupId: async () =>
+        (await findActiveBuildingLineup(this.db))?.id ?? null,
+      addInterest: (userId: number, gameId: number) =>
+        addDiscordInterest(this.db, userId, gameId),
+      findLinkedUser: (discordId: string) =>
+        findLinkedRlUser(this.db, discordId),
+      setAutoNominatePref: (userId: number, enabled: boolean) =>
+        setAutoNominateSteamUrlsPref(this.db, userId, enabled),
+    };
   }
 }
-
-// --- Pure helpers ---
 
 /** Check if a channel type is a guild text channel. */
 function isGuildTextChannel(type: ChannelType): boolean {
   return (
     type === ChannelType.GuildText || type === ChannelType.GuildAnnouncement
   );
-}
-
-/** Build the action row with 3 buttons for the interest prompt. */
-function buildButtonRow(gameId: number): ActionRowBuilder<ButtonBuilder> {
-  return new ActionRowBuilder<ButtonBuilder>().addComponents(
-    new ButtonBuilder()
-      .setCustomId(`${STEAM_INTEREST_BUTTON_IDS.HEART}:${gameId}`)
-      .setLabel('Interested')
-      .setStyle(ButtonStyle.Success),
-    new ButtonBuilder()
-      .setCustomId(`${STEAM_INTEREST_BUTTON_IDS.DISMISS}:${gameId}`)
-      .setLabel('Not Interested')
-      .setStyle(ButtonStyle.Secondary),
-    new ButtonBuilder()
-      .setCustomId(`${STEAM_INTEREST_BUTTON_IDS.AUTO}:${gameId}`)
-      .setLabel('Always Auto-Interest')
-      .setStyle(ButtonStyle.Primary),
-  );
-}
-
-/** Parse a steam interest button custom ID into action + gameId. */
-function parseSteamButtonId(
-  customId: string,
-): { action: string; gameId: number } | null {
-  const parts = customId.split(':');
-  if (parts.length !== 2) return null;
-  const [action, gameIdStr] = parts;
-  const gameId = parseInt(gameIdStr, 10);
-  if (isNaN(gameId)) return null;
-  const validActions = [
-    STEAM_INTEREST_BUTTON_IDS.HEART,
-    STEAM_INTEREST_BUTTON_IDS.DISMISS,
-    STEAM_INTEREST_BUTTON_IDS.AUTO,
-  ];
-  if (!validActions.includes(action as (typeof validActions)[number])) {
-    return null;
-  }
-  return { action, gameId };
 }

--- a/api/src/discord-bot/listeners/steam-link.listener.ts
+++ b/api/src/discord-bot/listeners/steam-link.listener.ts
@@ -9,13 +9,8 @@
  * Nomination flow (building lineup active) — 4 buttons:
  *   Nominate / Just Heart It / Always Auto-Nominate / Dismiss
  */
-import {
-  Injectable,
-  Inject,
-  Logger,
-  Optional,
-  forwardRef,
-} from '@nestjs/common';
+import { Injectable, Inject, Logger, Optional } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
 import { OnEvent } from '@nestjs/event-emitter';
 import {
   Events,
@@ -81,11 +76,24 @@ export class SteamLinkListener {
     @Optional() private readonly itadService: ItadService,
     @Optional() private readonly igdbService: IgdbService,
     private readonly settingsService: SettingsService,
-    @Optional()
-    @Inject(forwardRef(() => LineupsService))
-    private readonly lineupsService?: LineupsService,
+    @Optional() private readonly moduleRef?: ModuleRef,
   ) {
     this.startDedupCleanup();
+  }
+
+  /**
+   * Lazily resolve LineupsService via ModuleRef to avoid an import-time
+   * cycle between DiscordBotModule <-> LineupsModule. Returns null when
+   * the service isn't registered (e.g. in isolated unit tests without
+   * the full module graph).
+   */
+  private getLineupsService(): LineupsService | null {
+    if (!this.moduleRef) return null;
+    try {
+      return this.moduleRef.get(LineupsService, { strict: false });
+    } catch {
+      return null;
+    }
   }
 
   /** Periodically clean up expired dedup entries. */
@@ -233,12 +241,13 @@ export class SteamLinkListener {
     game: Game,
     lineupId: number,
   ): Promise<void> {
-    if (!this.lineupsService) {
+    const lineups = this.getLineupsService();
+    if (!lineups) {
       await this.sendDmSafe(message, 'Auto-nominate is not available.');
       return;
     }
     const copy = await safeNominate(
-      this.lineupsService,
+      lineups,
       lineupId,
       game.id,
       game.name,
@@ -297,7 +306,7 @@ export class SteamLinkListener {
   private buildNominateDeps() {
     return {
       db: this.db,
-      lineupsService: this.lineupsService,
+      lineupsService: this.getLineupsService() ?? undefined,
       findActiveBuildingLineupId: async () =>
         (await findActiveBuildingLineup(this.db))?.id ?? null,
       addInterest: (userId: number, gameId: number) =>

--- a/tools/test-bot/src/smoke/run.ts
+++ b/tools/test-bot/src/smoke/run.ts
@@ -22,6 +22,7 @@ import { pushContentTests } from './tests/push-content.test.js';
 import { slashCommandTests } from './tests/slash-commands.test.js';
 import { cdpSlashCommandTests } from './tests/cdp-slash-commands.test.js';
 import { cdpSteamInterestTests } from './tests/cdp-steam-interest.test.js';
+import { cdpSteamNominationTests } from './tests/cdp-steam-nomination.test.js';
 import { scheduledEventCompletionTests } from './tests/scheduled-event-completion.test.js';
 import { aiChatTests } from './tests/ai-chat.test.js';
 import { lineupTitleTests } from './tests/lineup-title.test.js';
@@ -136,6 +137,7 @@ function collectTests(filterCat?: string): SmokeTest[] {
     ...slashCommandTests,
     ...cdpSlashCommandTests,
     ...cdpSteamInterestTests,
+    ...cdpSteamNominationTests,
     ...scheduledEventCompletionTests,
     ...aiChatTests,
     ...lineupTitleTests,

--- a/tools/test-bot/src/smoke/tests/cdp-steam-interest.test.ts
+++ b/tools/test-bot/src/smoke/tests/cdp-steam-interest.test.ts
@@ -115,6 +115,19 @@ function buildCdpSteamTests(): SmokeTest[] {
       enabled: false,
     });
 
+    // ROK-1081: the listener now offers a nomination DM when a building
+    // Community Lineup is active. These heart-flow tests assert the
+    // unchanged ROK-966 copy, so make a best-effort attempt to archive
+    // any active building lineup. The endpoint may 404 if no lineup exists
+    // or if the test-only endpoint has not yet been deployed.
+    try {
+      await ctx.api.post('/admin/test/archive-active-lineup', {});
+    } catch {
+      // Endpoint is new (ROK-1081) and may not exist in older deployments.
+      // Ignore — the test will still catch heart-flow regressions when
+      // no lineup is present, which is the common case.
+    }
+
     return { gameName, discordId };
   }
 

--- a/tools/test-bot/src/smoke/tests/cdp-steam-nomination.test.ts
+++ b/tools/test-bot/src/smoke/tests/cdp-steam-nomination.test.ts
@@ -1,0 +1,289 @@
+/**
+ * CDP-based E2E test for Steam URL paste-to-nominate (ROK-1081).
+ *
+ * Seeds an active Community Lineup in `building` status, then posts a
+ * Steam store URL as the logged-in Discord user and verifies the bot
+ * sends a DM offering to nominate the game for the current lineup.
+ *
+ * Gated behind DISCORD_CDP=true environment variable.
+ * Requires Discord launched with: ./scripts/launch-discord.sh
+ *
+ * These tests depend on new DEMO_MODE-only endpoints that do NOT exist yet:
+ *   - POST /admin/test/create-building-lineup
+ *   - POST /admin/test/nominate-game
+ *   - POST /admin/test/archive-lineup
+ * Tests MUST fail until the dev agent adds these endpoints.
+ */
+import type { SmokeTest, TestContext } from '../types.js';
+import { SMOKE } from '../config.js';
+
+/** Arbitrary Steam app ID used as a fixture marker for this suite. */
+const TEST_STEAM_APP_ID = 99902;
+
+function buildCdpSteamNominationTests(): SmokeTest[] {
+  if (!process.env.DISCORD_CDP) return [];
+
+  let cachedPage: import('playwright').Page | null = null;
+
+  async function getPage(
+    ctx: TestContext,
+  ): Promise<import('playwright').Page> {
+    if (cachedPage) return cachedPage;
+    const { connectDiscordCDP, navigateToChannel, dismissEphemeralMessages } =
+      await import('../cdp/discord-page.js');
+    const { page } = await connectDiscordCDP();
+    const p = page as import('playwright').Page;
+    await navigateToChannel(p, SMOKE.guildId, ctx.defaultChannelId);
+    await p.waitForTimeout(2000);
+    await dismissEphemeralMessages(p);
+    await p.waitForTimeout(1000);
+    cachedPage = p;
+    return p;
+  }
+
+  /**
+   * Intercept Discord's CDP traffic to extract the auth token, then query
+   * /users/@me to get the logged-in user's Discord ID.
+   */
+  async function getLoggedInDiscordId(
+    page: import('playwright').Page,
+  ): Promise<string> {
+    const cdpSession = await page.context().newCDPSession(page);
+    await cdpSession.send('Network.enable');
+    let token: string | null = null;
+    cdpSession.on(
+      'Network.requestWillBeSent',
+      (ev: { request: { headers: Record<string, string> } }) => {
+        const a = ev.request.headers['Authorization'];
+        if (a && !token) token = a;
+      },
+    );
+    await page.evaluate(() => window.location.reload());
+    await page.waitForTimeout(5000);
+    await cdpSession.detach();
+    if (!token) return '';
+    const res = await fetch('https://discord.com/api/v10/users/@me', {
+      headers: { Authorization: token },
+    });
+    if (!res.ok) return '';
+    const user = (await res.json()) as { id: string };
+    return user.id;
+  }
+
+  /**
+   * Set up: create a building lineup, assign steamAppId to a game, link the
+   * logged-in user, and clear both auto-heart + auto-nominate preferences.
+   */
+  async function setupFixtures(
+    ctx: TestContext,
+    page: import('playwright').Page,
+  ): Promise<{ gameName: string; discordId: string; lineupId: number }> {
+    const game = ctx.games[0];
+    if (!game) throw new Error('No games in test context');
+
+    // Create a building lineup for the test user.
+    const lineup = await ctx.api.post<{ id: number }>(
+      '/admin/test/create-building-lineup',
+      { createdByUserId: ctx.testUserId },
+    );
+
+    // Assign steamAppId on the game so the listener resolves it.
+    await ctx.api.post('/admin/test/set-steam-app-id', {
+      gameId: game.id,
+      steamAppId: TEST_STEAM_APP_ID,
+    });
+
+    const dbGame = await ctx.api.post<{ id: number; name: string }>(
+      '/admin/test/get-game',
+      { id: game.id },
+    );
+    const gameName = dbGame.name;
+
+    // Link Discord ID to the admin user.
+    const discordId = await getLoggedInDiscordId(page);
+    if (!discordId) {
+      throw new Error(
+        'Could not extract Discord user ID from CDP. Is Discord logged in?',
+      );
+    }
+    await ctx.api.post('/admin/test/link-discord', {
+      userId: ctx.testUserId,
+      discordId,
+      username: 'cdp-nominate-user',
+    });
+
+    // Clean baseline: no existing interest, both auto-prefs disabled.
+    await ctx.api.post('/admin/test/clear-game-interest', {
+      userId: ctx.testUserId,
+      gameId: game.id,
+    });
+    await ctx.api.post('/admin/test/set-auto-heart-pref', {
+      userId: ctx.testUserId,
+      enabled: false,
+    });
+    await ctx.api.post('/admin/test/set-auto-nominate-pref', {
+      userId: ctx.testUserId,
+      enabled: false,
+    });
+
+    return { gameName, discordId, lineupId: lineup.id };
+  }
+
+  /** Best-effort cleanup: archive the lineup so later tests see no building lineup. */
+  async function cleanupLineup(
+    ctx: TestContext,
+    lineupId: number,
+  ): Promise<void> {
+    try {
+      await ctx.api.post('/admin/test/archive-lineup', { lineupId });
+    } catch {
+      // Ignore — endpoint may not exist yet, or lineup may already be gone.
+    }
+  }
+
+  /** Navigate to DMs and read the most recent DM message. */
+  async function readLastDm(
+    page: import('playwright').Page,
+    timeoutMs: number,
+  ): Promise<string> {
+    await page.evaluate(() => {
+      window.location.href = 'https://discord.com/channels/@me';
+    });
+    await page.waitForTimeout(3000);
+
+    const deadline = Date.now() + timeoutMs;
+    while (Date.now() < deadline) {
+      const clicked = await page.evaluate(() => {
+        const links = Array.from(document.querySelectorAll('a'));
+        const dmLink = links.find(
+          (a) => a.href?.includes('/@me/') && !a.href?.endsWith('/@me'),
+        );
+        if (dmLink) {
+          dmLink.click();
+          return true;
+        }
+        return false;
+      });
+
+      if (clicked) {
+        await page.waitForTimeout(2000);
+        const lastMsg = await page.evaluate(() => {
+          const msgs = document.querySelectorAll(
+            '[id^="message-content-"], [class*="messageContent"]',
+          );
+          const last = msgs[msgs.length - 1];
+          return last?.textContent?.trim() ?? '';
+        });
+        if (lastMsg) return lastMsg;
+      }
+      await page.waitForTimeout(1000);
+    }
+    return '';
+  }
+
+  /** Post a Steam URL in the default channel after ensuring the UI is ready. */
+  async function postSteamUrl(
+    ctx: TestContext,
+    p: import('playwright').Page,
+  ): Promise<void> {
+    const { typeMessage, navigateToChannel, dismissEphemeralMessages } =
+      await import('../cdp/discord-page.js');
+    await navigateToChannel(p, SMOKE.guildId, ctx.defaultChannelId);
+    await p.waitForTimeout(2000);
+    await dismissEphemeralMessages(p);
+    const url = `https://store.steampowered.com/app/${TEST_STEAM_APP_ID}/`;
+    await typeMessage(p, url);
+    await p.waitForTimeout(5000);
+  }
+
+  /** Return to the default test channel for subsequent tests. */
+  async function returnToTestChannel(
+    ctx: TestContext,
+    p: import('playwright').Page,
+  ): Promise<void> {
+    const { navigateToChannel } = await import('../cdp/discord-page.js');
+    await navigateToChannel(p, SMOKE.guildId, ctx.defaultChannelId);
+    await p.waitForTimeout(1000);
+  }
+
+  const tests: SmokeTest[] = [
+    {
+      name: 'CDP: Steam URL with active building lineup triggers nomination DM',
+      category: 'cdp-command',
+      async run(ctx) {
+        const p = await getPage(ctx);
+        const fixtures = await setupFixtures(ctx, p);
+        try {
+          await postSteamUrl(ctx, p);
+
+          const dmText = await readLastDm(p, 15_000);
+          if (!dmText) {
+            throw new Error(
+              `Expected nomination DM for "${fixtures.gameName}", got no DM`,
+            );
+          }
+
+          const lc = dmText.toLowerCase();
+          const hasGameName = lc.includes(fixtures.gameName.toLowerCase());
+          const hasLineupCopy = lc.includes('community lineup');
+          if (!hasGameName || !hasLineupCopy) {
+            throw new Error(
+              `DM content "${dmText}" missing expected markers ` +
+                `(gameName=${hasGameName}, communityLineupCopy=${hasLineupCopy}) ` +
+                `for game "${fixtures.gameName}"`,
+            );
+          }
+        } finally {
+          await cleanupLineup(ctx, fixtures.lineupId);
+          await returnToTestChannel(ctx, p);
+        }
+      },
+    },
+    {
+      name: 'CDP: Steam URL on already-nominated game triggers "already nominated" DM',
+      category: 'cdp-command',
+      async run(ctx) {
+        const p = await getPage(ctx);
+        const fixtures = await setupFixtures(ctx, p);
+        try {
+          const game = ctx.games[0];
+          if (!game) throw new Error('No games in test context');
+
+          // Pre-nominate the game so the listener takes the already-nominated path.
+          await ctx.api.post('/admin/test/nominate-game', {
+            lineupId: fixtures.lineupId,
+            gameId: game.id,
+            userId: ctx.testUserId,
+          });
+
+          await postSteamUrl(ctx, p);
+
+          const dmText = await readLastDm(p, 15_000);
+          if (!dmText) {
+            throw new Error(
+              `Expected "already nominated" DM for "${fixtures.gameName}", got no DM`,
+            );
+          }
+
+          const lc = dmText.toLowerCase();
+          const hasGameName = lc.includes(fixtures.gameName.toLowerCase());
+          const hasAlreadyNominated = lc.includes('already nominated');
+          if (!hasGameName || !hasAlreadyNominated) {
+            throw new Error(
+              `DM content "${dmText}" missing expected markers ` +
+                `(gameName=${hasGameName}, alreadyNominatedPhrase=${hasAlreadyNominated}) ` +
+                `for game "${fixtures.gameName}"`,
+            );
+          }
+        } finally {
+          await cleanupLineup(ctx, fixtures.lineupId);
+          await returnToTestChannel(ctx, p);
+        }
+      },
+    },
+  ];
+
+  return tests;
+}
+
+export const cdpSteamNominationTests = buildCdpSteamNominationTests();


### PR DESCRIPTION
## Summary
- When a Community Lineup is in `building` phase, pasting a Steam store URL in a guild text channel now DMs a 4-button prompt: **Nominate / Just Heart It / Always Auto-Nominate / Dismiss**. Closes the parity gap promised by the "Nominations Open" embed copy.
- Adds a new `autoNominateSteamUrls` user preference (mirrors existing `autoHeartSteamUrls`). Opt-in via the 4th button.
- No active building lineup → existing ROK-966 heart/interest flow runs unchanged.

## Linear
ROK-1081

## Behavior matrix
| Scenario | DM copy |
|---|---|
| Building lineup + game not nominated + no auto-pref | `**{game}** — add to the current Community Lineup?` + 4 buttons |
| Building lineup + game already nominated | `**{game}** is already nominated for the current lineup.` |
| Building lineup + `autoNominateSteamUrls=true` | `Auto-nominated **{game}** to the current lineup!` |
| Nomination cap reached | Exact API error message (e.g. `Lineup has reached the 25-entry cap`) |
| Race: building → voting between paste + click | `Nominations have closed for the current lineup.` |
| No building lineup | Existing 3-button heart prompt (unchanged) |

## Architecture notes
- New helpers in `steam-link-interest.helpers.ts`: `findActiveBuildingLineup` (building-only, separate from `findActiveLineup` to preserve voting callers), `isGameNominated`, `getAutoNominateSteamUrlsPref`, `setAutoNominateSteamUrlsPref`.
- Listener split into `interest-flow` + `nomination-flow` modules to stay under the 300-line file limit.
- `LineupsService` is lazy-resolved via `ModuleRef` to avoid a DiscordBotModule ↔ LineupsModule circular import.
- 5 new `DEMO_MODE`-only admin test endpoints (`create-building-lineup`, `nominate-game`, `archive-lineup`, `archive-active-lineup`, `set-auto-nominate-pref`) backed by a new `DemoTestLineupService`.

## Scope decisions (operator-approved)
- AC-5 included (auto-nominate preference).
- AC-6 member check dropped — data model has one global active lineup.
- Single DM with 4 buttons; updates in place via `interaction.update` on click.

## Test plan
- [x] Unit tests added: 13 new nomination tests + 7 new helper tests (76 total passing)
- [x] Existing ROK-966 heart-flow tests still pass (5 tests updated to stub the new building-lineup lookup)
- [x] CI passes — `validate-ci.sh --full` green (build + lint + type + unit + integration)
- [x] Operator tested locally in Discord — paste Steam URL, clicked Nominate, game appeared on lineup
- [x] Code review passed (0 blockers, 5 low-severity tech debt items tracked)

## Follow-ups
- Ephemeral response (user-private) isn't possible from a `messageCreate` listener — requires a slash command. Tracked as ROK-940.
- Tech debt: auto-nominate pref written before service-availability check (low); nomination prompt DM not wrapped in `sendDmSafe` (low); CDP smoke tests still use `waitForTimeout` (low).

🤖 Generated with [Claude Code](https://claude.com/claude-code)