### PR TITLE
ROK-1065: private / targeted lineup

### DIFF
--- a/api/src/discord-bot/ai-chat/tree/lineup.tree.ts
+++ b/api/src/discord-bot/ai-chat/tree/lineup.tree.ts
@@ -32,13 +32,24 @@ export async function handleLineup(
   return lineupMenu();
 }
 
-/** Fetch the currently active community lineup. */
+/**
+ * Fetch the currently active community lineup (ROK-1065).
+ * findActive now returns an array; the AI chat surface picks the newest
+ * lineup to describe.
+ */
 async function fetchActiveLineup(
   deps: AiChatDeps,
   userId: number | null,
 ): Promise<TreeResult> {
   try {
-    const lineup = await deps.lineupsService.findActive(userId ?? undefined);
+    const active = await deps.lineupsService.findActive();
+    if (active.length === 0) {
+      return leaf(null, 'No active lineup right now.', deps);
+    }
+    const lineup = await deps.lineupsService.findById(
+      active[0].id,
+      userId ?? undefined,
+    );
     const gameName = lineup.decidedGameName ?? 'TBD';
     const status = lineup.status ?? 'unknown';
     const entries = lineup.entries?.length ?? 0;
@@ -56,13 +67,20 @@ async function fetchActiveLineup(
   }
 }
 
-/** Fetch current nominations. */
+/** Fetch current nominations from the newest active lineup (ROK-1065). */
 async function fetchNominations(
   deps: AiChatDeps,
   userId: number | null,
 ): Promise<TreeResult> {
   try {
-    const lineup = await deps.lineupsService.findActive(userId ?? undefined);
+    const active = await deps.lineupsService.findActive();
+    if (active.length === 0) {
+      return leaf(null, 'No active lineup right now.', deps);
+    }
+    const lineup = await deps.lineupsService.findById(
+      active[0].id,
+      userId ?? undefined,
+    );
     const entries = lineup.entries ?? [];
     if (entries.length === 0) {
       return leaf(null, 'No nominations yet.', deps);

--- a/api/src/drizzle/migrations/0125_private_lineups.sql
+++ b/api/src/drizzle/migrations/0125_private_lineups.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "community_lineup_invitees" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"lineup_id" integer NOT NULL,
+	"user_id" integer NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "uq_lineup_invitee_user" UNIQUE("lineup_id","user_id")
+);
+--> statement-breakpoint
+ALTER TABLE "community_lineups" ADD COLUMN "visibility" text DEFAULT 'public' NOT NULL;--> statement-breakpoint
+ALTER TABLE "community_lineups" ADD CONSTRAINT "chk_community_lineups_visibility" CHECK ("visibility" IN ('public', 'private'));--> statement-breakpoint
+ALTER TABLE "community_lineup_invitees" ADD CONSTRAINT "community_lineup_invitees_lineup_id_community_lineups_id_fk" FOREIGN KEY ("lineup_id") REFERENCES "public"."community_lineups"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "community_lineup_invitees" ADD CONSTRAINT "community_lineup_invitees_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;

--- a/api/src/drizzle/migrations/meta/0125_snapshot.json
+++ b/api/src/drizzle/migrations/meta/0125_snapshot.json
@@ -1,0 +1,6844 @@
+{
+  "id": "12581505-a759-41e1-9ead-e2d1bc3e9d4b",
+  "prevId": "29ef1686-f30a-4444-a9b6-3ace413b1eac",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_id": {
+          "name": "steam_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_avatar_url": {
+          "name": "custom_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_time_confirmed_at": {
+          "name": "game_time_confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_discord_id_unique": {
+          "name": "users_discord_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_id"
+          ]
+        },
+        "users_steam_id_unique": {
+          "name": "users_steam_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "steam_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "display_name_length": {
+          "name": "display_name_length",
+          "value": "\"users\".\"display_name\" IS NULL OR (LENGTH(\"users\".\"display_name\") >= 2 AND LENGTH(\"users\".\"display_name\") <= 30)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "tsrange",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_config": {
+          "name": "slot_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_attendees": {
+          "name": "max_attendees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_unbench": {
+          "name": "auto_unbench",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "recurrence_group_id": {
+          "name": "recurrence_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_rule": {
+          "name": "recurrence_rule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_instances": {
+          "name": "content_instances",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_15min": {
+          "name": "reminder_15min",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_1hour": {
+          "name": "reminder_1hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_24hour": {
+          "name": "reminder_24hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_ad_hoc": {
+          "name": "is_ad_hoc",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ad_hoc_status": {
+          "name": "ad_hoc_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_binding_id": {
+          "name": "channel_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_scheduled_event_id": {
+          "name": "discord_scheduled_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extended_until": {
+          "name": "extended_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_channel_override": {
+          "name": "notification_channel_override",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rescheduling_poll_id": {
+          "name": "rescheduling_poll_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_events_creator_id": {
+          "name": "idx_events_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_game_id": {
+          "name": "idx_events_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_ad_hoc_binding": {
+          "name": "idx_events_ad_hoc_binding",
+          "columns": [
+            {
+              "expression": "channel_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_ad_hoc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_recurrence_group_id": {
+          "name": "idx_events_recurrence_group_id",
+          "columns": [
+            {
+              "expression": "recurrence_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_cancelled_at": {
+          "name": "idx_events_cancelled_at",
+          "columns": [
+            {
+              "expression": "cancelled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_discord_scheduled_event_id": {
+          "name": "idx_events_discord_scheduled_event_id",
+          "columns": [
+            {
+              "expression": "discord_scheduled_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_game_id_games_id_fk": {
+          "name": "events_game_id_games_id_fk",
+          "tableFrom": "events",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_creator_id_users_id_fk": {
+          "name": "events_creator_id_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_channel_binding_id_channel_bindings_id_fk": {
+          "name": "events_channel_binding_id_channel_bindings_id_fk",
+          "tableFrom": "events",
+          "tableTo": "channel_bindings",
+          "columnsFrom": [
+            "channel_binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_types": {
+      "name": "event_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_player_cap": {
+          "name": "default_player_cap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_duration_minutes": {
+          "name": "default_duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_composition": {
+          "name": "requires_composition",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_event_types_game_id": {
+          "name": "idx_event_types_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_types_game_id_games_id_fk": {
+          "name": "event_types_game_id_games_id_fk",
+          "tableFrom": "event_types",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_types_game_slug_unique": {
+          "name": "event_types_game_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "game_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "igdb_id": {
+          "name": "igdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregated_rating": {
+          "name": "aggregated_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "popularity": {
+          "name": "popularity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_modes": {
+          "name": "game_modes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "themes": {
+          "name": "themes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "platforms": {
+          "name": "platforms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "screenshots": {
+          "name": "screenshots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "videos": {
+          "name": "videos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "first_release_date": {
+          "name": "first_release_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_count": {
+          "name": "player_count",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitch_game_id": {
+          "name": "twitch_game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_app_id": {
+          "name": "steam_app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crossplay": {
+          "name": "crossplay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color_hex": {
+          "name": "color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_roles": {
+          "name": "has_roles",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_specs": {
+          "name": "has_specs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "itad_game_id": {
+          "name": "itad_game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_boxart_url": {
+          "name": "itad_boxart_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_tags": {
+          "name": "itad_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "max_characters_per_user": {
+          "name": "max_characters_per_user",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "api_namespace_prefix": {
+          "name": "api_namespace_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_current_price": {
+          "name": "itad_current_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_current_cut": {
+          "name": "itad_current_cut",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_current_shop": {
+          "name": "itad_current_shop",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_current_url": {
+          "name": "itad_current_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_lowest_price": {
+          "name": "itad_lowest_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_lowest_cut": {
+          "name": "itad_lowest_cut",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_price_updated_at": {
+          "name": "itad_price_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "early_access": {
+          "name": "early_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "igdb_enrichment_status": {
+          "name": "igdb_enrichment_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "igdb_enrichment_retry_count": {
+          "name": "igdb_enrichment_retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "games_igdb_id_unique": {
+          "name": "games_igdb_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "igdb_id"
+          ]
+        },
+        "games_slug_unique": {
+          "name": "games_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "games_itad_game_id_unique": {
+          "name": "games_itad_game_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "itad_game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_signups": {
+      "name": "event_signups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_avatar_hash": {
+          "name": "discord_avatar_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation_status": {
+          "name": "confirmation_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'signed_up'"
+        },
+        "preferred_roles": {
+          "name": "preferred_roles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attendance_status": {
+          "name": "attendance_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attendance_recorded_at": {
+          "name": "attendance_recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roached_out_at": {
+          "name": "roached_out_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_up_at": {
+          "name": "signed_up_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_event_signups_event_id": {
+          "name": "idx_event_signups_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_signups_discord_user_id": {
+          "name": "idx_event_signups_discord_user_id",
+          "columns": [
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_signups_user_id": {
+          "name": "idx_event_signups_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_signups_event_id_status": {
+          "name": "idx_event_signups_event_id_status",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_signups_event_id_events_id_fk": {
+          "name": "event_signups_event_id_events_id_fk",
+          "tableFrom": "event_signups",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_signups_user_id_users_id_fk": {
+          "name": "event_signups_user_id_users_id_fk",
+          "tableFrom": "event_signups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_signups_character_id_characters_id_fk": {
+          "name": "event_signups_character_id_characters_id_fk",
+          "tableFrom": "event_signups",
+          "tableTo": "characters",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_user": {
+          "name": "unique_event_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id"
+          ]
+        },
+        "unique_event_discord_user": {
+          "name": "unique_event_discord_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "discord_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_or_discord": {
+          "name": "user_or_discord",
+          "value": "\"event_signups\".\"user_id\" IS NOT NULL OR \"event_signups\".\"discord_user_id\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.characters": {
+      "name": "characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "realm": {
+          "name": "realm",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class": {
+          "name": "class",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_override": {
+          "name": "role_override",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_main": {
+          "name": "is_main",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "item_level": {
+          "name": "item_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "render_url": {
+          "name": "render_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "race": {
+          "name": "race",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faction": {
+          "name": "faction",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_url": {
+          "name": "profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_variant": {
+          "name": "game_variant",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "equipment": {
+          "name": "equipment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "talents": {
+          "name": "talents",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_one_main_per_game": {
+          "name": "idx_one_main_per_game",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"characters\".\"is_main\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_characters_user_id": {
+          "name": "idx_characters_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_characters_user_id_name": {
+          "name": "idx_characters_user_id_name",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "characters_user_id_users_id_fk": {
+          "name": "characters_user_id_users_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "characters_game_id_games_id_fk": {
+          "name": "characters_game_id_games_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_game_character": {
+          "name": "unique_user_game_character",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id",
+            "name",
+            "realm"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.local_credentials": {
+      "name": "local_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "local_credentials_user_id_users_id_fk": {
+          "name": "local_credentials_user_id_users_id_fk",
+          "tableFrom": "local_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "local_credentials_email_unique": {
+          "name": "local_credentials_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.availability": {
+      "name": "availability",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_range": {
+          "name": "time_range",
+          "type": "tsrange",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_availability_user_id": {
+          "name": "idx_availability_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "availability_user_id_users_id_fk": {
+          "name": "availability_user_id_users_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "availability_game_id_games_id_fk": {
+          "name": "availability_game_id_games_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "availability_source_event_id_events_id_fk": {
+          "name": "availability_source_event_id_events_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "events",
+          "columnsFrom": [
+            "source_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roster_assignments": {
+      "name": "roster_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signup_id": {
+          "name": "signup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "is_override": {
+          "name": "is_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_roster_assignments_event_id": {
+          "name": "idx_roster_assignments_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_roster_assignments_signup_id": {
+          "name": "idx_roster_assignments_signup_id",
+          "columns": [
+            {
+              "expression": "signup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roster_assignments_event_id_events_id_fk": {
+          "name": "roster_assignments_event_id_events_id_fk",
+          "tableFrom": "roster_assignments",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "roster_assignments_signup_id_event_signups_id_fk": {
+          "name": "roster_assignments_signup_id_event_signups_id_fk",
+          "tableFrom": "roster_assignments",
+          "tableTo": "event_signups",
+          "columnsFrom": [
+            "signup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_signup": {
+          "name": "unique_event_signup",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "signup_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_settings_key_unique": {
+          "name": "app_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_expires_at": {
+          "name": "idx_notifications_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_preferences": {
+      "name": "user_notification_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_prefs": {
+          "name": "channel_prefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"slot_vacated\":{\"inApp\":true,\"push\":true,\"discord\":true},\"event_reminder\":{\"inApp\":true,\"push\":true,\"discord\":true},\"new_event\":{\"inApp\":true,\"push\":true,\"discord\":true},\"subscribed_game\":{\"inApp\":true,\"push\":true,\"discord\":true},\"achievement_unlocked\":{\"inApp\":true,\"push\":false,\"discord\":false},\"level_up\":{\"inApp\":true,\"push\":false,\"discord\":false},\"missed_event_nudge\":{\"inApp\":true,\"push\":true,\"discord\":true},\"event_rescheduled\":{\"inApp\":true,\"push\":true,\"discord\":true},\"bench_promoted\":{\"inApp\":true,\"push\":true,\"discord\":true},\"event_cancelled\":{\"inApp\":true,\"push\":true,\"discord\":true},\"roster_reassigned\":{\"inApp\":true,\"push\":true,\"discord\":true},\"tentative_displaced\":{\"inApp\":true,\"push\":true,\"discord\":true},\"member_returned\":{\"inApp\":true,\"push\":true,\"discord\":true},\"recruitment_reminder\":{\"inApp\":true,\"push\":true,\"discord\":true},\"role_gap_alert\":{\"inApp\":true,\"push\":true,\"discord\":true},\"lineup_steam_nudge\":{\"inApp\":true,\"push\":false,\"discord\":true},\"community_lineup\":{\"inApp\":true,\"push\":true,\"discord\":true},\"system\":{\"inApp\":true,\"push\":false,\"discord\":false}}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_preferences_user_id_users_id_fk": {
+          "name": "user_notification_preferences_user_id_users_id_fk",
+          "tableFrom": "user_notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_preference_key": {
+          "name": "unique_user_preference_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_time_templates": {
+      "name": "game_time_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_hour": {
+          "name": "start_hour",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_time_templates_user_id_idx": {
+          "name": "game_time_templates_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_time_templates_user_id_users_id_fk": {
+          "name": "game_time_templates_user_id_users_id_fk",
+          "tableFrom": "game_time_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_game_time_slot": {
+          "name": "unique_user_game_time_slot",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "day_of_week",
+            "start_hour"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_time_absences": {
+      "name": "game_time_absences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_time_absences_user_id_idx": {
+          "name": "game_time_absences_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_time_absences_user_id_users_id_fk": {
+          "name": "game_time_absences_user_id_users_id_fk",
+          "tableFrom": "game_time_absences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_time_overrides": {
+      "name": "game_time_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hour": {
+          "name": "hour",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_time_overrides_user_id_idx": {
+          "name": "game_time_overrides_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_time_overrides_user_id_users_id_fk": {
+          "name": "game_time_overrides_user_id_users_id_fk",
+          "tableFrom": "game_time_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_override_date_hour": {
+          "name": "unique_user_override_date_hour",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "date",
+            "hour"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_interests": {
+      "name": "game_interests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "playtime_forever": {
+          "name": "playtime_forever",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playtime_2weeks": {
+          "name": "playtime_2weeks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_game_interests_game_id": {
+          "name": "idx_game_interests_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_interests_user_id_users_id_fk": {
+          "name": "game_interests_user_id_users_id_fk",
+          "tableFrom": "game_interests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_interests_game_id_games_id_fk": {
+          "name": "game_interests_game_id_games_id_fk",
+          "tableFrom": "game_interests",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_user_game_interest_source": {
+          "name": "uq_user_game_interest_source",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id",
+            "source"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_reminders_sent": {
+      "name": "event_reminders_sent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reminder_type": {
+          "name": "reminder_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_reminders_sent_event_id_events_id_fk": {
+          "name": "event_reminders_sent_event_id_events_id_fk",
+          "tableFrom": "event_reminders_sent",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_reminders_sent_user_id_users_id_fk": {
+          "name": "event_reminders_sent_user_id_users_id_fk",
+          "tableFrom": "event_reminders_sent",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_user_reminder": {
+          "name": "unique_event_user_reminder",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id",
+            "reminder_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_templates": {
+      "name": "event_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_templates_user_id_users_id_fk": {
+          "name": "event_templates_user_id_users_id_fk",
+          "tableFrom": "event_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plugins": {
+      "name": "plugins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config_json": {
+          "name": "config_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plugins_slug_unique": {
+          "name": "plugins_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_user_id_users_id_fk": {
+          "name": "feedback_user_id_users_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pug_slots": {
+      "name": "pug_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_avatar_hash": {
+          "name": "discord_avatar_hash",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class": {
+          "name": "class",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "server_invite_url": {
+          "name": "server_invite_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_event_pug": {
+          "name": "unique_event_pug",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pug_slots\".\"discord_username\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_invite_code": {
+          "name": "unique_invite_code",
+          "columns": [
+            {
+              "expression": "invite_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pug_slots\".\"invite_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pug_slots_event_id_events_id_fk": {
+          "name": "pug_slots_event_id_events_id_fk",
+          "tableFrom": "pug_slots",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pug_slots_claimed_by_user_id_users_id_fk": {
+          "name": "pug_slots_claimed_by_user_id_users_id_fk",
+          "tableFrom": "pug_slots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "claimed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pug_slots_created_by_users_id_fk": {
+          "name": "pug_slots_created_by_users_id_fk",
+          "tableFrom": "pug_slots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cron_jobs": {
+      "name": "cron_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_slug": {
+          "name": "plugin_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Other'"
+        },
+        "paused": {
+          "name": "paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cron_jobs_name_unique": {
+          "name": "cron_jobs_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cron_job_executions": {
+      "name": "cron_job_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cron_job_id": {
+          "name": "cron_job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cron_job_executions_job_started_idx": {
+          "name": "cron_job_executions_job_started_idx",
+          "columns": [
+            {
+              "expression": "cron_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cron_job_executions_cron_job_id_cron_jobs_id_fk": {
+          "name": "cron_job_executions_cron_job_id_cron_jobs_id_fk",
+          "tableFrom": "cron_job_executions",
+          "tableTo": "cron_jobs",
+          "columnsFrom": [
+            "cron_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_event_messages": {
+      "name": "discord_event_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embed_state": {
+          "name": "embed_state",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'posted'"
+        },
+        "bump_message_id": {
+          "name": "bump_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_discord_event_messages_event": {
+          "name": "idx_discord_event_messages_event",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_discord_event_messages_message": {
+          "name": "idx_discord_event_messages_message",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_event_messages_event_id_events_id_fk": {
+          "name": "discord_event_messages_event_id_events_id_fk",
+          "tableFrom": "discord_event_messages",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_channel_message": {
+          "name": "unique_event_channel_message",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "channel_id",
+            "message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_bindings": {
+      "name": "channel_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding_purpose": {
+          "name": "binding_purpose",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_group_id": {
+          "name": "recurrence_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_bindings_guild_channel_series_unique": {
+          "name": "channel_bindings_guild_channel_series_unique",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurrence_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_bindings_guild": {
+          "name": "idx_channel_bindings_guild",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_bindings_game": {
+          "name": "idx_channel_bindings_game",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_bindings_recurrence_group": {
+          "name": "idx_channel_bindings_recurrence_group",
+          "columns": [
+            {
+              "expression": "recurrence_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_bindings_game_id_games_id_fk": {
+          "name": "channel_bindings_game_id_games_id_fk",
+          "tableFrom": "channel_bindings",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_event_reminders_sent": {
+      "name": "post_event_reminders_sent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pug_slot_id": {
+          "name": "pug_slot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_event_reminders_sent_event_id_events_id_fk": {
+          "name": "post_event_reminders_sent_event_id_events_id_fk",
+          "tableFrom": "post_event_reminders_sent",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_event_reminders_sent_pug_slot_id_pug_slots_id_fk": {
+          "name": "post_event_reminders_sent_pug_slot_id_pug_slots_id_fk",
+          "tableFrom": "post_event_reminders_sent",
+          "tableTo": "pug_slots",
+          "columnsFrom": [
+            "pug_slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_post_event_pug_reminder": {
+          "name": "unique_post_event_pug_reminder",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "pug_slot_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_plans": {
+      "name": "event_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slot_config": {
+          "name": "slot_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_attendees": {
+          "name": "max_attendees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_unbench": {
+          "name": "auto_unbench",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_options": {
+          "name": "poll_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_duration_hours": {
+          "name": "poll_duration_hours",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_mode": {
+          "name": "poll_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "poll_round": {
+          "name": "poll_round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "poll_channel_id": {
+          "name": "poll_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_message_id": {
+          "name": "poll_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "winning_option": {
+          "name": "winning_option",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_event_id": {
+          "name": "created_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_instances": {
+          "name": "content_instances",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_15min": {
+          "name": "reminder_15min",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_1hour": {
+          "name": "reminder_1hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_24hour": {
+          "name": "reminder_24hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "poll_started_at": {
+          "name": "poll_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_ends_at": {
+          "name": "poll_ends_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_event_plans_creator_id": {
+          "name": "idx_event_plans_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_plans_status": {
+          "name": "idx_event_plans_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_plans_creator_id_users_id_fk": {
+          "name": "event_plans_creator_id_users_id_fk",
+          "tableFrom": "event_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_plans_game_id_games_id_fk": {
+          "name": "event_plans_game_id_games_id_fk",
+          "tableFrom": "event_plans",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "event_plans_created_event_id_events_id_fk": {
+          "name": "event_plans_created_event_id_events_id_fk",
+          "tableFrom": "event_plans",
+          "tableTo": "events",
+          "columnsFrom": [
+            "created_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_dungeon_quests": {
+      "name": "wow_classic_dungeon_quests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dungeon_instance_id": {
+          "name": "dungeon_instance_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quest_level": {
+          "name": "quest_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_level": {
+          "name": "required_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expansion": {
+          "name": "expansion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quest_giver_npc": {
+          "name": "quest_giver_npc",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quest_giver_zone": {
+          "name": "quest_giver_zone",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_quest_id": {
+          "name": "prev_quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_quest_id": {
+          "name": "next_quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewards_json": {
+          "name": "rewards_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objectives": {
+          "name": "objectives",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_restriction": {
+          "name": "class_restriction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "race_restriction": {
+          "name": "race_restriction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_inside_dungeon": {
+          "name": "starts_inside_dungeon",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sharable": {
+          "name": "sharable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reward_xp": {
+          "name": "reward_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_gold": {
+          "name": "reward_gold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_type": {
+          "name": "reward_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wow_classic_dungeon_quests_quest_id_unique": {
+          "name": "wow_classic_dungeon_quests_quest_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "quest_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_boss_loot": {
+      "name": "wow_classic_boss_loot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "boss_id": {
+          "name": "boss_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot": {
+          "name": "slot",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality": {
+          "name": "quality",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_level": {
+          "name": "item_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drop_rate": {
+          "name": "drop_rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expansion": {
+          "name": "expansion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_restrictions": {
+          "name": "class_restrictions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_subclass": {
+          "name": "item_subclass",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wow_classic_boss_loot_boss_id_wow_classic_bosses_id_fk": {
+          "name": "wow_classic_boss_loot_boss_id_wow_classic_bosses_id_fk",
+          "tableFrom": "wow_classic_boss_loot",
+          "tableTo": "wow_classic_bosses",
+          "columnsFrom": [
+            "boss_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_loot_boss_item_expansion": {
+          "name": "uq_loot_boss_item_expansion",
+          "nullsNotDistinct": false,
+          "columns": [
+            "boss_id",
+            "item_id",
+            "expansion"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_bosses": {
+      "name": "wow_classic_bosses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expansion": {
+          "name": "expansion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sod_modified": {
+          "name": "sod_modified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_boss_instance_name_expansion": {
+          "name": "uq_boss_instance_name_expansion",
+          "nullsNotDistinct": false,
+          "columns": [
+            "instance_id",
+            "name",
+            "expansion"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_quest_progress": {
+      "name": "wow_classic_quest_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picked_up": {
+          "name": "picked_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wow_classic_quest_progress_event_id_events_id_fk": {
+          "name": "wow_classic_quest_progress_event_id_events_id_fk",
+          "tableFrom": "wow_classic_quest_progress",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wow_classic_quest_progress_user_id_users_id_fk": {
+          "name": "wow_classic_quest_progress_user_id_users_id_fk",
+          "tableFrom": "wow_classic_quest_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_quest_progress_event_user_quest": {
+          "name": "uq_quest_progress_event_user_quest",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id",
+            "quest_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_activity_sessions": {
+      "name": "game_activity_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_activity_name": {
+          "name": "discord_activity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "game_activity_sessions_user_game_started_idx": {
+          "name": "game_activity_sessions_user_game_started_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "game_activity_sessions_game_started_idx": {
+          "name": "game_activity_sessions_game_started_idx",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_activity_sessions_user_id_users_id_fk": {
+          "name": "game_activity_sessions_user_id_users_id_fk",
+          "tableFrom": "game_activity_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_activity_sessions_game_id_games_id_fk": {
+          "name": "game_activity_sessions_game_id_games_id_fk",
+          "tableFrom": "game_activity_sessions",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_activity_rollups": {
+      "name": "game_activity_rollups",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period": {
+          "name": "period",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_seconds": {
+          "name": "total_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "game_activity_rollups_game_period_start_idx": {
+          "name": "game_activity_rollups_game_period_start_idx",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_activity_rollups_user_id_users_id_fk": {
+          "name": "game_activity_rollups_user_id_users_id_fk",
+          "tableFrom": "game_activity_rollups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_activity_rollups_game_id_games_id_fk": {
+          "name": "game_activity_rollups_game_id_games_id_fk",
+          "tableFrom": "game_activity_rollups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "game_activity_rollups_user_game_period_unique": {
+          "name": "game_activity_rollups_user_game_period_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id",
+            "period",
+            "period_start"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_game_mappings": {
+      "name": "discord_game_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "discord_activity_name": {
+          "name": "discord_activity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "discord_game_mappings_game_id_games_id_fk": {
+          "name": "discord_game_mappings_game_id_games_id_fk",
+          "tableFrom": "discord_game_mappings",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_game_mappings_discord_activity_name_unique": {
+          "name": "discord_game_mappings_discord_activity_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_activity_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ad_hoc_participants": {
+      "name": "ad_hoc_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_avatar_hash": {
+          "name": "discord_avatar_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_duration_seconds": {
+          "name": "total_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "ad_hoc_participants_event_discord_user_unique": {
+          "name": "ad_hoc_participants_event_discord_user_unique",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ad_hoc_participants_event": {
+          "name": "idx_ad_hoc_participants_event",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ad_hoc_participants_user": {
+          "name": "idx_ad_hoc_participants_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ad_hoc_participants_event_id_events_id_fk": {
+          "name": "ad_hoc_participants_event_id_events_id_fk",
+          "tableFrom": "ad_hoc_participants",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ad_hoc_participants_user_id_users_id_fk": {
+          "name": "ad_hoc_participants_user_id_users_id_fk",
+          "tableFrom": "ad_hoc_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_interest_suppressions": {
+      "name": "game_interest_suppressions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suppressed_at": {
+          "name": "suppressed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_interest_suppressions_user_id_users_id_fk": {
+          "name": "game_interest_suppressions_user_id_users_id_fk",
+          "tableFrom": "game_interest_suppressions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_interest_suppressions_game_id_games_id_fk": {
+          "name": "game_interest_suppressions_game_id_games_id_fk",
+          "tableFrom": "game_interest_suppressions",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_user_game_suppression": {
+          "name": "uq_user_game_suppression",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_voice_sessions": {
+      "name": "event_voice_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_join_at": {
+          "name": "first_join_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_leave_at": {
+          "name": "last_leave_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_duration_sec": {
+          "name": "total_duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "segments": {
+          "name": "segments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "event_voice_sessions_event_discord_user_unique": {
+          "name": "event_voice_sessions_event_discord_user_unique",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_voice_sessions_event": {
+          "name": "idx_event_voice_sessions_event",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_voice_sessions_event_id_events_id_fk": {
+          "name": "event_voice_sessions_event_id_events_id_fk",
+          "tableFrom": "event_voice_sessions",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_voice_sessions_user_id_users_id_fk": {
+          "name": "event_voice_sessions_user_id_users_id_fk",
+          "tableFrom": "event_voice_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrichments": {
+      "name": "enrichments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enricher_key": {
+          "name": "enricher_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_enrichments_entity": {
+          "name": "idx_enrichments_entity",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_entity_enricher": {
+          "name": "unique_entity_enricher",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "enricher_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_request_logs": {
+      "name": "ai_request_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "feature": {
+          "name": "feature",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ai_request_logs_created_at": {
+          "name": "idx_ai_request_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_request_logs_feature_created_at": {
+          "name": "idx_ai_request_logs_feature_created_at",
+          "columns": [
+            {
+              "expression": "feature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_request_logs_user_id_users_id_fk": {
+          "name": "ai_request_logs_user_id_users_id_fk",
+          "tableFrom": "ai_request_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_entries": {
+      "name": "community_lineup_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nominated_by": {
+          "name": "nominated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carried_over_from": {
+          "name": "carried_over_from",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_entries_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_entries_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_entries",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_entries_game_id_games_id_fk": {
+          "name": "community_lineup_entries_game_id_games_id_fk",
+          "tableFrom": "community_lineup_entries",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_entries_nominated_by_users_id_fk": {
+          "name": "community_lineup_entries_nominated_by_users_id_fk",
+          "tableFrom": "community_lineup_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "nominated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_entries_carried_over_from_community_lineups_id_fk": {
+          "name": "community_lineup_entries_carried_over_from_community_lineups_id_fk",
+          "tableFrom": "community_lineup_entries",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "carried_over_from"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lineup_entry_game": {
+          "name": "uq_lineup_entry_game",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineup_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_invitees": {
+      "name": "community_lineup_invitees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_invitees_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_invitees_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_invitees",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_invitees_user_id_users_id_fk": {
+          "name": "community_lineup_invitees_user_id_users_id_fk",
+          "tableFrom": "community_lineup_invitees",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lineup_invitee_user": {
+          "name": "uq_lineup_invitee_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineup_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_votes": {
+      "name": "community_lineup_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_votes_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_votes_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_votes",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_votes_user_id_users_id_fk": {
+          "name": "community_lineup_votes_user_id_users_id_fk",
+          "tableFrom": "community_lineup_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_votes_game_id_games_id_fk": {
+          "name": "community_lineup_votes_game_id_games_id_fk",
+          "tableFrom": "community_lineup_votes",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lineup_vote_user_game": {
+          "name": "uq_lineup_vote_user_game",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineup_id",
+            "user_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineups": {
+      "name": "community_lineups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'building'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_game_id": {
+          "name": "decided_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_event_id": {
+          "name": "linked_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voting_deadline": {
+          "name": "voting_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase_deadline": {
+          "name": "phase_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase_duration_override": {
+          "name": "phase_duration_override",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_threshold": {
+          "name": "match_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 35
+        },
+        "max_votes_per_player": {
+          "name": "max_votes_per_player",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "default_tiebreaker_mode": {
+          "name": "default_tiebreaker_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_tiebreaker_id": {
+          "name": "active_tiebreaker_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_created_channel_id": {
+          "name": "discord_created_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_created_message_id": {
+          "name": "discord_created_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_override_id": {
+          "name": "channel_override_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineups_decided_game_id_games_id_fk": {
+          "name": "community_lineups_decided_game_id_games_id_fk",
+          "tableFrom": "community_lineups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "decided_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_lineups_linked_event_id_events_id_fk": {
+          "name": "community_lineups_linked_event_id_events_id_fk",
+          "tableFrom": "community_lineups",
+          "tableTo": "events",
+          "columnsFrom": [
+            "linked_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_lineups_created_by_users_id_fk": {
+          "name": "community_lineups_created_by_users_id_fk",
+          "tableFrom": "community_lineups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_tiebreaker_bracket_matchups": {
+      "name": "community_lineup_tiebreaker_bracket_matchups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tiebreaker_id": {
+          "name": "tiebreaker_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_a_id": {
+          "name": "game_a_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_b_id": {
+          "name": "game_b_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "winner_game_id": {
+          "name": "winner_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bye": {
+          "name": "is_bye",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_tiebreaker_bracket_matchups_tiebreaker_id_community_lineup_tiebreakers_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_matchups_tiebreaker_id_community_lineup_tiebreakers_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_matchups",
+          "tableTo": "community_lineup_tiebreakers",
+          "columnsFrom": [
+            "tiebreaker_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_matchups_game_a_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_matchups_game_a_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_matchups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_matchups_game_b_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_matchups_game_b_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_matchups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_matchups_winner_game_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_matchups_winner_game_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_matchups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "winner_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_tiebreaker_matchup_round_pos": {
+          "name": "uq_tiebreaker_matchup_round_pos",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tiebreaker_id",
+            "round",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_tiebreaker_bracket_votes": {
+      "name": "community_lineup_tiebreaker_bracket_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "matchup_id": {
+          "name": "matchup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_tiebreaker_bracket_votes_matchup_id_community_lineup_tiebreaker_bracket_matchups_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_votes_matchup_id_community_lineup_tiebreaker_bracket_matchups_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_votes",
+          "tableTo": "community_lineup_tiebreaker_bracket_matchups",
+          "columnsFrom": [
+            "matchup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_votes_user_id_users_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_votes_user_id_users_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_votes_game_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_votes_game_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_votes",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_tiebreaker_bracket_vote": {
+          "name": "uq_tiebreaker_bracket_vote",
+          "nullsNotDistinct": false,
+          "columns": [
+            "matchup_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_tiebreaker_vetoes": {
+      "name": "community_lineup_tiebreaker_vetoes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tiebreaker_id": {
+          "name": "tiebreaker_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revealed": {
+          "name": "revealed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_tiebreaker_vetoes_tiebreaker_id_community_lineup_tiebreakers_id_fk": {
+          "name": "community_lineup_tiebreaker_vetoes_tiebreaker_id_community_lineup_tiebreakers_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_vetoes",
+          "tableTo": "community_lineup_tiebreakers",
+          "columnsFrom": [
+            "tiebreaker_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_vetoes_user_id_users_id_fk": {
+          "name": "community_lineup_tiebreaker_vetoes_user_id_users_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_vetoes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_vetoes_game_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_vetoes_game_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_vetoes",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_tiebreaker_veto_user": {
+          "name": "uq_tiebreaker_veto_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tiebreaker_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_tiebreakers": {
+      "name": "community_lineup_tiebreakers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "tied_game_ids": {
+          "name": "tied_game_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_vote_count": {
+          "name": "original_vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "winner_game_id": {
+          "name": "winner_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round_deadline": {
+          "name": "round_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_tiebreakers_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_tiebreakers_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_tiebreakers",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreakers_winner_game_id_games_id_fk": {
+          "name": "community_lineup_tiebreakers_winner_game_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreakers",
+          "tableTo": "games",
+          "columnsFrom": [
+            "winner_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_match_members": {
+      "name": "community_lineup_match_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_match_members_match_id_community_lineup_matches_id_fk": {
+          "name": "community_lineup_match_members_match_id_community_lineup_matches_id_fk",
+          "tableFrom": "community_lineup_match_members",
+          "tableTo": "community_lineup_matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_match_members_user_id_users_id_fk": {
+          "name": "community_lineup_match_members_user_id_users_id_fk",
+          "tableFrom": "community_lineup_match_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_match_member_user": {
+          "name": "uq_match_member_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_matches": {
+      "name": "community_lineup_matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'suggested'"
+        },
+        "threshold_met": {
+          "name": "threshold_met",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "vote_percentage": {
+          "name": "vote_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fit_type": {
+          "name": "fit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_event_id": {
+          "name": "linked_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_message_id": {
+          "name": "embed_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_channel_id": {
+          "name": "embed_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_vote_threshold": {
+          "name": "min_vote_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threshold_notified_at": {
+          "name": "threshold_notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_matches_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_matches_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_matches",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_matches_game_id_games_id_fk": {
+          "name": "community_lineup_matches_game_id_games_id_fk",
+          "tableFrom": "community_lineup_matches",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_matches_linked_event_id_events_id_fk": {
+          "name": "community_lineup_matches_linked_event_id_events_id_fk",
+          "tableFrom": "community_lineup_matches",
+          "tableTo": "events",
+          "columnsFrom": [
+            "linked_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lineup_match_game": {
+          "name": "uq_lineup_match_game",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineup_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_schedule_slots": {
+      "name": "community_lineup_schedule_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_time": {
+          "name": "proposed_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overlap_score": {
+          "name": "overlap_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_by": {
+          "name": "suggested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_schedule_slots_match_id_community_lineup_matches_id_fk": {
+          "name": "community_lineup_schedule_slots_match_id_community_lineup_matches_id_fk",
+          "tableFrom": "community_lineup_schedule_slots",
+          "tableTo": "community_lineup_matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_schedule_votes": {
+      "name": "community_lineup_schedule_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slot_id": {
+          "name": "slot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_schedule_votes_slot_id_community_lineup_schedule_slots_id_fk": {
+          "name": "community_lineup_schedule_votes_slot_id_community_lineup_schedule_slots_id_fk",
+          "tableFrom": "community_lineup_schedule_votes",
+          "tableTo": "community_lineup_schedule_slots",
+          "columnsFrom": [
+            "slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_schedule_votes_user_id_users_id_fk": {
+          "name": "community_lineup_schedule_votes_user_id_users_id_fk",
+          "tableFrom": "community_lineup_schedule_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_schedule_vote_user": {
+          "name": "uq_schedule_vote_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slot_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_activity_log_entity": {
+          "name": "idx_activity_log_entity",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_actor_id_users_id_fk": {
+          "name": "activity_log_actor_id_users_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_dedup": {
+      "name": "notification_dedup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_notification_dedup_key": {
+          "name": "uq_notification_dedup_key",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_dedup_expires_at": {
+          "name": "idx_notification_dedup_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consumed_intent_tokens": {
+      "name": "consumed_intent_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_consumed_intent_tokens_consumed_at": {
+          "name": "idx_consumed_intent_tokens_consumed_at",
+          "columns": [
+            {
+              "expression": "consumed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "consumed_intent_tokens_token_hash_unique": {
+          "name": "consumed_intent_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_taste_vectors": {
+      "name": "player_taste_vectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vector": {
+          "name": "vector",
+          "type": "vector(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intensity_metrics": {
+          "name": "intensity_metrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archetype": {
+          "name": "archetype",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "signal_hash": {
+          "name": "signal_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "player_taste_vectors_computed_at_idx": {
+          "name": "player_taste_vectors_computed_at_idx",
+          "columns": [
+            {
+              "expression": "computed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "player_taste_vectors_user_id_users_id_fk": {
+          "name": "player_taste_vectors_user_id_users_id_fk",
+          "tableFrom": "player_taste_vectors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "player_taste_vectors_user_id_unique": {
+          "name": "player_taste_vectors_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_intensity_snapshots": {
+      "name": "player_intensity_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_start": {
+          "name": "week_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_hours": {
+          "name": "total_hours",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_breakdown": {
+          "name": "game_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unique_games": {
+          "name": "unique_games",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longest_session_hours": {
+          "name": "longest_session_hours",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longest_session_game_id": {
+          "name": "longest_session_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "player_intensity_snapshots_week_start_idx": {
+          "name": "player_intensity_snapshots_week_start_idx",
+          "columns": [
+            {
+              "expression": "week_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "player_intensity_snapshots_user_id_users_id_fk": {
+          "name": "player_intensity_snapshots_user_id_users_id_fk",
+          "tableFrom": "player_intensity_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "player_intensity_snapshots_longest_session_game_id_games_id_fk": {
+          "name": "player_intensity_snapshots_longest_session_game_id_games_id_fk",
+          "tableFrom": "player_intensity_snapshots",
+          "tableTo": "games",
+          "columnsFrom": [
+            "longest_session_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_player_intensity_user_week": {
+          "name": "uq_player_intensity_user_week",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "week_start"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_co_play": {
+      "name": "player_co_play",
+      "schema": "",
+      "columns": {
+        "user_id_a": {
+          "name": "user_id_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id_b": {
+          "name": "user_id_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_minutes": {
+          "name": "total_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_played_at": {
+          "name": "last_played_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "games_played": {
+          "name": "games_played",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "player_co_play_user_id_a_users_id_fk": {
+          "name": "player_co_play_user_id_a_users_id_fk",
+          "tableFrom": "player_co_play",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id_a"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "player_co_play_user_id_b_users_id_fk": {
+          "name": "player_co_play_user_id_b_users_id_fk",
+          "tableFrom": "player_co_play",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id_b"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "player_co_play_user_id_a_user_id_b_pk": {
+          "name": "player_co_play_user_id_a_user_id_b_pk",
+          "columns": [
+            "user_id_a",
+            "user_id_b"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_player_co_play_canonical_order": {
+          "name": "chk_player_co_play_canonical_order",
+          "value": "\"player_co_play\".\"user_id_a\" < \"player_co_play\".\"user_id_b\""
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/src/drizzle/migrations/meta/_journal.json
+++ b/api/src/drizzle/migrations/meta/_journal.json
@@ -876,6 +876,13 @@
       "when": 1776559231021,
       "tag": "0124_lineup_channel_override",
       "breakpoints": true
+    },
+    {
+      "idx": 125,
+      "version": "7",
+      "when": 1776654398936,
+      "tag": "0125_private_lineups",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/drizzle/schema/community-lineups.ts
+++ b/api/src/drizzle/schema/community-lineups.ts
@@ -15,11 +15,15 @@ import { events } from './events';
 
 export type LineupStatus = 'building' | 'voting' | 'decided' | 'archived';
 
+/** Visibility mode for a community lineup (ROK-1065). */
+export type LineupVisibility = 'public' | 'private';
+
 /**
  * Community Lineups — collaborative game selection (ROK-933).
  *
  * Status flow: building → voting → decided → archived
- * Only one lineup may be in `building` or `voting` at a time.
+ * Multiple lineups may be active at once (ROK-1065 removed the
+ * "one active at a time" restriction).
  */
 export const communityLineups = pgTable('community_lineups', {
   id: serial('id').primaryKey(),
@@ -31,6 +35,16 @@ export const communityLineups = pgTable('community_lineups', {
     enum: ['building', 'voting', 'decided', 'archived'],
   })
     .default('building')
+    .notNull(),
+  /**
+   * Visibility mode (ROK-1065). 'public' lineups DM every linked member
+   * and post lifecycle embeds to the channel; 'private' lineups DM only
+   * invitees (plus the creator) and suppress the channel embed.
+   */
+  visibility: text('visibility', {
+    enum: ['public', 'private'],
+  })
+    .default('public')
     .notNull(),
   targetDate: timestamp('target_date'),
   decidedGameId: integer('decided_game_id').references(() => games.id),
@@ -117,5 +131,29 @@ export const communityLineupVotes = pgTable(
       table.userId,
       table.gameId,
     ),
+  ],
+);
+
+/**
+ * Per-lineup invitee list (ROK-1065).
+ *
+ * A private lineup's participation roster: only users rowed here (plus the
+ * creator and any admin/operator) may nominate or vote. For public lineups
+ * this table is unused.
+ */
+export const communityLineupInvitees = pgTable(
+  'community_lineup_invitees',
+  {
+    id: serial('id').primaryKey(),
+    lineupId: integer('lineup_id')
+      .references(() => communityLineups.id, { onDelete: 'cascade' })
+      .notNull(),
+    userId: integer('user_id')
+      .references(() => users.id, { onDelete: 'cascade' })
+      .notNull(),
+    createdAt: timestamp('created_at').defaultNow().notNull(),
+  },
+  (table) => [
+    unique('uq_lineup_invitee_user').on(table.lineupId, table.userId),
   ],
 );

--- a/api/src/igdb/igdb-itad-merge.helpers.ts
+++ b/api/src/igdb/igdb-itad-merge.helpers.ts
@@ -79,6 +79,9 @@ function buildItadBaseFields(itad: ItadSearchGame, boxart: string | null) {
     earlyAccess: false,
     firstReleaseDate: parseReleaseDate(itad.releaseDate),
     popularity: null,
+    // ITAD owns the Steam app ID mapping — IGDB's external_games.uid is
+    // unreliable for games that aren't sold on Steam, so we defer to ITAD.
+    steamAppId: itad.steamAppId ?? null,
   };
 }
 

--- a/api/src/igdb/igdb.mappers.ts
+++ b/api/src/igdb/igdb.mappers.ts
@@ -156,10 +156,10 @@ export function mapDbRowToDetail(
     twitchGameId: g.twitchGameId,
     crossplay: g.crossplay ?? null,
     earlyAccess: g.earlyAccess ?? false,
-    // IGDB external_games sometimes lists a Steam app ID for games that
-    // aren't actually on Steam (e.g. Blizzard MMOs). ITAD only indexes
-    // real digital-store listings, so treat a missing itad_game_id as a
-    // signal that the Steam ID is unreliable and hide the link.
+    // ITAD is the authoritative source for Steam app IDs — IGDB's
+    // external_games.uid is unreliable for games that aren't actually
+    // on Steam (e.g. Blizzard MMOs). Only surface steam_app_id when
+    // ITAD has also indexed the game, which confirms a real listing.
     steamAppId: g.itadGameId ? (g.steamAppId ?? null) : null,
     ...mapItadPricing(g),
   };

--- a/api/src/igdb/igdb.mappers.ts
+++ b/api/src/igdb/igdb.mappers.ts
@@ -156,6 +156,7 @@ export function mapDbRowToDetail(
     twitchGameId: g.twitchGameId,
     crossplay: g.crossplay ?? null,
     earlyAccess: g.earlyAccess ?? false,
+    steamAppId: g.steamAppId ?? null,
     ...mapItadPricing(g),
   };
 }

--- a/api/src/igdb/igdb.mappers.ts
+++ b/api/src/igdb/igdb.mappers.ts
@@ -156,7 +156,11 @@ export function mapDbRowToDetail(
     twitchGameId: g.twitchGameId,
     crossplay: g.crossplay ?? null,
     earlyAccess: g.earlyAccess ?? false,
-    steamAppId: g.steamAppId ?? null,
+    // IGDB external_games sometimes lists a Steam app ID for games that
+    // aren't actually on Steam (e.g. Blizzard MMOs). ITAD only indexes
+    // real digital-store listings, so treat a missing itad_game_id as a
+    // signal that the Steam ID is unreliable and hide the link.
+    steamAppId: g.itadGameId ? (g.steamAppId ?? null) : null,
     ...mapItadPricing(g),
   };
 }

--- a/api/src/igdb/igdb.service.spec.ts
+++ b/api/src/igdb/igdb.service.spec.ts
@@ -101,6 +101,7 @@ describe('IgdbService', () => {
       itadLowestCut: null,
       itadPriceUpdatedAt: null,
       earlyAccess: false,
+      steamAppId: null,
     },
   ];
 

--- a/api/src/lineups/common-ground-context.helpers.ts
+++ b/api/src/lineups/common-ground-context.helpers.ts
@@ -5,7 +5,7 @@
  * stays testable and under the 30-lines-per-function budget.
  */
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
-import { NotFoundException } from '@nestjs/common';
+import { BadRequestException, NotFoundException } from '@nestjs/common';
 import type {
   CommonGroundQueryDto,
   CommonGroundResponseDto,
@@ -17,6 +17,7 @@ import {
   countDistinctNominators,
   findBuildingLineup,
   findCoPlayPartnerIds,
+  findLineupById,
   findLineupVoterIds,
   findNominatedGameIds,
 } from './lineups-query.helpers';
@@ -78,8 +79,36 @@ function averageIntensityBucket(
 }
 
 /**
- * Orchestrate the full Common Ground query for the building lineup. Kept
- * here so `lineups.service` stays under the 300-line limit (ROK-950).
+ * Resolve the lineup to score Common Ground against (ROK-1065).
+ * Prefers `filters.lineupId` when the client specifies one — required for
+ * multi-lineup UIs (Schedule-a-Game picker, private-lineup pages) so the
+ * response reflects the lineup the user is viewing. Falls back to the
+ * newest building lineup when omitted. 400s when the requested lineup
+ * exists but isn't in building status; 404s when neither path finds one.
+ */
+async function resolveScoringLineup(
+  db: PostgresJsDatabase<typeof schema>,
+  filters: CommonGroundQueryDto,
+): Promise<{ id: number }> {
+  if (filters.lineupId != null) {
+    const [row] = await findLineupById(db, filters.lineupId);
+    if (!row) throw new NotFoundException('Lineup not found');
+    if (row.status !== 'building') {
+      throw new BadRequestException('Lineup is not in building status');
+    }
+    return { id: row.id };
+  }
+  const [lineup] = await findBuildingLineup(db);
+  if (!lineup)
+    throw new NotFoundException('No active lineup in building status');
+  return { id: lineup.id };
+}
+
+/**
+ * Orchestrate the full Common Ground query for a building lineup.
+ * Honors `filters.lineupId` (ROK-1065) so multi-lineup UIs can target the
+ * lineup the user is currently viewing instead of always scoring against
+ * the newest building row.
  */
 export async function runCommonGroundForBuildingLineup(
   db: PostgresJsDatabase<typeof schema>,
@@ -87,9 +116,7 @@ export async function runCommonGroundForBuildingLineup(
   tasteProfile: TasteProfileService,
   settings: SettingsService,
 ): Promise<CommonGroundResponseDto> {
-  const [lineup] = await findBuildingLineup(db);
-  if (!lineup)
-    throw new NotFoundException('No active lineup in building status');
+  const lineup = await resolveScoringLineup(db, filters);
   const nominated = await findNominatedGameIds(db, lineup.id);
   const [nominators] = await countDistinctNominators(db, lineup.id);
   const ctx = await buildScoringContext(db, lineup.id, tasteProfile, settings);

--- a/api/src/lineups/lineup-notification-dm-batch.helpers.ts
+++ b/api/src/lineups/lineup-notification-dm-batch.helpers.ts
@@ -13,6 +13,7 @@ import {
   sendEventCreatedDM,
   sendPrivateInviteDM,
 } from './lineup-notification-dm.helpers';
+import { dispatchMatchMemberDM } from './lineup-notification-dms.helpers';
 import {
   findDiscordLinkedMembers,
   findInviteeDiscordMembers,
@@ -103,6 +104,33 @@ export async function fanOutSchedulingDMs(
   const members = await findMatchMemberUsers(db, match.id);
   for (const m of members) {
     await sendSchedulingDM(notificationService, dedupService, match, m);
+  }
+}
+
+/**
+ * Fan-out decided-phase DMs: each member of each match receives a DM
+ * listing the game and their co-players on that match.
+ */
+export async function fanOutMatchMemberDMs(
+  db: Db,
+  notificationService: NotificationService,
+  dedupService: NotificationDedupService,
+  lineupId: number,
+  matches: ReadonlyArray<MatchInfo>,
+): Promise<void> {
+  for (const match of matches) {
+    const members = await findMatchMemberUsers(db, match.id);
+    const names = members.map((m) => m.displayName);
+    for (const member of members) {
+      const coPlayers = names.filter((n) => n !== member.displayName);
+      await dispatchMatchMemberDM(dedupService, notificationService, {
+        matchId: match.id,
+        userId: member.userId,
+        gameName: match.gameName,
+        coPlayers,
+        lineupId,
+      });
+    }
   }
 }
 

--- a/api/src/lineups/lineup-notification-dm-batch.helpers.ts
+++ b/api/src/lineups/lineup-notification-dm-batch.helpers.ts
@@ -14,6 +14,7 @@ import {
 } from './lineup-notification-dm.helpers';
 import {
   findDiscordLinkedMembers,
+  findInviteeDiscordMembers,
   findMatchMemberUsers,
 } from './lineup-notification-targets.helpers';
 
@@ -36,6 +37,49 @@ export async function fanOutVotingDMs(
       member,
       gameCount,
     );
+  }
+}
+
+/**
+ * Fan-out voting-open DMs to invitees + creator only (ROK-1065).
+ * Used for `visibility === 'private'` lineups.
+ */
+export async function fanOutVotingDMsToInvitees(
+  db: Db,
+  notificationService: NotificationService,
+  dedupService: NotificationDedupService,
+  lineup: LineupInfo,
+  gameCount: number,
+): Promise<void> {
+  const members = await findInviteeDiscordMembers(db, lineup.id);
+  for (const member of members) {
+    await sendVotingDM(
+      notificationService,
+      dedupService,
+      lineup,
+      member,
+      gameCount,
+    );
+  }
+}
+
+/**
+ * Fan-out lineup-created DMs to invitees + creator (ROK-1065).
+ *
+ * Private lineups suppress the channel embed and instead DM each invitee.
+ * Reuses sendVotingDM so the DM references the lineup title; the smoke
+ * test only asserts that *some* DM mentioning the title reaches the
+ * invitee before the lineup transitions to voting.
+ */
+export async function fanOutLineupCreatedDMsToInvitees(
+  db: Db,
+  notificationService: NotificationService,
+  dedupService: NotificationDedupService,
+  lineup: LineupInfo,
+): Promise<void> {
+  const members = await findInviteeDiscordMembers(db, lineup.id);
+  for (const member of members) {
+    await sendVotingDM(notificationService, dedupService, lineup, member, 0);
   }
 }
 

--- a/api/src/lineups/lineup-notification-dm-batch.helpers.ts
+++ b/api/src/lineups/lineup-notification-dm-batch.helpers.ts
@@ -11,6 +11,7 @@ import {
   sendVotingDM,
   sendSchedulingDM,
   sendEventCreatedDM,
+  sendPrivateInviteDM,
 } from './lineup-notification-dm.helpers';
 import {
   findDiscordLinkedMembers,
@@ -79,7 +80,12 @@ export async function fanOutLineupCreatedDMsToInvitees(
 ): Promise<void> {
   const members = await findInviteeDiscordMembers(db, lineup.id);
   for (const member of members) {
-    await sendVotingDM(notificationService, dedupService, lineup, member, 0);
+    await sendPrivateInviteDM(
+      notificationService,
+      dedupService,
+      lineup,
+      member,
+    );
   }
 }
 

--- a/api/src/lineups/lineup-notification-dm-batch.helpers.ts
+++ b/api/src/lineups/lineup-notification-dm-batch.helpers.ts
@@ -27,7 +27,7 @@ export async function fanOutVotingDMs(
   notificationService: NotificationService,
   dedupService: NotificationDedupService,
   lineup: LineupInfo,
-  gameCount: number,
+  games: ReadonlyArray<{ id: number; name: string }>,
 ): Promise<void> {
   const members = await findDiscordLinkedMembers(db);
   for (const member of members) {
@@ -36,7 +36,7 @@ export async function fanOutVotingDMs(
       dedupService,
       lineup,
       member,
-      gameCount,
+      games,
     );
   }
 }
@@ -50,7 +50,7 @@ export async function fanOutVotingDMsToInvitees(
   notificationService: NotificationService,
   dedupService: NotificationDedupService,
   lineup: LineupInfo,
-  gameCount: number,
+  games: ReadonlyArray<{ id: number; name: string }>,
 ): Promise<void> {
   const members = await findInviteeDiscordMembers(db, lineup.id);
   for (const member of members) {
@@ -59,7 +59,7 @@ export async function fanOutVotingDMsToInvitees(
       dedupService,
       lineup,
       member,
-      gameCount,
+      games,
     );
   }
 }

--- a/api/src/lineups/lineup-notification-dm-batch.helpers.ts
+++ b/api/src/lineups/lineup-notification-dm-batch.helpers.ts
@@ -28,6 +28,7 @@ export async function fanOutVotingDMs(
   dedupService: NotificationDedupService,
   lineup: LineupInfo,
   games: ReadonlyArray<{ id: number; name: string }>,
+  baseUrl?: string,
 ): Promise<void> {
   const members = await findDiscordLinkedMembers(db);
   for (const member of members) {
@@ -37,6 +38,7 @@ export async function fanOutVotingDMs(
       lineup,
       member,
       games,
+      baseUrl,
     );
   }
 }
@@ -51,6 +53,7 @@ export async function fanOutVotingDMsToInvitees(
   dedupService: NotificationDedupService,
   lineup: LineupInfo,
   games: ReadonlyArray<{ id: number; name: string }>,
+  baseUrl?: string,
 ): Promise<void> {
   const members = await findInviteeDiscordMembers(db, lineup.id);
   for (const member of members) {
@@ -60,6 +63,7 @@ export async function fanOutVotingDMsToInvitees(
       lineup,
       member,
       games,
+      baseUrl,
     );
   }
 }

--- a/api/src/lineups/lineup-notification-dm.helpers.ts
+++ b/api/src/lineups/lineup-notification-dm.helpers.ts
@@ -25,6 +25,35 @@ export interface MatchDmInfo {
 /** Shape of a lineup for voting DMs. */
 export interface LineupDmInfo {
   id: number;
+  title?: string;
+}
+
+/**
+ * Send an invite DM for a private lineup (ROK-1065).
+ * The body includes the lineup title so the smoke test can match on it,
+ * and the DM is scoped per-invitee via a dedup key distinct from the
+ * voting-open key.
+ */
+export async function sendPrivateInviteDM(
+  notificationService: NotificationService,
+  dedupService: NotificationDedupService,
+  lineup: LineupDmInfo,
+  member: DiscordMember,
+): Promise<void> {
+  const key = `lineup-invite-dm:${lineup.id}:${member.userId}`;
+  if (await dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
+  const title = lineup.title ?? `Lineup #${lineup.id}`;
+
+  await notificationService.create({
+    userId: member.userId,
+    type: 'community_lineup',
+    title: `You're invited: ${title}`,
+    message: `You've been invited to the private Community Lineup "${title}". Head to the site to nominate and vote.`,
+    payload: {
+      subtype: 'lineup_invite',
+      lineupId: lineup.id,
+    },
+  });
 }
 
 /** Send a single voting-open DM to a member. */
@@ -37,11 +66,12 @@ export async function sendVotingDM(
 ): Promise<void> {
   const key = `lineup-vote-dm:${lineup.id}:${member.userId}`;
   if (await dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
+  const titleSuffix = lineup.title ? ` — ${lineup.title}` : '';
 
   await notificationService.create({
     userId: member.userId,
     type: 'community_lineup',
-    title: 'Time to vote on the Community Lineup!',
+    title: `Time to vote on the Community Lineup${titleSuffix}!`,
     message: `${gameCount} games are on the ballot — pick your favorites before voting closes.`,
     payload: {
       subtype: 'lineup_voting_open',

--- a/api/src/lineups/lineup-notification-dm.helpers.ts
+++ b/api/src/lineups/lineup-notification-dm.helpers.ts
@@ -26,13 +26,62 @@ export interface MatchDmInfo {
 export interface LineupDmInfo {
   id: number;
   title?: string;
+  /** Operator-authored markdown description (ROK-1063). */
+  description?: string | null;
+  /** Optional target play date, shown as Discord-native timestamp. */
+  targetDate?: Date;
+  /** Optional voting deadline, shown in the voting-open DM. */
+  votingDeadline?: Date;
+}
+
+/** Format a Date as a Discord-native relative+absolute timestamp. */
+function discordTs(d: Date): string {
+  const sec = Math.floor(d.getTime() / 1000);
+  return `<t:${sec}:F> (<t:${sec}:R>)`;
+}
+
+/** Phase-flow breadcrumb shared across lineup DMs (matches channel embeds). */
+const PHASE_FLOW =
+  '1. \u{1F539} **Nominations** — suggest games to play\n' +
+  '2. \u2796 **Voting** — pick your favorites from the nominees\n' +
+  '3. \u2796 **Scheduling** — top picks are matched, scheduled, and played!';
+
+/** Compose the invite DM body, mirroring the channel "Nominations Open" embed. */
+function composeInviteMessage(lineup: LineupDmInfo): string {
+  const title = lineup.title ?? `Lineup #${lineup.id}`;
+  const desc = lineup.description ? `${lineup.description}\n\n` : '';
+  const deadline = lineup.targetDate
+    ? `\n\n\u{1F4C5} **Target play date:** ${discordTs(lineup.targetDate)}`
+    : '';
+  return (
+    `${desc}You've been invited to the private Community Lineup **${title}**.\n\n` +
+    'Nominate games now; voting opens automatically once nominations close. ' +
+    'Phases advance on their own as each deadline passes:\n\n' +
+    `${PHASE_FLOW}\n\n` +
+    '\u{1F512} Only invitees (plus admins) can nominate or vote on this lineup — ' +
+    'the channel stays silent.' +
+    deadline
+  );
+}
+
+/** Compose the voting-open DM body, mirroring the channel "Voting Open" embed. */
+function composeVotingMessage(lineup: LineupDmInfo, gameCount: number): string {
+  const desc = lineup.description ? `${lineup.description}\n\n` : '';
+  const deadline = lineup.votingDeadline
+    ? `\n\n\u23F0 **Voting closes:** ${discordTs(lineup.votingDeadline)}`
+    : '';
+  return (
+    `${desc}Nominations are closed — voting is now open on your private lineup. ` +
+    `**${gameCount}** game${gameCount === 1 ? '' : 's'} on the ballot. ` +
+    'Each member gets a limited number of votes, so choose wisely.' +
+    deadline
+  );
 }
 
 /**
  * Send an invite DM for a private lineup (ROK-1065).
- * The body includes the lineup title so the smoke test can match on it,
- * and the DM is scoped per-invitee via a dedup key distinct from the
- * voting-open key.
+ * Body mirrors the "Nominations Open" channel embed so invitees get the
+ * same phase-flow context. Dedup key is distinct from the voting-open key.
  */
 export async function sendPrivateInviteDM(
   notificationService: NotificationService,
@@ -48,7 +97,7 @@ export async function sendPrivateInviteDM(
     userId: member.userId,
     type: 'community_lineup',
     title: `You're invited: ${title}`,
-    message: `You've been invited to the private Community Lineup "${title}". Head to the site to nominate and vote.`,
+    message: composeInviteMessage(lineup),
     payload: {
       subtype: 'lineup_invite',
       lineupId: lineup.id,
@@ -72,7 +121,7 @@ export async function sendVotingDM(
     userId: member.userId,
     type: 'community_lineup',
     title: `Time to vote on the Community Lineup${titleSuffix}!`,
-    message: `${gameCount} games are on the ballot — pick your favorites before voting closes.`,
+    message: composeVotingMessage(lineup, gameCount),
     payload: {
       subtype: 'lineup_voting_open',
       lineupId: lineup.id,

--- a/api/src/lineups/lineup-notification-dm.helpers.ts
+++ b/api/src/lineups/lineup-notification-dm.helpers.ts
@@ -65,17 +65,33 @@ function composeInviteMessage(lineup: LineupDmInfo): string {
 }
 
 /** Compose the voting-open DM body, mirroring the channel "Voting Open" embed. */
-function composeVotingMessage(lineup: LineupDmInfo, gameCount: number): string {
+function composeVotingMessage(
+  lineup: LineupDmInfo,
+  games: ReadonlyArray<{ id: number; name: string }>,
+): string {
   const desc = lineup.description ? `${lineup.description}\n\n` : '';
   const deadline = lineup.votingDeadline
     ? `\n\n\u23F0 **Voting closes:** ${discordTs(lineup.votingDeadline)}`
     : '';
+  const ballot = buildBallot(games);
   return (
     `${desc}Nominations are closed — voting is now open on your private lineup. ` +
-    `**${gameCount}** game${gameCount === 1 ? '' : 's'} on the ballot. ` +
-    'Each member gets a limited number of votes, so choose wisely.' +
+    'Pick the games you most want to play; each member gets a limited number ' +
+    'of votes, so choose wisely.' +
+    ballot +
     deadline
   );
+}
+
+/** Render up to 15 nominees as a bulleted ballot, matching the channel embed. */
+function buildBallot(
+  games: ReadonlyArray<{ id: number; name: string }>,
+): string {
+  if (games.length === 0) return '';
+  const lines = games.slice(0, 15).map((g) => `\u{1F3AE} **${g.name}**`);
+  const overflow =
+    games.length > 15 ? `\n*...and ${games.length - 15} more*` : '';
+  return `\n\n**Games on the Ballot (${games.length})**\n${lines.join('\n')}${overflow}`;
 }
 
 /**
@@ -111,7 +127,7 @@ export async function sendVotingDM(
   dedupService: NotificationDedupService,
   lineup: LineupDmInfo,
   member: DiscordMember,
-  gameCount: number,
+  games: ReadonlyArray<{ id: number; name: string }>,
 ): Promise<void> {
   const key = `lineup-vote-dm:${lineup.id}:${member.userId}`;
   if (await dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
@@ -121,7 +137,7 @@ export async function sendVotingDM(
     userId: member.userId,
     type: 'community_lineup',
     title: `Time to vote on the Community Lineup${titleSuffix}!`,
-    message: composeVotingMessage(lineup, gameCount),
+    message: composeVotingMessage(lineup, games),
     payload: {
       subtype: 'lineup_voting_open',
       lineupId: lineup.id,

--- a/api/src/lineups/lineup-notification-dm.helpers.ts
+++ b/api/src/lineups/lineup-notification-dm.helpers.ts
@@ -137,7 +137,13 @@ export async function sendVotingDM(
   games: ReadonlyArray<{ id: number; name: string }>,
   baseUrl?: string,
 ): Promise<void> {
-  const key = `lineup-vote-dm:${lineup.id}:${member.userId}`;
+  // Include the voting deadline in the dedup key so reverting
+  // voting → building → voting (which regenerates phaseDeadline) fires
+  // a fresh DM instead of being suppressed by the prior run's dedup.
+  const deadlineTag = lineup.votingDeadline
+    ? lineup.votingDeadline.toISOString()
+    : 'none';
+  const key = `lineup-vote-dm:${lineup.id}:${member.userId}:${deadlineTag}`;
   if (await dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
   const titleSuffix = lineup.title ? ` — ${lineup.title}` : '';
 

--- a/api/src/lineups/lineup-notification-dm.helpers.ts
+++ b/api/src/lineups/lineup-notification-dm.helpers.ts
@@ -68,12 +68,13 @@ function composeInviteMessage(lineup: LineupDmInfo): string {
 function composeVotingMessage(
   lineup: LineupDmInfo,
   games: ReadonlyArray<{ id: number; name: string }>,
+  baseUrl?: string,
 ): string {
   const desc = lineup.description ? `${lineup.description}\n\n` : '';
   const deadline = lineup.votingDeadline
     ? `\n\n\u23F0 **Voting closes:** ${discordTs(lineup.votingDeadline)}`
     : '';
-  const ballot = buildBallot(games);
+  const ballot = buildBallot(games, baseUrl);
   return (
     `${desc}Nominations are closed — voting is now open on your private lineup. ` +
     'Pick the games you most want to play; each member gets a limited number ' +
@@ -86,9 +87,15 @@ function composeVotingMessage(
 /** Render up to 15 nominees as a bulleted ballot, matching the channel embed. */
 function buildBallot(
   games: ReadonlyArray<{ id: number; name: string }>,
+  baseUrl?: string,
 ): string {
   if (games.length === 0) return '';
-  const lines = games.slice(0, 15).map((g) => `\u{1F3AE} **${g.name}**`);
+  const lines = games.slice(0, 15).map((g) => {
+    const label = baseUrl
+      ? `[**${g.name}**](${baseUrl}/games/${g.id})`
+      : `**${g.name}**`;
+    return `\u{1F3AE} ${label}`;
+  });
   const overflow =
     games.length > 15 ? `\n*...and ${games.length - 15} more*` : '';
   return `\n\n**Games on the Ballot (${games.length})**\n${lines.join('\n')}${overflow}`;
@@ -128,6 +135,7 @@ export async function sendVotingDM(
   lineup: LineupDmInfo,
   member: DiscordMember,
   games: ReadonlyArray<{ id: number; name: string }>,
+  baseUrl?: string,
 ): Promise<void> {
   const key = `lineup-vote-dm:${lineup.id}:${member.userId}`;
   if (await dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
@@ -137,7 +145,7 @@ export async function sendVotingDM(
     userId: member.userId,
     type: 'community_lineup',
     title: `Time to vote on the Community Lineup${titleSuffix}!`,
-    message: composeVotingMessage(lineup, games),
+    message: composeVotingMessage(lineup, games, baseUrl),
     payload: {
       subtype: 'lineup_voting_open',
       lineupId: lineup.id,

--- a/api/src/lineups/lineup-notification-routing.helpers.ts
+++ b/api/src/lineups/lineup-notification-routing.helpers.ts
@@ -1,0 +1,85 @@
+/**
+ * Visibility-routing helpers for LineupNotificationService (ROK-1065).
+ * Extracted to keep lineup-notification.service.ts under the 300-line ESLint ceiling.
+ *
+ * Private lineups suppress the channel embed and instead DM each invitee
+ * (plus the creator). These helpers centralize the `resolveVisibility`
+ * DB probe and the DM fan-out short-circuit used by `notifyLineupCreated`
+ * and `notifyVotingOpen`.
+ */
+import { eq } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from '../drizzle/schema';
+import type { NotificationService } from '../notifications/notification.service';
+import type { NotificationDedupService } from '../notifications/notification-dedup.service';
+import type { LineupInfo } from './lineup-notification.service';
+import {
+  fanOutLineupCreatedDMsToInvitees,
+  fanOutVotingDMsToInvitees,
+} from './lineup-notification-dm-batch.helpers';
+
+type Db = PostgresJsDatabase<typeof schema>;
+
+/**
+ * Resolve lineup visibility: prefer the caller-provided value, fall back
+ * to a DB lookup so older callers aren't broken (ROK-1065).
+ */
+export async function resolveLineupVisibility(
+  db: Db,
+  lineup: LineupInfo,
+): Promise<'public' | 'private'> {
+  if (lineup.visibility) return lineup.visibility;
+  const [row] = await db
+    .select({ visibility: schema.communityLineups.visibility })
+    .from(schema.communityLineups)
+    .where(eq(schema.communityLineups.id, lineup.id))
+    .limit(1);
+  return row?.visibility ?? 'public';
+}
+
+/**
+ * Private-branch dispatch for `notifyLineupCreated`: DM invitees and skip
+ * the channel embed. Returns true if the private path was taken.
+ */
+export async function routeLineupCreatedIfPrivate(
+  db: Db,
+  notificationService: NotificationService,
+  dedupService: NotificationDedupService,
+  lineup: LineupInfo,
+): Promise<boolean> {
+  const visibility = await resolveLineupVisibility(db, lineup);
+  if (visibility !== 'private') return false;
+  await fanOutLineupCreatedDMsToInvitees(
+    db,
+    notificationService,
+    dedupService,
+    lineup,
+  );
+  return true;
+}
+
+/**
+ * Private-branch dispatch for `notifyVotingOpen`: DM invitees with the
+ * voting game list and skip the channel embed. Returns true if the
+ * private path was taken.
+ */
+export async function routeVotingOpenIfPrivate(
+  db: Db,
+  notificationService: NotificationService,
+  dedupService: NotificationDedupService,
+  lineup: LineupInfo,
+  games: ReadonlyArray<{ id: number; name: string }>,
+  baseUrl: string | undefined,
+): Promise<boolean> {
+  const visibility = await resolveLineupVisibility(db, lineup);
+  if (visibility !== 'private') return false;
+  await fanOutVotingDMsToInvitees(
+    db,
+    notificationService,
+    dedupService,
+    lineup,
+    games,
+    baseUrl,
+  );
+  return true;
+}

--- a/api/src/lineups/lineup-notification-targets.helpers.ts
+++ b/api/src/lineups/lineup-notification-targets.helpers.ts
@@ -22,6 +22,32 @@ export async function findDiscordLinkedMembers(
   `)) as unknown as DiscordMember[];
 }
 
+/**
+ * Get Discord-linked invitees + creator for a private lineup (ROK-1065).
+ * The distinct union guarantees the creator is always included even if they
+ * haven't been explicitly invited.
+ */
+export async function findInviteeDiscordMembers(
+  db: Db,
+  lineupId: number,
+): Promise<DiscordMember[]> {
+  return (await db.execute(sql`
+    SELECT DISTINCT u.id, u.id AS "userId",
+           COALESCE(u.display_name, u.username) AS "displayName",
+           u.discord_id AS "discordId"
+    FROM users u
+    WHERE u.discord_id IS NOT NULL
+      AND (
+        u.id IN (
+          SELECT user_id FROM community_lineup_invitees WHERE lineup_id = ${lineupId}
+        )
+        OR u.id = (
+          SELECT created_by FROM community_lineups WHERE id = ${lineupId}
+        )
+      )
+  `)) as unknown as DiscordMember[];
+}
+
 /** Check if a match already has a poll embed posted (ROK-1033). */
 export async function hasExistingPollEmbed(
   db: Db,

--- a/api/src/lineups/lineup-notification.service.spec.ts
+++ b/api/src/lineups/lineup-notification.service.spec.ts
@@ -215,6 +215,34 @@ describe('LineupNotificationService', () => {
 
       expect(mockDb.update).not.toHaveBeenCalled();
     });
+
+    // ROK-1065: private visibility routes to invitee DMs instead of channel
+    describe('private visibility (ROK-1065)', () => {
+      it('dispatches invite DMs to invitees and skips the channel embed', async () => {
+        const invitees = [makeMember(11), makeMember(12)];
+        mockDb.execute.mockResolvedValueOnce(invitees);
+
+        await service.notifyLineupCreated(
+          makeLineup({ visibility: 'private', title: 'Team Night' }),
+        );
+
+        expect(mockBotClient.sendEmbed).not.toHaveBeenCalled();
+        expect(mockNotificationService.create).toHaveBeenCalledTimes(2);
+      });
+
+      it('uses the lineup-invite-dm dedup key per invitee', async () => {
+        mockDb.execute.mockResolvedValueOnce([makeMember(11)]);
+
+        await service.notifyLineupCreated(
+          makeLineup({ visibility: 'private' }),
+        );
+
+        expect(mockDedupService.checkAndMarkSent).toHaveBeenCalledWith(
+          `lineup-invite-dm:${LINEUP_ID}:11`,
+          expect.anything(),
+        );
+      });
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -432,6 +460,64 @@ describe('LineupNotificationService', () => {
         `lineup-voting:${LINEUP_ID}`,
         expect.anything(),
       );
+    });
+
+    // ROK-1065: private visibility routes to invitee DMs instead of channel
+    describe('private visibility (ROK-1065)', () => {
+      it('dispatches voting DMs to invitees and skips the channel embed', async () => {
+        const invitees = [makeMember(11), makeMember(12)];
+        mockDb.execute.mockResolvedValueOnce(invitees);
+
+        await service.notifyVotingOpen(
+          makeLineup({
+            status: 'voting',
+            votingDeadline: deadline,
+            visibility: 'private',
+          }),
+          games,
+        );
+
+        expect(mockBotClient.sendEmbed).not.toHaveBeenCalled();
+        expect(mockNotificationService.create).toHaveBeenCalledTimes(2);
+      });
+
+      it('includes the voting deadline in the dedup key so replays re-fire', async () => {
+        mockDb.execute.mockResolvedValueOnce([makeMember(11)]);
+
+        await service.notifyVotingOpen(
+          makeLineup({
+            status: 'voting',
+            votingDeadline: deadline,
+            visibility: 'private',
+          }),
+          games,
+        );
+
+        expect(mockDedupService.checkAndMarkSent).toHaveBeenCalledWith(
+          `lineup-vote-dm:${LINEUP_ID}:11:${deadline.toISOString()}`,
+          expect.anything(),
+        );
+      });
+
+      it('forwards the games list to the invitee DM payload', async () => {
+        mockDb.execute.mockResolvedValueOnce([makeMember(11)]);
+
+        await service.notifyVotingOpen(
+          makeLineup({
+            status: 'voting',
+            votingDeadline: deadline,
+            visibility: 'private',
+          }),
+          games,
+        );
+
+        const [[call]] = mockNotificationService.create.mock.calls;
+        expect(call).toMatchObject({
+          type: 'community_lineup',
+          payload: expect.objectContaining({ subtype: 'lineup_voting_open' }),
+        });
+        expect(call.message).toContain('Game A');
+      });
     });
   });
 

--- a/api/src/lineups/lineup-notification.service.spec.ts
+++ b/api/src/lineups/lineup-notification.service.spec.ts
@@ -408,7 +408,7 @@ describe('LineupNotificationService', () => {
       );
     });
 
-    it('uses dedup key lineup-vote-dm:{lineupId}:{userId}', async () => {
+    it('uses dedup key lineup-vote-dm:{lineupId}:{userId}:{deadline} so re-entering voting re-fires (ROK-1065)', async () => {
       mockDb.execute.mockResolvedValueOnce([makeMember(7)]);
 
       await service.notifyVotingOpen(
@@ -417,7 +417,7 @@ describe('LineupNotificationService', () => {
       );
 
       expect(mockDedupService.checkAndMarkSent).toHaveBeenCalledWith(
-        `lineup-vote-dm:${LINEUP_ID}:7`,
+        `lineup-vote-dm:${LINEUP_ID}:7:${deadline.toISOString()}`,
         expect.anything(),
       );
     });

--- a/api/src/lineups/lineup-notification.service.ts
+++ b/api/src/lineups/lineup-notification.service.ts
@@ -4,6 +4,7 @@
  * decided, scheduling, event creation, and operator removal.
  */
 import { Inject, Injectable, Logger } from '@nestjs/common';
+import { eq } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
 import * as schema from '../drizzle/schema';
@@ -36,6 +37,8 @@ import {
 } from './lineup-notification-embed.helpers';
 import {
   fanOutVotingDMs,
+  fanOutVotingDMsToInvitees,
+  fanOutLineupCreatedDMsToInvitees,
   fanOutSchedulingDMs,
   fanOutEventCreatedDMs,
 } from './lineup-notification-dm-batch.helpers';
@@ -61,6 +64,8 @@ export interface LineupInfo {
   phaseDeadline?: Date | null;
   /** Per-lineup Discord channel override (ROK-1064). */
   channelOverrideId?: string | null;
+  /** Lineup visibility (ROK-1065). 'private' routes to invitee DMs only. */
+  visibility?: 'public' | 'private';
 }
 
 /** Shape of a match passed to notification methods. */
@@ -107,11 +112,21 @@ export class LineupNotificationService {
 
   /** AC-1: Post channel embed when lineup is created. */
   async notifyLineupCreated(lineup: LineupInfo): Promise<void> {
+    const visibility = await this.resolveVisibility(lineup);
+    // ROK-1065: private lineups skip the channel embed and DM invitees.
+    if (visibility === 'private') {
+      await fanOutLineupCreatedDMsToInvitees(
+        this.db,
+        this.notificationService,
+        this.dedupService,
+        lineup,
+      );
+      return;
+    }
     const ctx = await this.resolveCtx(lineup.id, 'nominations', {
       title: lineup.title,
       description: lineup.description ?? null,
     });
-    // If caller passed the override explicitly, use it; otherwise load from DB.
     const sent = await this.postChannelEmbed(
       `lineup-created:${lineup.id}`,
       () => buildCreatedEmbed(ctx, lineup.targetDate),
@@ -126,6 +141,22 @@ export class LineupNotificationService {
         sent.messageId,
       );
     }
+  }
+
+  /**
+   * Resolve lineup visibility: prefer the caller-provided value, fall back
+   * to a DB lookup so older callers aren't broken (ROK-1065).
+   */
+  private async resolveVisibility(
+    lineup: LineupInfo,
+  ): Promise<'public' | 'private'> {
+    if (lineup.visibility) return lineup.visibility;
+    const [row] = await this.db
+      .select({ visibility: schema.communityLineups.visibility })
+      .from(schema.communityLineups)
+      .where(eq(schema.communityLineups.id, lineup.id))
+      .limit(1);
+    return row?.visibility ?? 'public';
   }
 
   /**
@@ -170,6 +201,18 @@ export class LineupNotificationService {
     lineup: LineupInfo,
     games: { id: number; name: string }[],
   ): Promise<void> {
+    const visibility = await this.resolveVisibility(lineup);
+    // ROK-1065: private lineups skip the channel embed and DM invitees only.
+    if (visibility === 'private') {
+      await fanOutVotingDMsToInvitees(
+        this.db,
+        this.notificationService,
+        this.dedupService,
+        lineup,
+        games.length,
+      );
+      return;
+    }
     const ctx = await this.resolveCtx(lineup.id, 'voting');
     await this.postChannelEmbed(
       `lineup-voting:${lineup.id}`,

--- a/api/src/lineups/lineup-notification.service.ts
+++ b/api/src/lineups/lineup-notification.service.ts
@@ -209,7 +209,7 @@ export class LineupNotificationService {
         this.notificationService,
         this.dedupService,
         lineup,
-        games.length,
+        games,
       );
       return;
     }
@@ -224,7 +224,7 @@ export class LineupNotificationService {
       this.notificationService,
       this.dedupService,
       lineup,
-      games.length,
+      games,
     );
   }
 

--- a/api/src/lineups/lineup-notification.service.ts
+++ b/api/src/lineups/lineup-notification.service.ts
@@ -202,6 +202,7 @@ export class LineupNotificationService {
     games: { id: number; name: string }[],
   ): Promise<void> {
     const visibility = await this.resolveVisibility(lineup);
+    const clientUrl = await this.settingsService.getClientUrl();
     // ROK-1065: private lineups skip the channel embed and DM invitees only.
     if (visibility === 'private') {
       await fanOutVotingDMsToInvitees(
@@ -210,6 +211,7 @@ export class LineupNotificationService {
         this.dedupService,
         lineup,
         games,
+        clientUrl,
       );
       return;
     }
@@ -225,6 +227,7 @@ export class LineupNotificationService {
       this.dedupService,
       lineup,
       games,
+      clientUrl,
     );
   }
 

--- a/api/src/lineups/lineup-notification.service.ts
+++ b/api/src/lineups/lineup-notification.service.ts
@@ -4,7 +4,6 @@
  * decided, scheduling, event creation, and operator removal.
  */
 import { Inject, Injectable, Logger } from '@nestjs/common';
-import { eq } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
 import * as schema from '../drizzle/schema';
@@ -37,11 +36,14 @@ import {
 } from './lineup-notification-embed.helpers';
 import {
   fanOutVotingDMs,
-  fanOutVotingDMsToInvitees,
-  fanOutLineupCreatedDMsToInvitees,
   fanOutSchedulingDMs,
   fanOutEventCreatedDMs,
+  fanOutMatchMemberDMs,
 } from './lineup-notification-dm-batch.helpers';
+import {
+  routeLineupCreatedIfPrivate,
+  routeVotingOpenIfPrivate,
+} from './lineup-notification-routing.helpers';
 import {
   findMatchMemberUsers,
   hasExistingPollEmbed,
@@ -94,12 +96,8 @@ export class LineupNotificationService {
   ) {}
 
   private get dispatchDeps(): DispatchDeps {
-    return {
-      db: this.db,
-      settingsService: this.settingsService,
-      botClient: this.botClient,
-      dedupService: this.dedupService,
-    };
+    const { db, settingsService, botClient, dedupService } = this;
+    return { db, settingsService, botClient, dedupService };
   }
 
   private resolveCtx(
@@ -112,17 +110,13 @@ export class LineupNotificationService {
 
   /** AC-1: Post channel embed when lineup is created. */
   async notifyLineupCreated(lineup: LineupInfo): Promise<void> {
-    const visibility = await this.resolveVisibility(lineup);
-    // ROK-1065: private lineups skip the channel embed and DM invitees.
-    if (visibility === 'private') {
-      await fanOutLineupCreatedDMsToInvitees(
-        this.db,
-        this.notificationService,
-        this.dedupService,
-        lineup,
-      );
-      return;
-    }
+    const routedPrivate = await routeLineupCreatedIfPrivate(
+      this.db,
+      this.notificationService,
+      this.dedupService,
+      lineup,
+    );
+    if (routedPrivate) return;
     const ctx = await this.resolveCtx(lineup.id, 'nominations', {
       title: lineup.title,
       description: lineup.description ?? null,
@@ -141,22 +135,6 @@ export class LineupNotificationService {
         sent.messageId,
       );
     }
-  }
-
-  /**
-   * Resolve lineup visibility: prefer the caller-provided value, fall back
-   * to a DB lookup so older callers aren't broken (ROK-1065).
-   */
-  private async resolveVisibility(
-    lineup: LineupInfo,
-  ): Promise<'public' | 'private'> {
-    if (lineup.visibility) return lineup.visibility;
-    const [row] = await this.db
-      .select({ visibility: schema.communityLineups.visibility })
-      .from(schema.communityLineups)
-      .where(eq(schema.communityLineups.id, lineup.id))
-      .limit(1);
-    return row?.visibility ?? 'public';
   }
 
   /**
@@ -201,20 +179,16 @@ export class LineupNotificationService {
     lineup: LineupInfo,
     games: { id: number; name: string }[],
   ): Promise<void> {
-    const visibility = await this.resolveVisibility(lineup);
     const clientUrl = await this.settingsService.getClientUrl();
-    // ROK-1065: private lineups skip the channel embed and DM invitees only.
-    if (visibility === 'private') {
-      await fanOutVotingDMsToInvitees(
-        this.db,
-        this.notificationService,
-        this.dedupService,
-        lineup,
-        games,
-        clientUrl,
-      );
-      return;
-    }
+    const routedPrivate = await routeVotingOpenIfPrivate(
+      this.db,
+      this.notificationService,
+      this.dedupService,
+      lineup,
+      games,
+      clientUrl,
+    );
+    if (routedPrivate) return;
     const ctx = await this.resolveCtx(lineup.id, 'voting');
     await this.postChannelEmbed(
       `lineup-voting:${lineup.id}`,
@@ -242,25 +216,13 @@ export class LineupNotificationService {
       () => buildDecidedEmbed(ctx, matches),
       ctx,
     );
-    await this.sendMatchMemberDMs(lineupId, matches);
-  }
-
-  /** Send DMs to each member of each match (M is typically 3-5). */
-  private async sendMatchMemberDMs(lineupId: number, matches: MatchInfo[]) {
-    for (const match of matches) {
-      const members = await findMatchMemberUsers(this.db, match.id);
-      const names = members.map((m) => m.displayName);
-      for (const member of members) {
-        const coPlayers = names.filter((n) => n !== member.displayName);
-        await this.notifyMatchMember(
-          match.id,
-          member.userId,
-          match.gameName,
-          coPlayers,
-          lineupId,
-        );
-      }
-    }
+    await fanOutMatchMemberDMs(
+      this.db,
+      this.notificationService,
+      this.dedupService,
+      lineupId,
+      matches,
+    );
   }
 
   /** AC-6: Send DM to a match member with game + co-players. */

--- a/api/src/lineups/lineups-actions.helpers.ts
+++ b/api/src/lineups/lineups-actions.helpers.ts
@@ -1,0 +1,189 @@
+/**
+ * Action orchestration helpers extracted from LineupsService (ROK-1065).
+ * Kept separate so lineups.service.ts stays under the 300-line ESLint ceiling.
+ *
+ * Each helper is a direct 1:1 extraction of a service method body — the
+ * service remains the public entry point for tests/controllers.
+ */
+import { BadRequestException, Logger, NotFoundException } from '@nestjs/common';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import type {
+  CreateLineupDto,
+  LineupDetailResponseDto,
+  NominateGameDto,
+} from '@raid-ledger/contract';
+import * as schema from '../drizzle/schema';
+import type { ActivityLogService } from '../activity-log/activity-log.service';
+import type { SettingsService } from '../settings/settings.service';
+import type { LineupPhaseQueueService } from './queue/lineup-phase.queue';
+import type { LineupSteamNudgeService } from './lineup-steam-nudge.service';
+import type { LineupNotificationService } from './lineup-notification.service';
+import { findLineupById } from './lineups-query.helpers';
+import { assertUserCanParticipate } from './lineups-eligibility.helpers';
+import { insertLineup } from './lineups-lifecycle.helpers';
+import { buildDetailResponse } from './lineups-response.helpers';
+import {
+  validateNominationCap,
+  validateGameExists,
+  insertNomination,
+} from './lineups-nomination.helpers';
+import {
+  hasDurationParams,
+  buildOverrides,
+  computeInitialDeadline,
+} from './lineups-phase.helpers';
+import { logNomination } from './lineups-activity.helpers';
+import { toggleVote as toggleVoteHelper } from './lineups-voting.helpers';
+import { carryOverFromLastDecided } from './lineups-carryover.helpers';
+import {
+  fireLineupCreated,
+  fireNominationMilestone,
+} from './lineups-notify-hooks.helpers';
+
+type Db = PostgresJsDatabase<typeof schema>;
+type ResolveChannelName = (channelId: string) => string | null;
+
+export interface CreateLineupDeps {
+  db: Db;
+  activityLog: ActivityLogService;
+  settings: SettingsService;
+  phaseQueue: LineupPhaseQueueService;
+  steamNudge: LineupSteamNudgeService;
+  lineupNotifications: LineupNotificationService;
+  logger: Logger;
+  resolveChannelName: ResolveChannelName;
+}
+
+/**
+ * Create a new lineup (ROK-1065).
+ * Multiple lineups may be active simultaneously post-ROK-1065. Steam nudges
+ * and carryover only fire for public lineups since private lineups have a
+ * scoped participant roster.
+ */
+export async function runCreateLineup(
+  deps: CreateLineupDeps,
+  dto: CreateLineupDto,
+  userId: number,
+): Promise<LineupDetailResponseDto> {
+  const overrides = hasDurationParams(dto) ? buildOverrides(dto) : null;
+  const phaseDeadline = await computeInitialDeadline(dto, deps.settings);
+
+  const [row] = await insertLineup(
+    deps.db,
+    dto,
+    userId,
+    phaseDeadline,
+    overrides,
+  );
+  await deps.activityLog.log('lineup', row.id, 'lineup_created', userId);
+  if (row.visibility === 'public') {
+    void deps.steamNudge.nudgeUnlinkedMembers(row.id);
+    await carryOverFromLastDecided(deps.db, row.id);
+  }
+
+  const delayMs = phaseDeadline.getTime() - Date.now();
+  await deps.phaseQueue.scheduleTransition(row.id, 'voting', delayMs);
+
+  fireLineupCreated(deps.lineupNotifications, deps.logger, {
+    id: row.id,
+    title: row.title,
+    description: row.description ?? null,
+    targetDate: dto.targetDate ? new Date(dto.targetDate) : undefined,
+    channelOverrideId: row.channelOverrideId ?? null,
+    visibility: row.visibility,
+  });
+
+  return buildDetailResponse(
+    deps.db,
+    row.id,
+    undefined,
+    deps.resolveChannelName,
+  );
+}
+
+export interface VoteDeps {
+  db: Db;
+  activityLog: ActivityLogService;
+  resolveChannelName: ResolveChannelName;
+}
+
+/** Toggle a vote for a game in a lineup (ROK-936). */
+export async function runToggleVote(
+  deps: VoteDeps,
+  lineupId: number,
+  gameId: number,
+  userId: number,
+  callerRole: string | undefined,
+): Promise<LineupDetailResponseDto> {
+  const [lineup] = await findLineupById(deps.db, lineupId);
+  if (!lineup) throw new NotFoundException('Lineup not found');
+  if (lineup.status !== 'voting') {
+    throw new BadRequestException('Voting is only allowed in voting status');
+  }
+  await assertUserCanParticipate(deps.db, lineup, {
+    id: userId,
+    role: callerRole,
+  });
+  const action = await toggleVoteHelper(
+    deps.db,
+    lineupId,
+    userId,
+    gameId,
+    lineup.maxVotesPerPlayer ?? 3,
+  );
+  await deps.activityLog.log('lineup', lineupId, 'vote_cast', userId, {
+    gameId,
+    action,
+  });
+  return buildDetailResponse(
+    deps.db,
+    lineupId,
+    userId,
+    deps.resolveChannelName,
+  );
+}
+
+export interface NominateDeps {
+  db: Db;
+  activityLog: ActivityLogService;
+  lineupNotifications: LineupNotificationService;
+  logger: Logger;
+  resolveChannelName: ResolveChannelName;
+}
+
+/** Nominate a game into a lineup. */
+export async function runNominate(
+  deps: NominateDeps,
+  lineupId: number,
+  dto: NominateGameDto,
+  userId: number,
+  callerRole: string | undefined,
+): Promise<LineupDetailResponseDto> {
+  const [lineup] = await findLineupById(deps.db, lineupId);
+  if (!lineup) throw new NotFoundException('Lineup not found');
+  if (lineup.status !== 'building')
+    throw new BadRequestException('Lineup is not in building status');
+  await assertUserCanParticipate(deps.db, lineup, {
+    id: userId,
+    role: callerRole,
+  });
+
+  await validateNominationCap(deps.db, lineupId);
+  await validateGameExists(deps.db, dto.gameId);
+  await insertNomination(deps.db, lineupId, dto, userId);
+  await logNomination(deps.db, deps.activityLog, lineupId, dto, userId);
+
+  fireNominationMilestone(
+    deps.lineupNotifications,
+    deps.logger,
+    deps.db,
+    lineupId,
+  );
+
+  return buildDetailResponse(
+    deps.db,
+    lineupId,
+    undefined,
+    deps.resolveChannelName,
+  );
+}

--- a/api/src/lineups/lineups-banner.helpers.spec.ts
+++ b/api/src/lineups/lineups-banner.helpers.spec.ts
@@ -20,6 +20,7 @@ const mockLineup = {
   createdAt: NOW,
   updatedAt: NOW,
   linkedEventId: null as number | null,
+  visibility: 'public' as const,
 };
 
 describe('buildBannerResponse', () => {

--- a/api/src/lineups/lineups-banner.helpers.ts
+++ b/api/src/lineups/lineups-banner.helpers.ts
@@ -40,6 +40,7 @@ interface BannerLineup {
   phaseDeadline?: Date | null;
   decidedGameId: number | null;
   decidedGameName: string | null;
+  visibility: 'public' | 'private';
 }
 
 /**
@@ -133,5 +134,8 @@ export function buildBannerResponse(
       voteCount: voteMap.get(e.gameId) ?? 0,
     })),
     tiebreakerActive: false,
+    // ROK-1065: visibility surfaced to the banner so the UI can render a
+    // private badge.
+    visibility: lineup.visibility,
   };
 }

--- a/api/src/lineups/lineups-carryover.helpers.ts
+++ b/api/src/lineups/lineups-carryover.helpers.ts
@@ -10,7 +10,11 @@ type Db = PostgresJsDatabase<typeof schema>;
 
 const CARRYOVER_STATUSES = ['decided', 'archived'] as const;
 
-/** Find the most recent lineup in decided or archived status. */
+/**
+ * Find the most recent PUBLIC lineup in decided or archived status (ROK-1065).
+ * Private lineups never contribute to carryover — their invitee-scoped
+ * suggestion history is intentionally isolated from public rollover.
+ */
 async function findPreviousLineup(db: Db, excludeId: number) {
   return db
     .select({ id: schema.communityLineups.id })
@@ -19,6 +23,7 @@ async function findPreviousLineup(db: Db, excludeId: number) {
       and(
         ne(schema.communityLineups.id, excludeId),
         inArray(schema.communityLineups.status, [...CARRYOVER_STATUSES]),
+        eq(schema.communityLineups.visibility, 'public'),
       ),
     )
     .orderBy(desc(schema.communityLineups.createdAt))

--- a/api/src/lineups/lineups-eligibility.helpers.spec.ts
+++ b/api/src/lineups/lineups-eligibility.helpers.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * Unit tests for private-lineup eligibility (ROK-1065).
+ */
+import { ForbiddenException } from '@nestjs/common';
+import {
+  assertUserCanParticipate,
+  type VisibilityLineup,
+  type EligibilityCaller,
+} from './lineups-eligibility.helpers';
+
+function makeLineup(
+  overrides: Partial<VisibilityLineup> = {},
+): VisibilityLineup {
+  return { id: 1, createdBy: 10, visibility: 'public', ...overrides };
+}
+
+function makeDb(inviteeUserIds: number[]) {
+  const limit = jest.fn().mockResolvedValue(
+    inviteeUserIds.length > 0 ? [{ id: 1 }] : [],
+  );
+  const where = jest.fn().mockReturnValue({ limit });
+  const from = jest.fn().mockReturnValue({ where });
+  const select = jest.fn().mockReturnValue({ from });
+  return { select } as unknown as Parameters<typeof assertUserCanParticipate>[0];
+}
+
+describe('assertUserCanParticipate', () => {
+  it('allows anyone on a public lineup', async () => {
+    const db = makeDb([]);
+    const lineup = makeLineup({ visibility: 'public' });
+    const caller: EligibilityCaller = { id: 999, role: 'member' };
+    await expect(
+      assertUserCanParticipate(db, lineup, caller),
+    ).resolves.toBeUndefined();
+  });
+
+  it('allows the creator on a private lineup', async () => {
+    const db = makeDb([]);
+    const lineup = makeLineup({ visibility: 'private', createdBy: 10 });
+    await expect(
+      assertUserCanParticipate(db, lineup, { id: 10, role: 'member' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('allows admin and operator roles on a private lineup', async () => {
+    const db = makeDb([]);
+    const lineup = makeLineup({ visibility: 'private', createdBy: 10 });
+    await expect(
+      assertUserCanParticipate(db, lineup, { id: 5, role: 'admin' }),
+    ).resolves.toBeUndefined();
+    await expect(
+      assertUserCanParticipate(db, lineup, { id: 5, role: 'operator' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('allows listed invitees', async () => {
+    const db = makeDb([42]);
+    const lineup = makeLineup({ visibility: 'private', createdBy: 10 });
+    await expect(
+      assertUserCanParticipate(db, lineup, { id: 42, role: 'member' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('rejects non-invitees on a private lineup', async () => {
+    const db = makeDb([]);
+    const lineup = makeLineup({ visibility: 'private', createdBy: 10 });
+    await expect(
+      assertUserCanParticipate(db, lineup, { id: 77, role: 'member' }),
+    ).rejects.toThrow(ForbiddenException);
+  });
+});

--- a/api/src/lineups/lineups-eligibility.helpers.spec.ts
+++ b/api/src/lineups/lineups-eligibility.helpers.spec.ts
@@ -15,13 +15,15 @@ function makeLineup(
 }
 
 function makeDb(inviteeUserIds: number[]) {
-  const limit = jest.fn().mockResolvedValue(
-    inviteeUserIds.length > 0 ? [{ id: 1 }] : [],
-  );
+  const limit = jest
+    .fn()
+    .mockResolvedValue(inviteeUserIds.length > 0 ? [{ id: 1 }] : []);
   const where = jest.fn().mockReturnValue({ limit });
   const from = jest.fn().mockReturnValue({ where });
   const select = jest.fn().mockReturnValue({ from });
-  return { select } as unknown as Parameters<typeof assertUserCanParticipate>[0];
+  return { select } as unknown as Parameters<
+    typeof assertUserCanParticipate
+  >[0];
 }
 
 describe('assertUserCanParticipate', () => {

--- a/api/src/lineups/lineups-eligibility.helpers.ts
+++ b/api/src/lineups/lineups-eligibility.helpers.ts
@@ -1,0 +1,83 @@
+/**
+ * Private-lineup participation eligibility (ROK-1065).
+ *
+ * Public lineups allow any community member; private lineups are scoped to
+ * the creator, explicit invitees in `community_lineup_invitees`, and any
+ * admin/operator. These helpers encapsulate the visibility check so
+ * controllers, services, and listeners share one definition.
+ */
+import { ForbiddenException } from '@nestjs/common';
+import { and, eq } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from '../drizzle/schema';
+
+type Db = PostgresJsDatabase<typeof schema>;
+
+/** Subset of lineup fields required for visibility checks. */
+export interface VisibilityLineup {
+  id: number;
+  createdBy: number;
+  visibility: 'public' | 'private';
+}
+
+/** Caller identity (matches CallerIdentity in lineups.service.ts). */
+export interface EligibilityCaller {
+  id: number;
+  role?: string;
+}
+
+/**
+ * Return every user ID pinned as an invitee on the given lineup.
+ * Empty array for public lineups (invitees are only meaningful for private).
+ */
+export async function loadInvitees(
+  db: Db,
+  lineupId: number,
+): Promise<number[]> {
+  const rows = await db
+    .select({ userId: schema.communityLineupInvitees.userId })
+    .from(schema.communityLineupInvitees)
+    .where(eq(schema.communityLineupInvitees.lineupId, lineupId));
+  return rows.map((r) => r.userId);
+}
+
+/**
+ * True when the caller is a member of the lineup's invitee list (a plain
+ * invitee, not counting the creator or admin/operator roles).
+ */
+export async function isInvitee(
+  db: Db,
+  lineupId: number,
+  userId: number,
+): Promise<boolean> {
+  const [row] = await db
+    .select({ id: schema.communityLineupInvitees.id })
+    .from(schema.communityLineupInvitees)
+    .where(
+      and(
+        eq(schema.communityLineupInvitees.lineupId, lineupId),
+        eq(schema.communityLineupInvitees.userId, userId),
+      ),
+    )
+    .limit(1);
+  return !!row;
+}
+
+/**
+ * Throw ForbiddenException when the caller may not participate
+ * (nominate / vote / bandwagon-join) on a private lineup. Public lineups
+ * always pass.
+ */
+export async function assertUserCanParticipate(
+  db: Db,
+  lineup: VisibilityLineup,
+  caller: EligibilityCaller,
+): Promise<void> {
+  if (lineup.visibility !== 'private') return;
+  if (caller.role === 'admin' || caller.role === 'operator') return;
+  if (lineup.createdBy === caller.id) return;
+  const invited = await isInvitee(db, lineup.id, caller.id);
+  if (!invited) {
+    throw new ForbiddenException('Not invited to this lineup');
+  }
+}

--- a/api/src/lineups/lineups-invitees-actions.helpers.ts
+++ b/api/src/lineups/lineups-invitees-actions.helpers.ts
@@ -1,0 +1,46 @@
+/**
+ * Thin helper around invitee add/remove that also loads the lineup,
+ * validates existence, and returns the refreshed detail response. Kept
+ * separate from the low-level helpers so lineups.service.ts stays under
+ * the 300-line ESLint ceiling (ROK-1065).
+ */
+import { NotFoundException } from '@nestjs/common';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import type { LineupDetailResponseDto } from '@raid-ledger/contract';
+import * as schema from '../drizzle/schema';
+import { findLineupById } from './lineups-query.helpers';
+import {
+  addInvitees,
+  removeInvitee as removeInviteeLow,
+} from './lineups-invitees.helpers';
+import { buildDetailResponse } from './lineups-response.helpers';
+
+type Db = PostgresJsDatabase<typeof schema>;
+
+/** Add one or more invitees; return refreshed lineup detail. */
+export async function runAddInvitees(
+  db: Db,
+  resolveChannelName: (channelId: string) => string | null,
+  lineupId: number,
+  userIds: number[],
+  callerId: number,
+): Promise<LineupDetailResponseDto> {
+  const [lineup] = await findLineupById(db, lineupId);
+  if (!lineup) throw new NotFoundException('Lineup not found');
+  await addInvitees(db, lineupId, userIds);
+  return buildDetailResponse(db, lineupId, callerId, resolveChannelName);
+}
+
+/** Remove a single invitee; return refreshed lineup detail. */
+export async function runRemoveInvitee(
+  db: Db,
+  resolveChannelName: (channelId: string) => string | null,
+  lineupId: number,
+  userId: number,
+  callerId: number,
+): Promise<LineupDetailResponseDto> {
+  const [lineup] = await findLineupById(db, lineupId);
+  if (!lineup) throw new NotFoundException('Lineup not found');
+  await removeInviteeLow(db, lineupId, userId);
+  return buildDetailResponse(db, lineupId, callerId, resolveChannelName);
+}

--- a/api/src/lineups/lineups-invitees.helpers.ts
+++ b/api/src/lineups/lineups-invitees.helpers.ts
@@ -1,0 +1,89 @@
+/**
+ * Invitee CRUD helpers for community lineups (ROK-1065).
+ * Used by the lineups service + controller to manage the invitee roster.
+ */
+import { NotFoundException } from '@nestjs/common';
+import { and, eq, inArray, sql } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from '../drizzle/schema';
+import type { LineupInviteeResponseDto } from '@raid-ledger/contract';
+
+type Db = PostgresJsDatabase<typeof schema>;
+
+/**
+ * Insert new invitees. Probes the users table first so unknown IDs surface
+ * as a 404 instead of a 500 FK violation. `ON CONFLICT DO NOTHING` makes
+ * the operation idempotent when an invitee already exists.
+ */
+export async function addInvitees(
+  db: Db,
+  lineupId: number,
+  userIds: number[],
+): Promise<void> {
+  if (userIds.length === 0) return;
+  const unique = Array.from(new Set(userIds));
+  const found = await db
+    .select({ id: schema.users.id })
+    .from(schema.users)
+    .where(inArray(schema.users.id, unique));
+  const foundIds = new Set(found.map((r) => r.id));
+  const missing = unique.filter((id) => !foundIds.has(id));
+  if (missing.length > 0) {
+    throw new NotFoundException(`Unknown user id(s): ${missing.join(', ')}`);
+  }
+  await db
+    .insert(schema.communityLineupInvitees)
+    .values(unique.map((userId) => ({ lineupId, userId })))
+    .onConflictDoNothing({
+      target: [
+        schema.communityLineupInvitees.lineupId,
+        schema.communityLineupInvitees.userId,
+      ],
+    });
+}
+
+/** Remove a single invitee from a lineup. */
+export async function removeInvitee(
+  db: Db,
+  lineupId: number,
+  userId: number,
+): Promise<void> {
+  await db
+    .delete(schema.communityLineupInvitees)
+    .where(
+      and(
+        eq(schema.communityLineupInvitees.lineupId, lineupId),
+        eq(schema.communityLineupInvitees.userId, userId),
+      ),
+    );
+}
+
+/**
+ * Load invitees with display name + steam-linked flag for the detail
+ * response. Steam linkage is derived from `users.steam_id IS NOT NULL`.
+ */
+export async function listInviteesWithProfile(
+  db: Db,
+  lineupId: number,
+): Promise<LineupInviteeResponseDto[]> {
+  const rows = await db
+    .select({
+      id: schema.users.id,
+      displayName:
+        sql<string>`COALESCE(${schema.users.displayName}, ${schema.users.username})`.as(
+          'display_name',
+        ),
+      steamId: schema.users.steamId,
+    })
+    .from(schema.communityLineupInvitees)
+    .innerJoin(
+      schema.users,
+      eq(schema.communityLineupInvitees.userId, schema.users.id),
+    )
+    .where(eq(schema.communityLineupInvitees.lineupId, lineupId));
+  return rows.map((r) => ({
+    id: r.id,
+    displayName: r.displayName,
+    steamLinked: !!r.steamId,
+  }));
+}

--- a/api/src/lineups/lineups-lifecycle.helpers.ts
+++ b/api/src/lineups/lineups-lifecycle.helpers.ts
@@ -2,11 +2,7 @@
  * Lifecycle helpers extracted from LineupsService to stay
  * under the 300-line file limit (ROK-932).
  */
-import {
-  BadRequestException,
-  ConflictException,
-  type Logger,
-} from '@nestjs/common';
+import { BadRequestException, type Logger } from '@nestjs/common';
 import { eq } from 'drizzle-orm';
 import { clearLinkedEventsByLineup } from './standalone-poll/standalone-poll-query.helpers';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
@@ -19,7 +15,6 @@ import type { LineupStatus } from '../drizzle/schema';
 import type { SettingsService } from '../settings/settings.service';
 import type { LineupPhaseQueueService } from './queue/lineup-phase.queue';
 import {
-  findActiveLineup,
   VALID_TRANSITIONS,
   VALID_REVERSIONS,
 } from './lineups-query.helpers';
@@ -29,10 +24,17 @@ import {
   buildTransitionValues,
 } from './lineups-phase.helpers';
 import { buildMatchesForLineup } from './lineups-matching.helpers';
+import { addInvitees } from './lineups-invitees.helpers';
 
 type Db = PostgresJsDatabase<typeof schema>;
 
-/** Insert a new lineup row with phase scheduling fields. */
+/**
+ * Insert a new lineup row with phase scheduling fields (ROK-1065).
+ *
+ * ROK-1065 removed the "only one active lineup" 409 — multiple lineups may
+ * run concurrently. Private lineups seed their invitee roster inside the
+ * same transaction so the detail response is immediately consistent.
+ */
 export function insertLineup(
   db: Db,
   dto: CreateLineupDto,
@@ -41,9 +43,7 @@ export function insertLineup(
   overrides: Record<string, number | undefined> | null,
 ) {
   return db.transaction(async (tx) => {
-    const [existing] = await findActiveLineup(tx);
-    if (existing) throw new ConflictException('A lineup is already active');
-    return tx
+    const rows = await tx
       .insert(schema.communityLineups)
       .values({
         title: dto.title,
@@ -57,8 +57,15 @@ export function insertLineup(
         defaultTiebreakerMode: dto.defaultTiebreakerMode ?? undefined,
         // ROK-1064: per-lineup Discord channel override (nullable).
         channelOverrideId: dto.channelOverrideId ?? null,
+        // ROK-1065: visibility defaults to 'public' when not provided.
+        visibility: dto.visibility ?? 'public',
       })
       .returning();
+    const [row] = rows;
+    if (row && dto.inviteeUserIds && dto.inviteeUserIds.length > 0) {
+      await addInvitees(tx as Db, row.id, dto.inviteeUserIds);
+    }
+    return rows;
   });
 }
 

--- a/api/src/lineups/lineups-lifecycle.helpers.ts
+++ b/api/src/lineups/lineups-lifecycle.helpers.ts
@@ -14,10 +14,7 @@ import * as schema from '../drizzle/schema';
 import type { LineupStatus } from '../drizzle/schema';
 import type { SettingsService } from '../settings/settings.service';
 import type { LineupPhaseQueueService } from './queue/lineup-phase.queue';
-import {
-  VALID_TRANSITIONS,
-  VALID_REVERSIONS,
-} from './lineups-query.helpers';
+import { VALID_TRANSITIONS, VALID_REVERSIONS } from './lineups-query.helpers';
 import {
   computeTransitionDeadline,
   getNextPhase,

--- a/api/src/lineups/lineups-match-actions.helpers.ts
+++ b/api/src/lineups/lineups-match-actions.helpers.ts
@@ -3,7 +3,7 @@
  * Extracted from lineups.service.ts in ROK-1063 to keep the service under
  * the 300-line ESLint limit.
  */
-import type { Logger } from '@nestjs/common';
+import { NotFoundException, type Logger } from '@nestjs/common';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type { BandwagonJoinResponseDto } from '@raid-ledger/contract';
 import * as schema from '../drizzle/schema';
@@ -13,9 +13,17 @@ import {
   advanceMatch as advanceMatchHelper,
 } from './lineups-bandwagon.helpers';
 import { fireSchedulingOpen } from './lineups-notify-hooks.helpers';
+import { findLineupById } from './lineups-query.helpers';
+import { assertUserCanParticipate } from './lineups-eligibility.helpers';
 
 type Db = PostgresJsDatabase<typeof schema>;
 
+/**
+ * Run a bandwagon-join (ROK-937, ROK-1065).
+ * Loads the lineup and enforces the private-lineup eligibility gate before
+ * accepting the join. A non-invitee (no admin/operator role, not the
+ * creator, not in the invitee list) cannot bandwagon onto a private lineup.
+ */
 export async function runBandwagonJoin(
   db: Db,
   notifications: LineupNotificationService,
@@ -23,7 +31,11 @@ export async function runBandwagonJoin(
   lineupId: number,
   matchId: number,
   userId: number,
+  callerRole?: string,
 ): Promise<BandwagonJoinResponseDto> {
+  const [lineup] = await findLineupById(db, lineupId);
+  if (!lineup) throw new NotFoundException('Lineup not found');
+  await assertUserCanParticipate(db, lineup, { id: userId, role: callerRole });
   const result = await executeBandwagonJoin(db, lineupId, matchId, userId);
   if (result.promoted) fireSchedulingOpen(notifications, logger, db, matchId);
   return result;

--- a/api/src/lineups/lineups-notify-hooks.helpers.ts
+++ b/api/src/lineups/lineups-notify-hooks.helpers.ts
@@ -73,14 +73,42 @@ export function fireVotingOpen(
   lineupId: number,
   phaseDeadline: Date | null,
 ): void {
-  findNominatedGames(db, lineupId)
-    .then((games) =>
-      svc.notifyVotingOpen(
-        { id: lineupId, votingDeadline: phaseDeadline ?? undefined },
+  loadLineupForNotification(db, lineupId)
+    .then(async (row) => {
+      if (!row) return;
+      const games = await findNominatedGames(db, lineupId);
+      return svc.notifyVotingOpen(
+        {
+          id: lineupId,
+          title: row.title,
+          votingDeadline: phaseDeadline ?? undefined,
+          visibility: row.visibility,
+        },
         games,
-      ),
-    )
+      );
+    })
     .catch(logError(logger, 'voting-open'));
+}
+
+/** Load fields notify hooks need from the lineup row (ROK-1065). */
+async function loadLineupForNotification(
+  db: Db,
+  lineupId: number,
+): Promise<{
+  id: number;
+  title: string;
+  visibility: 'public' | 'private';
+} | null> {
+  const [row] = await db
+    .select({
+      id: schema.communityLineups.id,
+      title: schema.communityLineups.title,
+      visibility: schema.communityLineups.visibility,
+    })
+    .from(schema.communityLineups)
+    .where(eq(schema.communityLineups.id, lineupId))
+    .limit(1);
+  return row ?? null;
 }
 
 /** Fire decided-phase notifications (channel embed). */

--- a/api/src/lineups/lineups-private.integration.spec.ts
+++ b/api/src/lineups/lineups-private.integration.spec.ts
@@ -8,6 +8,7 @@
  * - I7: common-ground explicit lineupId vs fallback
  * - I8: remove-invitee preserves prior votes
  * - Invitee CRUD dedupe + non-creator 403
+ * - A6: findInviteeDiscordMembers creator-union, DISTINCT dedupe, NULL discord_id filter
  */
 import { getTestApp, type TestApp } from '../common/testing/test-app';
 import {
@@ -16,6 +17,7 @@ import {
 } from '../common/testing/integration-helpers';
 import * as schema from '../drizzle/schema';
 import { eq } from 'drizzle-orm';
+import { findInviteeDiscordMembers } from './lineup-notification-targets.helpers';
 
 function describePrivateLineups() {
   let testApp: TestApp;
@@ -268,6 +270,85 @@ function describePrivateLineups() {
     expect(res.status).toBe(200);
     expect(res.body.data).toBeDefined();
     expect(res.body.meta.activeLineupId).toBe(lineupId);
+  });
+
+  // ── A6: findInviteeDiscordMembers creator-union ──────────────
+
+  it('findInviteeDiscordMembers includes the creator even when not invited (A6)', async () => {
+    // Admin (seed user) creates the lineup but is NOT in inviteeUserIds.
+    // The DISTINCT union in findInviteeDiscordMembers should still return
+    // the creator alongside the invitee.
+    const invitee = await createMember('a6-invitee@test.local', 'a6invitee');
+    const createRes = await createPrivateLineup(adminToken, [invitee.id]);
+    const lineupId = createRes.body.id as number;
+
+    // Give the creator a Discord ID so the `discord_id IS NOT NULL` filter
+    // lets them through.
+    await testApp.db
+      .update(schema.users)
+      .set({ discordId: 'discord:admin-a6' })
+      .where(eq(schema.users.id, testApp.seed.adminUser.id));
+    await testApp.db
+      .update(schema.users)
+      .set({ discordId: 'discord:a6-invitee' })
+      .where(eq(schema.users.id, invitee.id));
+
+    const members = await findInviteeDiscordMembers(testApp.db, lineupId);
+    const ids = members.map((m) => m.userId).sort();
+    expect(ids).toContain(testApp.seed.adminUser.id);
+    expect(ids).toContain(invitee.id);
+    // DISTINCT guard: no duplicates even if the creator is also an invitee
+    // in a separate setup — this case covers union, dedupe is the next test.
+  });
+
+  it('findInviteeDiscordMembers dedupes when the creator is also an explicit invitee', async () => {
+    // Explicitly invite the admin so the union has a collision.
+    await testApp.db
+      .update(schema.users)
+      .set({ discordId: 'discord:admin-dup' })
+      .where(eq(schema.users.id, testApp.seed.adminUser.id));
+
+    const invitee = await createMember('dup-inv@test.local', 'dupinv');
+    await testApp.db
+      .update(schema.users)
+      .set({ discordId: 'discord:dup-inv' })
+      .where(eq(schema.users.id, invitee.id));
+
+    const createRes = await createPrivateLineup(adminToken, [
+      testApp.seed.adminUser.id,
+      invitee.id,
+    ]);
+    const lineupId = createRes.body.id as number;
+
+    const members = await findInviteeDiscordMembers(testApp.db, lineupId);
+    const adminCount = members.filter(
+      (m) => m.userId === testApp.seed.adminUser.id,
+    ).length;
+    expect(adminCount).toBe(1);
+  });
+
+  it('findInviteeDiscordMembers excludes users with no discord_id', async () => {
+    const withDiscord = await createMember('with-d@test.local', 'withd');
+    const withoutDiscord = await createMember('no-d@test.local', 'nod');
+    await testApp.db
+      .update(schema.users)
+      .set({ discordId: 'discord:with-d' })
+      .where(eq(schema.users.id, withDiscord.id));
+    await testApp.db
+      .update(schema.users)
+      .set({ discordId: null })
+      .where(eq(schema.users.id, withoutDiscord.id));
+
+    const createRes = await createPrivateLineup(adminToken, [
+      withDiscord.id,
+      withoutDiscord.id,
+    ]);
+    const lineupId = createRes.body.id as number;
+
+    const members = await findInviteeDiscordMembers(testApp.db, lineupId);
+    const ids = members.map((m) => m.userId);
+    expect(ids).toContain(withDiscord.id);
+    expect(ids).not.toContain(withoutDiscord.id);
   });
 
   it('common-ground falls back to the current building lineup when lineupId is omitted', async () => {

--- a/api/src/lineups/lineups-private.integration.spec.ts
+++ b/api/src/lineups/lineups-private.integration.spec.ts
@@ -1,0 +1,289 @@
+/**
+ * Private / targeted lineup integration tests (ROK-1065).
+ *
+ * Covers spec Test-plan ACs that were missing from the bundled change:
+ * - I1: create private lineup with empty invitees → 400
+ * - I2: non-invitee nominate on private lineup → 403 (HTTP path)
+ * - I6: carryover filters out private decided lineups
+ * - I7: common-ground explicit lineupId vs fallback
+ * - I8: remove-invitee preserves prior votes
+ * - Invitee CRUD dedupe + non-creator 403
+ */
+import { getTestApp, type TestApp } from '../common/testing/test-app';
+import {
+  truncateAllTables,
+  loginAsAdmin,
+} from '../common/testing/integration-helpers';
+import * as schema from '../drizzle/schema';
+import { eq } from 'drizzle-orm';
+
+function describePrivateLineups() {
+  let testApp: TestApp;
+  let adminToken: string;
+
+  beforeAll(async () => {
+    testApp = await getTestApp();
+    adminToken = await loginAsAdmin(testApp.request, testApp.seed);
+  });
+
+  afterEach(async () => {
+    testApp.seed = await truncateAllTables(testApp.db);
+    adminToken = await loginAsAdmin(testApp.request, testApp.seed);
+  });
+
+  // ── Helpers ──────────────────────────────────────────────────
+
+  async function createMember(
+    email: string,
+    username: string,
+    role: 'member' | 'operator' = 'member',
+  ): Promise<{ id: number; token: string }> {
+    const bcrypt = await import('bcrypt');
+    const hash = await bcrypt.hash('Pass1Pass1!', 4);
+    const [user] = await testApp.db
+      .insert(schema.users)
+      .values({
+        discordId: `local:${email}`,
+        username,
+        role,
+      })
+      .returning();
+    await testApp.db.insert(schema.localCredentials).values({
+      email,
+      passwordHash: hash,
+      userId: user.id,
+    });
+    const res = await testApp.request
+      .post('/auth/local')
+      .send({ email, password: 'Pass1Pass1!' });
+    return { id: user.id, token: res.body.access_token as string };
+  }
+
+  async function createPrivateLineup(token: string, inviteeUserIds: number[]) {
+    return testApp.request
+      .post('/lineups')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        title: 'Private Lineup',
+        visibility: 'private',
+        inviteeUserIds,
+      });
+  }
+
+  // ── I1: empty invitees → 400 ─────────────────────────────────
+
+  it('rejects a private lineup with an empty invitee list (I1)', async () => {
+    const res = await testApp.request
+      .post('/lineups')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        title: 'Empty',
+        visibility: 'private',
+        inviteeUserIds: [],
+      });
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects a private lineup with no inviteeUserIds field (I1)', async () => {
+    const res = await testApp.request
+      .post('/lineups')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({
+        title: 'Missing',
+        visibility: 'private',
+      });
+    expect(res.status).toBe(400);
+  });
+
+  // ── I2: non-invitee nominate → 403 ───────────────────────────
+
+  it('blocks non-invitee nominate on private lineup with 403 (I2)', async () => {
+    const invitee = await createMember('invitee@test.local', 'invitee');
+    const outsider = await createMember('outsider@test.local', 'outsider');
+
+    const createRes = await createPrivateLineup(adminToken, [invitee.id]);
+    expect(createRes.status).toBe(201);
+    const lineupId = createRes.body.id as number;
+
+    const res = await testApp.request
+      .post(`/lineups/${lineupId}/nominate`)
+      .set('Authorization', `Bearer ${outsider.token}`)
+      .send({ gameId: testApp.seed.game.id });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('allows an invitee to nominate on a private lineup', async () => {
+    const invitee = await createMember('invitee2@test.local', 'invitee2');
+    const createRes = await createPrivateLineup(adminToken, [invitee.id]);
+    const lineupId = createRes.body.id as number;
+
+    const res = await testApp.request
+      .post(`/lineups/${lineupId}/nominate`)
+      .set('Authorization', `Bearer ${invitee.token}`)
+      .send({ gameId: testApp.seed.game.id });
+
+    expect(res.status).toBe(201);
+  });
+
+  // ── Invitee CRUD: dedupe + 403 non-creator ───────────────────
+
+  it('dedupes repeated invitee IDs via ON CONFLICT DO NOTHING', async () => {
+    const a = await createMember('dup-a@test.local', 'dupa');
+    const createRes = await createPrivateLineup(adminToken, [a.id]);
+    const lineupId = createRes.body.id as number;
+
+    const res = await testApp.request
+      .post(`/lineups/${lineupId}/invitees`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ userIds: [a.id, a.id] });
+
+    expect(res.status).toBe(201);
+    const invitees = res.body.invitees as { id: number }[];
+    expect(invitees.filter((i) => i.id === a.id)).toHaveLength(1);
+  });
+
+  it('returns 403 when a non-creator member tries to add invitees', async () => {
+    const invitee = await createMember('existing@test.local', 'existing');
+    const outsider = await createMember('out-member@test.local', 'outmem');
+    const createRes = await createPrivateLineup(adminToken, [invitee.id]);
+    const lineupId = createRes.body.id as number;
+
+    const res = await testApp.request
+      .post(`/lineups/${lineupId}/invitees`)
+      .set('Authorization', `Bearer ${outsider.token}`)
+      .send({ userIds: [outsider.id] });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when add-invitees body has an empty userIds array', async () => {
+    const invitee = await createMember('x@test.local', 'x');
+    const createRes = await createPrivateLineup(adminToken, [invitee.id]);
+    const lineupId = createRes.body.id as number;
+
+    const res = await testApp.request
+      .post(`/lineups/${lineupId}/invitees`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ userIds: [] });
+
+    expect(res.status).toBe(400);
+  });
+
+  // ── I8: remove-invitee preserves past votes ──────────────────
+
+  it('preserves prior votes when an invitee is removed (I8)', async () => {
+    const invitee = await createMember('voter@test.local', 'voter');
+    const createRes = await createPrivateLineup(adminToken, [invitee.id]);
+    const lineupId = createRes.body.id as number;
+
+    // Nominate a game so there's something to vote on.
+    await testApp.request
+      .post(`/lineups/${lineupId}/nominate`)
+      .set('Authorization', `Bearer ${invitee.token}`)
+      .send({ gameId: testApp.seed.game.id });
+    // Transition to voting.
+    await testApp.request
+      .patch(`/lineups/${lineupId}/status`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ status: 'voting' });
+    // Invitee casts a vote.
+    await testApp.request
+      .post(`/lineups/${lineupId}/vote`)
+      .set('Authorization', `Bearer ${invitee.token}`)
+      .send({ gameId: testApp.seed.game.id });
+
+    const votesBefore = await testApp.db
+      .select()
+      .from(schema.communityLineupVotes)
+      .where(eq(schema.communityLineupVotes.lineupId, lineupId));
+    expect(votesBefore).toHaveLength(1);
+
+    // Now remove the invitee.
+    const removeRes = await testApp.request
+      .delete(`/lineups/${lineupId}/invitees/${invitee.id}`)
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(removeRes.status).toBe(200);
+
+    const votesAfter = await testApp.db
+      .select()
+      .from(schema.communityLineupVotes)
+      .where(eq(schema.communityLineupVotes.lineupId, lineupId));
+    expect(votesAfter).toHaveLength(1);
+    expect(votesAfter[0].userId).toBe(invitee.id);
+  });
+
+  // ── I6: carryover skips private decided lineups ──────────────
+
+  it('carryover does not pull suggestions from a decided private lineup (I6)', async () => {
+    const invitee = await createMember('carryover@test.local', 'co');
+    // Private decided lineup with a match in decided phase.
+    const privateRes = await createPrivateLineup(adminToken, [invitee.id]);
+    const privateId = privateRes.body.id as number;
+
+    // Seed a suggested match on the private lineup so carryover would
+    // otherwise pick it up.
+    await testApp.db.insert(schema.communityLineupMatches).values({
+      lineupId: privateId,
+      gameId: testApp.seed.game.id,
+      status: 'suggested',
+      voteCount: 5,
+      thresholdMet: true,
+    });
+    await testApp.db
+      .update(schema.communityLineups)
+      .set({ status: 'decided' })
+      .where(eq(schema.communityLineups.id, privateId));
+
+    // New public lineup — carryover fires inside create.
+    const publicRes = await testApp.request
+      .post('/lineups')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ title: 'Next public' });
+    expect(publicRes.status).toBe(201);
+    const publicId = publicRes.body.id as number;
+
+    // No carryover rows should exist on the new public lineup.
+    const carried = await testApp.db
+      .select()
+      .from(schema.communityLineupMatches)
+      .where(eq(schema.communityLineupMatches.lineupId, publicId));
+    expect(carried).toHaveLength(0);
+  });
+
+  // ── I7: common-ground explicit lineupId vs fallback ──────────
+
+  it('common-ground honors explicit lineupId for a private lineup (I7)', async () => {
+    const invitee = await createMember('cg@test.local', 'cg');
+    const createRes = await createPrivateLineup(adminToken, [invitee.id]);
+    const lineupId = createRes.body.id as number;
+
+    const res = await testApp.request
+      .get('/lineups/common-ground')
+      .query({ lineupId })
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    // Explicit lineupId path — request succeeds and echoes the private
+    // lineup as the active one in meta.
+    expect(res.status).toBe(200);
+    expect(res.body.data).toBeDefined();
+    expect(res.body.meta.activeLineupId).toBe(lineupId);
+  });
+
+  it('common-ground falls back to the current building lineup when lineupId is omitted', async () => {
+    const createRes = await testApp.request
+      .post('/lineups')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ title: 'Public CG' });
+    const lineupId = createRes.body.id as number;
+
+    const res = await testApp.request
+      .get('/lineups/common-ground')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body.meta.activeLineupId).toBe(lineupId);
+  });
+}
+
+describe('Lineups — private / invitee (integration)', describePrivateLineups);

--- a/api/src/lineups/lineups-query.helpers.ts
+++ b/api/src/lineups/lineups-query.helpers.ts
@@ -6,12 +6,37 @@ import type { LineupStatus } from '../drizzle/schema';
 
 const ACTIVE_STATUSES: LineupStatus[] = ['building', 'voting'];
 
-/** Find any lineup in building or voting status. */
-export function findActiveLineup(db: PostgresJsDatabase<typeof schema>) {
+/**
+ * Find every lineup currently in building or voting status (ROK-1065).
+ * Multiple active lineups are permitted post-ROK-1065; callers no longer
+ * assume uniqueness. Ordered newest-first for deterministic UI stacks.
+ */
+export function findActiveLineups(db: PostgresJsDatabase<typeof schema>) {
+  return db
+    .select()
+    .from(schema.communityLineups)
+    .where(inArray(schema.communityLineups.status, ACTIVE_STATUSES))
+    .orderBy(desc(schema.communityLineups.createdAt));
+}
+
+/**
+ * Find the most recent public decided/archived lineup (ROK-1065).
+ * Used by carryover so private lineups never contribute to public history
+ * and public lineups never inherit from private ones.
+ */
+export function findLatestDecidedPublicLineup(
+  db: PostgresJsDatabase<typeof schema>,
+  excludeId: number,
+) {
   return db
     .select({ id: schema.communityLineups.id })
     .from(schema.communityLineups)
-    .where(inArray(schema.communityLineups.status, ACTIVE_STATUSES))
+    .where(
+      sql`${schema.communityLineups.visibility} = 'public'
+          AND ${schema.communityLineups.status} IN ('decided', 'archived')
+          AND ${schema.communityLineups.id} <> ${excludeId}`,
+    )
+    .orderBy(desc(schema.communityLineups.createdAt))
     .limit(1);
 }
 

--- a/api/src/lineups/lineups-response.helpers.spec.ts
+++ b/api/src/lineups/lineups-response.helpers.spec.ts
@@ -210,6 +210,8 @@ describe('buildDetailResponse', () => {
     mockDb.select.mockReturnValueOnce(
       makeSelectChain({ whereResult: [{ count: 10 }] }),
     );
+    // 10. listInviteesWithProfile (ROK-1065) — empty for public lineup
+    mockDb.select.mockReturnValueOnce(makeSelectChain({ whereResult: [] }));
 
     const result = await buildDetailResponse(mockDb as any, 1);
 

--- a/api/src/lineups/lineups-response.helpers.spec.ts
+++ b/api/src/lineups/lineups-response.helpers.spec.ts
@@ -17,6 +17,8 @@ const mockLineup = {
   votingDeadline: null as Date | null,
   createdAt: NOW,
   updatedAt: NOW,
+  visibility: 'public' as 'public' | 'private',
+  channelOverrideId: null as string | null,
 };
 
 const mockEntry = {
@@ -150,6 +152,8 @@ describe('buildDetailResponse', () => {
     mockDb.select.mockReturnValueOnce(
       makeSelectChain({ whereResult: [{ count: 15 }] }),
     );
+    // 10. listInviteesWithProfile (ROK-1065) — empty for public lineup
+    mockDb.select.mockReturnValueOnce(makeSelectChain({ whereResult: [] }));
 
     const result = await buildDetailResponse(mockDb as any, 1);
 

--- a/api/src/lineups/lineups-response.helpers.ts
+++ b/api/src/lineups/lineups-response.helpers.ts
@@ -30,6 +30,7 @@ import {
 import { findUserVotes } from './lineups-voting.helpers';
 import { findPendingOrActiveTiebreaker } from './tiebreaker/tiebreaker-query.helpers';
 import { buildTiebreakerDetail } from './tiebreaker/tiebreaker-response.helpers';
+import { listInviteesWithProfile } from './lineups-invitees.helpers';
 
 type Db = PostgresJsDatabase<typeof schema>;
 
@@ -101,6 +102,8 @@ function mapLineupCore(
     // ROK-1064: per-lineup Discord channel override + resolved name.
     channelOverrideId: lineup.channelOverrideId ?? null,
     channelOverrideName,
+    // ROK-1065: visibility drives DM vs channel embed dispatch.
+    visibility: lineup.visibility,
   };
 }
 
@@ -125,6 +128,8 @@ function mapToDetailResponse(
     myVotes,
     unlinkedSteamCount: enrichment.unlinkedSteamCount,
     unlinkedSteamMembers: enrichment.unlinkedSteamMembers,
+    // ROK-1065: populated below via a parallel query.
+    invitees: [],
   };
 }
 
@@ -198,6 +203,8 @@ export async function buildDetailResponse(
     myVotes,
     channelOverrideName,
   );
+  // ROK-1065: invitees populated for both public (empty) and private lineups.
+  detail.invitees = await listInviteesWithProfile(db, lineupId);
 
   // Attach tiebreaker detail if one exists (ROK-938)
   if (lineup.activeTiebreakerId) {

--- a/api/src/lineups/lineups-summary.helpers.ts
+++ b/api/src/lineups/lineups-summary.helpers.ts
@@ -1,0 +1,75 @@
+/**
+ * Summary helpers for LineupsService.findActive (ROK-1065).
+ * Extracted from lineups.service.ts to keep the service file under the
+ * 300-line ESLint cap.
+ */
+import { inArray, sql } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import type { LineupSummaryResponseDto } from '@raid-ledger/contract';
+import * as schema from '../drizzle/schema';
+import { findActiveLineups } from './lineups-query.helpers';
+
+type Db = PostgresJsDatabase<typeof schema>;
+
+/**
+ * Load entry + voter counts for many lineups in two grouped queries.
+ * Returns empty maps when no ids are supplied.
+ */
+async function loadSummaryCounts(
+  db: Db,
+  lineupIds: number[],
+): Promise<{
+  entries: Map<number, number>;
+  voters: Map<number, number>;
+}> {
+  if (lineupIds.length === 0) {
+    return { entries: new Map(), voters: new Map() };
+  }
+  const entryRows = await db
+    .select({
+      lineupId: schema.communityLineupEntries.lineupId,
+      count: sql<number>`count(*)::int`.as('count'),
+    })
+    .from(schema.communityLineupEntries)
+    .where(inArray(schema.communityLineupEntries.lineupId, lineupIds))
+    .groupBy(schema.communityLineupEntries.lineupId);
+  const voterRows = await db
+    .select({
+      lineupId: schema.communityLineupVotes.lineupId,
+      count:
+        sql<number>`count(distinct ${schema.communityLineupVotes.userId})::int`.as(
+          'count',
+        ),
+    })
+    .from(schema.communityLineupVotes)
+    .where(inArray(schema.communityLineupVotes.lineupId, lineupIds))
+    .groupBy(schema.communityLineupVotes.lineupId);
+  return {
+    entries: new Map(entryRows.map((r) => [r.lineupId, r.count])),
+    voters: new Map(voterRows.map((r) => [r.lineupId, r.count])),
+  };
+}
+
+/**
+ * Build the array of active lineup summaries returned by GET /lineups/active
+ * (ROK-1065). Never filters by viewer — private lineups are read-open.
+ */
+export async function buildActiveLineupSummaries(
+  db: Db,
+): Promise<LineupSummaryResponseDto[]> {
+  const rows = await findActiveLineups(db);
+  const counts = await loadSummaryCounts(
+    db,
+    rows.map((r) => r.id),
+  );
+  return rows.map((r) => ({
+    id: r.id,
+    title: r.title,
+    status: r.status,
+    targetDate: r.targetDate ? r.targetDate.toISOString() : null,
+    entryCount: counts.entries.get(r.id) ?? 0,
+    totalVoters: counts.voters.get(r.id) ?? 0,
+    createdAt: r.createdAt.toISOString(),
+    visibility: r.visibility,
+  }));
+}

--- a/api/src/lineups/lineups-voting.integration.spec.ts
+++ b/api/src/lineups/lineups-voting.integration.spec.ts
@@ -336,10 +336,10 @@ function describeVoting() {
 
       expect(res.status).toBe(200);
       expect(Array.isArray(res.body)).toBe(true);
-      const summaries = res.body as { id: number }[];
+      const summaries = res.body as Array<Record<string, unknown>>;
       const summary = summaries.find((r) => r.id === lineupId);
       expect(summary).toBeDefined();
-      expect(summary.myVotes).toBeUndefined();
+      expect(summary?.myVotes).toBeUndefined();
       expect(summary).toMatchObject({
         id: lineupId,
         status: expect.any(String),

--- a/api/src/lineups/lineups-voting.integration.spec.ts
+++ b/api/src/lineups/lineups-voting.integration.spec.ts
@@ -317,7 +317,11 @@ function describeVoting() {
       expect(res.body.myVotes).toHaveLength(0);
     });
 
-    it('should include myVotes in GET /lineups/active', async () => {
+    it('GET /lineups/active returns summary rows (no myVotes, ROK-1065)', async () => {
+      // ROK-1065: /lineups/active now returns an array of summaries; myVotes
+      // is a detail-only field. This test keeps the vote pre-condition but
+      // asserts on the summary shape to prevent a regression to the old
+      // single-detail response.
       const { lineupId, games } = await setupVotingLineup();
       const { token } = await loginAsMember();
 
@@ -331,8 +335,19 @@ function describeVoting() {
         .set('Authorization', `Bearer ${token}`);
 
       expect(res.status).toBe(200);
-      expect(res.body.myVotes).toBeDefined();
-      expect(res.body.myVotes).toContain(games[1].id);
+      expect(Array.isArray(res.body)).toBe(true);
+      const summary = res.body.find(
+        (r: { id: number }) => r.id === lineupId,
+      );
+      expect(summary).toBeDefined();
+      expect(summary.myVotes).toBeUndefined();
+      expect(summary).toMatchObject({
+        id: lineupId,
+        status: expect.any(String),
+        visibility: expect.any(String),
+        entryCount: expect.any(Number),
+        totalVoters: expect.any(Number),
+      });
     });
   }
   describe('GET /lineups/:id — myVotes', describeMyVotes);

--- a/api/src/lineups/lineups-voting.integration.spec.ts
+++ b/api/src/lineups/lineups-voting.integration.spec.ts
@@ -336,7 +336,8 @@ function describeVoting() {
 
       expect(res.status).toBe(200);
       expect(Array.isArray(res.body)).toBe(true);
-      const summary = res.body.find((r: { id: number }) => r.id === lineupId);
+      const summaries = res.body as { id: number }[];
+      const summary = summaries.find((r) => r.id === lineupId);
       expect(summary).toBeDefined();
       expect(summary.myVotes).toBeUndefined();
       expect(summary).toMatchObject({

--- a/api/src/lineups/lineups-voting.integration.spec.ts
+++ b/api/src/lineups/lineups-voting.integration.spec.ts
@@ -336,9 +336,7 @@ function describeVoting() {
 
       expect(res.status).toBe(200);
       expect(Array.isArray(res.body)).toBe(true);
-      const summary = res.body.find(
-        (r: { id: number }) => r.id === lineupId,
-      );
+      const summary = res.body.find((r: { id: number }) => r.id === lineupId);
       expect(summary).toBeDefined();
       expect(summary.myVotes).toBeUndefined();
       expect(summary).toMatchObject({

--- a/api/src/lineups/lineups.controller.ts
+++ b/api/src/lineups/lineups.controller.ts
@@ -206,7 +206,12 @@ export class LineupsController {
     @Param('matchId', ParseIntPipe) matchId: number,
     @Req() req: AuthRequest,
   ): Promise<BandwagonJoinResponseDto> {
-    return this.lineupsService.bandwagonJoin(id, matchId, req.user.id);
+    return this.lineupsService.bandwagonJoin(
+      id,
+      matchId,
+      req.user.id,
+      req.user.role,
+    );
   }
 
   /** POST /lineups/:id/matches/:matchId/advance — operator advance (ROK-937). */

--- a/api/src/lineups/lineups.controller.ts
+++ b/api/src/lineups/lineups.controller.ts
@@ -24,8 +24,10 @@ import {
   CommonGroundQuerySchema,
   NominateGameSchema,
   CastVoteSchema,
+  AddInviteesSchema,
   type LineupDetailResponseDto,
   type LineupBannerResponseDto,
+  type LineupSummaryResponseDto,
   type CommonGroundResponseDto,
   type ActivityTimelineResponseDto,
   type GroupedMatchesResponseDto,
@@ -62,10 +64,14 @@ export class LineupsController {
     return this.lineupsService.create(parsed.data, req.user.id);
   }
 
-  /** GET /lineups/active — current active lineup. */
+  /**
+   * GET /lineups/active — every lineup currently in building or voting
+   * status (ROK-1065). Returns an array (was singular pre-ROK-1065).
+   * Not filtered by viewer — private lineups are read-open.
+   */
   @Get('active')
-  async getActive(@Req() req: AuthRequest): Promise<LineupDetailResponseDto> {
-    return this.lineupsService.findActive(req.user.id);
+  async getActive(): Promise<LineupSummaryResponseDto[]> {
+    return this.lineupsService.findActive();
   }
 
   /** GET /lineups/banner — lightweight banner for Games page. */
@@ -107,7 +113,12 @@ export class LineupsController {
     if (!parsed.success) {
       throw new BadRequestException(parsed.error.flatten().fieldErrors);
     }
-    return this.lineupsService.toggleVote(id, parsed.data.gameId, req.user.id);
+    return this.lineupsService.toggleVote(
+      id,
+      parsed.data.gameId,
+      req.user.id,
+      req.user.role,
+    );
   }
 
   /** POST /lineups/:id/nominate — add a game to a lineup. */
@@ -122,7 +133,12 @@ export class LineupsController {
     if (!parsed.success) {
       throw new BadRequestException(parsed.error.flatten().fieldErrors);
     }
-    return this.lineupsService.nominate(id, parsed.data, req.user.id);
+    return this.lineupsService.nominate(
+      id,
+      parsed.data,
+      req.user.id,
+      req.user.role,
+    );
   }
 
   /** DELETE /lineups/:id/nominations/:gameId — remove a nomination. */
@@ -211,5 +227,43 @@ export class LineupsController {
     @Param('id', ParseIntPipe) id: number,
   ): Promise<ActivityTimelineResponseDto> {
     return this.activityLog.getTimeline('lineup', id);
+  }
+
+  /**
+   * POST /lineups/:id/invitees — add one or more invitees (ROK-1065).
+   * Admin/operator only.
+   */
+  @Post(':id/invitees')
+  @UseGuards(RolesGuard)
+  @Roles('operator')
+  async addInvitees(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() body: unknown,
+    @Req() req: AuthRequest,
+  ): Promise<LineupDetailResponseDto> {
+    const parsed = AddInviteesSchema.safeParse(body);
+    if (!parsed.success) {
+      throw new BadRequestException(parsed.error.flatten().fieldErrors);
+    }
+    return this.lineupsService.addInvitees(
+      id,
+      parsed.data.userIds,
+      req.user.id,
+    );
+  }
+
+  /**
+   * DELETE /lineups/:id/invitees/:userId — remove a single invitee (ROK-1065).
+   * Admin/operator only.
+   */
+  @Delete(':id/invitees/:userId')
+  @UseGuards(RolesGuard)
+  @Roles('operator')
+  async removeInvitee(
+    @Param('id', ParseIntPipe) id: number,
+    @Param('userId', ParseIntPipe) userId: number,
+    @Req() req: AuthRequest,
+  ): Promise<LineupDetailResponseDto> {
+    return this.lineupsService.removeInvitee(id, userId, req.user.id);
   }
 }

--- a/api/src/lineups/lineups.integration.spec.ts
+++ b/api/src/lineups/lineups.integration.spec.ts
@@ -125,11 +125,13 @@ function describeLineups() {
       expect(rows[0].status).toBe('building');
     });
 
-    it('should return 409 when active lineup exists', async () => {
+    it('should allow creating a second active lineup (ROK-1065)', async () => {
+      // ROK-1065 removed the 409 single-active constraint — multiple
+      // concurrent lineups are now allowed (private ones coexist with public).
       await createLineup(adminToken);
       const res = await createLineup(adminToken);
 
-      expect(res.status).toBe(409);
+      expect(res.status).toBe(201);
     });
 
     it('should require authentication', async () => {
@@ -154,22 +156,26 @@ function describeLineups() {
   // ── GET /lineups/active ──────────────────────────────────────
 
   function describeGETActive() {
-    it('should return the active lineup', async () => {
+    it('should return the active lineup as an array (ROK-1065)', async () => {
       await createLineup(adminToken);
       const res = await testApp.request
         .get('/lineups/active')
         .set('Authorization', `Bearer ${adminToken}`);
 
       expect(res.status).toBe(200);
-      expect(res.body.status).toBe('building');
+      expect(Array.isArray(res.body)).toBe(true);
+      expect(res.body).toHaveLength(1);
+      expect(res.body[0].status).toBe('building');
     });
 
-    it('should return 404 when no active lineup', async () => {
+    it('should return an empty array when no active lineup (ROK-1065)', async () => {
       const res = await testApp.request
         .get('/lineups/active')
         .set('Authorization', `Bearer ${adminToken}`);
 
-      expect(res.status).toBe(404);
+      // ROK-1065: endpoint now always 200 — empty array when no lineups.
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual([]);
     });
 
     it('should be accessible to members', async () => {
@@ -181,6 +187,7 @@ function describeLineups() {
         .set('Authorization', `Bearer ${memberToken}`);
 
       expect(res.status).toBe(200);
+      expect(Array.isArray(res.body)).toBe(true);
     });
 
     it('should require authentication', async () => {
@@ -453,7 +460,9 @@ function describeLineups() {
       expect(res2.status).toBe(201);
     });
 
-    it('should block creating while voting is active', async () => {
+    it('should permit creating while another lineup is in voting (ROK-1065)', async () => {
+      // ROK-1065: the single-active-lineup constraint is gone. Private and
+      // public lineups can coexist at any phase.
       const res1 = await createLineup(adminToken);
       const id = res1.body.id as number;
       await testApp.request
@@ -462,7 +471,7 @@ function describeLineups() {
         .send({ status: 'voting' });
 
       const res2 = await createLineup(adminToken);
-      expect(res2.status).toBe(409);
+      expect(res2.status).toBe(201);
     });
   }
   describe('Active lineup constraint', describeActiveConstraint);

--- a/api/src/lineups/lineups.service.spec.ts
+++ b/api/src/lineups/lineups.service.spec.ts
@@ -1,8 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import {
-  NotFoundException,
-  BadRequestException,
-} from '@nestjs/common';
+import { NotFoundException, BadRequestException } from '@nestjs/common';
 import { LineupsService } from './lineups.service';
 import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
 import { ActivityLogService } from '../activity-log/activity-log.service';

--- a/api/src/lineups/lineups.service.spec.ts
+++ b/api/src/lineups/lineups.service.spec.ts
@@ -1,6 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import {
-  ConflictException,
   NotFoundException,
   BadRequestException,
 } from '@nestjs/common';
@@ -55,6 +54,8 @@ const mockLineup = {
   matchThreshold: 35,
   createdAt: NOW,
   updatedAt: NOW,
+  visibility: 'public' as 'public' | 'private',
+  channelOverrideId: null as string | null,
 };
 
 const mockUser = { id: 10, displayName: 'TestUser', username: 'TestUser' };
@@ -224,11 +225,9 @@ function describeLineupsService() {
   beforeEach(() => createService());
 
   describe('create', () => {
-    it('should create a lineup when none is active', async () => {
-      // findActiveLineup → empty (no active)
-      mockSelects(makeSelectChain({ limitResult: [] }));
-      mockInsert([{ ...mockLineup, id: 1 }]);
-      mockBuildDetail();
+    it('should create a lineup (ROK-1065: no more 409 when one is already active)', async () => {
+      mockInsert([{ ...mockLineup, id: 1, visibility: 'public' }]);
+      mockBuildDetail({ ...mockLineup, visibility: 'public' });
 
       const result = await service.create({ title: 'Test Lineup' }, 10);
 
@@ -237,20 +236,20 @@ function describeLineupsService() {
       expect(mockDb.insert).toHaveBeenCalled();
     });
 
-    it('should throw ConflictException when active lineup exists', async () => {
-      mockSelects(makeSelectChain({ limitResult: [{ id: 99 }] }));
-
-      await expect(
-        service.create({ title: 'Test Lineup' }, 10),
-      ).rejects.toThrow(ConflictException);
-      expect(mockDb.insert).not.toHaveBeenCalled();
-    });
-
     it('should pass targetDate to insert', async () => {
       const targetDate = '2026-04-01T00:00:00Z';
-      mockSelects(makeSelectChain({ limitResult: [] }));
-      mockInsert([{ ...mockLineup, targetDate: new Date(targetDate) }]);
-      mockBuildDetail({ ...mockLineup, targetDate: new Date(targetDate) });
+      mockInsert([
+        {
+          ...mockLineup,
+          targetDate: new Date(targetDate),
+          visibility: 'public',
+        },
+      ]);
+      mockBuildDetail({
+        ...mockLineup,
+        targetDate: new Date(targetDate),
+        visibility: 'public',
+      });
 
       const result = await service.create(
         { title: 'Test Lineup', targetDate },
@@ -261,33 +260,33 @@ function describeLineupsService() {
     });
   });
 
-  describe('findActive', () => {
-    it('should return the active lineup', async () => {
-      // findActive select
-      mockSelects(makeSelectChain({ limitResult: [mockLineup] }));
-      // buildDetailResponse
-      mockBuildDetail();
+  describe('findActive (ROK-1065 array return)', () => {
+    it('returns an array entry for each active lineup', async () => {
+      // findActiveLineups → whereResult (thenable awaited directly)
+      mockSelects(
+        makeSelectChain({
+          whereResult: [{ ...mockLineup, visibility: 'public' }],
+        }),
+      );
+      // loadSummaryCounts: entry count + voter count
+      mockSelects(makeSelectChain({ groupByResult: [] }));
+      mockSelects(makeSelectChain({ groupByResult: [] }));
 
       const result = await service.findActive();
 
-      expect(result.id).toBe(1);
-      expect(result.status).toBe('building');
+      expect(Array.isArray(result)).toBe(true);
+      expect(result[0].id).toBe(1);
+      expect(result[0].status).toBe('building');
+      expect(result[0].visibility).toBe('public');
     });
 
-    it('should return voting lineup as active', async () => {
-      const votingLineup = { ...mockLineup, status: 'voting' };
-      mockSelects(makeSelectChain({ limitResult: [votingLineup] }));
-      mockBuildDetail(votingLineup);
+    it('returns an empty array when no lineups are active', async () => {
+      mockSelects(makeSelectChain({ whereResult: [] }));
+      // loadSummaryCounts skipped because ids is empty
 
       const result = await service.findActive();
 
-      expect(result.status).toBe('voting');
-    });
-
-    it('should throw NotFoundException when no active lineup', async () => {
-      mockSelects(makeSelectChain({ limitResult: [] }));
-
-      await expect(service.findActive()).rejects.toThrow(NotFoundException);
+      expect(result).toEqual([]);
     });
   });
 

--- a/api/src/lineups/lineups.service.spec.ts
+++ b/api/src/lineups/lineups.service.spec.ts
@@ -170,6 +170,8 @@ function describeLineupsService() {
     }
     // Enrichment: only countTotalMembers calls DB (others short-circuit on empty gameIds)
     chains.push(makeSelectChain({ whereResult: [{ count: 10 }] }));
+    // ROK-1065: listInviteesWithProfile (empty for public lineup).
+    chains.push(makeSelectChain({ whereResult: [] }));
     mockSelects(...chains);
   }
 
@@ -433,6 +435,7 @@ function describeLineupsService() {
         }),
       ); // creator
       mockSelects(makeSelectChain({ whereResult: [{ count: 10 }] })); // totalMembers
+      mockSelects(makeSelectChain({ whereResult: [] })); // ROK-1065 invitees
 
       const result = await service.transitionStatus(1, {
         status: 'decided',

--- a/api/src/lineups/lineups.service.ts
+++ b/api/src/lineups/lineups.service.ts
@@ -145,7 +145,7 @@ export class LineupsService {
     return buildDetailResponse(
       this.db,
       row.id,
-      userId,
+      undefined,
       this.resolveChannelName,
     );
   }

--- a/api/src/lineups/lineups.service.ts
+++ b/api/src/lineups/lineups.service.ts
@@ -28,14 +28,12 @@ import { LineupPhaseQueueService } from './queue/lineup-phase.queue';
 import { LineupSteamNudgeService } from './lineup-steam-nudge.service';
 import { LineupNotificationService } from './lineup-notification.service';
 import { findLineupById } from './lineups-query.helpers';
-import { assertUserCanParticipate } from './lineups-eligibility.helpers';
 import {
   runAddInvitees,
   runRemoveInvitee,
 } from './lineups-invitees-actions.helpers';
 import { TasteProfileService } from '../taste-profile/taste-profile.service';
 import { runCommonGroundForBuildingLineup } from './common-ground-context.helpers';
-import { insertLineup } from './lineups-lifecycle.helpers';
 import { buildDetailResponse } from './lineups-response.helpers';
 import { findBannerLineup, buildBannerData } from './lineups-banner.helpers';
 import { buildActiveLineupSummaries } from './lineups-summary.helpers';
@@ -44,31 +42,19 @@ import {
   validateRemoval,
   deleteEntry,
 } from './lineups-removal.helpers';
-import {
-  validateNominationCap,
-  validateGameExists,
-  insertNomination,
-} from './lineups-nomination.helpers';
-import {
-  hasDurationParams,
-  buildOverrides,
-  computeInitialDeadline,
-} from './lineups-phase.helpers';
-import { logNomination } from './lineups-activity.helpers';
-import { toggleVote as toggleVoteHelper } from './lineups-voting.helpers';
 import { buildGroupedMatchesResponse } from './lineups-match-response.helpers';
-import { carryOverFromLastDecided } from './lineups-carryover.helpers';
 import { runMetadataUpdate } from './lineups-metadata.helpers';
 import { runStatusTransition } from './lineups-transition.helpers';
 import {
   runBandwagonJoin,
   runAdvanceMatch,
 } from './lineups-match-actions.helpers';
+import { fireNominationRemoved } from './lineups-notify-hooks.helpers';
 import {
-  fireLineupCreated,
-  fireNominationMilestone,
-  fireNominationRemoved,
-} from './lineups-notify-hooks.helpers';
+  runCreateLineup,
+  runToggleVote,
+  runNominate,
+} from './lineups-actions.helpers';
 
 /** Caller identity for authorization checks. */
 export interface CallerIdentity {
@@ -99,52 +85,24 @@ export class LineupsService {
     return channel?.name ?? null;
   };
 
-  /**
-   * Create a new lineup (ROK-1065).
-   * Multiple lineups may be active simultaneously post-ROK-1065. Steam
-   * nudges and carryover only fire for public lineups since private lineups
-   * have a scoped participant roster.
-   */
-  async create(
+  /** Create a new lineup (ROK-1065). */
+  create(
     dto: CreateLineupDto,
     userId: number,
   ): Promise<LineupDetailResponseDto> {
-    const overrides = hasDurationParams(dto) ? buildOverrides(dto) : null;
-    const phaseDeadline = await computeInitialDeadline(dto, this.settings);
-
-    const [row] = await insertLineup(
-      this.db,
+    return runCreateLineup(
+      {
+        db: this.db,
+        activityLog: this.activityLog,
+        settings: this.settings,
+        phaseQueue: this.phaseQueue,
+        steamNudge: this.steamNudge,
+        lineupNotifications: this.lineupNotifications,
+        logger: this.logger,
+        resolveChannelName: this.resolveChannelName,
+      },
       dto,
       userId,
-      phaseDeadline,
-      overrides,
-    );
-    await this.activityLog.log('lineup', row.id, 'lineup_created', userId);
-    const isPublic = row.visibility === 'public';
-    if (isPublic) {
-      void this.steamNudge.nudgeUnlinkedMembers(row.id);
-      await carryOverFromLastDecided(this.db, row.id);
-    }
-
-    const delayMs = phaseDeadline.getTime() - Date.now();
-    await this.phaseQueue.scheduleTransition(row.id, 'voting', delayMs);
-
-    fireLineupCreated(this.lineupNotifications, this.logger, {
-      id: row.id,
-      title: row.title,
-      description: row.description ?? null,
-      targetDate: dto.targetDate ? new Date(dto.targetDate) : undefined,
-      // ROK-1064: per-lineup Discord channel override.
-      channelOverrideId: row.channelOverrideId ?? null,
-      // ROK-1065: visibility drives DM vs. channel dispatch.
-      visibility: row.visibility,
-    });
-
-    return buildDetailResponse(
-      this.db,
-      row.id,
-      undefined,
-      this.resolveChannelName,
     );
   }
 
@@ -169,37 +127,22 @@ export class LineupsService {
   }
 
   /** Toggle a vote for a game in a lineup (ROK-936). */
-  async toggleVote(
+  toggleVote(
     lineupId: number,
     gameId: number,
     userId: number,
     callerRole?: string,
   ): Promise<LineupDetailResponseDto> {
-    const [lineup] = await findLineupById(this.db, lineupId);
-    if (!lineup) throw new NotFoundException('Lineup not found');
-    if (lineup.status !== 'voting') {
-      throw new BadRequestException('Voting is only allowed in voting status');
-    }
-    await assertUserCanParticipate(this.db, lineup, {
-      id: userId,
-      role: callerRole,
-    });
-    const action = await toggleVoteHelper(
-      this.db,
+    return runToggleVote(
+      {
+        db: this.db,
+        activityLog: this.activityLog,
+        resolveChannelName: this.resolveChannelName,
+      },
       lineupId,
-      userId,
       gameId,
-      lineup.maxVotesPerPlayer ?? 3,
-    );
-    await this.activityLog.log('lineup', lineupId, 'vote_cast', userId, {
-      gameId,
-      action,
-    });
-    return buildDetailResponse(
-      this.db,
-      lineupId,
       userId,
-      this.resolveChannelName,
+      callerRole,
     );
   }
 
@@ -235,38 +178,24 @@ export class LineupsService {
   }
 
   /** Nominate a game into a lineup. */
-  async nominate(
+  nominate(
     lineupId: number,
     dto: NominateGameDto,
     userId: number,
     callerRole?: string,
-  ) {
-    const [lineup] = await findLineupById(this.db, lineupId);
-    if (!lineup) throw new NotFoundException('Lineup not found');
-    if (lineup.status !== 'building')
-      throw new BadRequestException('Lineup is not in building status');
-    await assertUserCanParticipate(this.db, lineup, {
-      id: userId,
-      role: callerRole,
-    });
-
-    await validateNominationCap(this.db, lineupId);
-    await validateGameExists(this.db, dto.gameId);
-    await insertNomination(this.db, lineupId, dto, userId);
-    await logNomination(this.db, this.activityLog, lineupId, dto, userId);
-
-    fireNominationMilestone(
-      this.lineupNotifications,
-      this.logger,
-      this.db,
+  ): Promise<LineupDetailResponseDto> {
+    return runNominate(
+      {
+        db: this.db,
+        activityLog: this.activityLog,
+        lineupNotifications: this.lineupNotifications,
+        logger: this.logger,
+        resolveChannelName: this.resolveChannelName,
+      },
       lineupId,
-    );
-
-    return buildDetailResponse(
-      this.db,
-      lineupId,
-      undefined,
-      this.resolveChannelName,
+      dto,
+      userId,
+      callerRole,
     );
   }
 

--- a/api/src/lineups/lineups.service.ts
+++ b/api/src/lineups/lineups.service.ts
@@ -315,11 +315,16 @@ export class LineupsService {
     return buildGroupedMatchesResponse(this.db, id);
   }
 
-  /** Bandwagon join a match (ROK-937). */
+  /**
+   * Bandwagon join a match (ROK-937, ROK-1065).
+   * `callerRole` is used to enforce the private-lineup eligibility gate
+   * (non-invitees may not bandwagon onto a private lineup's match).
+   */
   bandwagonJoin(
     lineupId: number,
     matchId: number,
     userId: number,
+    callerRole?: string,
   ): Promise<BandwagonJoinResponseDto> {
     return runBandwagonJoin(
       this.db,
@@ -328,6 +333,7 @@ export class LineupsService {
       lineupId,
       matchId,
       userId,
+      callerRole,
     );
   }
 

--- a/api/src/lineups/lineups.service.ts
+++ b/api/src/lineups/lineups.service.ts
@@ -27,7 +27,7 @@ import { DiscordBotClientService } from '../discord-bot/discord-bot-client.servi
 import { LineupPhaseQueueService } from './queue/lineup-phase.queue';
 import { LineupSteamNudgeService } from './lineup-steam-nudge.service';
 import { LineupNotificationService } from './lineup-notification.service';
-import { findActiveLineups, findLineupById } from './lineups-query.helpers';
+import { findLineupById } from './lineups-query.helpers';
 import { assertUserCanParticipate } from './lineups-eligibility.helpers';
 import {
   runAddInvitees,
@@ -38,6 +38,7 @@ import { runCommonGroundForBuildingLineup } from './common-ground-context.helper
 import { insertLineup } from './lineups-lifecycle.helpers';
 import { buildDetailResponse } from './lineups-response.helpers';
 import { findBannerLineup, buildBannerData } from './lineups-banner.helpers';
+import { buildActiveLineupSummaries } from './lineups-summary.helpers';
 import {
   findEntry,
   validateRemoval,
@@ -155,55 +156,8 @@ export class LineupsService {
    * public ones, so the client receives all in-flight lineups. Never
    * filtered by viewer; private participation is gated at mutation time.
    */
-  async findActive(): Promise<
-    import('@raid-ledger/contract').LineupSummaryResponseDto[]
-  > {
-    const rows = await findActiveLineups(this.db);
-    const ids = rows.map((r) => r.id);
-    const counts = await this.loadSummaryCounts(ids);
-    return rows.map((r) => ({
-      id: r.id,
-      title: r.title,
-      status: r.status,
-      targetDate: r.targetDate ? r.targetDate.toISOString() : null,
-      entryCount: counts.entries.get(r.id) ?? 0,
-      totalVoters: counts.voters.get(r.id) ?? 0,
-      createdAt: r.createdAt.toISOString(),
-      visibility: r.visibility,
-    }));
-  }
-
-  /** Load entry and voter counts for multiple lineups in two queries. */
-  private async loadSummaryCounts(lineupIds: number[]): Promise<{
-    entries: Map<number, number>;
-    voters: Map<number, number>;
-  }> {
-    if (lineupIds.length === 0) {
-      return { entries: new Map(), voters: new Map() };
-    }
-    const entryRows = await this.db
-      .select({
-        lineupId: schema.communityLineupEntries.lineupId,
-        count: sql<number>`count(*)::int`.as('count'),
-      })
-      .from(schema.communityLineupEntries)
-      .where(inArray(schema.communityLineupEntries.lineupId, lineupIds))
-      .groupBy(schema.communityLineupEntries.lineupId);
-    const voterRows = await this.db
-      .select({
-        lineupId: schema.communityLineupVotes.lineupId,
-        count:
-          sql<number>`count(distinct ${schema.communityLineupVotes.userId})::int`.as(
-            'count',
-          ),
-      })
-      .from(schema.communityLineupVotes)
-      .where(inArray(schema.communityLineupVotes.lineupId, lineupIds))
-      .groupBy(schema.communityLineupVotes.lineupId);
-    return {
-      entries: new Map(entryRows.map((r) => [r.lineupId, r.count])),
-      voters: new Map(voterRows.map((r) => [r.lineupId, r.count])),
-    };
+  async findActive(): Promise<LineupSummaryResponseDto[]> {
+    return buildActiveLineupSummaries(this.db);
   }
 
   /** Get a lineup by ID with full detail. */

--- a/api/src/lineups/lineups.service.ts
+++ b/api/src/lineups/lineups.service.ts
@@ -5,7 +5,6 @@ import {
   Logger,
   NotFoundException,
 } from '@nestjs/common';
-import { inArray, sql } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type {
   BandwagonJoinResponseDto,
@@ -15,6 +14,7 @@ import type {
   GroupedMatchesResponseDto,
   LineupBannerResponseDto,
   LineupDetailResponseDto,
+  LineupSummaryResponseDto,
   NominateGameDto,
   UpdateLineupMetadataDto,
   UpdateLineupStatusDto,
@@ -27,10 +27,7 @@ import { DiscordBotClientService } from '../discord-bot/discord-bot-client.servi
 import { LineupPhaseQueueService } from './queue/lineup-phase.queue';
 import { LineupSteamNudgeService } from './lineup-steam-nudge.service';
 import { LineupNotificationService } from './lineup-notification.service';
-import {
-  findActiveLineups,
-  findLineupById,
-} from './lineups-query.helpers';
+import { findActiveLineups, findLineupById } from './lineups-query.helpers';
 import { assertUserCanParticipate } from './lineups-eligibility.helpers';
 import {
   runAddInvitees,
@@ -177,9 +174,7 @@ export class LineupsService {
   }
 
   /** Load entry and voter counts for multiple lineups in two queries. */
-  private async loadSummaryCounts(
-    lineupIds: number[],
-  ): Promise<{
+  private async loadSummaryCounts(lineupIds: number[]): Promise<{
     entries: Map<number, number>;
     voters: Map<number, number>;
   }> {
@@ -197,9 +192,10 @@ export class LineupsService {
     const voterRows = await this.db
       .select({
         lineupId: schema.communityLineupVotes.lineupId,
-        count: sql<number>`count(distinct ${schema.communityLineupVotes.userId})::int`.as(
-          'count',
-        ),
+        count:
+          sql<number>`count(distinct ${schema.communityLineupVotes.userId})::int`.as(
+            'count',
+          ),
       })
       .from(schema.communityLineupVotes)
       .where(inArray(schema.communityLineupVotes.lineupId, lineupIds))

--- a/api/src/lineups/lineups.service.ts
+++ b/api/src/lineups/lineups.service.ts
@@ -26,7 +26,15 @@ import { DiscordBotClientService } from '../discord-bot/discord-bot-client.servi
 import { LineupPhaseQueueService } from './queue/lineup-phase.queue';
 import { LineupSteamNudgeService } from './lineup-steam-nudge.service';
 import { LineupNotificationService } from './lineup-notification.service';
-import { findActiveLineup, findLineupById } from './lineups-query.helpers';
+import {
+  findActiveLineups,
+  findLineupById,
+} from './lineups-query.helpers';
+import { assertUserCanParticipate } from './lineups-eligibility.helpers';
+import {
+  runAddInvitees,
+  runRemoveInvitee,
+} from './lineups-invitees-actions.helpers';
 import { TasteProfileService } from '../taste-profile/taste-profile.service';
 import { runCommonGroundForBuildingLineup } from './common-ground-context.helpers';
 import { insertLineup } from './lineups-lifecycle.helpers';
@@ -92,7 +100,12 @@ export class LineupsService {
     return channel?.name ?? null;
   };
 
-  /** Create a new lineup. Throws 409 if an active lineup already exists. */
+  /**
+   * Create a new lineup (ROK-1065).
+   * Multiple lineups may be active simultaneously post-ROK-1065. Steam
+   * nudges and carryover only fire for public lineups since private lineups
+   * have a scoped participant roster.
+   */
   async create(
     dto: CreateLineupDto,
     userId: number,
@@ -108,8 +121,11 @@ export class LineupsService {
       overrides,
     );
     await this.activityLog.log('lineup', row.id, 'lineup_created', userId);
-    void this.steamNudge.nudgeUnlinkedMembers(row.id);
-    await carryOverFromLastDecided(this.db, row.id);
+    const isPublic = row.visibility === 'public';
+    if (isPublic) {
+      void this.steamNudge.nudgeUnlinkedMembers(row.id);
+      await carryOverFromLastDecided(this.db, row.id);
+    }
 
     const delayMs = phaseDeadline.getTime() - Date.now();
     await this.phaseQueue.scheduleTransition(row.id, 'voting', delayMs);
@@ -121,26 +137,77 @@ export class LineupsService {
       targetDate: dto.targetDate ? new Date(dto.targetDate) : undefined,
       // ROK-1064: per-lineup Discord channel override.
       channelOverrideId: row.channelOverrideId ?? null,
+      // ROK-1065: visibility drives DM vs. channel dispatch.
+      visibility: row.visibility,
     });
 
-    return buildDetailResponse(
-      this.db,
-      row.id,
-      undefined,
-      this.resolveChannelName,
-    );
-  }
-
-  /** Get the currently active lineup (building or voting). */
-  async findActive(userId?: number): Promise<LineupDetailResponseDto> {
-    const [row] = await findActiveLineup(this.db);
-    if (!row) throw new NotFoundException('No active lineup');
     return buildDetailResponse(
       this.db,
       row.id,
       userId,
       this.resolveChannelName,
     );
+  }
+
+  /**
+   * Get every active lineup (ROK-1065).
+   *
+   * Returns `LineupSummaryResponseDto[]`. ROK-1065 changed this from a
+   * singular detail object to an array — private lineups coexist with
+   * public ones, so the client receives all in-flight lineups. Never
+   * filtered by viewer; private participation is gated at mutation time.
+   */
+  async findActive(): Promise<
+    import('@raid-ledger/contract').LineupSummaryResponseDto[]
+  > {
+    const rows = await findActiveLineups(this.db);
+    const ids = rows.map((r) => r.id);
+    const counts = await this.loadSummaryCounts(ids);
+    return rows.map((r) => ({
+      id: r.id,
+      title: r.title,
+      status: r.status,
+      targetDate: r.targetDate ? r.targetDate.toISOString() : null,
+      entryCount: counts.entries.get(r.id) ?? 0,
+      totalVoters: counts.voters.get(r.id) ?? 0,
+      createdAt: r.createdAt.toISOString(),
+      visibility: r.visibility,
+    }));
+  }
+
+  /** Load entry and voter counts for multiple lineups in two queries. */
+  private async loadSummaryCounts(
+    lineupIds: number[],
+  ): Promise<{
+    entries: Map<number, number>;
+    voters: Map<number, number>;
+  }> {
+    if (lineupIds.length === 0) {
+      return { entries: new Map(), voters: new Map() };
+    }
+    const { inArray, sql } = await import('drizzle-orm');
+    const entryRows = await this.db
+      .select({
+        lineupId: schema.communityLineupEntries.lineupId,
+        count: sql<number>`count(*)::int`.as('count'),
+      })
+      .from(schema.communityLineupEntries)
+      .where(inArray(schema.communityLineupEntries.lineupId, lineupIds))
+      .groupBy(schema.communityLineupEntries.lineupId);
+    const voterRows = await this.db
+      .select({
+        lineupId: schema.communityLineupVotes.lineupId,
+        count: sql<number>`count(distinct ${schema.communityLineupVotes.userId})::int`.as(
+          'count',
+        ),
+      })
+      .from(schema.communityLineupVotes)
+      .where(inArray(schema.communityLineupVotes.lineupId, lineupIds))
+      .groupBy(schema.communityLineupVotes.lineupId);
+    return {
+      entries: new Map(entryRows.map((r) => [r.lineupId, r.count])),
+      voters: new Map(voterRows.map((r) => [r.lineupId, r.count])),
+    };
   }
 
   /** Get a lineup by ID with full detail. */
@@ -156,12 +223,17 @@ export class LineupsService {
     lineupId: number,
     gameId: number,
     userId: number,
+    callerRole?: string,
   ): Promise<LineupDetailResponseDto> {
     const [lineup] = await findLineupById(this.db, lineupId);
     if (!lineup) throw new NotFoundException('Lineup not found');
     if (lineup.status !== 'voting') {
       throw new BadRequestException('Voting is only allowed in voting status');
     }
+    await assertUserCanParticipate(this.db, lineup, {
+      id: userId,
+      role: callerRole,
+    });
     const action = await toggleVoteHelper(
       this.db,
       lineupId,
@@ -213,11 +285,20 @@ export class LineupsService {
   }
 
   /** Nominate a game into a lineup. */
-  async nominate(lineupId: number, dto: NominateGameDto, userId: number) {
+  async nominate(
+    lineupId: number,
+    dto: NominateGameDto,
+    userId: number,
+    callerRole?: string,
+  ) {
     const [lineup] = await findLineupById(this.db, lineupId);
     if (!lineup) throw new NotFoundException('Lineup not found');
     if (lineup.status !== 'building')
       throw new BadRequestException('Lineup is not in building status');
+    await assertUserCanParticipate(this.db, lineup, {
+      id: userId,
+      role: callerRole,
+    });
 
     await validateNominationCap(this.db, lineupId);
     await validateGameExists(this.db, dto.gameId);
@@ -327,6 +408,40 @@ export class LineupsService {
       id,
       dto,
       caller,
+    );
+  }
+
+  /**
+   * Add one or more invitees to a lineup (ROK-1065).
+   * 404s if any userId is unknown (the helper probes users first). Idempotent
+   * for already-invited users via ON CONFLICT DO NOTHING.
+   */
+  addInvitees(
+    lineupId: number,
+    userIds: number[],
+    callerId: number,
+  ): Promise<LineupDetailResponseDto> {
+    return runAddInvitees(
+      this.db,
+      this.resolveChannelName,
+      lineupId,
+      userIds,
+      callerId,
+    );
+  }
+
+  /** Remove a single invitee (ROK-1065). */
+  removeInvitee(
+    lineupId: number,
+    userId: number,
+    callerId: number,
+  ): Promise<LineupDetailResponseDto> {
+    return runRemoveInvitee(
+      this.db,
+      this.resolveChannelName,
+      lineupId,
+      userId,
+      callerId,
     );
   }
 }

--- a/api/src/lineups/lineups.service.ts
+++ b/api/src/lineups/lineups.service.ts
@@ -5,6 +5,7 @@ import {
   Logger,
   NotFoundException,
 } from '@nestjs/common';
+import { inArray, sql } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type {
   BandwagonJoinResponseDto,
@@ -185,7 +186,6 @@ export class LineupsService {
     if (lineupIds.length === 0) {
       return { entries: new Map(), voters: new Map() };
     }
-    const { inArray, sql } = await import('drizzle-orm');
     const entryRows = await this.db
       .select({
         lineupId: schema.communityLineupEntries.lineupId,

--- a/packages/contract/src/games.schema.ts
+++ b/packages/contract/src/games.schema.ts
@@ -74,6 +74,8 @@ export const GameDetailSchema = z.object({
     itadPriceUpdatedAt: z.string().nullable().optional(),
     /** ROK-934: Whether this game is in early access (from ITAD) */
     earlyAccess: z.boolean().optional(),
+    /** Steam app ID for linking to the Steam store page. */
+    steamAppId: z.number().nullable().optional(),
 });
 
 export type GameDetailDto = z.infer<typeof GameDetailSchema>;

--- a/packages/contract/src/lineup-invitees.schema.ts
+++ b/packages/contract/src/lineup-invitees.schema.ts
@@ -1,0 +1,35 @@
+/**
+ * Community Lineup invitees (ROK-1065).
+ *
+ * A "private" lineup is visibility-scoped: only explicit invitees (plus the
+ * creator and any admin/operator) may participate. These schemas cover the
+ * add / remove invitee endpoints used by the operator management UI.
+ */
+import { z } from 'zod';
+
+/** Visibility mode for a community lineup (ROK-1065). */
+export const LineupVisibilitySchema = z.enum(['public', 'private']);
+
+export type LineupVisibilityDto = z.infer<typeof LineupVisibilitySchema>;
+
+/**
+ * Body for POST /lineups/:id/invitees — add one or more users as invitees.
+ * A private lineup must have at least one invitee at all times.
+ */
+export const AddInviteesSchema = z.object({
+    userIds: z.array(z.number().int().positive()).min(1),
+});
+
+export type AddInviteesDto = z.infer<typeof AddInviteesSchema>;
+
+/** A single invitee row returned in lineup detail responses. */
+export const LineupInviteeResponseSchema = z.object({
+    id: z.number(),
+    displayName: z.string(),
+    /** True when the user has linked their Steam account. */
+    steamLinked: z.boolean(),
+});
+
+export type LineupInviteeResponseDto = z.infer<
+    typeof LineupInviteeResponseSchema
+>;

--- a/packages/contract/src/lineup.schema.ts
+++ b/packages/contract/src/lineup.schema.ts
@@ -6,6 +6,11 @@ export * from './lineup-match.schema.js';
 // Re-export tiebreaker schemas (ROK-938)
 export * from './lineup-tiebreaker.schema.js';
 
+// Re-export invitee / visibility schemas (ROK-1065)
+export * from './lineup-invitees.schema.js';
+
+import { LineupVisibilitySchema, LineupInviteeResponseSchema } from './lineup-invitees.schema.js';
+
 // ============================================================
 // Community Lineup Schemas (ROK-933)
 // ============================================================
@@ -25,35 +30,53 @@ export type LineupStatusDto = z.infer<typeof LineupStatusSchema>;
 // ============================================================
 
 /** Create a new lineup (ROK-1063: title required, description optional markdown). */
-export const CreateLineupSchema = z.object({
-    /** Operator-authored title (1-100 chars, ROK-1063). */
-    title: z.string().trim().min(1).max(100),
-    /** Optional operator-authored markdown description (<=500 chars, ROK-1063). */
-    description: z.string().max(500).nullable().optional(),
-    targetDate: z.string().datetime({ offset: true }).nullable().optional(),
-    /** Hours for the building phase (1-720, default from admin settings). */
-    buildingDurationHours: z.number().int().min(1).max(720).optional(),
-    /** Hours for the voting phase (1-720, default from admin settings). */
-    votingDurationHours: z.number().int().min(1).max(720).optional(),
-    /** Hours for the decided phase (1-720, default from admin settings). */
-    decidedDurationHours: z.number().int().min(1).max(720).optional(),
-    /** Match threshold percentage for grouping algorithm (0–100, default 35). */
-    matchThreshold: z.number().int().min(0).max(100).optional(),
-    /** Max votes each player can cast during voting (1–10, default 3). */
-    votesPerPlayer: z.number().int().min(1).max(10).optional(),
-    /** Default tiebreaker mode when voting deadline expires. Null = skip tiebreaker. */
-    defaultTiebreakerMode: z.enum(['bracket', 'veto']).nullable().optional(),
-    /**
-     * Optional per-lineup Discord channel override (ROK-1064).
-     * When set, every lineup lifecycle embed posts to this channel instead
-     * of the guild-bound default. Must be a Discord snowflake (17–20 digits).
-     */
-    channelOverrideId: z
-        .string()
-        .regex(/^\d{17,20}$/)
-        .nullable()
-        .optional(),
-});
+export const CreateLineupSchema = z
+    .object({
+        /** Operator-authored title (1-100 chars, ROK-1063). */
+        title: z.string().trim().min(1).max(100),
+        /** Optional operator-authored markdown description (<=500 chars, ROK-1063). */
+        description: z.string().max(500).nullable().optional(),
+        targetDate: z.string().datetime({ offset: true }).nullable().optional(),
+        /** Hours for the building phase (1-720, default from admin settings). */
+        buildingDurationHours: z.number().int().min(1).max(720).optional(),
+        /** Hours for the voting phase (1-720, default from admin settings). */
+        votingDurationHours: z.number().int().min(1).max(720).optional(),
+        /** Hours for the decided phase (1-720, default from admin settings). */
+        decidedDurationHours: z.number().int().min(1).max(720).optional(),
+        /** Match threshold percentage for grouping algorithm (0–100, default 35). */
+        matchThreshold: z.number().int().min(0).max(100).optional(),
+        /** Max votes each player can cast during voting (1–10, default 3). */
+        votesPerPlayer: z.number().int().min(1).max(10).optional(),
+        /** Default tiebreaker mode when voting deadline expires. Null = skip tiebreaker. */
+        defaultTiebreakerMode: z.enum(['bracket', 'veto']).nullable().optional(),
+        /**
+         * Optional per-lineup Discord channel override (ROK-1064).
+         * When set, every lineup lifecycle embed posts to this channel instead
+         * of the guild-bound default. Must be a Discord snowflake (17–20 digits).
+         */
+        channelOverrideId: z
+            .string()
+            .regex(/^\d{17,20}$/)
+            .nullable()
+            .optional(),
+        /** Lineup visibility (ROK-1065). Defaults to 'public'. */
+        visibility: LineupVisibilitySchema.default('public').optional(),
+        /**
+         * Initial invitees (required when visibility === 'private').
+         * Users pinned here — along with the creator and any admin/operator —
+         * are the only ones who may nominate or vote on the lineup.
+         */
+        inviteeUserIds: z.array(z.number().int().positive()).optional(),
+    })
+    .refine(
+        (d) =>
+            d.visibility !== 'private' ||
+            (Array.isArray(d.inviteeUserIds) && d.inviteeUserIds.length > 0),
+        {
+            message: 'Private lineups require at least one invitee',
+            path: ['inviteeUserIds'],
+        },
+    );
 
 export type CreateLineupDto = z.infer<typeof CreateLineupSchema>;
 
@@ -169,6 +192,10 @@ export const LineupDetailResponseSchema = z.object({
      * visible to the bot.
      */
     channelOverrideName: z.string().nullable(),
+    /** Lineup visibility — 'public' or 'private' (ROK-1065). */
+    visibility: LineupVisibilitySchema,
+    /** Explicit invitees when visibility === 'private' (ROK-1065). */
+    invitees: z.array(LineupInviteeResponseSchema),
 });
 
 export type LineupDetailResponseDto = z.infer<typeof LineupDetailResponseSchema>;
@@ -199,6 +226,8 @@ export const LineupBannerResponseSchema = z.object({
     entries: z.array(LineupBannerEntrySchema),
     /** Whether a tiebreaker is active on this lineup (ROK-938). */
     tiebreakerActive: z.boolean().optional(),
+    /** Lineup visibility (ROK-1065). */
+    visibility: LineupVisibilitySchema,
 });
 
 export type LineupBannerResponseDto = z.infer<typeof LineupBannerResponseSchema>;
@@ -206,11 +235,15 @@ export type LineupBannerResponseDto = z.infer<typeof LineupBannerResponseSchema>
 /** Lightweight lineup summary for lists. */
 export const LineupSummaryResponseSchema = z.object({
     id: z.number(),
+    /** Operator-authored title (ROK-1063). */
+    title: z.string(),
     status: LineupStatusSchema,
     targetDate: z.string().nullable(),
     entryCount: z.number(),
     totalVoters: z.number(),
     createdAt: z.string(),
+    /** Lineup visibility (ROK-1065). */
+    visibility: LineupVisibilitySchema,
 });
 
 export type LineupSummaryResponseDto = z.infer<typeof LineupSummaryResponseSchema>;
@@ -228,6 +261,11 @@ export const CommonGroundQuerySchema = z.object({
     /** Case-insensitive game name search (ILIKE). */
     search: z.string().max(100).optional(),
     limit: z.coerce.number().int().min(1).max(50).default(50),
+    /**
+     * Explicit lineup to score against (ROK-1065).
+     * When omitted the server falls back to the newest public building lineup.
+     */
+    lineupId: z.coerce.number().int().positive().optional(),
 });
 
 export type CommonGroundQueryDto = z.infer<typeof CommonGroundQuerySchema>;

--- a/tools/test-bot/src/smoke/run.ts
+++ b/tools/test-bot/src/smoke/run.ts
@@ -160,7 +160,10 @@ async function teardown(
 
 async function main(): Promise<void> {
   const ctx = await setup();
-  const allTests = collectTests(process.env.SMOKE_CATEGORY);
+  const nameFilter = process.env.SMOKE_NAME_FILTER;
+  const allTests = collectTests(process.env.SMOKE_CATEGORY).filter(
+    (t) => !nameFilter || t.name.toLowerCase().includes(nameFilter.toLowerCase()),
+  );
 
   const sequentialCats = new Set(['voice', 'cdp-command']);
   const sequentialTests = allTests.filter((t) => sequentialCats.has(t.category));

--- a/tools/test-bot/src/smoke/run.ts
+++ b/tools/test-bot/src/smoke/run.ts
@@ -26,6 +26,7 @@ import { cdpSteamNominationTests } from './tests/cdp-steam-nomination.test.js';
 import { scheduledEventCompletionTests } from './tests/scheduled-event-completion.test.js';
 import { aiChatTests } from './tests/ai-chat.test.js';
 import { lineupTitleTests } from './tests/lineup-title.test.js';
+import { privateLineupTests } from './tests/private-lineup.test.js';
 
 /** Build a TestResult from a test, status, and timing info. */
 function buildResult(
@@ -141,6 +142,7 @@ function collectTests(filterCat?: string): SmokeTest[] {
     ...scheduledEventCompletionTests,
     ...aiChatTests,
     ...lineupTitleTests,
+    ...privateLineupTests,
   ].filter((t) => !filterCat || t.category === filterCat);
 }
 

--- a/tools/test-bot/src/smoke/tests/private-lineup.test.ts
+++ b/tools/test-bot/src/smoke/tests/private-lineup.test.ts
@@ -1,29 +1,30 @@
 /**
- * ROK-1065 — private / targeted lineup Discord smoke test.
+ * ROK-1065 — private / targeted lineup smoke test.
  *
- * Behavior being verified (feature does not exist yet; these tests MUST fail):
+ * Behavior being verified:
  *
- *   1. Creating a lineup with `{ visibility: 'private', inviteeUserIds: [<botUserId>] }`
- *      fires a DM to each invitee and does NOT post a lineup-created embed to
- *      the bound notification channel.
- *   2. Transitioning a private lineup from `building` -> `voting` fires DMs
- *      to invitees and does NOT post a voting-open embed to the channel.
+ *   1. Creating a lineup with `{ visibility: 'private', inviteeUserIds: [<userId>] }`
+ *      fires an in-app invite notification for each invitee (that the Discord
+ *      DM dispatcher would forward to Discord) and does NOT post a
+ *      lineup-created embed to the bound notification channel.
+ *   2. Transitioning a private lineup from `building` -> `voting` fires an
+ *      in-app voting-open notification for invitees and does NOT post a
+ *      voting-open embed to the channel.
+ *   3. The create response echoes the invitees array.
+ *   4. Multiple concurrent active lineups are allowed (the 409 check is gone).
  *
- * The test bot's Discord ID is linked to `ctx.dmRecipientUserId` during
- * smoke setup — we use that user as the invitee so the companion bot can
- * observe the DM.
- *
- * Current (pre-implementation) behavior strips unknown schema keys in
- * CreateLineupSchema, so `visibility` is ignored and the lineup is created
- * as public: channel embed posts, no DM fires. Both assertions fail until
- * the spec is implemented.
+ * We poll `/admin/test/notifications?userId=<invitee>&type=community_lineup`
+ * instead of Discord DMs because Discord disallows bot-to-bot DMs and the
+ * companion test bot doubles as the invitee. The in-app notification is the
+ * single source of truth that the notification pipeline fires; the Discord
+ * DM queue is tested separately in unit tests.
  */
-import { waitForDM } from '../../helpers/polling.js';
 import { readLastMessages } from '../../helpers/messages.js';
 import {
   awaitProcessing,
   assertConditionNeverMet,
 } from '../fixtures.js';
+import { pollForCondition } from '../../helpers/polling.js';
 import type { SmokeTest, TestContext } from '../types.js';
 import type { ApiClient } from '../api.js';
 import type { SimpleMessage } from '../../helpers/messages.js';
@@ -36,10 +37,18 @@ interface LineupPayload {
   [k: string]: unknown;
 }
 
+interface TestNotification {
+  id: number;
+  type: string;
+  title?: string;
+  message?: string;
+  payload?: { subtype?: string; lineupId?: number } | null;
+  createdAt?: string;
+}
+
 /** Best-effort archival of any currently active lineup(s) so create succeeds. */
 async function archiveAllLineups(api: ApiClient): Promise<void> {
   try {
-    // Spec renames this to an array; pre-impl still returns a single object.
     const res = await api.get<
       { id: number }[] | { id: number } | null
     >('/lineups/active');
@@ -83,7 +92,36 @@ async function createPrivateLineup(
   });
 }
 
-// ── AC 1: Create private lineup → DM invitee, no channel embed ──
+/** Fetch the invitee's community_lineup notifications via the demo-test route. */
+async function fetchInviteeNotifications(
+  ctx: TestContext,
+): Promise<TestNotification[]> {
+  const res = await ctx.api
+    .get<TestNotification[]>(
+      `/admin/test/notifications?userId=${ctx.dmRecipientUserId}&type=community_lineup&limit=25`,
+    )
+    .catch(() => [] as TestNotification[]);
+  return Array.isArray(res) ? res : [];
+}
+
+/** Poll notifications until one matching `predicate` arrives, or timeout. */
+async function waitForNotification(
+  ctx: TestContext,
+  predicate: (n: TestNotification) => boolean,
+  timeoutMs: number,
+): Promise<TestNotification> {
+  const hit = await pollForCondition(
+    async () => {
+      const list = await fetchInviteeNotifications(ctx);
+      return list.find(predicate) ?? null;
+    },
+    timeoutMs,
+    { intervalMs: 1500 },
+  );
+  return hit;
+}
+
+// ── AC 1: Create private lineup → notify invitee, no channel embed ──
 
 const privateLineupDmsInviteeNoChannelEmbed: SmokeTest = {
   name: 'Private lineup creation DMs invitee and suppresses channel embed (ROK-1065)',
@@ -94,7 +132,6 @@ const privateLineupDmsInviteeNoChannelEmbed: SmokeTest = {
     const title = `Private Smoke ${Date.now()}`;
     const lineup = await createPrivateLineup(ctx, title);
     try {
-      // Assert the server acknowledged visibility in the response (spec AC).
       if (lineup.visibility !== 'private') {
         throw new Error(
           `Expected response.visibility === 'private', got ${JSON.stringify(
@@ -105,22 +142,14 @@ const privateLineupDmsInviteeNoChannelEmbed: SmokeTest = {
 
       await awaitProcessing(ctx.api);
 
-      // Invitee must receive a DM referencing the lineup title.
-      const dm = await waitForDM(
-        ctx.testBotDiscordId,
-        (m) =>
-          m.content.includes(title) ||
-          m.embeds.some((e) => {
-            const hay = [e.title ?? '', e.description ?? ''].join(' ');
-            return hay.includes(title);
-          }),
+      await waitForNotification(
+        ctx,
+        (n) =>
+          n.payload?.subtype === 'lineup_invite' &&
+          n.payload.lineupId === lineup.id,
         ctx.config.timeoutMs,
       );
-      if (!dm) {
-        throw new Error('Invitee did not receive a DM for the private lineup');
-      }
 
-      // No lineup-created embed should appear in the bound channel.
       await assertConditionNeverMet(
         async () => {
           const msgs = await readLastMessages(ctx.defaultChannelId, 25);
@@ -144,7 +173,7 @@ const privateLineupDmsInviteeNoChannelEmbed: SmokeTest = {
   },
 };
 
-// ── AC 2: Phase transition on private lineup → DMs invitee, no channel embed ──
+// ── AC 2: Phase transition on private lineup → notify invitee, no channel embed ──
 
 const privateLineupPhaseTransitionSuppressesChannel: SmokeTest = {
   name: 'Private lineup building→voting DMs invitee and suppresses channel embed (ROK-1065)',
@@ -157,29 +186,19 @@ const privateLineupPhaseTransitionSuppressesChannel: SmokeTest = {
     try {
       await awaitProcessing(ctx.api);
 
-      // Transition to voting — this is the second notification hook.
       await ctx.api.patch(`/lineups/${lineup.id}/status`, {
         status: 'voting',
       });
       await awaitProcessing(ctx.api);
 
-      // Invitee must receive a voting-open DM.
-      const dm = await waitForDM(
-        ctx.testBotDiscordId,
-        (m) =>
-          m.embeds.some((e) => {
-            const hay = [e.title ?? '', e.description ?? ''].join(' ');
-            return /vote|voting/i.test(hay);
-          }),
+      await waitForNotification(
+        ctx,
+        (n) =>
+          n.payload?.subtype === 'lineup_voting_open' &&
+          n.payload.lineupId === lineup.id,
         ctx.config.timeoutMs,
       );
-      if (!dm) {
-        throw new Error(
-          'Invitee did not receive a voting-open DM for the private lineup',
-        );
-      }
 
-      // No voting-open embed should be posted to the channel.
       await assertConditionNeverMet(
         async () => {
           const msgs = await readLastMessages(ctx.defaultChannelId, 25);
@@ -251,7 +270,6 @@ const multipleConcurrentLineupsAllowed: SmokeTest = {
     });
     let second: LineupPayload | null = null;
     try {
-      // Second create must succeed. Under pre-ROK-1065 code it returns 409.
       second = await ctx.api.post<LineupPayload>('/lineups', {
         title: secondTitle,
         description: 'second concurrent',
@@ -262,7 +280,6 @@ const multipleConcurrentLineupsAllowed: SmokeTest = {
         );
       }
 
-      // Confirm both show up as active.
       await awaitProcessing(ctx.api);
       const activeRes = await ctx.api.get<
         { id: number }[] | { id: number }

--- a/tools/test-bot/src/smoke/tests/private-lineup.test.ts
+++ b/tools/test-bot/src/smoke/tests/private-lineup.test.ts
@@ -1,0 +1,295 @@
+/**
+ * ROK-1065 — private / targeted lineup Discord smoke test.
+ *
+ * Behavior being verified (feature does not exist yet; these tests MUST fail):
+ *
+ *   1. Creating a lineup with `{ visibility: 'private', inviteeUserIds: [<botUserId>] }`
+ *      fires a DM to each invitee and does NOT post a lineup-created embed to
+ *      the bound notification channel.
+ *   2. Transitioning a private lineup from `building` -> `voting` fires DMs
+ *      to invitees and does NOT post a voting-open embed to the channel.
+ *
+ * The test bot's Discord ID is linked to `ctx.dmRecipientUserId` during
+ * smoke setup — we use that user as the invitee so the companion bot can
+ * observe the DM.
+ *
+ * Current (pre-implementation) behavior strips unknown schema keys in
+ * CreateLineupSchema, so `visibility` is ignored and the lineup is created
+ * as public: channel embed posts, no DM fires. Both assertions fail until
+ * the spec is implemented.
+ */
+import { waitForDM } from '../../helpers/polling.js';
+import { readLastMessages } from '../../helpers/messages.js';
+import {
+  awaitProcessing,
+  assertConditionNeverMet,
+} from '../fixtures.js';
+import type { SmokeTest, TestContext } from '../types.js';
+import type { ApiClient } from '../api.js';
+import type { SimpleMessage } from '../../helpers/messages.js';
+
+interface LineupPayload {
+  id: number;
+  title?: string;
+  visibility?: string;
+  invitees?: unknown[];
+  [k: string]: unknown;
+}
+
+/** Best-effort archival of any currently active lineup(s) so create succeeds. */
+async function archiveAllLineups(api: ApiClient): Promise<void> {
+  try {
+    // Spec renames this to an array; pre-impl still returns a single object.
+    const res = await api.get<
+      { id: number }[] | { id: number } | null
+    >('/lineups/active');
+    const list = Array.isArray(res) ? res : res ? [res] : [];
+    for (const row of list) {
+      if (!row?.id) continue;
+      await api
+        .patch(`/lineups/${row.id}/status`, { status: 'archived' })
+        .catch(() => null);
+    }
+  } catch {
+    /* no active lineups */
+  }
+}
+
+async function deleteLineup(api: ApiClient, id: number): Promise<void> {
+  await api.delete(`/lineups/${id}`).catch(() => {
+    return api
+      .patch(`/lineups/${id}/status`, { status: 'archived' })
+      .catch(() => null);
+  });
+}
+
+/** Returns true if any recent channel message is a lineup-lifecycle embed. */
+function hasLineupEmbed(msgs: SimpleMessage[], titlePattern: RegExp): boolean {
+  return msgs.some((m) =>
+    m.embeds.some((e) => !!e.title && titlePattern.test(e.title)),
+  );
+}
+
+/** Create a private lineup pinned to a single invitee (the test bot's user). */
+async function createPrivateLineup(
+  ctx: TestContext,
+  title: string,
+): Promise<LineupPayload> {
+  return ctx.api.post<LineupPayload>('/lineups', {
+    title,
+    description: 'Invite-only smoke lineup',
+    visibility: 'private',
+    inviteeUserIds: [ctx.dmRecipientUserId],
+  });
+}
+
+// ── AC 1: Create private lineup → DM invitee, no channel embed ──
+
+const privateLineupDmsInviteeNoChannelEmbed: SmokeTest = {
+  name: 'Private lineup creation DMs invitee and suppresses channel embed (ROK-1065)',
+  category: 'dm',
+  async run(ctx: TestContext) {
+    await archiveAllLineups(ctx.api);
+
+    const title = `Private Smoke ${Date.now()}`;
+    const lineup = await createPrivateLineup(ctx, title);
+    try {
+      // Assert the server acknowledged visibility in the response (spec AC).
+      if (lineup.visibility !== 'private') {
+        throw new Error(
+          `Expected response.visibility === 'private', got ${JSON.stringify(
+            lineup.visibility,
+          )}`,
+        );
+      }
+
+      await awaitProcessing(ctx.api);
+
+      // Invitee must receive a DM referencing the lineup title.
+      const dm = await waitForDM(
+        ctx.testBotDiscordId,
+        (m) =>
+          m.content.includes(title) ||
+          m.embeds.some((e) => {
+            const hay = [e.title ?? '', e.description ?? ''].join(' ');
+            return hay.includes(title);
+          }),
+        ctx.config.timeoutMs,
+      );
+      if (!dm) {
+        throw new Error('Invitee did not receive a DM for the private lineup');
+      }
+
+      // No lineup-created embed should appear in the bound channel.
+      await assertConditionNeverMet(
+        async () => {
+          const msgs = await readLastMessages(ctx.defaultChannelId, 25);
+          return hasLineupEmbed(
+            msgs,
+            /Nominations Open|Community Lineup/i,
+          ) && msgs.some((m) =>
+            m.embeds.some((e) => {
+              const hay = [e.title ?? '', e.description ?? ''].join(' ');
+              return hay.includes(title);
+            }),
+          );
+        },
+        8_000,
+        `Channel received a lineup-created embed for private lineup "${title}" — expected none`,
+        { intervalMs: 2000 },
+      );
+    } finally {
+      await deleteLineup(ctx.api, lineup.id);
+    }
+  },
+};
+
+// ── AC 2: Phase transition on private lineup → DMs invitee, no channel embed ──
+
+const privateLineupPhaseTransitionSuppressesChannel: SmokeTest = {
+  name: 'Private lineup building→voting DMs invitee and suppresses channel embed (ROK-1065)',
+  category: 'dm',
+  async run(ctx: TestContext) {
+    await archiveAllLineups(ctx.api);
+
+    const title = `Private Phase ${Date.now()}`;
+    const lineup = await createPrivateLineup(ctx, title);
+    try {
+      await awaitProcessing(ctx.api);
+
+      // Transition to voting — this is the second notification hook.
+      await ctx.api.patch(`/lineups/${lineup.id}/status`, {
+        status: 'voting',
+      });
+      await awaitProcessing(ctx.api);
+
+      // Invitee must receive a voting-open DM.
+      const dm = await waitForDM(
+        ctx.testBotDiscordId,
+        (m) =>
+          m.embeds.some((e) => {
+            const hay = [e.title ?? '', e.description ?? ''].join(' ');
+            return /vote|voting/i.test(hay);
+          }),
+        ctx.config.timeoutMs,
+      );
+      if (!dm) {
+        throw new Error(
+          'Invitee did not receive a voting-open DM for the private lineup',
+        );
+      }
+
+      // No voting-open embed should be posted to the channel.
+      await assertConditionNeverMet(
+        async () => {
+          const msgs = await readLastMessages(ctx.defaultChannelId, 25);
+          return msgs.some((m) =>
+            m.embeds.some((e) => {
+              const hay = [e.title ?? '', e.description ?? ''].join(' ');
+              return /vote|voting/i.test(hay) && hay.includes(title);
+            }),
+          );
+        },
+        8_000,
+        `Channel received a voting-open embed for private lineup "${title}" — expected none`,
+        { intervalMs: 2000 },
+      );
+    } finally {
+      await deleteLineup(ctx.api, lineup.id);
+    }
+  },
+};
+
+// ── AC 3: Response includes invitees array with the expected invitee ──
+
+const privateLineupResponseIncludesInvitees: SmokeTest = {
+  name: 'Private lineup create response includes invitees array (ROK-1065)',
+  category: 'dm',
+  async run(ctx: TestContext) {
+    await archiveAllLineups(ctx.api);
+
+    const title = `Private Invitees ${Date.now()}`;
+    const lineup = await createPrivateLineup(ctx, title);
+    try {
+      const invitees = Array.isArray(lineup.invitees) ? lineup.invitees : null;
+      if (!invitees) {
+        throw new Error(
+          `Expected lineup.invitees to be an array, got ${JSON.stringify(
+            lineup.invitees,
+          )}`,
+        );
+      }
+      const ids = invitees
+        .map((row) => (row as { id?: number } | null)?.id)
+        .filter((v): v is number => typeof v === 'number');
+      if (!ids.includes(ctx.dmRecipientUserId)) {
+        throw new Error(
+          `Expected invitees to contain user ${ctx.dmRecipientUserId}, got ${JSON.stringify(
+            ids,
+          )}`,
+        );
+      }
+    } finally {
+      await deleteLineup(ctx.api, lineup.id);
+    }
+  },
+};
+
+// ── AC 4: Multiple concurrent lineups allowed (the 409 check must be gone) ──
+
+const multipleConcurrentLineupsAllowed: SmokeTest = {
+  name: 'Multiple concurrent active lineups permitted — no 409 (ROK-1065)',
+  category: 'dm',
+  async run(ctx: TestContext) {
+    await archiveAllLineups(ctx.api);
+
+    const firstTitle = `Concurrent A ${Date.now()}`;
+    const secondTitle = `Concurrent B ${Date.now()}`;
+    const first = await ctx.api.post<LineupPayload>('/lineups', {
+      title: firstTitle,
+      description: 'first concurrent',
+    });
+    let second: LineupPayload | null = null;
+    try {
+      // Second create must succeed. Under pre-ROK-1065 code it returns 409.
+      second = await ctx.api.post<LineupPayload>('/lineups', {
+        title: secondTitle,
+        description: 'second concurrent',
+      });
+      if (!second?.id) {
+        throw new Error(
+          `Second lineup create did not return an id: ${JSON.stringify(second)}`,
+        );
+      }
+
+      // Confirm both show up as active.
+      await awaitProcessing(ctx.api);
+      const activeRes = await ctx.api.get<
+        { id: number }[] | { id: number }
+      >('/lineups/active');
+      const list = Array.isArray(activeRes)
+        ? activeRes
+        : activeRes
+          ? [activeRes]
+          : [];
+      const ids = list.map((l) => l.id);
+      if (!ids.includes(first.id) || !ids.includes(second.id)) {
+        throw new Error(
+          `Expected GET /lineups/active to include both ${first.id} and ${second.id}, got ${JSON.stringify(
+            ids,
+          )}`,
+        );
+      }
+    } finally {
+      await deleteLineup(ctx.api, first.id);
+      if (second?.id) await deleteLineup(ctx.api, second.id);
+    }
+  },
+};
+
+export const privateLineupTests: SmokeTest[] = [
+  privateLineupDmsInviteeNoChannelEmbed,
+  privateLineupPhaseTransitionSuppressesChannel,
+  privateLineupResponseIncludesInvitees,
+  multipleConcurrentLineupsAllowed,
+];

--- a/web/src/components/games/unified-game-card.tsx
+++ b/web/src/components/games/unified-game-card.tsx
@@ -88,32 +88,30 @@ function buildCardClasses(props: UnifiedGameCardProps): string {
     return `${base} border border-edge/50 hover:border-emerald-500/50 ${hover} ${sizing}`.trim();
 }
 
-/** Genre + price badge row below the card title. */
+/** Genre + price + optional Steam-available badge row below the card title. */
 function CardBadgeRow({
     primaryGenre,
     pricing,
+    hasSteamAppId,
 }: {
     primaryGenre: string | null;
     pricing: ItadGamePricingDto | null | undefined;
+    hasSteamAppId: boolean;
 }): JSX.Element {
     return (
         <div className="flex items-center gap-1.5 mt-1">
             {primaryGenre && <GenreBadge label={primaryGenre} />}
             <PriceBadge pricing={pricing ?? null} />
+            {hasSteamAppId && (
+                <span
+                    data-testid="card-steam-badge"
+                    aria-label="Available on Steam"
+                    className="ml-auto inline-flex items-center justify-center w-5 h-5 rounded-full bg-black/50 text-emerald-300"
+                >
+                    <SteamIcon className="w-3 h-3" />
+                </span>
+            )}
         </div>
-    );
-}
-
-/** Small Steam icon badge rendered on the card cover (top-left). */
-function CardSteamBadge(): JSX.Element {
-    return (
-        <span
-            data-testid="card-steam-badge"
-            aria-label="Available on Steam"
-            className="absolute top-2 left-2 inline-flex items-center justify-center w-6 h-6 rounded-full bg-black/60 backdrop-blur-sm text-emerald-300"
-        >
-            <SteamIcon className="w-3.5 h-3.5" />
-        </span>
     );
 }
 
@@ -145,11 +143,14 @@ function CardCoverContent({
         <div className="relative aspect-[3/4] bg-panel">
             <CardCover game={game} />
             {showRating && rating != null && <RatingBadge rating={rating} />}
-            {game.steamAppId != null && <CardSteamBadge />}
             <GradientOverlay />
             <div className="absolute bottom-0 left-0 right-0 p-3">
                 <CardTitle name={game.name} />
-                <CardBadgeRow primaryGenre={primaryGenre} pricing={pricing} />
+                <CardBadgeRow
+                    primaryGenre={primaryGenre}
+                    pricing={pricing}
+                    hasSteamAppId={game.steamAppId != null}
+                />
             </div>
             {variant === 'toggle' && <HeartIcon selected={selected} />}
         </div>

--- a/web/src/components/games/unified-game-card.tsx
+++ b/web/src/components/games/unified-game-card.tsx
@@ -11,6 +11,7 @@ import { useAuth } from '../../hooks/use-auth';
 import { GENRE_MAP } from '../../lib/game-utils';
 import { PriceBadge } from './PriceBadge';
 import { MODE_MAP } from './game-card-constants';
+import { SteamIcon } from '../icons/SteamIcon';
 import {
     CoverImage,
     CoverPlaceholder,
@@ -33,6 +34,8 @@ interface GameProps {
     aggregatedRating?: number | null;
     rating?: number | null;
     gameModes?: number[];
+    /** When present, renders a small Steam badge on the card cover. */
+    steamAppId?: number | null;
 }
 
 /** Props shared by both variants. */
@@ -101,6 +104,19 @@ function CardBadgeRow({
     );
 }
 
+/** Small Steam icon badge rendered on the card cover (top-left). */
+function CardSteamBadge(): JSX.Element {
+    return (
+        <span
+            data-testid="card-steam-badge"
+            aria-label="Available on Steam"
+            className="absolute top-2 left-2 inline-flex items-center justify-center w-6 h-6 rounded-full bg-black/60 backdrop-blur-sm text-emerald-300"
+        >
+            <SteamIcon className="w-3.5 h-3.5" />
+        </span>
+    );
+}
+
 /** Cover image or placeholder. */
 function CardCover({ game }: { game: GameProps }): JSX.Element {
     if (game.coverUrl) return <CoverImage src={game.coverUrl} alt={game.name} />;
@@ -129,6 +145,7 @@ function CardCoverContent({
         <div className="relative aspect-[3/4] bg-panel">
             <CardCover game={game} />
             {showRating && rating != null && <RatingBadge rating={rating} />}
+            {game.steamAppId != null && <CardSteamBadge />}
             <GradientOverlay />
             <div className="absolute bottom-0 left-0 right-0 p-3">
                 <CardTitle name={game.name} />

--- a/web/src/components/lineups/AddInviteesButton.test.tsx
+++ b/web/src/components/lineups/AddInviteesButton.test.tsx
@@ -1,0 +1,73 @@
+/**
+ * Tests for AddInviteesButton (ROK-1065) — creator/admin-only trigger that
+ * opens a modal with the InviteeMultiSelect and submits user IDs to the
+ * add-invitees endpoint.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+import { AddInviteesButton } from './AddInviteesButton';
+
+const mockAdd = vi.fn();
+
+vi.mock('../../hooks/use-lineups', () => ({
+    useAddLineupInvitees: () => ({
+        mutateAsync: mockAdd,
+        isPending: false,
+    }),
+}));
+
+function wrap({ children }: { children: ReactNode }) {
+    const qc = new QueryClient({
+        defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    return createElement(QueryClientProvider, { client: qc }, children);
+}
+
+describe('AddInviteesButton (ROK-1065)', () => {
+    beforeEach(() => {
+        mockAdd.mockReset();
+        mockAdd.mockResolvedValue({});
+    });
+
+    it('renders an "Invite more" button', () => {
+        render(<AddInviteesButton lineupId={1} />, { wrapper: wrap });
+        expect(
+            screen.getByRole('button', { name: /invite more/i }),
+        ).toBeInTheDocument();
+    });
+
+    it('opens the modal when clicked', async () => {
+        const user = userEvent.setup();
+        render(<AddInviteesButton lineupId={1} />, { wrapper: wrap });
+        await user.click(screen.getByRole('button', { name: /invite more/i }));
+        expect(
+            screen.getByTestId('invitee-user-ids'),
+        ).toBeInTheDocument();
+    });
+
+    it('disables submit until at least one invitee id is entered', async () => {
+        const user = userEvent.setup();
+        render(<AddInviteesButton lineupId={1} />, { wrapper: wrap });
+        await user.click(screen.getByRole('button', { name: /invite more/i }));
+        const submit = screen.getByRole('button', { name: /^add invitees$/i });
+        expect(submit).toBeDisabled();
+    });
+
+    it('submits typed user ids to useAddLineupInvitees', async () => {
+        const user = userEvent.setup();
+        render(<AddInviteesButton lineupId={42} />, { wrapper: wrap });
+        await user.click(screen.getByRole('button', { name: /invite more/i }));
+        const input = screen.getByTestId('invitee-user-ids');
+        await user.type(input, '5, 7');
+        const submit = screen.getByRole('button', { name: /^add invitees$/i });
+        await user.click(submit);
+        expect(mockAdd).toHaveBeenCalledWith({
+            lineupId: 42,
+            userIds: [5, 7],
+        });
+    });
+});

--- a/web/src/components/lineups/AddInviteesButton.test.tsx
+++ b/web/src/components/lineups/AddInviteesButton.test.tsx
@@ -20,6 +20,24 @@ vi.mock('../../hooks/use-lineups', () => ({
     }),
 }));
 
+vi.mock('../../lib/api-client', () => ({
+    getPlayers: vi.fn(),
+}));
+
+import { getPlayers } from '../../lib/api-client';
+
+const playerListResponse = (
+    members: Array<{ id: number; username: string; discordId: string | null }>,
+) => ({
+    data: members.map((m) => ({
+        id: m.id,
+        username: m.username,
+        avatar: null,
+        discordId: m.discordId,
+    })),
+    meta: { total: members.length, page: 1, pageSize: 20, hasMore: false },
+});
+
 function wrap({ children }: { children: ReactNode }) {
     const qc = new QueryClient({
         defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
@@ -31,6 +49,13 @@ describe('AddInviteesButton (ROK-1065)', () => {
     beforeEach(() => {
         mockAdd.mockReset();
         mockAdd.mockResolvedValue({});
+        vi.mocked(getPlayers).mockReset();
+        vi.mocked(getPlayers).mockResolvedValue(
+            playerListResponse([
+                { id: 5, username: 'alice', discordId: 'd-5' },
+                { id: 7, username: 'bob', discordId: 'd-7' },
+            ]),
+        );
     });
 
     it('renders an "Invite more" button', () => {
@@ -40,16 +65,16 @@ describe('AddInviteesButton (ROK-1065)', () => {
         ).toBeInTheDocument();
     });
 
-    it('opens the modal when clicked', async () => {
+    it('opens the modal when clicked and renders the invitee picker', async () => {
         const user = userEvent.setup();
         render(<AddInviteesButton lineupId={1} />, { wrapper: wrap });
         await user.click(screen.getByRole('button', { name: /invite more/i }));
         expect(
-            screen.getByTestId('invitee-user-ids'),
+            await screen.findByTestId('invitee-multi-select'),
         ).toBeInTheDocument();
     });
 
-    it('disables submit until at least one invitee id is entered', async () => {
+    it('disables submit until at least one invitee is selected', async () => {
         const user = userEvent.setup();
         render(<AddInviteesButton lineupId={1} />, { wrapper: wrap });
         await user.click(screen.getByRole('button', { name: /invite more/i }));
@@ -57,12 +82,16 @@ describe('AddInviteesButton (ROK-1065)', () => {
         expect(submit).toBeDisabled();
     });
 
-    it('submits typed user ids to useAddLineupInvitees', async () => {
+    it('submits checked user ids to useAddLineupInvitees', async () => {
         const user = userEvent.setup();
         render(<AddInviteesButton lineupId={42} />, { wrapper: wrap });
         await user.click(screen.getByRole('button', { name: /invite more/i }));
-        const input = screen.getByTestId('invitee-user-ids');
-        await user.type(input, '5, 7');
+
+        const alice = await screen.findByTestId('invitee-option-5');
+        const bob = screen.getByTestId('invitee-option-7');
+        await user.click(alice.querySelector('input[type="checkbox"]')!);
+        await user.click(bob.querySelector('input[type="checkbox"]')!);
+
         const submit = screen.getByRole('button', { name: /^add invitees$/i });
         await user.click(submit);
         expect(mockAdd).toHaveBeenCalledWith({

--- a/web/src/components/lineups/AddInviteesButton.tsx
+++ b/web/src/components/lineups/AddInviteesButton.tsx
@@ -1,0 +1,91 @@
+/**
+ * Trigger + modal pair for adding invitees to an existing private lineup
+ * (ROK-1065).
+ *
+ * Reuses the same `InviteeMultiSelect` input as the Start Lineup modal so
+ * the UX is consistent. Only rendered by the parent (lineup detail page)
+ * when the current viewer is the creator, an admin, or an operator.
+ */
+import { useState, type JSX } from 'react';
+import { Modal } from '../ui/modal';
+import { InviteeMultiSelect } from './InviteeMultiSelect';
+import { useAddLineupInvitees } from '../../hooks/use-lineups';
+import { toast } from '../../lib/toast';
+
+export interface AddInviteesButtonProps {
+  lineupId: number;
+}
+
+/** Render the "Invite more" button and its modal. */
+export function AddInviteesButton({
+  lineupId,
+}: AddInviteesButtonProps): JSX.Element {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        data-testid="add-invitees-button"
+        className="inline-flex items-center gap-1 px-2.5 py-1.5 text-xs text-muted hover:text-foreground rounded border border-edge/50 hover:bg-overlay/50 transition-colors"
+      >
+        Invite more
+      </button>
+      {open && (
+        <AddInviteesModal
+          lineupId={lineupId}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </>
+  );
+}
+
+function AddInviteesModal({
+  lineupId,
+  onClose,
+}: {
+  lineupId: number;
+  onClose: () => void;
+}): JSX.Element {
+  const [userIds, setUserIds] = useState<number[]>([]);
+  const addInvitees = useAddLineupInvitees();
+  const canSubmit = userIds.length > 0 && !addInvitees.isPending;
+
+  async function handleSubmit(): Promise<void> {
+    try {
+      await addInvitees.mutateAsync({ lineupId, userIds });
+      toast.success(`Added ${userIds.length} invitee(s)`);
+      onClose();
+    } catch (err) {
+      toast.error(
+        err instanceof Error ? err.message : 'Failed to add invitees',
+      );
+    }
+  }
+
+  return (
+    <Modal isOpen onClose={onClose} title="Add Invitees">
+      <div className="space-y-4">
+        <InviteeMultiSelect value={userIds} onChange={setUserIds} />
+        <div className="flex justify-end gap-3 pt-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 text-sm font-medium text-secondary bg-panel border border-edge rounded-lg hover:bg-overlay transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={() => void handleSubmit()}
+            disabled={!canSubmit}
+            className="px-4 py-2 text-sm font-medium bg-emerald-600 text-white rounded-lg hover:bg-emerald-500 transition-colors disabled:opacity-50"
+          >
+            {addInvitees.isPending ? 'Adding...' : 'Add Invitees'}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/web/src/components/lineups/CommonGroundPanel.tsx
+++ b/web/src/components/lineups/CommonGroundPanel.tsx
@@ -5,7 +5,7 @@
 import { type JSX, useRef, useState, useEffect, useMemo, useCallback } from 'react';
 import type { CommonGroundResponseDto } from '@raid-ledger/contract';
 import type { CommonGroundParams } from '../../lib/api-client';
-import { useActiveLineup, useCommonGround, useNominateGame } from '../../hooks/use-lineups';
+import { useActiveLineups, useCommonGround, useNominateGame } from '../../hooks/use-lineups';
 import { useDebouncedValue } from '../../hooks/use-debounced-value';
 import { CommonGroundFilters } from './CommonGroundFilters';
 import { CommonGroundGameCard } from './CommonGroundGameCard';
@@ -198,14 +198,27 @@ function PanelContent({
     );
 }
 
-/** Main Common Ground panel. Pass lineupId when the parent already has it. */
+/**
+ * Main Common Ground panel (ROK-1065).
+ * Pass `lineupId` when the parent already has it — that bypasses the
+ * active-lineup lookup entirely. Without a prop we pick the newest
+ * building lineup from /lineups/active (array).
+ */
 export function CommonGroundPanel({ lineupId: propLineupId }: { lineupId?: number } = {}): JSX.Element | null {
-    const { data: lineup } = useActiveLineup();
-    const resolvedId = propLineupId ?? lineup?.id;
+    const { data: activeLineups } = useActiveLineups();
+    const newestBuilding = activeLineups?.find((l) => l.status === 'building') ?? null;
+    const resolvedId = propLineupId ?? newestBuilding?.id;
     const [filters, setFilters] = useState<CommonGroundParams>({ minOwners: 0 });
     const [search, setSearch] = useState('');
-    const hasBuilding = propLineupId != null || lineup?.status === 'building';
-    const apiParams = useMemo(() => ({ ...filters, search: search.trim() || undefined }), [filters, search]);
+    const hasBuilding = propLineupId != null || !!newestBuilding;
+    const apiParams = useMemo(
+        () => ({
+            ...filters,
+            search: search.trim() || undefined,
+            lineupId: resolvedId,
+        }),
+        [filters, search, resolvedId],
+    );
     const debouncedParams = useDebouncedValue(apiParams, 300);
     const { data, isLoading, isError, refetch } = useCommonGround(debouncedParams, hasBuilding);
     const availableTags = useMemo(() => (data?.data ? extractUniqueTags(data.data) : []), [data]);

--- a/web/src/components/lineups/CommonGroundPanel.tsx
+++ b/web/src/components/lineups/CommonGroundPanel.tsx
@@ -202,9 +202,16 @@ function PanelContent({
  * Main Common Ground panel (ROK-1065).
  * Pass `lineupId` when the parent already has it — that bypasses the
  * active-lineup lookup entirely. Without a prop we pick the newest
- * building lineup from /lineups/active (array).
+ * building lineup from /lineups/active (array). `canParticipate=false`
+ * disables the Nominate buttons (private-lineup non-invitees).
  */
-export function CommonGroundPanel({ lineupId: propLineupId }: { lineupId?: number } = {}): JSX.Element | null {
+export function CommonGroundPanel({
+    lineupId: propLineupId,
+    canParticipate = true,
+}: {
+    lineupId?: number;
+    canParticipate?: boolean;
+} = {}): JSX.Element | null {
     const { data: activeLineups } = useActiveLineups();
     const newestBuilding = activeLineups?.find((l) => l.status === 'building') ?? null;
     const resolvedId = propLineupId ?? newestBuilding?.id;
@@ -222,7 +229,8 @@ export function CommonGroundPanel({ lineupId: propLineupId }: { lineupId?: numbe
     const debouncedParams = useDebouncedValue(apiParams, 300);
     const { data, isLoading, isError, refetch } = useCommonGround(debouncedParams, hasBuilding);
     const availableTags = useMemo(() => (data?.data ? extractUniqueTags(data.data) : []), [data]);
-    const atCap = (data?.meta.nominatedCount ?? 0) >= (data?.meta.maxNominations ?? 20);
+    const rawAtCap = (data?.meta.nominatedCount ?? 0) >= (data?.meta.maxNominations ?? 20);
+    const atCap = rawAtCap || !canParticipate;
     const { nominatingId, handleNominate } = useNomination(resolvedId);
 
     if (!hasBuilding) return null;

--- a/web/src/components/lineups/InviteeList.test.tsx
+++ b/web/src/components/lineups/InviteeList.test.tsx
@@ -1,0 +1,106 @@
+/**
+ * Tests for InviteeList — the read-only roster panel that shows every
+ * invitee on a private lineup, with a trash icon available to the
+ * creator/admin/operator for quick removal (ROK-1065).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+import { InviteeList } from './InviteeList';
+
+const mockRemove = vi.fn();
+
+vi.mock('../../hooks/use-lineups', () => ({
+    useRemoveLineupInvitee: () => ({
+        mutate: mockRemove,
+        isPending: false,
+    }),
+}));
+
+function wrap({ children }: { children: ReactNode }) {
+    const qc = new QueryClient({
+        defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+    return createElement(QueryClientProvider, { client: qc }, children);
+}
+
+const invitees = [
+    { id: 1, displayName: 'Alice', steamLinked: true },
+    { id: 2, displayName: 'Bob', steamLinked: false },
+];
+
+describe('InviteeList (ROK-1065)', () => {
+    beforeEach(() => {
+        mockRemove.mockReset();
+    });
+
+    it('renders one row per invitee with display names', () => {
+        render(
+            <InviteeList
+                lineupId={1}
+                invitees={invitees}
+                canManage={false}
+            />,
+            { wrapper: wrap },
+        );
+        expect(screen.getByText('Alice')).toBeInTheDocument();
+        expect(screen.getByText('Bob')).toBeInTheDocument();
+    });
+
+    it('hides remove buttons when canManage is false', () => {
+        render(
+            <InviteeList
+                lineupId={1}
+                invitees={invitees}
+                canManage={false}
+            />,
+            { wrapper: wrap },
+        );
+        expect(
+            screen.queryAllByRole('button', { name: /remove/i }),
+        ).toHaveLength(0);
+    });
+
+    it('shows a remove button per invitee when canManage is true', () => {
+        render(
+            <InviteeList
+                lineupId={1}
+                invitees={invitees}
+                canManage={true}
+            />,
+            { wrapper: wrap },
+        );
+        expect(
+            screen.getAllByRole('button', { name: /remove/i }),
+        ).toHaveLength(2);
+    });
+
+    it('calls the remove mutation with the lineup+user id on click', async () => {
+        const user = userEvent.setup();
+        render(
+            <InviteeList
+                lineupId={7}
+                invitees={invitees}
+                canManage={true}
+            />,
+            { wrapper: wrap },
+        );
+        const [firstBtn] = screen.getAllByRole('button', { name: /remove/i });
+        await user.click(firstBtn);
+        expect(mockRemove).toHaveBeenCalledWith(
+            { lineupId: 7, userId: 1 },
+            expect.any(Object),
+        );
+    });
+
+    it('renders an empty state when there are no invitees', () => {
+        render(
+            <InviteeList lineupId={1} invitees={[]} canManage={false} />,
+            { wrapper: wrap },
+        );
+        expect(screen.getByText(/no invitees/i)).toBeInTheDocument();
+    });
+});

--- a/web/src/components/lineups/InviteeList.tsx
+++ b/web/src/components/lineups/InviteeList.tsx
@@ -1,0 +1,116 @@
+/**
+ * Read-only invitee roster for a private lineup (ROK-1065).
+ *
+ * Each row shows the invitee display name and a Steam-link indicator.
+ * The creator/admin/operator sees a trash icon that calls the remove-invitee
+ * mutation. Remains rendered for everyone (even non-managers) so private
+ * lineups feel like a real roster on the detail page.
+ */
+import { type JSX } from 'react';
+import type { LineupInviteeResponseDto } from '@raid-ledger/contract';
+import { useRemoveLineupInvitee } from '../../hooks/use-lineups';
+import { toast } from '../../lib/toast';
+
+export interface InviteeListProps {
+  lineupId: number;
+  invitees: LineupInviteeResponseDto[];
+  /** True when the viewer can remove invitees (creator/admin/operator). */
+  canManage: boolean;
+}
+
+/**
+ * Render the invitee roster with optional remove buttons.
+ */
+export function InviteeList({
+  lineupId,
+  invitees,
+  canManage,
+}: InviteeListProps): JSX.Element {
+  if (invitees.length === 0) {
+    return (
+      <div
+        data-testid="invitee-list-empty"
+        className="text-sm text-muted italic"
+      >
+        No invitees yet.
+      </div>
+    );
+  }
+  return (
+    <ul
+      data-testid="invitee-list"
+      className="flex flex-wrap gap-2"
+    >
+      {invitees.map((inv) => (
+        <InviteeRow
+          key={inv.id}
+          lineupId={lineupId}
+          invitee={inv}
+          canManage={canManage}
+        />
+      ))}
+    </ul>
+  );
+}
+
+function InviteeRow({
+  lineupId,
+  invitee,
+  canManage,
+}: {
+  lineupId: number;
+  invitee: LineupInviteeResponseDto;
+  canManage: boolean;
+}): JSX.Element {
+  const remove = useRemoveLineupInvitee();
+  const handleRemove = (): void => {
+    remove.mutate(
+      { lineupId, userId: invitee.id },
+      {
+        onError: (err) =>
+          toast.error(
+            err instanceof Error ? err.message : 'Failed to remove invitee',
+          ),
+      },
+    );
+  };
+  return (
+    <li
+      data-testid={`invitee-row-${invitee.id}`}
+      className="inline-flex items-center gap-2 px-2 py-1 rounded border border-edge bg-panel text-sm"
+    >
+      <span className="text-primary">{invitee.displayName}</span>
+      {invitee.steamLinked && (
+        <span
+          title="Steam account linked"
+          className="text-xs text-muted"
+        >
+          · Steam
+        </span>
+      )}
+      {canManage && (
+        <button
+          type="button"
+          aria-label={`Remove ${invitee.displayName}`}
+          onClick={handleRemove}
+          disabled={remove.isPending}
+          className="text-muted hover:text-red-400 transition-colors disabled:opacity-50"
+        >
+          <svg
+            className="w-4 h-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M6 18L18 6M6 6l12 12"
+            />
+          </svg>
+        </button>
+      )}
+    </li>
+  );
+}

--- a/web/src/components/lineups/InviteeMultiSelect.test.tsx
+++ b/web/src/components/lineups/InviteeMultiSelect.test.tsx
@@ -38,7 +38,7 @@ describe('InviteeMultiSelect', () => {
     vi.mocked(getPlayers).mockReset();
   });
 
-  it('renders Discord-linked members and hides unlinked ones', async () => {
+  it('renders every guild member and flags non-Discord-linked rows', async () => {
     vi.mocked(getPlayers).mockResolvedValue(
       makeResponse([
         { id: 1, username: 'alice', discordId: 'd-1' },
@@ -50,8 +50,11 @@ describe('InviteeMultiSelect', () => {
     renderWithClient(<InviteeMultiSelect value={[]} onChange={() => {}} />);
 
     expect(await screen.findByTestId('invitee-option-1')).toBeInTheDocument();
-    expect(screen.queryByTestId('invitee-option-2')).not.toBeInTheDocument();
+    expect(screen.getByTestId('invitee-option-2')).toBeInTheDocument();
     expect(screen.getByTestId('invitee-option-3')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('invitee-option-2').textContent,
+    ).toMatch(/No Discord/i);
   });
 
   it('toggles selection via checkbox and invokes onChange with the new id array', async () => {

--- a/web/src/components/lineups/InviteeMultiSelect.test.tsx
+++ b/web/src/components/lineups/InviteeMultiSelect.test.tsx
@@ -1,0 +1,30 @@
+/**
+ * Tests for InviteeMultiSelect (ROK-1065).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { InviteeMultiSelect } from './InviteeMultiSelect';
+
+describe('InviteeMultiSelect', () => {
+  it('renders the current IDs as comma-separated text in the input', () => {
+    render(<InviteeMultiSelect value={[12, 18, 31]} onChange={() => {}} />);
+    const input = screen.getByTestId('invitee-user-ids') as HTMLInputElement;
+    expect(input.value).toBe('12,18,31');
+  });
+
+  it('parses comma-separated numbers and drops junk on change', () => {
+    const onChange = vi.fn();
+    render(<InviteeMultiSelect value={[]} onChange={onChange} />);
+    const input = screen.getByTestId('invitee-user-ids') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '12, 18, abc, -3, 31' } });
+    expect(onChange).toHaveBeenCalledWith([12, 18, 31]);
+  });
+
+  it('collapses whitespace and returns empty array when blank', () => {
+    const onChange = vi.fn();
+    render(<InviteeMultiSelect value={[1]} onChange={onChange} />);
+    const input = screen.getByTestId('invitee-user-ids') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '   ' } });
+    expect(onChange).toHaveBeenCalledWith([]);
+  });
+});

--- a/web/src/components/lineups/InviteeMultiSelect.test.tsx
+++ b/web/src/components/lineups/InviteeMultiSelect.test.tsx
@@ -1,30 +1,88 @@
 /**
  * Tests for InviteeMultiSelect (ROK-1065).
  */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { InviteeMultiSelect } from './InviteeMultiSelect';
 
+vi.mock('../../lib/api-client', () => ({
+  getPlayers: vi.fn(),
+}));
+
+import { getPlayers } from '../../lib/api-client';
+
+function renderWithClient(ui: React.ReactElement) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>{ui}</QueryClientProvider>,
+  );
+}
+
+const makeResponse = (
+  members: Array<{ id: number; username: string; discordId: string | null }>,
+) => ({
+  data: members.map((m) => ({
+    id: m.id,
+    username: m.username,
+    avatar: null,
+    discordId: m.discordId,
+  })),
+  meta: { total: members.length, page: 1, pageSize: 20, hasMore: false },
+});
+
 describe('InviteeMultiSelect', () => {
-  it('renders the current IDs as comma-separated text in the input', () => {
-    render(<InviteeMultiSelect value={[12, 18, 31]} onChange={() => {}} />);
-    const input = screen.getByTestId('invitee-user-ids') as HTMLInputElement;
-    expect(input.value).toBe('12,18,31');
+  beforeEach(() => {
+    vi.mocked(getPlayers).mockReset();
   });
 
-  it('parses comma-separated numbers and drops junk on change', () => {
-    const onChange = vi.fn();
-    render(<InviteeMultiSelect value={[]} onChange={onChange} />);
-    const input = screen.getByTestId('invitee-user-ids') as HTMLInputElement;
-    fireEvent.change(input, { target: { value: '12, 18, abc, -3, 31' } });
-    expect(onChange).toHaveBeenCalledWith([12, 18, 31]);
+  it('renders Discord-linked members and hides unlinked ones', async () => {
+    vi.mocked(getPlayers).mockResolvedValue(
+      makeResponse([
+        { id: 1, username: 'alice', discordId: 'd-1' },
+        { id: 2, username: 'bob', discordId: null },
+        { id: 3, username: 'carol', discordId: 'd-3' },
+      ]),
+    );
+
+    renderWithClient(<InviteeMultiSelect value={[]} onChange={() => {}} />);
+
+    expect(await screen.findByTestId('invitee-option-1')).toBeInTheDocument();
+    expect(screen.queryByTestId('invitee-option-2')).not.toBeInTheDocument();
+    expect(screen.getByTestId('invitee-option-3')).toBeInTheDocument();
   });
 
-  it('collapses whitespace and returns empty array when blank', () => {
+  it('toggles selection via checkbox and invokes onChange with the new id array', async () => {
+    vi.mocked(getPlayers).mockResolvedValue(
+      makeResponse([
+        { id: 11, username: 'dan', discordId: 'd-11' },
+        { id: 12, username: 'eve', discordId: 'd-12' },
+      ]),
+    );
     const onChange = vi.fn();
-    render(<InviteeMultiSelect value={[1]} onChange={onChange} />);
-    const input = screen.getByTestId('invitee-user-ids') as HTMLInputElement;
-    fireEvent.change(input, { target: { value: '   ' } });
-    expect(onChange).toHaveBeenCalledWith([]);
+
+    renderWithClient(
+      <InviteeMultiSelect value={[11]} onChange={onChange} />,
+    );
+
+    const row12 = await screen.findByTestId('invitee-option-12');
+    fireEvent.click(row12.querySelector('input[type="checkbox"]')!);
+    expect(onChange).toHaveBeenCalledWith([11, 12]);
+
+    const row11 = screen.getByTestId('invitee-option-11');
+    fireEvent.click(row11.querySelector('input[type="checkbox"]')!);
+    expect(onChange).toHaveBeenLastCalledWith([]);
+  });
+
+  it('renders the selection count hint when at least one invitee is picked', async () => {
+    vi.mocked(getPlayers).mockResolvedValue(
+      makeResponse([{ id: 7, username: 'frank', discordId: 'd-7' }]),
+    );
+
+    renderWithClient(<InviteeMultiSelect value={[7]} onChange={() => {}} />);
+
+    expect(await screen.findByText(/1 invitee selected/i)).toBeInTheDocument();
   });
 });

--- a/web/src/components/lineups/InviteeMultiSelect.tsx
+++ b/web/src/components/lineups/InviteeMultiSelect.tsx
@@ -7,9 +7,12 @@
  *
  * The input tracks raw text locally so intermediate punctuation
  * (commas, spaces) isn't clobbered by parent re-renders that only
- * round-trip the parsed numeric array.
+ * round-trip the parsed numeric array. Sync with the controlled `value`
+ * happens during render via the React "derive-state-from-props" pattern
+ * (setState in render, not in an effect) so cursor state is preserved
+ * without triggering cascading effects.
  */
-import { useEffect, useRef, useState, type JSX, type ChangeEvent } from 'react';
+import { useState, type JSX, type ChangeEvent } from 'react';
 
 export interface InviteeMultiSelectProps {
   value: number[];
@@ -21,20 +24,21 @@ export function InviteeMultiSelect({
   value,
   onChange,
 }: InviteeMultiSelectProps): JSX.Element {
-  const [raw, setRaw] = useState<string>(() => value.join(','));
-  const lastEmitted = useRef<string>(value.join(','));
-  useEffect(() => {
-    const next = value.join(',');
-    if (next !== lastEmitted.current) {
-      setRaw(next);
-      lastEmitted.current = next;
-    }
-  }, [value]);
+  const canonical = value.join(',');
+  const [state, setState] = useState<{ raw: string; emitted: string }>({
+    raw: canonical,
+    emitted: canonical,
+  });
+  // Derive-state-from-props: parent pushed a different value than we last
+  // emitted — resync the raw input on this render (no effect needed).
+  if (canonical !== state.emitted) {
+    setState({ raw: canonical, emitted: canonical });
+  }
 
   function handleChange(e: ChangeEvent<HTMLInputElement>): void {
-    setRaw(e.target.value);
-    const parsed = parseIds(e.target.value);
-    lastEmitted.current = parsed.join(',');
+    const next = e.target.value;
+    const parsed = parseIds(next);
+    setState({ raw: next, emitted: parsed.join(',') });
     onChange(parsed);
   }
 
@@ -51,7 +55,7 @@ export function InviteeMultiSelect({
         data-testid="invitee-user-ids"
         type="text"
         inputMode="numeric"
-        value={raw}
+        value={state.raw}
         onChange={handleChange}
         placeholder="e.g. 12, 18, 31"
         className="w-full px-3 py-2 text-sm bg-panel border border-edge rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500"

--- a/web/src/components/lineups/InviteeMultiSelect.tsx
+++ b/web/src/components/lineups/InviteeMultiSelect.tsx
@@ -1,77 +1,128 @@
 /**
- * Minimal invitee multi-select input (ROK-1065).
+ * Invitee multi-select for private lineups (ROK-1065).
  *
- * For the initial private-lineup shipping cut, operators paste
- * comma-separated user IDs. A richer picker with user search can replace
- * this component later without breaking the parent modal contract.
- *
- * The input tracks raw text locally so intermediate punctuation
- * (commas, spaces) isn't clobbered by parent re-renders that only
- * round-trip the parsed numeric array. Sync with the controlled `value`
- * happens during render via the React "derive-state-from-props" pattern
- * (setState in render, not in an effect) so cursor state is preserved
- * without triggering cascading effects.
+ * Checkbox list of Discord-linked guild members with a search box —
+ * mirrors the `MemberPicker` used in the Schedule a Game poll modal.
+ * Parent contract unchanged: controlled `value: number[]` + `onChange`.
  */
-import { useState, type JSX, type ChangeEvent } from 'react';
+import { useMemo, useState, type JSX } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { getPlayers } from '../../lib/api-client';
+
+interface GuildMember {
+  id: number;
+  username: string;
+  discordLinked: boolean;
+}
 
 export interface InviteeMultiSelectProps {
   value: number[];
   onChange: (next: number[]) => void;
 }
 
-/** Render a basic comma-separated user-id input with validation. */
+function useGuildMembers(search: string) {
+  return useQuery({
+    queryKey: ['players', 'invitee-picker', search],
+    queryFn: () => getPlayers({ search: search || undefined, page: 1 }),
+    select: (data): GuildMember[] =>
+      (data.data ?? []).map((u) => ({
+        id: u.id,
+        username: u.username,
+        discordLinked: !!u.discordId,
+      })),
+  });
+}
+
+function MemberRow({
+  member,
+  checked,
+  onToggle,
+}: {
+  member: GuildMember;
+  checked: boolean;
+  onToggle: () => void;
+}): JSX.Element {
+  return (
+    <label
+      data-testid={`invitee-option-${member.id}`}
+      className="flex items-center gap-2 px-3 py-2 hover:bg-panel rounded cursor-pointer"
+    >
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={onToggle}
+        className="rounded border-edge"
+      />
+      <span className="text-sm text-foreground flex-1">{member.username}</span>
+      {!member.discordLinked && (
+        <span className="text-[10px] uppercase tracking-wide text-muted">
+          No Discord
+        </span>
+      )}
+    </label>
+  );
+}
+
+/** Guild-member multi-select with search + checkboxes. */
 export function InviteeMultiSelect({
   value,
   onChange,
 }: InviteeMultiSelectProps): JSX.Element {
-  const canonical = value.join(',');
-  const [state, setState] = useState<{ raw: string; emitted: string }>({
-    raw: canonical,
-    emitted: canonical,
-  });
-  // Derive-state-from-props: parent pushed a different value than we last
-  // emitted — resync the raw input on this render (no effect needed).
-  if (canonical !== state.emitted) {
-    setState({ raw: canonical, emitted: canonical });
-  }
+  const [search, setSearch] = useState('');
+  const { data: members = [], isLoading } = useGuildMembers(search);
 
-  function handleChange(e: ChangeEvent<HTMLInputElement>): void {
-    const next = e.target.value;
-    const parsed = parseIds(next);
-    setState({ raw: next, emitted: parsed.join(',') });
-    onChange(parsed);
+  const filtered = useMemo(() => {
+    const discordOnly = members.filter((m) => m.discordLinked);
+    if (!search) return discordOnly;
+    const q = search.toLowerCase();
+    return discordOnly.filter((m) => m.username.toLowerCase().includes(q));
+  }, [members, search]);
+
+  function toggle(id: number): void {
+    onChange(
+      value.includes(id) ? value.filter((v) => v !== id) : [...value, id],
+    );
   }
 
   return (
-    <div className="space-y-2">
+    <div data-testid="invitee-multi-select" className="space-y-2">
       <label
-        htmlFor="invitee-user-ids"
+        htmlFor="invitee-search"
         className="block text-sm font-medium text-primary"
       >
-        Invitees (user IDs)
+        Invitees
       </label>
       <input
-        id="invitee-user-ids"
-        data-testid="invitee-user-ids"
+        id="invitee-search"
+        data-testid="invitee-search"
         type="text"
-        inputMode="numeric"
-        value={state.raw}
-        onChange={handleChange}
-        placeholder="e.g. 12, 18, 31"
-        className="w-full px-3 py-2 text-sm bg-panel border border-edge rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="Search members..."
+        aria-label="Search members"
+        className="w-full px-3 py-2 text-sm bg-panel border border-edge rounded-lg text-foreground placeholder-dim focus:outline-none focus:ring-2 focus:ring-amber-500"
       />
+      <div className="max-h-48 overflow-y-auto border border-edge rounded-lg">
+        {isLoading && (
+          <div className="px-3 py-2 text-sm text-muted">Loading...</div>
+        )}
+        {!isLoading && filtered.length === 0 && (
+          <div className="px-3 py-2 text-sm text-muted">No members found</div>
+        )}
+        {filtered.map((m) => (
+          <MemberRow
+            key={m.id}
+            member={m}
+            checked={value.includes(m.id)}
+            onToggle={() => toggle(m.id)}
+          />
+        ))}
+      </div>
       <p className="text-xs text-muted">
-        Comma-separate numeric user IDs. Private lineups require at least one.
+        {value.length > 0
+          ? `${value.length} invitee${value.length !== 1 ? 's' : ''} selected`
+          : 'Pick at least one guild member. Private lineups require ≥1 invitee.'}
       </p>
     </div>
   );
-}
-
-function parseIds(raw: string): number[] {
-  return raw
-    .split(',')
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0)
-    .map((s) => Number.parseInt(s, 10))
-    .filter((n) => Number.isFinite(n) && n > 0);
 }

--- a/web/src/components/lineups/InviteeMultiSelect.tsx
+++ b/web/src/components/lineups/InviteeMultiSelect.tsx
@@ -4,8 +4,12 @@
  * For the initial private-lineup shipping cut, operators paste
  * comma-separated user IDs. A richer picker with user search can replace
  * this component later without breaking the parent modal contract.
+ *
+ * The input tracks raw text locally so intermediate punctuation
+ * (commas, spaces) isn't clobbered by parent re-renders that only
+ * round-trip the parsed numeric array.
  */
-import { type JSX } from 'react';
+import { useEffect, useRef, useState, type JSX, type ChangeEvent } from 'react';
 
 export interface InviteeMultiSelectProps {
   value: number[];
@@ -17,6 +21,23 @@ export function InviteeMultiSelect({
   value,
   onChange,
 }: InviteeMultiSelectProps): JSX.Element {
+  const [raw, setRaw] = useState<string>(() => value.join(','));
+  const lastEmitted = useRef<string>(value.join(','));
+  useEffect(() => {
+    const next = value.join(',');
+    if (next !== lastEmitted.current) {
+      setRaw(next);
+      lastEmitted.current = next;
+    }
+  }, [value]);
+
+  function handleChange(e: ChangeEvent<HTMLInputElement>): void {
+    setRaw(e.target.value);
+    const parsed = parseIds(e.target.value);
+    lastEmitted.current = parsed.join(',');
+    onChange(parsed);
+  }
+
   return (
     <div className="space-y-2">
       <label
@@ -30,8 +51,8 @@ export function InviteeMultiSelect({
         data-testid="invitee-user-ids"
         type="text"
         inputMode="numeric"
-        value={value.join(',')}
-        onChange={(e) => onChange(parseIds(e.target.value))}
+        value={raw}
+        onChange={handleChange}
         placeholder="e.g. 12, 18, 31"
         className="w-full px-3 py-2 text-sm bg-panel border border-edge rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500"
       />

--- a/web/src/components/lineups/InviteeMultiSelect.tsx
+++ b/web/src/components/lineups/InviteeMultiSelect.tsx
@@ -23,7 +23,12 @@ export interface InviteeMultiSelectProps {
 function useGuildMembers(search: string) {
   return useQuery({
     queryKey: ['players', 'invitee-picker', search],
-    queryFn: () => getPlayers({ search: search || undefined, page: 1 }),
+    queryFn: () =>
+      getPlayers({
+        search: search || undefined,
+        page: 1,
+        pageSize: 200,
+      }),
     select: (data): GuildMember[] =>
       (data.data ?? []).map((u) => ({
         id: u.id,
@@ -56,7 +61,7 @@ function MemberRow({
       <span className="text-sm text-foreground flex-1">{member.username}</span>
       {!member.discordLinked && (
         <span className="text-[10px] uppercase tracking-wide text-muted">
-          No Discord
+          No Discord — DMs won't reach them
         </span>
       )}
     </label>
@@ -72,10 +77,9 @@ export function InviteeMultiSelect({
   const { data: members = [], isLoading } = useGuildMembers(search);
 
   const filtered = useMemo(() => {
-    const discordOnly = members.filter((m) => m.discordLinked);
-    if (!search) return discordOnly;
+    if (!search) return members;
     const q = search.toLowerCase();
-    return discordOnly.filter((m) => m.username.toLowerCase().includes(q));
+    return members.filter((m) => m.username.toLowerCase().includes(q));
   }, [members, search]);
 
   function toggle(id: number): void {

--- a/web/src/components/lineups/InviteeMultiSelect.tsx
+++ b/web/src/components/lineups/InviteeMultiSelect.tsx
@@ -1,0 +1,52 @@
+/**
+ * Minimal invitee multi-select input (ROK-1065).
+ *
+ * For the initial private-lineup shipping cut, operators paste
+ * comma-separated user IDs. A richer picker with user search can replace
+ * this component later without breaking the parent modal contract.
+ */
+import { type JSX } from 'react';
+
+export interface InviteeMultiSelectProps {
+  value: number[];
+  onChange: (next: number[]) => void;
+}
+
+/** Render a basic comma-separated user-id input with validation. */
+export function InviteeMultiSelect({
+  value,
+  onChange,
+}: InviteeMultiSelectProps): JSX.Element {
+  return (
+    <div className="space-y-2">
+      <label
+        htmlFor="invitee-user-ids"
+        className="block text-sm font-medium text-primary"
+      >
+        Invitees (user IDs)
+      </label>
+      <input
+        id="invitee-user-ids"
+        data-testid="invitee-user-ids"
+        type="text"
+        inputMode="numeric"
+        value={value.join(',')}
+        onChange={(e) => onChange(parseIds(e.target.value))}
+        placeholder="e.g. 12, 18, 31"
+        className="w-full px-3 py-2 text-sm bg-panel border border-edge rounded-lg focus:outline-none focus:ring-2 focus:ring-amber-500"
+      />
+      <p className="text-xs text-muted">
+        Comma-separate numeric user IDs. Private lineups require at least one.
+      </p>
+    </div>
+  );
+}
+
+function parseIds(raw: string): number[] {
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .map((s) => Number.parseInt(s, 10))
+    .filter((n) => Number.isFinite(n) && n > 0);
+}

--- a/web/src/components/lineups/InviteeMultiSelect.tsx
+++ b/web/src/components/lineups/InviteeMultiSelect.tsx
@@ -59,6 +59,9 @@ function MemberRow({
         className="rounded border-edge"
       />
       <span className="text-sm text-foreground flex-1">{member.username}</span>
+      {/* TD-2: spec asked for "No Steam linked — limited data"; implementing
+          that requires adding `steamLinked` to GetPlayersResponseDto. Tracked
+          as follow-up. */}
       {!member.discordLinked && (
         <span className="text-[10px] uppercase tracking-wide text-muted">
           No Discord — DMs won't reach them

--- a/web/src/components/lineups/LineupBanner.test.tsx
+++ b/web/src/components/lineups/LineupBanner.test.tsx
@@ -11,6 +11,7 @@ import { LineupBanner } from './LineupBanner';
 // Mock the hooks module
 vi.mock('../../hooks/use-lineups', () => ({
     useLineupBanner: vi.fn(),
+    useActiveLineups: vi.fn(() => ({ data: [], isLoading: false })),
 }));
 
 // Mock NominateModal to avoid its internal hook dependencies

--- a/web/src/components/lineups/LineupBanner.title.test.tsx
+++ b/web/src/components/lineups/LineupBanner.title.test.tsx
@@ -12,6 +12,7 @@ import { LineupBanner } from './LineupBanner';
 
 vi.mock('../../hooks/use-lineups', () => ({
     useLineupBanner: vi.fn(),
+    useActiveLineups: vi.fn(() => ({ data: [], isLoading: false })),
 }));
 
 vi.mock('./NominateModal', () => ({

--- a/web/src/components/lineups/LineupBanner.tsx
+++ b/web/src/components/lineups/LineupBanner.tsx
@@ -59,6 +59,14 @@ function BannerHeading({ banner }: { banner: LineupBannerResponseDto }): JSX.Ele
                 {banner.title}
             </h2>
             <LineupStatusBadge status={banner.status} />
+            {banner.visibility === 'private' && (
+                <span
+                    data-testid="lineup-private-badge"
+                    className="px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider rounded border border-amber-500/40 bg-amber-500/10 text-amber-300"
+                >
+                    Private
+                </span>
+            )}
             {banner.tiebreakerActive && <TiebreakerBadge />}
         </div>
     );
@@ -114,13 +122,17 @@ function ThumbnailRow({ entries }: { entries: LineupBannerResponseDto['entries']
     );
 }
 
-/** CTA buttons: view lineup link and nominate button. */
-function BannerActions({ id, status, onNominate }: {
-    id: number; status: string; onNominate: () => void;
+/** CTA buttons: view lineup link, nominate button, and (ROK-1065) start another for ops. */
+function BannerActions({ id, status, onNominate, canStartAnother, onStartAnother }: {
+    id: number;
+    status: string;
+    onNominate: () => void;
+    canStartAnother: boolean;
+    onStartAnother: () => void;
 }): JSX.Element {
     const ctaLabel = status === 'voting' ? 'View Lineup & Vote' : 'View Lineup';
     return (
-        <div className="flex items-center gap-3">
+        <div className="flex items-center gap-3 flex-wrap">
             <Link
                 to={`/community-lineup/${id}`}
                 className="px-4 py-2 text-sm font-medium bg-emerald-600 text-white rounded-lg hover:bg-emerald-500 transition-colors"
@@ -133,13 +145,26 @@ function BannerActions({ id, status, onNominate }: {
                     Nominate
                 </button>
             )}
+            {canStartAnother && (
+                <button
+                    type="button"
+                    onClick={onStartAnother}
+                    data-testid="start-another-lineup"
+                    className="px-4 py-2 text-sm font-medium bg-panel text-amber-300 border border-amber-500/40 rounded-lg hover:bg-amber-500/10 transition-colors"
+                >
+                    Start another lineup
+                </button>
+            )}
         </div>
     );
 }
 
 /** Populated banner content. */
-function BannerContent({ banner, onNominate }: {
-    banner: LineupBannerResponseDto; onNominate: () => void;
+function BannerContent({ banner, onNominate, canStartAnother, onStartAnother }: {
+    banner: LineupBannerResponseDto;
+    onNominate: () => void;
+    canStartAnother: boolean;
+    onStartAnother: () => void;
 }): JSX.Element {
     return (
         <div className="rounded-xl bg-panel/50 border border-edge/50 p-6 mb-8">
@@ -147,7 +172,13 @@ function BannerContent({ banner, onNominate }: {
             <BannerHeading banner={banner} />
             <BannerSubtitle banner={banner} />
             {banner.entries.length > 0 && <ThumbnailRow entries={banner.entries} />}
-            <BannerActions id={banner.id} status={banner.status} onNominate={onNominate} />
+            <BannerActions
+                id={banner.id}
+                status={banner.status}
+                onNominate={onNominate}
+                canStartAnother={canStartAnother}
+                onStartAnother={onStartAnother}
+            />
         </div>
     );
 }
@@ -189,10 +220,20 @@ export function LineupBanner(): JSX.Element | null {
         );
     }
 
+    const canStartAnother = isOperatorOrAdmin(user);
+
     return (
         <>
-            <BannerContent banner={banner} onNominate={() => setNominateOpen(true)} />
+            <BannerContent
+                banner={banner}
+                onNominate={() => setNominateOpen(true)}
+                canStartAnother={canStartAnother}
+                onStartAnother={() => setStartOpen(true)}
+            />
             <NominateModal isOpen={nominateOpen} onClose={() => setNominateOpen(false)} lineupId={banner.id} />
+            {canStartAnother && (
+                <StartLineupModal isOpen={startOpen} onClose={() => setStartOpen(false)} />
+            )}
         </>
     );
 }

--- a/web/src/components/lineups/LineupBanner.tsx
+++ b/web/src/components/lineups/LineupBanner.tsx
@@ -15,6 +15,7 @@ import { StartLineupModal } from './start-lineup-modal';
 import { PhaseCountdown } from './phase-countdown';
 import { formatTargetDate } from './lineup-banner-helpers';
 import { TiebreakerBadge } from './tiebreaker/TiebreakerBadge';
+import { OtherActiveLineups } from './OtherActiveLineups';
 
 /** Pulsing green dot indicator for active lineup. */
 function PulsingDot(): JSX.Element {
@@ -230,6 +231,7 @@ export function LineupBanner(): JSX.Element | null {
                 canStartAnother={canStartAnother}
                 onStartAnother={() => setStartOpen(true)}
             />
+            <OtherActiveLineups primaryLineupId={banner.id} />
             <NominateModal isOpen={nominateOpen} onClose={() => setNominateOpen(false)} lineupId={banner.id} />
             {canStartAnother && (
                 <StartLineupModal isOpen={startOpen} onClose={() => setStartOpen(false)} />

--- a/web/src/components/lineups/LineupDetailHeader.test.tsx
+++ b/web/src/components/lineups/LineupDetailHeader.test.tsx
@@ -72,3 +72,22 @@ describe('LineupDetailHeader — description (ROK-1063)', () => {
         ).toBeInTheDocument();
     });
 });
+
+describe('LineupDetailHeader — private badge (ROK-1065)', () => {
+    it('renders the Private badge when visibility is private', () => {
+        const lineup = buildDetail({
+            title: 'Stealth Night',
+            visibility: 'private',
+        } as DetailOverrides);
+        renderWithProviders(<LineupDetailHeader lineup={lineup} />);
+
+        expect(screen.getByTestId('lineup-private-badge')).toBeInTheDocument();
+    });
+
+    it('does not render the Private badge when visibility is public', () => {
+        const lineup = buildDetail({ title: 'Raid Night' });
+        renderWithProviders(<LineupDetailHeader lineup={lineup} />);
+
+        expect(screen.queryByTestId('lineup-private-badge')).toBeNull();
+    });
+});

--- a/web/src/components/lineups/LineupDetailHeader.tsx
+++ b/web/src/components/lineups/LineupDetailHeader.tsx
@@ -219,6 +219,15 @@ export function LineupDetailHeader({ lineup, onTiebreakerIntercept }: Props): JS
           {lineup.title}
         </h1>
         <LineupStatusBadge status={lineup.status} />
+        {lineup.visibility === 'private' && (
+          <span
+            data-testid="lineup-private-badge"
+            title="Invite-only lineup"
+            className="px-2 py-0.5 text-xs font-semibold rounded bg-amber-600/20 text-amber-400 border border-amber-500/40"
+          >
+            Private
+          </span>
+        )}
         {canEdit && <EditButton onClick={() => setEditOpen(true)} />}
         {/* Desktop-only inline breadcrumb + circle after edit */}
         <div className="hidden md:flex items-center gap-3 flex-shrink-0">

--- a/web/src/components/lineups/OtherActiveLineups.tsx
+++ b/web/src/components/lineups/OtherActiveLineups.tsx
@@ -1,0 +1,77 @@
+/**
+ * Chip row linking to other active lineups besides the banner's primary
+ * one (ROK-1065). Mirrors the SchedulingBanner chip pattern so operators
+ * can navigate between concurrent lineups without losing them after the
+ * banner shifted to a newly created lineup.
+ */
+import type { JSX } from 'react';
+import { Link } from 'react-router-dom';
+import type { LineupSummaryResponseDto } from '@raid-ledger/contract';
+import { useActiveLineups } from '../../hooks/use-lineups';
+
+function statusLabel(status: LineupSummaryResponseDto['status']): string {
+  switch (status) {
+    case 'building':
+      return 'Nominating';
+    case 'voting':
+      return 'Voting';
+    case 'decided':
+      return 'Decided';
+    default:
+      return status;
+  }
+}
+
+function LineupChip({
+  lineup,
+}: {
+  lineup: LineupSummaryResponseDto;
+}): JSX.Element {
+  return (
+    <Link
+      data-testid={`other-lineup-chip-${lineup.id}`}
+      to={`/community-lineup/${lineup.id}`}
+      className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-surface hover:bg-overlay transition-colors text-sm"
+    >
+      <span className="text-foreground font-medium truncate max-w-[14rem]">
+        {lineup.title}
+      </span>
+      {lineup.visibility === 'private' && (
+        <span className="text-[10px] uppercase tracking-wider text-amber-300">
+          Private
+        </span>
+      )}
+      <span className="text-muted text-xs">{statusLabel(lineup.status)}</span>
+      <span className="text-emerald-400 text-xs font-medium">Open</span>
+    </Link>
+  );
+}
+
+/**
+ * Render chips for every active lineup the viewer can see except
+ * `primaryLineupId` (which is already rendered as the banner above).
+ */
+export function OtherActiveLineups({
+  primaryLineupId,
+}: {
+  primaryLineupId: number;
+}): JSX.Element | null {
+  const { data: lineups = [] } = useActiveLineups();
+  const others = lineups.filter(
+    (l) => l.id !== primaryLineupId && l.status !== 'archived',
+  );
+  if (others.length === 0) return null;
+  return (
+    <div
+      data-testid="other-active-lineups"
+      className="mb-6 -mt-4 px-1 flex flex-wrap items-center gap-2"
+    >
+      <span className="text-xs text-muted uppercase tracking-wider">
+        Other active lineups
+      </span>
+      {others.map((l) => (
+        <LineupChip key={l.id} lineup={l} />
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/lineups/VisibilityToggle.test.tsx
+++ b/web/src/components/lineups/VisibilityToggle.test.tsx
@@ -1,0 +1,38 @@
+/**
+ * Tests for VisibilityToggle (ROK-1065).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { VisibilityToggle } from './VisibilityToggle';
+
+describe('VisibilityToggle', () => {
+  it('renders both options with the current value marked active', () => {
+    render(<VisibilityToggle value="public" onChange={() => {}} />);
+    const publicBtn = screen.getByTestId('visibility-public');
+    const privateBtn = screen.getByTestId('visibility-private');
+    expect(publicBtn.getAttribute('aria-checked')).toBe('true');
+    expect(privateBtn.getAttribute('aria-checked')).toBe('false');
+  });
+
+  it('calls onChange when a different option is clicked', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<VisibilityToggle value="public" onChange={onChange} />);
+    await user.click(screen.getByTestId('visibility-private'));
+    expect(onChange).toHaveBeenCalledWith('private');
+  });
+
+  it('updates the description text based on the current value', () => {
+    const { rerender } = render(
+      <VisibilityToggle value="public" onChange={() => {}} />,
+    );
+    expect(
+      screen.getByText(/every community member/i),
+    ).toBeInTheDocument();
+    rerender(<VisibilityToggle value="private" onChange={() => {}} />);
+    expect(
+      screen.getByText(/only invited users/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/components/lineups/VisibilityToggle.tsx
+++ b/web/src/components/lineups/VisibilityToggle.tsx
@@ -1,0 +1,62 @@
+/**
+ * Visibility toggle for the Start Lineup modal (ROK-1065).
+ * Switches the lineup between public and private modes. When private is
+ * selected, the parent form must collect invitees before submitting.
+ */
+import { type JSX } from 'react';
+
+export interface VisibilityToggleProps {
+  value: 'public' | 'private';
+  onChange: (next: 'public' | 'private') => void;
+}
+
+/** Render a labeled segmented control for lineup visibility. */
+export function VisibilityToggle({
+  value,
+  onChange,
+}: VisibilityToggleProps): JSX.Element {
+  return (
+    <fieldset className="space-y-2">
+      <legend className="text-sm font-medium text-primary">Visibility</legend>
+      <div
+        role="radiogroup"
+        aria-label="Lineup visibility"
+        className="flex gap-2"
+      >
+        <button
+          type="button"
+          role="radio"
+          aria-checked={value === 'public'}
+          onClick={() => onChange('public')}
+          data-testid="visibility-public"
+          className={`flex-1 px-3 py-2 text-sm rounded-lg border transition-colors ${
+            value === 'public'
+              ? 'bg-emerald-600 text-white border-emerald-500'
+              : 'bg-panel border-edge text-secondary hover:bg-overlay'
+          }`}
+        >
+          Public
+        </button>
+        <button
+          type="button"
+          role="radio"
+          aria-checked={value === 'private'}
+          onClick={() => onChange('private')}
+          data-testid="visibility-private"
+          className={`flex-1 px-3 py-2 text-sm rounded-lg border transition-colors ${
+            value === 'private'
+              ? 'bg-amber-600 text-white border-amber-500'
+              : 'bg-panel border-edge text-secondary hover:bg-overlay'
+          }`}
+        >
+          Private
+        </button>
+      </div>
+      <p className="text-xs text-muted">
+        {value === 'public'
+          ? 'Every community member can nominate and vote.'
+          : 'Only invited users (plus admins) can nominate and vote. At least one invitee required.'}
+      </p>
+    </fieldset>
+  );
+}

--- a/web/src/components/lineups/VotingLeaderboard.tsx
+++ b/web/src/components/lineups/VotingLeaderboard.tsx
@@ -18,6 +18,8 @@ interface VotingLeaderboardProps {
   totalMembers: number;
   /** Per-lineup vote limit from the server (ROK-976). */
   maxVotesPerPlayer?: number;
+  /** When false, voting is disabled UI-side (ROK-1065 eligibility). */
+  canParticipate?: boolean;
 }
 
 const DEFAULT_MAX_VOTES = 3;
@@ -33,7 +35,7 @@ function sortByVotes(entries: LineupEntryResponseDto[]): LineupEntryResponseDto[
 /** Voting leaderboard with status bar, sorted rows, and configurable vote limit. */
 export function VotingLeaderboard({
   entries, lineupId, myVotes, totalVoters, totalMembers,
-  maxVotesPerPlayer,
+  maxVotesPerPlayer, canParticipate = true,
 }: VotingLeaderboardProps): JSX.Element {
   const maxVotes = maxVotesPerPlayer ?? DEFAULT_MAX_VOTES;
   const sorted = useMemo(() => sortByVotes(entries), [entries]);
@@ -60,6 +62,14 @@ export function VotingLeaderboard({
         totalVoters={totalVoters}
         totalMembers={totalMembers}
       />
+      {!canParticipate && (
+        <p
+          data-testid="voting-private-notice"
+          className="mt-2 text-xs text-amber-400"
+        >
+          Private lineup — ask the creator for an invite to cast votes.
+        </p>
+      )}
       <div className="bg-surface border border-edge rounded-xl overflow-hidden mt-4">
         <div className="bg-panel/50 border-b border-edge px-4 py-2.5 flex items-center justify-between">
           <span className="text-xs text-muted font-semibold uppercase tracking-wider">Rank</span>
@@ -75,7 +85,7 @@ export function VotingLeaderboard({
               totalVoters={totalVoters}
               isVoted={isVoted}
               onToggleVote={() => handleToggle(entry.gameId)}
-              disabled={atLimit && !isVoted}
+              disabled={!canParticipate || (atLimit && !isVoted)}
             />
           );
         })}

--- a/web/src/components/lineups/start-lineup-modal.test.tsx
+++ b/web/src/components/lineups/start-lineup-modal.test.tsx
@@ -28,6 +28,10 @@ vi.mock('../../hooks/use-postable-discord-channels', () => ({
     usePostableDiscordChannels: vi.fn(),
 }));
 
+vi.mock('../../lib/api-client', () => ({
+    getPlayers: vi.fn(),
+}));
+
 vi.mock('react-router-dom', async () => {
     const actual = await vi.importActual<typeof import('react-router-dom')>(
         'react-router-dom',
@@ -38,6 +42,7 @@ vi.mock('react-router-dom', async () => {
 import { useCreateLineup } from '../../hooks/use-lineups';
 import { useLineupSettings } from '../../hooks/admin/use-lineup-settings';
 import { usePostableDiscordChannels } from '../../hooks/use-postable-discord-channels';
+import { getPlayers } from '../../lib/api-client';
 
 const mutateAsync = vi.fn();
 
@@ -84,6 +89,13 @@ beforeEach(() => {
         { id: '100000000000000001', name: 'general' },
         { id: '100000000000000002', name: 'events' },
     ]);
+    vi.mocked(getPlayers).mockResolvedValue({
+        data: [
+            { id: 10, username: 'alice', avatar: null, discordId: 'd-10' },
+            { id: 11, username: 'bob', avatar: null, discordId: null },
+        ],
+        meta: { total: 2, page: 1, pageSize: 20, hasMore: false },
+    } as unknown as Awaited<ReturnType<typeof getPlayers>>);
 });
 
 describe('StartLineupModal — title field', () => {
@@ -224,5 +236,83 @@ describe('StartLineupModal — channel override picker (ROK-1064)', () => {
             <StartLineupModal isOpen={true} onClose={vi.fn()} />,
         );
         expect(screen.queryByLabelText(/post embeds to/i)).toBeNull();
+    });
+});
+
+describe('StartLineupModal — visibility toggle + invitees (ROK-1065)', () => {
+    it('renders a visibility toggle that defaults to public', () => {
+        renderWithProviders(
+            <StartLineupModal isOpen={true} onClose={vi.fn()} />,
+        );
+        const publicBtn = screen.getByTestId('visibility-public');
+        const privateBtn = screen.getByTestId('visibility-private');
+        expect(publicBtn).toHaveAttribute('aria-checked', 'true');
+        expect(privateBtn).toHaveAttribute('aria-checked', 'false');
+        // The invitee picker is hidden on public.
+        expect(screen.queryByTestId('invitee-multi-select')).toBeNull();
+    });
+
+    it('reveals the invitee picker when switched to private', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(
+            <StartLineupModal isOpen={true} onClose={vi.fn()} />,
+        );
+        await user.click(screen.getByTestId('visibility-private'));
+        expect(
+            await screen.findByTestId('invitee-multi-select'),
+        ).toBeInTheDocument();
+    });
+
+    it('disables Create while private is selected and no invitees picked', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(
+            <StartLineupModal isOpen={true} onClose={vi.fn()} />,
+        );
+        await user.click(screen.getByTestId('visibility-private'));
+        const createBtn = screen.getByRole('button', { name: /create lineup/i });
+        expect(createBtn).toBeDisabled();
+    });
+
+    it('enables Create once at least one invitee is picked on private', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(
+            <StartLineupModal isOpen={true} onClose={vi.fn()} />,
+        );
+        await user.click(screen.getByTestId('visibility-private'));
+        const row = await screen.findByTestId('invitee-option-10');
+        await user.click(row);
+        const createBtn = screen.getByRole('button', { name: /create lineup/i });
+        expect(createBtn).not.toBeDisabled();
+    });
+
+    it('submits visibility + inviteeUserIds when a private lineup is created', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(
+            <StartLineupModal isOpen={true} onClose={vi.fn()} />,
+        );
+        await user.click(screen.getByTestId('visibility-private'));
+        const row = await screen.findByTestId('invitee-option-10');
+        await user.click(row);
+        await user.click(
+            screen.getByRole('button', { name: /create lineup/i }),
+        );
+        expect(mutateAsync).toHaveBeenCalledTimes(1);
+        expect(mutateAsync.mock.calls[0][0]).toMatchObject({
+            visibility: 'private',
+            inviteeUserIds: [10],
+        });
+    });
+
+    it('omits visibility + inviteeUserIds from submit when public (default)', async () => {
+        const user = userEvent.setup();
+        renderWithProviders(
+            <StartLineupModal isOpen={true} onClose={vi.fn()} />,
+        );
+        await user.click(
+            screen.getByRole('button', { name: /create lineup/i }),
+        );
+        const body = mutateAsync.mock.calls[0][0];
+        expect('visibility' in body).toBe(false);
+        expect('inviteeUserIds' in body).toBe(false);
     });
 });

--- a/web/src/components/lineups/start-lineup-modal.tsx
+++ b/web/src/components/lineups/start-lineup-modal.tsx
@@ -10,6 +10,8 @@ import { useCreateLineup } from '../../hooks/use-lineups';
 import { useLineupSettings } from '../../hooks/admin/use-lineup-settings';
 import { toast } from '../../lib/toast';
 import { LineupChannelOverrideSelect } from './lineup-channel-override-select';
+import { VisibilityToggle } from './VisibilityToggle';
+import { InviteeMultiSelect } from './InviteeMultiSelect';
 import {
   DurationSlider,
   VotesPerPlayerSlider,
@@ -66,11 +68,22 @@ export function StartLineupModal({ isOpen, onClose }: Props) {
   const [title, setTitle] = useState<string>(defaultTitle);
   const [description, setDescription] = useState<string>('');
   const [channelOverrideId, setChannelOverrideId] = useState<string>('');
+  // ROK-1065: visibility + invitees.
+  const [visibility, setVisibility] = useState<'public' | 'private'>('public');
+  const [inviteeUserIds, setInviteeUserIds] = useState<number[]>([]);
+
+  const canSubmit =
+    title.trim() !== '' &&
+    (visibility === 'public' || inviteeUserIds.length > 0);
 
   async function handleSubmit() {
     const trimmed = title.trim();
     if (!trimmed) {
       toast.error('Title is required');
+      return;
+    }
+    if (visibility === 'private' && inviteeUserIds.length === 0) {
+      toast.error('Private lineups require at least one invitee');
       return;
     }
     try {
@@ -84,6 +97,10 @@ export function StartLineupModal({ isOpen, onClose }: Props) {
         defaultTiebreakerMode: durations.tiebreakerMode,
         // ROK-1064: empty string → omit the field (use community default).
         ...(channelOverrideId ? { channelOverrideId } : {}),
+        // ROK-1065: only send when non-default.
+        ...(visibility === 'private'
+          ? { visibility, inviteeUserIds }
+          : {}),
       });
       onClose();
       navigate(`/community-lineup/${result.id}`);
@@ -97,6 +114,13 @@ export function StartLineupModal({ isOpen, onClose }: Props) {
       <div className="space-y-4">
         <TitleField value={title} onChange={setTitle} />
         <DescriptionField value={description} onChange={setDescription} />
+        <VisibilityToggle value={visibility} onChange={setVisibility} />
+        {visibility === 'private' && (
+          <InviteeMultiSelect
+            value={inviteeUserIds}
+            onChange={setInviteeUserIds}
+          />
+        )}
         <LineupChannelOverrideSelect
           value={channelOverrideId}
           onChange={setChannelOverrideId}
@@ -144,7 +168,7 @@ export function StartLineupModal({ isOpen, onClose }: Props) {
           <button
             type="button"
             onClick={() => void handleSubmit()}
-            disabled={createLineup.isPending || title.trim() === ''}
+            disabled={createLineup.isPending || !canSubmit}
             className="px-4 py-2 text-sm font-medium bg-emerald-600 text-white rounded-lg hover:bg-emerald-500 transition-colors disabled:opacity-50"
           >
             {createLineup.isPending ? 'Creating...' : 'Create Lineup'}

--- a/web/src/hooks/use-lineups.test.ts
+++ b/web/src/hooks/use-lineups.test.ts
@@ -1,6 +1,6 @@
 /**
- * Tests for use-lineups hooks (ROK-934).
- * Validates useActiveLineup, useCommonGround, and useNominateGame query behavior.
+ * Tests for use-lineups hooks (ROK-934, ROK-1065).
+ * Validates useActiveLineups (array), useCommonGround, and useNominateGame.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
@@ -8,28 +8,34 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createElement, type ReactNode } from 'react';
 
 // --- API client mocks ---
-const mockGetActiveLineup = vi.fn();
+const mockGetActiveLineups = vi.fn();
 const mockGetCommonGround = vi.fn();
 const mockNominateGame = vi.fn();
 const mockGetLineupBanner = vi.fn();
 const mockGetLineupById = vi.fn();
 const mockRemoveNomination = vi.fn();
 const mockToggleVote = vi.fn();
+const mockAddLineupInvitees = vi.fn();
+const mockRemoveLineupInvitee = vi.fn();
 
 vi.mock('../lib/api-client', () => ({
-    getActiveLineup: (...args: unknown[]) => mockGetActiveLineup(...args),
+    getActiveLineups: (...args: unknown[]) => mockGetActiveLineups(...args),
     getCommonGround: (...args: unknown[]) => mockGetCommonGround(...args),
     nominateGame: (...args: unknown[]) => mockNominateGame(...args),
     getLineupBanner: (...args: unknown[]) => mockGetLineupBanner(...args),
     getLineupById: (...args: unknown[]) => mockGetLineupById(...args),
     removeNomination: (...args: unknown[]) => mockRemoveNomination(...args),
     toggleVote: (...args: unknown[]) => mockToggleVote(...args),
+    addLineupInvitees: (...args: unknown[]) => mockAddLineupInvitees(...args),
+    removeLineupInvitee: (...args: unknown[]) =>
+        mockRemoveLineupInvitee(...args),
 }));
 
 import {
-    useActiveLineup, useCommonGround, useNominateGame,
+    useActiveLineups, useCommonGround, useNominateGame,
     useLineupBanner, useLineupDetail, useRemoveNomination,
     useToggleVote,
+    useAddLineupInvitees, useRemoveLineupInvitee,
 } from './use-lineups';
 
 // --- Helpers ---
@@ -52,6 +58,8 @@ function createWrapper() {
 
 const mockLineupResponse = {
     id: 1,
+    title: 'Test Lineup',
+    description: null,
     status: 'building' as const,
     targetDate: null,
     decidedGameId: null,
@@ -63,6 +71,9 @@ const mockLineupResponse = {
     totalVoters: 0,
     createdAt: '2026-03-01T00:00:00Z',
     updatedAt: '2026-03-01T00:00:00Z',
+    // ROK-1065
+    visibility: 'public' as const,
+    invitees: [],
 };
 
 const mockCommonGroundResponse = {
@@ -95,30 +106,71 @@ const mockCommonGroundResponse = {
 
 // --- Tests ---
 
-describe('useActiveLineup', () => {
+describe('useActiveLineups (ROK-1065)', () => {
     beforeEach(() => {
         vi.clearAllMocks();
     });
 
-    it('returns lineup data on success', async () => {
-        const { wrapper } = createWrapper();
-        mockGetActiveLineup.mockResolvedValue(mockLineupResponse);
+    const mockSummaryRow = {
+        id: 1,
+        title: 'Weekend Raid',
+        status: 'building' as const,
+        targetDate: null,
+        entryCount: 0,
+        totalVoters: 0,
+        createdAt: '2026-03-01T00:00:00Z',
+        visibility: 'public' as const,
+    };
 
-        const { result } = renderHook(() => useActiveLineup(), { wrapper });
+    it('returns lineup array on success', async () => {
+        const { wrapper } = createWrapper();
+        mockGetActiveLineups.mockResolvedValue([mockSummaryRow]);
+
+        const { result } = renderHook(() => useActiveLineups(), { wrapper });
 
         await waitFor(() => expect(result.current.isSuccess).toBe(true));
-        expect(result.current.data).toEqual(mockLineupResponse);
-        expect(mockGetActiveLineup).toHaveBeenCalledTimes(1);
+        expect(result.current.data).toEqual([mockSummaryRow]);
+        expect(mockGetActiveLineups).toHaveBeenCalledTimes(1);
     });
 
     it('returns error state when API call fails', async () => {
         const { wrapper } = createWrapper();
-        mockGetActiveLineup.mockRejectedValue(new Error('Not found'));
+        mockGetActiveLineups.mockRejectedValue(new Error('Boom'));
 
-        const { result } = renderHook(() => useActiveLineup(), { wrapper });
+        const { result } = renderHook(() => useActiveLineups(), { wrapper });
 
         await waitFor(() => expect(result.current.isError).toBe(true));
         expect(result.current.error).toBeInstanceOf(Error);
+    });
+});
+
+describe('useAddLineupInvitees / useRemoveLineupInvitee (ROK-1065)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('add invitees calls API with lineupId + userIds', async () => {
+        mockAddLineupInvitees.mockResolvedValue(mockLineupResponse);
+        const { wrapper } = createWrapper();
+        const { result } = renderHook(() => useAddLineupInvitees(), {
+            wrapper,
+        });
+        await act(async () => {
+            await result.current.mutateAsync({ lineupId: 1, userIds: [5, 7] });
+        });
+        expect(mockAddLineupInvitees).toHaveBeenCalledWith(1, [5, 7]);
+    });
+
+    it('remove invitee calls API with lineupId + userId', async () => {
+        mockRemoveLineupInvitee.mockResolvedValue(mockLineupResponse);
+        const { wrapper } = createWrapper();
+        const { result } = renderHook(() => useRemoveLineupInvitee(), {
+            wrapper,
+        });
+        await act(async () => {
+            await result.current.mutateAsync({ lineupId: 1, userId: 5 });
+        });
+        expect(mockRemoveLineupInvitee).toHaveBeenCalledWith(1, 5);
     });
 });
 

--- a/web/src/hooks/use-lineups.ts
+++ b/web/src/hooks/use-lineups.ts
@@ -5,12 +5,13 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import type {
   LineupDetailResponseDto,
   LineupBannerResponseDto,
+  LineupSummaryResponseDto,
   CommonGroundResponseDto,
   NominateGameDto,
 } from '@raid-ledger/contract';
 import type { CommonGroundParams } from '../lib/api-client';
 import {
-  getActiveLineup,
+  getActiveLineups,
   getCommonGround,
   nominateGame,
   getLineupBanner,
@@ -20,6 +21,8 @@ import {
   transitionLineupStatus,
   toggleVote,
   updateLineupMetadata,
+  addLineupInvitees,
+  removeLineupInvitee,
 } from '../lib/api-client';
 import type {
   CreateLineupParams,
@@ -37,11 +40,14 @@ const COMMON_GROUND_KEY = ['common-ground'] as const;
 /** Shared prefix for all lineup query invalidation. */
 const LINEUPS_PREFIX = ['lineups'] as const;
 
-/** Hook for fetching the active lineup. */
-export function useActiveLineup() {
-  return useQuery<LineupDetailResponseDto>({
+/**
+ * Hook for fetching every currently active lineup (ROK-1065).
+ * Returns an array ordered newest-first. Was singular pre-ROK-1065.
+ */
+export function useActiveLineups() {
+  return useQuery<LineupSummaryResponseDto[]>({
     queryKey: [...ACTIVE_LINEUP_KEY],
-    queryFn: getActiveLineup,
+    queryFn: getActiveLineups,
     staleTime: 30_000,
     retry: false,
   });
@@ -171,6 +177,40 @@ export function useTransitionLineupStatus() {
     { lineupId: number; body: { status: string; decidedGameId?: number | null } }
   >({
     mutationFn: ({ lineupId, body }) => transitionLineupStatus(lineupId, body),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: [...LINEUPS_PREFIX] });
+    },
+  });
+}
+
+/** Hook for adding invitees to a private lineup (ROK-1065). */
+export function useAddLineupInvitees() {
+  const qc = useQueryClient();
+
+  return useMutation<
+    LineupDetailResponseDto,
+    Error,
+    { lineupId: number; userIds: number[] }
+  >({
+    mutationFn: ({ lineupId, userIds }) =>
+      addLineupInvitees(lineupId, userIds),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: [...LINEUPS_PREFIX] });
+    },
+  });
+}
+
+/** Hook for removing an invitee from a private lineup (ROK-1065). */
+export function useRemoveLineupInvitee() {
+  const qc = useQueryClient();
+
+  return useMutation<
+    LineupDetailResponseDto,
+    Error,
+    { lineupId: number; userId: number }
+  >({
+    mutationFn: ({ lineupId, userId }) =>
+      removeLineupInvitee(lineupId, userId),
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: [...LINEUPS_PREFIX] });
     },

--- a/web/src/lib/api-client.ts
+++ b/web/src/lib/api-client.ts
@@ -173,7 +173,7 @@ export type {
     UpdateLineupMetadataParams,
 } from './api/lineups-api';
 export {
-    getActiveLineup,
+    getActiveLineups,
     getCommonGround,
     nominateGame,
     getLineupBanner,
@@ -183,6 +183,8 @@ export {
     transitionLineupStatus,
     toggleVote,
     updateLineupMetadata,
+    addLineupInvitees,
+    removeLineupInvitee,
 } from './api/lineups-api';
 
 // Activity Log (ROK-930)

--- a/web/src/lib/api/lineups-api.ts
+++ b/web/src/lib/api/lineups-api.ts
@@ -5,6 +5,7 @@
 import type {
   LineupDetailResponseDto,
   LineupBannerResponseDto,
+  LineupSummaryResponseDto,
   CommonGroundResponseDto,
   NominateGameDto,
 } from '@raid-ledger/contract';
@@ -17,10 +18,17 @@ export interface CommonGroundParams {
   genre?: string;
   search?: string;
   limit?: number;
+  /** Explicit lineup to score against (ROK-1065). */
+  lineupId?: number;
 }
 
-/** Fetch the currently active lineup. */
-export async function getActiveLineup(): Promise<LineupDetailResponseDto> {
+/**
+ * Fetch every currently active lineup (ROK-1065).
+ * Returns an array ordered newest-first. Was singular pre-ROK-1065.
+ */
+export async function getActiveLineups(): Promise<
+  LineupSummaryResponseDto[]
+> {
   return fetchApi('/lineups/active');
 }
 
@@ -34,6 +42,7 @@ export async function getCommonGround(
   if (params.genre) search.set('genre', params.genre);
   if (params.search) search.set('search', params.search);
   if (params.limit != null) search.set('limit', String(params.limit));
+  if (params.lineupId != null) search.set('lineupId', String(params.lineupId));
 
   const qs = search.toString();
   return fetchApi(`/lineups/common-ground${qs ? `?${qs}` : ''}`);
@@ -80,6 +89,13 @@ export interface CreateLineupParams {
   defaultTiebreakerMode?: 'bracket' | 'veto' | null;
   /** Optional per-lineup Discord channel override (ROK-1064). */
   channelOverrideId?: string | null;
+  /** Lineup visibility — 'public' (default) or 'private' (ROK-1065). */
+  visibility?: 'public' | 'private';
+  /**
+   * Explicit invitees when visibility === 'private' (ROK-1065).
+   * Server enforces that private lineups carry at least one invitee.
+   */
+  inviteeUserIds?: number[];
 }
 
 /** Create a new lineup with optional duration params. */
@@ -128,5 +144,30 @@ export async function transitionLineupStatus(
   return fetchApi(`/lineups/${lineupId}/status`, {
     method: 'PATCH',
     body: JSON.stringify(body),
+  });
+}
+
+/**
+ * Add one or more invitees to a private lineup (ROK-1065).
+ * Returns the refreshed lineup detail so the UI can update the roster
+ * inline without a separate refetch.
+ */
+export async function addLineupInvitees(
+  lineupId: number,
+  userIds: number[],
+): Promise<LineupDetailResponseDto> {
+  return fetchApi(`/lineups/${lineupId}/invitees`, {
+    method: 'POST',
+    body: JSON.stringify({ userIds }),
+  });
+}
+
+/** Remove a single invitee from a private lineup (ROK-1065). */
+export async function removeLineupInvitee(
+  lineupId: number,
+  userId: number,
+): Promise<LineupDetailResponseDto> {
+  return fetchApi(`/lineups/${lineupId}/invitees/${userId}`, {
+    method: 'DELETE',
   });
 }

--- a/web/src/lib/api/users-api.ts
+++ b/web/src/lib/api/users-api.ts
@@ -15,6 +15,7 @@ import { fetchApi } from "./fetch-api";
 /** Fetch paginated player list (public, ROK-821: extended filters). */
 export async function getPlayers(params?: {
   page?: number;
+  pageSize?: number;
   search?: string;
   gameId?: number;
   sources?: string;
@@ -24,6 +25,7 @@ export async function getPlayers(params?: {
 }): Promise<PlayersListResponseDto> {
   const sp = new URLSearchParams();
   if (params?.page) sp.set("page", String(params.page));
+  if (params?.pageSize) sp.set("limit", String(params.pageSize));
   if (params?.search) sp.set("search", params.search);
   if (params?.gameId) sp.set("gameId", String(params.gameId));
   if (params?.sources) sp.set("sources", params.sources);

--- a/web/src/lib/lineup-eligibility.test.ts
+++ b/web/src/lib/lineup-eligibility.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for canParticipateInLineup (ROK-1065).
+ * Mirror the server's assertUserCanParticipate so the UI disables write
+ * actions for non-invitees on private lineups. Covers all 6 branches.
+ */
+import { describe, expect, it } from 'vitest';
+import type { LineupDetailResponseDto } from '@raid-ledger/contract';
+import { canParticipateInLineup } from './lineup-eligibility';
+
+type LineupShape = Pick<
+  LineupDetailResponseDto,
+  'visibility' | 'createdBy' | 'invitees'
+>;
+
+function makePrivateLineup(overrides: Partial<LineupShape> = {}): LineupShape {
+  return {
+    visibility: 'private',
+    createdBy: { id: 1, displayName: 'Operator' },
+    invitees: [],
+    ...overrides,
+  };
+}
+
+describe('canParticipateInLineup', () => {
+  it('returns false when the lineup is null', () => {
+    expect(canParticipateInLineup(null, { id: 5 })).toBe(false);
+  });
+
+  it('returns false when the lineup is undefined', () => {
+    expect(canParticipateInLineup(undefined, { id: 5 })).toBe(false);
+  });
+
+  it('returns true for a public lineup regardless of user', () => {
+    const lineup: LineupShape = {
+      visibility: 'public',
+      createdBy: { id: 1, displayName: 'Op' },
+      invitees: [],
+    };
+    expect(canParticipateInLineup(lineup, null)).toBe(true);
+    expect(canParticipateInLineup(lineup, undefined)).toBe(true);
+    expect(canParticipateInLineup(lineup, { id: 99 })).toBe(true);
+  });
+
+  it('returns false for a private lineup when the user is anonymous', () => {
+    expect(canParticipateInLineup(makePrivateLineup(), null)).toBe(false);
+    expect(canParticipateInLineup(makePrivateLineup(), undefined)).toBe(false);
+  });
+
+  it('grants access to admins on a private lineup', () => {
+    expect(
+      canParticipateInLineup(makePrivateLineup(), { id: 77, role: 'admin' }),
+    ).toBe(true);
+  });
+
+  it('grants access to operators on a private lineup', () => {
+    expect(
+      canParticipateInLineup(makePrivateLineup(), { id: 77, role: 'operator' }),
+    ).toBe(true);
+  });
+
+  it('grants access to the creator of a private lineup', () => {
+    const lineup = makePrivateLineup({
+      createdBy: { id: 42, displayName: 'Owner' },
+    });
+    expect(canParticipateInLineup(lineup, { id: 42, role: 'member' })).toBe(
+      true,
+    );
+  });
+
+  it('grants access to an explicit invitee on a private lineup', () => {
+    const lineup = makePrivateLineup({
+      invitees: [
+        { id: 10, displayName: 'A', steamLinked: false },
+        { id: 11, displayName: 'B', steamLinked: true },
+      ],
+    });
+    expect(canParticipateInLineup(lineup, { id: 11, role: 'member' })).toBe(
+      true,
+    );
+  });
+
+  it('denies non-invitee members on a private lineup', () => {
+    const lineup = makePrivateLineup({
+      createdBy: { id: 1, displayName: 'Op' },
+      invitees: [{ id: 10, displayName: 'A', steamLinked: false }],
+    });
+    expect(canParticipateInLineup(lineup, { id: 99, role: 'member' })).toBe(
+      false,
+    );
+  });
+
+  it('treats an absent invitees list as an empty list', () => {
+    const lineup = {
+      visibility: 'private',
+      createdBy: { id: 1, displayName: 'Op' },
+    } as unknown as LineupShape;
+    expect(canParticipateInLineup(lineup, { id: 7, role: 'member' })).toBe(
+      false,
+    );
+  });
+});

--- a/web/src/lib/lineup-eligibility.ts
+++ b/web/src/lib/lineup-eligibility.ts
@@ -1,0 +1,32 @@
+/**
+ * Client-side mirror of the server's assertUserCanParticipate (ROK-1065).
+ * Authoritative check is still server-side; this lets the UI disable
+ * write actions (nominate / vote) for non-invitees on private lineups.
+ */
+import type { LineupDetailResponseDto } from '@raid-ledger/contract';
+
+interface ParticipantUser {
+  id: number;
+  role?: string;
+}
+
+/**
+ * Returns true when the viewer can nominate / vote on the given lineup:
+ * public lineups are always writable; private lineups only by admins,
+ * operators, the creator, or explicit invitees.
+ */
+export function canParticipateInLineup(
+  lineup: Pick<
+    LineupDetailResponseDto,
+    'visibility' | 'createdBy' | 'invitees'
+  > | null
+    | undefined,
+  user: ParticipantUser | null | undefined,
+): boolean {
+  if (!lineup) return false;
+  if (lineup.visibility === 'public') return true;
+  if (!user) return false;
+  if (user.role === 'admin' || user.role === 'operator') return true;
+  if (lineup.createdBy?.id === user.id) return true;
+  return (lineup.invitees ?? []).some((i) => i.id === user.id);
+}

--- a/web/src/pages/game-detail-page.tsx
+++ b/web/src/pages/game-detail-page.tsx
@@ -169,7 +169,7 @@ function GameBanner({ game, rating, genres, platforms, modes, pricing }: {
                     <DetailsGrid modes={modes} playerCount={game.playerCount} platforms={platforms} crossplay={game.crossplay} releaseDate={game.firstReleaseDate} />
                     {pricing && <GamePricingSummary pricing={pricing} />}
                     {game.steamAppId != null && (
-                        <div className="mt-3">
+                        <div className="mt-2 flex justify-end">
                             <SteamStoreLink appId={game.steamAppId} />
                         </div>
                     )}

--- a/web/src/pages/game-detail-page.tsx
+++ b/web/src/pages/game-detail-page.tsx
@@ -132,9 +132,25 @@ function BackButton({ navigate }: { navigate: NavigateFunction }): JSX.Element {
     );
 }
 
+/** External "View on Steam" link for the banner — same pattern as the ITAD deal link. */
+function SteamStoreLink({ appId }: { appId: number }): JSX.Element {
+    return (
+        <a
+            href={`https://store.steampowered.com/app/${appId}/`}
+            target="_blank"
+            rel="noopener noreferrer"
+            data-testid="steam-store-link"
+            className="inline-flex items-center gap-1.5 text-sm text-emerald-400 hover:text-emerald-300 transition-colors"
+        >
+            <SteamIcon className="w-4 h-4" />
+            View on Steam &rarr;
+        </a>
+    );
+}
+
 /** Game banner with cover, info, and details grid. ROK-773: IGDB cover > ITAD boxart > none */
 function GameBanner({ game, rating, genres, platforms, modes, pricing }: {
-    game: { name: string; coverUrl: string | null; itadBoxartUrl?: string | null; summary: string | null; playerCount: { min: number; max: number } | null; crossplay: boolean | null; firstReleaseDate: string | null };
+    game: { name: string; coverUrl: string | null; itadBoxartUrl?: string | null; summary: string | null; playerCount: { min: number; max: number } | null; crossplay: boolean | null; firstReleaseDate: string | null; steamAppId?: number | null };
     rating: number | null; genres: string[]; platforms: string[]; modes: string[]; pricing: ItadGamePricingDto | null;
 }): JSX.Element {
     const displayCover = game.coverUrl ?? game.itadBoxartUrl ?? null;
@@ -152,6 +168,11 @@ function GameBanner({ game, rating, genres, platforms, modes, pricing }: {
                     {game.summary && <p className="text-secondary text-sm leading-relaxed mb-4 line-clamp-4">{game.summary}</p>}
                     <DetailsGrid modes={modes} playerCount={game.playerCount} platforms={platforms} crossplay={game.crossplay} releaseDate={game.firstReleaseDate} />
                     {pricing && <GamePricingSummary pricing={pricing} />}
+                    {game.steamAppId != null && (
+                        <div className="mt-3">
+                            <SteamStoreLink appId={game.steamAppId} />
+                        </div>
+                    )}
                 </div>
             </div>
         </div>

--- a/web/src/pages/lineup-detail-page.tsx
+++ b/web/src/pages/lineup-detail-page.tsx
@@ -4,6 +4,8 @@ import { useParams, Link } from 'react-router-dom';
 import { useLineupDetail } from '../hooks/use-lineups';
 import { useTiebreakerDetail } from '../hooks/use-tiebreaker';
 import { LineupDetailHeader } from '../components/lineups/LineupDetailHeader';
+import { InviteeList } from '../components/lineups/InviteeList';
+import { AddInviteesButton } from '../components/lineups/AddInviteesButton';
 import { NominationGrid } from '../components/lineups/NominationGrid';
 import { VotingLeaderboard } from '../components/lineups/VotingLeaderboard';
 import { LineupEmptyState } from '../components/lineups/LineupEmptyState';
@@ -19,6 +21,39 @@ import { TiebreakerView } from '../components/lineups/tiebreaker/TiebreakerView'
 import { TiebreakerPromptModal } from '../components/lineups/tiebreaker/TiebreakerPromptModal';
 import { useAuth, isOperatorOrAdmin } from '../hooks/use-auth';
 import { useSteamPasteDetection } from '../hooks/use-steam-paste';
+
+/**
+ * Render the private-lineup invitee panel (ROK-1065). Creator/operator
+ * sees the "Invite more" button; everyone else sees the read-only roster.
+ */
+function PrivateInviteesSection({
+  lineupId,
+  invitees,
+  canManage,
+}: {
+  lineupId: number;
+  invitees: NonNullable<ReturnType<typeof useLineupDetail>['data']>['invitees'];
+  canManage: boolean;
+}): JSX.Element {
+  return (
+    <section
+      data-testid="private-invitees-section"
+      className="mt-4 p-4 rounded-lg border border-amber-500/30 bg-amber-500/5"
+    >
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-sm font-semibold text-primary">
+          Invitees ({invitees.length})
+        </h2>
+        {canManage && <AddInviteesButton lineupId={lineupId} />}
+      </div>
+      <InviteeList
+        lineupId={lineupId}
+        invitees={invitees}
+        canManage={canManage}
+      />
+    </section>
+  );
+}
 
 function LineupNotFound(): JSX.Element {
   return (
@@ -86,6 +121,14 @@ export function LineupDetailPage(): JSX.Element {
       </div>
 
       <ActivityTimeline entityType="lineup" entityId={lineup.id} collapsible maxVisible={5} />
+
+      {lineup.visibility === 'private' && (
+        <PrivateInviteesSection
+          lineupId={lineup.id}
+          invitees={lineup.invitees ?? []}
+          canManage={isOperator || user?.id === lineup.createdBy.id}
+        />
+      )}
 
       {isBuilding && (
         <div className="mt-3">

--- a/web/src/pages/lineup-detail-page.tsx
+++ b/web/src/pages/lineup-detail-page.tsx
@@ -21,6 +21,7 @@ import { TiebreakerView } from '../components/lineups/tiebreaker/TiebreakerView'
 import { TiebreakerPromptModal } from '../components/lineups/tiebreaker/TiebreakerPromptModal';
 import { useAuth, isOperatorOrAdmin } from '../hooks/use-auth';
 import { useSteamPasteDetection } from '../hooks/use-steam-paste';
+import { canParticipateInLineup } from '../lib/lineup-eligibility';
 
 /**
  * Render the private-lineup invitee panel (ROK-1065). Creator/operator
@@ -78,6 +79,8 @@ export function LineupDetailPage(): JSX.Element {
   const [tiebreakerPromptOpen, setTiebreakerPromptOpen] = useState(false);
 
   const isBuilding = !isLoading && !error && lineup?.status === 'building';
+  const canParticipate = canParticipateInLineup(lineup, user);
+  const canNominate = isBuilding && canParticipate;
 
   const handleGameResolved = useCallback((game: SelectedGame) => {
     setPreSelectedGame(game);
@@ -85,7 +88,7 @@ export function LineupDetailPage(): JSX.Element {
   }, []);
 
   useSteamPasteDetection({
-    enabled: isBuilding,
+    enabled: !!canNominate,
     modalOpen,
     onGameResolved: handleGameResolved,
   });
@@ -113,7 +116,13 @@ export function LineupDetailPage(): JSX.Element {
           <button
             type="button"
             onClick={() => setModalOpen(true)}
-            className="sm:mt-1 px-4 py-2 text-sm font-medium bg-emerald-600 text-white rounded-lg hover:bg-emerald-500 transition-colors flex-shrink-0 w-full sm:w-auto"
+            disabled={!canParticipate}
+            title={
+              !canParticipate
+                ? 'Private lineup — ask the creator for an invite'
+                : undefined
+            }
+            className="sm:mt-1 px-4 py-2 text-sm font-medium bg-emerald-600 text-white rounded-lg hover:bg-emerald-500 transition-colors flex-shrink-0 w-full sm:w-auto disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:bg-emerald-600"
           >
             Nominate
           </button>
@@ -138,7 +147,18 @@ export function LineupDetailPage(): JSX.Element {
 
       {lineup.status === 'building' && (
         <div className="mt-4">
-          <CommonGroundPanel lineupId={lineup.id} />
+          {!canParticipate && (
+            <p
+              data-testid="nominate-private-notice"
+              className="mb-2 text-xs text-amber-400"
+            >
+              Private lineup — ask the creator for an invite to nominate games.
+            </p>
+          )}
+          <CommonGroundPanel
+            lineupId={lineup.id}
+            canParticipate={canParticipate}
+          />
         </div>
       )}
 
@@ -154,6 +174,7 @@ export function LineupDetailPage(): JSX.Element {
           totalVoters={lineup.totalVoters}
           totalMembers={lineup.totalMembers}
           maxVotesPerPlayer={lineup.maxVotesPerPlayer}
+          canParticipate={canParticipate}
         />
       ) : hasEntries ? (
         <NominationGrid entries={lineup.entries} lineupId={lineup.id} />

--- a/web/src/test/lineup-factories.ts
+++ b/web/src/test/lineup-factories.ts
@@ -26,6 +26,8 @@ export function createMockBanner(
             { gameId: 1, gameName: 'Valheim', gameCoverUrl: '/cover1.jpg', ownerCount: 6, voteCount: 3 },
             { gameId: 2, gameName: 'Elden Ring', gameCoverUrl: '/cover2.jpg', ownerCount: 4, voteCount: 2 },
         ],
+        // ROK-1065: visibility surfaced in the banner response.
+        visibility: 'public',
         ...overrides,
     } as LineupBannerResponseDto;
 }
@@ -80,6 +82,9 @@ export function createMockLineupDetail(
         // ROK-1064: optional Discord channel override fields.
         channelOverrideId: null,
         channelOverrideName: null,
+        // ROK-1065: visibility + invitees.
+        visibility: 'public',
+        invitees: [],
         ...overrides,
     } as LineupDetailResponseDto;
 }

--- a/web/src/test/mocks/handlers.ts
+++ b/web/src/test/mocks/handlers.ts
@@ -147,4 +147,52 @@ export const handlers = [
     http.get(`${API_BASE}/users/:id/similar-players`, () =>
         HttpResponse.json({ similar: [] }),
     ),
+
+    // Lineups — active list (ROK-1065: array of summaries, empty by default).
+    http.get(`${API_BASE}/lineups/active`, () => HttpResponse.json([])),
+
+    // Lineups — banner (ROK-1065: visibility surfaces in banner response).
+    http.get(`${API_BASE}/lineups/banner`, () => HttpResponse.json(null)),
+
+    // Lineups — invitees add (ROK-1065). Returns refreshed detail.
+    http.post(
+        `${API_BASE}/lineups/:id/invitees`,
+        async ({ request, params }) => {
+            const lineupId = Number(params.id);
+            const body = (await request.json()) as { userIds?: number[] };
+            const userIds = Array.isArray(body?.userIds) ? body.userIds : [];
+            return HttpResponse.json({
+                id: lineupId,
+                title: 'Test Lineup',
+                description: null,
+                status: 'building',
+                targetDate: null,
+                decidedGameId: null,
+                decidedGameName: null,
+                linkedEventId: null,
+                createdBy: { id: 1, displayName: 'Admin' },
+                votingDeadline: null,
+                maxVotesPerPlayer: 3,
+                entries: [],
+                totalVoters: 0,
+                totalMembers: 0,
+                createdAt: '2026-03-20T00:00:00Z',
+                updatedAt: '2026-03-20T00:00:00Z',
+                channelOverrideId: null,
+                channelOverrideName: null,
+                visibility: 'private',
+                invitees: userIds.map((id) => ({
+                    id,
+                    displayName: `User ${id}`,
+                    steamLinked: false,
+                })),
+            });
+        },
+    ),
+
+    // Lineups — invitee remove (ROK-1065). 204 No Content.
+    http.delete(
+        `${API_BASE}/lineups/:id/invitees/:userId`,
+        () => new HttpResponse(null, { status: 204 }),
+    ),
 ];

--- a/web/src/test/mocks/handlers.ts
+++ b/web/src/test/mocks/handlers.ts
@@ -6,6 +6,7 @@
  * specific scenarios.
  */
 import { http, HttpResponse } from 'msw';
+import { createMockLineupDetail } from '../lineup-factories';
 
 const API_BASE = 'http://localhost:3000';
 
@@ -161,38 +162,38 @@ export const handlers = [
             const lineupId = Number(params.id);
             const body = (await request.json()) as { userIds?: number[] };
             const userIds = Array.isArray(body?.userIds) ? body.userIds : [];
-            return HttpResponse.json({
-                id: lineupId,
-                title: 'Test Lineup',
-                description: null,
-                status: 'building',
-                targetDate: null,
-                decidedGameId: null,
-                decidedGameName: null,
-                linkedEventId: null,
-                createdBy: { id: 1, displayName: 'Admin' },
-                votingDeadline: null,
-                maxVotesPerPlayer: 3,
-                entries: [],
-                totalVoters: 0,
-                totalMembers: 0,
-                createdAt: '2026-03-20T00:00:00Z',
-                updatedAt: '2026-03-20T00:00:00Z',
-                channelOverrideId: null,
-                channelOverrideName: null,
-                visibility: 'private',
-                invitees: userIds.map((id) => ({
-                    id,
-                    displayName: `User ${id}`,
-                    steamLinked: false,
-                })),
-            });
+            return HttpResponse.json(
+                createMockLineupDetail({
+                    id: lineupId,
+                    entries: [],
+                    totalVoters: 0,
+                    totalMembers: 0,
+                    visibility: 'private',
+                    invitees: userIds.map((id) => ({
+                        id,
+                        displayName: `User ${id}`,
+                        steamLinked: false,
+                    })),
+                }),
+            );
         },
     ),
 
-    // Lineups — invitee remove (ROK-1065). 204 No Content.
+    // Lineups — invitee remove (ROK-1065). API returns refreshed LineupDetailResponseDto.
     http.delete(
         `${API_BASE}/lineups/:id/invitees/:userId`,
-        () => new HttpResponse(null, { status: 204 }),
+        ({ params }) => {
+            const lineupId = Number(params.id);
+            return HttpResponse.json(
+                createMockLineupDetail({
+                    id: lineupId,
+                    entries: [],
+                    totalVoters: 0,
+                    totalMembers: 0,
+                    visibility: 'private',
+                    invitees: [],
+                }),
+            );
+        },
     ),
 ];


### PR DESCRIPTION
## Summary

Adds private-lineup support: invite-only nomination/vote, DM-based notifications (no channel embed), multi-active lineup concurrency, and a cascade of fixes that flowed from removing the "one active lineup" constraint. Bundled-in scope (per operator): Steam store link on game detail, game-card Steam badge, ITAD as authoritative source for Steam app IDs.

- **Data/contract/API:** `community_lineups.visibility`, `community_lineup_invitees` table, `POST/DELETE /lineups/:id/invitees`, `GET /lineups/active` returns array, Zod refinements.
- **Backend:** `assertUserCanParticipate` gating on nominate/vote/removeNomination/bandwagonJoin, visibility-aware notification pipeline (private → DM invitees only, enriched phase-flow + ballot-with-links + deadline), dedup-on-deadline for voting DM phase-revert refire, carryover + steam nudge + common-ground all scoped to public active. `lineup-notification-routing.helpers.ts` + `lineups-actions.helpers.ts` extractions to hit max-lines budget.
- **Frontend:** VisibilityToggle + InviteeMultiSelect (Discord-linked member picker, 200 page size), InviteeList + AddInviteesButton, LineupDetailHeader Private badge, OtherActiveLineups chip row, Games-page "Start another lineup" CTA, UI eligibility gate mirror, game-card Steam badge, game-detail "View on Steam" link.
- **Smoke:** `private-lineup.test.ts` (4 cases, all green): private DMs + no channel embed, phase transition to voting, response shape, multi-active allowed.

## Linear

ROK-1065

## Test plan

- [x] `validate-ci.sh --full` — build/typecheck/lint/unit tests all PASS. Integration: 52/53 suites PASS; `events-dashboard.actions.integration.spec` has a pre-existing cross-spec flake (passes 17/17 in isolation) — tracked as ROK-1100, does NOT touch ROK-1065 code paths.
- [x] Migration 0125 validated (`validate-migrations.sh` + drizzle-kit migrate against fresh Postgres)
- [x] Playwright desktop + mobile — 451 passed, 0 failed (18.7 min)
- [x] Discord smoke (ROK-1065) — 4/4 passed
- [x] Operator browser-tested: create private/public, multi-active, eligibility gates, invitee add/remove + past-vote preservation, Private badge, DM content (enriched + ballot links + phase revert re-fires), Steam store link + game-card badge, ITAD authoritative (Valheim/Elden Ring correct, WoW Classic correctly hidden)

## Review

- 3-agent parallel review (security + tests + style) → aggregated **CHANGES REQUESTED** → rework landed → re-verified
- Architect POST_REVIEW: **GUIDANCE** (5 non-blocking follow-ups tracked)
- Auto-fix commit \`3efac888\`: bandwagon-join eligibility gate + common-ground lineupId

## Deferred follow-ups

- TD-2: "No Steam linked" invitee badge (needs `steamLinked` on `GetPlayersResponseDto`)
- NominatePickerModal + ActiveLineupStack (chip row covers the need)
- Architect G1 (missing user_id index on invitees table), G2 (invited_by audit), G3 (findPreviousLineup vs findLatestDecidedPublicLineup dedup), G4 (document visibility in ROK-1062/1064)
- ROK-1100: flaky events-dashboard integration spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)