### PR TITLE
ROK-1083: fix: taste-profile archetype + demo signal seed

### DIFF
--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -40,10 +40,10 @@ Requirements Interview (plan mode, if spec incomplete)
   → Linear "In Progress" (1h)
   → E2E Test Agent writes FAILING test (2d — TDD)
   → Dev builds to pass test (2e)
-  → CI → Push → Deploy → Linear "In Review" → FULL STOP for operator
+  → CI → Deploy LOCAL (no push) → Linear "In Review" → FULL STOP for operator
   → Commit operator changes → Linear "Code Review" → Reviewer
   → Optional: Architect final (if needs_architect)
-  → Lead smoke tests → PR → Auto-merge (LAST) → Linear "Done"
+  → Lead smoke tests → git push → Create PR → Auto-merge (LAST) → Linear "Done"
 ```
 
 **Eight gates before PR:** requirements, e2e_test_first (N/A only for light), dev, ci, operator, reviewer, architect_final (if needed), smoke_test.
@@ -64,6 +64,8 @@ Requirements Interview (plan mode, if spec incomplete)
 
 **Agent comms:** mailbox via `SendMessage`. Never `TaskOutput` to check on agents. Never poll with `sleep + stat`. While waiting, do parallel useful work.
 
+**No `git push` before code review.** The branch stays LOCAL through Steps 1-4. The first push + PR creation happens only in Step 5, after operator approval AND reviewer approval. Do NOT invoke `/push`, `git push`, `gh pr create`, or `gh pr merge --auto` in Steps 1-4 — even with `--skip-pr`. Pushing pre-review risks PRs + auto-merge landing before a human has reviewed.
+
 **Auto-merge is the LAST action.** Never enable at PR creation. Create PR → complete all gates → enable auto-merge.
 
 **Subagent rules (applied via templates):** subagents stay in their worktree, never push, never create PRs, never enable auto-merge, never force-push, never call `mcp__linear__*`, never run destructive ops. Lead handles all of that.
@@ -78,9 +80,9 @@ Read each step file when you reach it — do not pre-load all steps.
 |------|------|-------------|
 | 1 | `steps/step-1-setup.md` | Cleanup, fetch, profile, requirements interview, init state, Linear → In Progress |
 | 2 | `steps/step-2-implement.md` | Worktrees, optional planner/architect, spawn devs + test agents |
-| 3 | `steps/step-3-validate.md` | CI, push, deploy, Linear → In Review, FULL STOP |
-| 4 | `steps/step-4-review.md` | Poll Linear, rework/approval, reviewer + architect + smoke |
-| 5 | `steps/step-5-ship.md` | Rebase, PR, auto-merge, Linear → Done, cleanup |
+| 3 | `steps/step-3-validate.md` | CI, deploy LOCAL (**no git push**), Linear → In Review, FULL STOP |
+| 4 | `steps/step-4-review.md` | Poll Linear, rework/approval, reviewer + architect + smoke (**still no push**) |
+| 5 | `steps/step-5-ship.md` | Rebase, `git push`, create PR, auto-merge, Linear → Done, cleanup |
 
 ---
 

--- a/.claude/skills/build/steps/step-3-validate.md
+++ b/.claude/skills/build/steps/step-3-validate.md
@@ -1,6 +1,19 @@
 # Step 3: Validate — CI, Deploy Locally, FULL STOP
 
-Lead runs everything. The branch is NOT pushed to origin in this step — "push" here means **deploy locally** so the operator can browser-verify. Nothing leaves the worktree until after code review (step 5). Gate 3a must pass before deploy.
+Lead runs everything.
+
+## HARD RULE — NO PUSH IN STEP 3
+
+The branch stays **local-only** through Steps 1–4. Do NOT invoke any of the following in this step:
+
+- `git push` (including `--force`, `--force-with-lease`)
+- `gh pr create`
+- `gh pr merge --auto`
+- the `/push` skill (even with `--skip-pr`)
+
+The first push happens in **Step 5**, after the operator approves AND the reviewer approves. Pushing pre-review risks a PR and auto-merge landing before a human reviews. If you find yourself about to run any push-adjacent command, stop — you are in the wrong step.
+
+"Push to origin" ≠ "deploy locally." In this step, "deploy" means `./scripts/deploy_dev.sh` so the operator can browser-test. Nothing leaves the worktree here. Gate 3a must pass before deploy.
 
 ---
 

--- a/.claude/skills/build/steps/step-4-review.md
+++ b/.claude/skills/build/steps/step-4-review.md
@@ -1,5 +1,9 @@
 # Step 4: Review — Poll Linear, Rework, Reviewer, Architect, Smoke
 
+## HARD RULE — STILL NO PUSH
+
+The branch remains **local-only** through this step. Do NOT invoke `git push`, `gh pr create`, `gh pr merge --auto`, or the `/push` skill (even with `--skip-pr`) anywhere in Step 4 — including during rework loops. The first push lives in Step 5.
+
 ---
 
 ## 4a. Check Story Status in Linear

--- a/.claude/skills/build/steps/step-5-ship.md
+++ b/.claude/skills/build/steps/step-5-ship.md
@@ -1,5 +1,11 @@
 # Step 5: Ship — Rebase, PR, Auto-Merge, Cleanup, Summary
 
+**This is the ONLY step that pushes.** Entering this step requires both gates from Step 4 to be PASS:
+- `gates.operator: PASS` (Linear status `Code Review`, operator approved in browser)
+- `gates.reviewer: PASS` (reviewer report APPROVED, blockers addressed)
+
+If either is still PENDING / WAITING / FAIL → return to Step 4. Do not push.
+
 ---
 
 ## 5a. Rebase, Push, Create PR (inline — no skill nesting)

--- a/.claude/skills/readlogs/SKILL.md
+++ b/.claude/skills/readlogs/SKILL.md
@@ -1,0 +1,279 @@
+---
+name: readlogs
+description: "Read recently-downloaded Raid Ledger admin logs from ~/Downloads. Context-aware: cold session → full deep-dive sweep across errors, perf, cadence, traffic shape, and cross-file correlation, then draft Linear stories; mid-task → search logs for clues relevant to the active work."
+argument-hint: "[--triage | --troubleshoot] [--service api|nginx|postgresql|redis|supervisor] [--file <name>] [--since <ISO|relative>] [--query <regex>]"
+allowed-tools: "Bash(ls *), Bash(stat *), Bash(file *), Bash(tar *), Bash(gunzip *), Bash(zcat *), Bash(grep *), Bash(rg *), Bash(awk *), Bash(sort *), Bash(uniq *), Bash(wc *), Bash(head *), Bash(tail *), Bash(cut *), Bash(tr *), Bash(find *), Bash(git status*), Bash(git branch*), Bash(git log*), Bash(git diff*), Read, Grep, Glob, mcp__linear__list_issues, mcp__linear__list_issue_labels, mcp__linear__save_issue"
+---
+
+# /readlogs — Read Raid Ledger admin log exports from ~/Downloads
+
+The Raid Ledger admin panel (`web/src/pages/admin/logs-panel.tsx`) lets the operator download individual rotated log files or a `.tar.gz` bundle. This skill reads whatever was most-recently downloaded and behaves differently depending on whether the conversation is **cold** (just started, no active task → triage mode) or **warm** (mid-task → troubleshoot mode).
+
+**Linear Project:** Raid Ledger (`1bc39f98-abaa-4d85-912f-ba62c8da1532`)
+**Team:** Roknua's projects (`0728c19f-5268-4e16-aa45-c944349ce386`)
+
+---
+
+## Step 1 — Discover candidate log files in `~/Downloads`
+
+Match these patterns (services align with `LogService` in `packages/contract`):
+
+| Service | Filename glob |
+|---|---|
+| Bundle export | `logs-*.tar.gz` |
+| api | `api*.log`, `api (*).log` |
+| nginx | `nginx-access*.log`, `nginx-error*.log`, `nginx*.log` |
+| postgresql | `postgresql*.log` |
+| redis | `redis*.log` |
+| supervisor | `supervisor*.log` |
+
+```bash
+ls -lat ~/Downloads/ | awk '{print $6,$7,$8,$9}' | grep -iE '(^|\s)(logs-[0-9].*\.tar\.gz|(api|nginx[-a-z]*|postgresql|redis|supervisor)( \([0-9]+\))?\.log)$'
+```
+
+**Selection rules:**
+- Default: take the **most-recent file per service** (mtime), keeping ones modified within the last 7 days.
+- If `--file <name>` is provided, use exactly that file.
+- If `--service <name>` is provided, restrict to that service.
+- If `--since <ts>` is provided, drop anything older.
+- If a `logs-*.tar.gz` is the freshest artifact, extract it to a temp dir (`mktemp -d`) and treat its contents as the canonical set, ignoring the loose `.log` files.
+
+**If nothing matches:** Tell the operator no recent admin-log downloads were found, suggest they download from the admin Logs panel ("Export .tar.gz" or per-service "Download"), and stop.
+
+Print the resolved file list (path + size + mtime) before proceeding.
+
+---
+
+## Step 2 — Detect mode (context awareness)
+
+Mode determines what we do with the logs.
+
+**`triage` mode (cold session)** is the default when ALL of these are true:
+- Argument does NOT include `--troubleshoot`.
+- Current git branch is `main` (or detached HEAD with no work).
+- No active `TaskList` items in this conversation.
+- No `planning-artifacts/specs/ROK-*.md` modified in the last hour.
+- The conversation so far does not reference a specific Linear story (`ROK-NNNN`), error, file path under active edit, or running dev server.
+
+**`troubleshoot` mode (warm session)** is used when ANY of:
+- `--troubleshoot` was passed.
+- Current branch is a story branch (`ROK-*`, `feat/*`, `fix/*`, etc.).
+- The operator has open tasks or recent edits.
+- The conversation references a specific failing test, exception, endpoint, or feature.
+
+If `--triage` or `--troubleshoot` is explicitly passed, that overrides the heuristic.
+
+State the chosen mode in one sentence before continuing.
+
+---
+
+## Step 3a — Triage mode (cold session)
+
+Goal: surface durable, actionable engineering work. **Do NOT propose stories about reducing log volume, log levels, or "noisy logging" — the operator wants the logs.**
+
+**Triage mode is always a deep dive.** Do not short-circuit to the first obvious signal, announce "nothing else" after a shallow pass, or present findings before the full sweep below is complete. The operator would rather wait a few extra minutes than be handed a thin list and forced to prompt for a second pass. Run the full sweep in 3a.i, write up the observations in 3a.ii, THEN draft stories.
+
+### 3a.i — Mandatory full sweep
+
+Walk the checklist below end to end. If a file is missing (e.g., no postgresql/redis in the bundle), note that explicitly and move on — do not skip silently. Strip ANSI color codes first on any api output: `sed -E $'s/\x1b\\[[0-9;]*m//g'`.
+
+**A. api log — errors & app health**
+- WARN/ERROR/FATAL/Unhandled/Exception total count
+- Group by Nest module tag (`\[[A-Z][A-Za-z0-9_]+\]` after the timestamp) to see which services are noisy
+- Normalize messages (strip UUIDs, timestamps, numeric IDs) and rank top 40 by frequency
+- Search for stack traces (`at [A-Z][a-zA-Z]+\.`, `UnhandledPromiseRejection`, `DeprecationWarning`)
+- Network failure codes: `ECONNREFUSED`, `ETIMEDOUT`, `ENOTFOUND`, `EADDRINUSE`, `socket hang up`, `circuit`
+- App restarts within window: `Bootstrapping`, `NestFactory`, `Application listening`, `Started in [0-9]+ms`
+
+**B. api log — performance surface (`[PERF]` output)**
+- Break out event type counts: `grep -oE '\[PERF\] [A-Z]+ \| [A-Za-z_/]+' | sort | uniq -c | sort -rn`
+- DB query histogram: frequency per `table=` (top 20). Investigate any table with >5k hits over a short window — likely a hot-path query or chatty cron.
+- Slowest DB queries: extract durations `DB \| query \| ([0-9]+)ms`, sort descending, review anything ≥100ms
+- HTTP request durations ≥500ms (exclude CRON lines): endpoint + latency + status
+- CRON job outliers: durations ≥1000ms OR `status != completed|no-op` — review what the service actually did
+- **HEAP trend:** extract `heapUsedMB=` and `rssMB=` over the window, report min/max/avg. Flag any monotonic growth (leak signal) vs stable oscillation (healthy).
+
+**C. api log — cadence & window**
+- First timestamp + last timestamp (confirm log window)
+- Per-cron cadence: sample 3 consecutive timestamps per cron job to confirm expected schedule (every-30s, every-1m, every-5m, every-15m, hourly, daily)
+- Look for cron iterations that are missing from the expected cadence (potential scheduler pause / event-loop block)
+
+**D. nginx-access — traffic shape**
+- Status distribution: `awk '{print $9}' | sort | uniq -c | sort -rn`
+- Top 25 paths: `awk '{print $7}' | sort | uniq -c | sort -rn | head -25` — identify healthcheck chatter, N+1 client patterns, top endpoints
+- Top client IPs: `awk '{print $1}' | sort | uniq -c | sort -rn` — separate internal (127.0.0.1, 172.17.0.1, Docker bridges) from real traffic
+- Top user agents: `awk -F'"' '{print $6}' | sort | uniq -c | sort -rn` — detect scrapers, bots, missing browsers
+- Enumerate paths for every 4xx/5xx: `awk '$9 ~ /^[45]/ {print $9, $7}' | sort | uniq -c | sort -rn`
+- Per-hour request rate: `awk '{print $4}' | sed -E 's/\[//' | cut -d: -f1-2 | sort | uniq -c | sort -rn | head -10` — spot spikes / dead periods
+- Non-health (real app) traffic count — separates healthcheck noise from actual user load
+- Any response-size outliers (column 10 in Combined format) if the format carries them
+
+**E. postgresql log** (only if a fresh file exists — note absence if stale)
+- Any `ERROR:`, `FATAL:`, `PANIC:` lines
+- Deadlocks, lock waits, `could not serialize access`
+- Long-running queries / statement timeouts
+- Connection spikes / auth failures / role issues
+- Vacuum / autovacuum warnings
+
+**F. redis log** (only if fresh)
+- `WARNING`, `MISCONF`, `OOM`, eviction notices, persistence (RDB/AOF) warnings
+- Slowlog entries if present
+- Replication / cluster state if applicable
+
+**G. supervisor log** (only if fresh)
+- Child process `EXITED`, `FATAL`, `crashed`, restart loops
+- Count per program + timestamps
+
+**H. Cross-file correlation**
+- For every nginx 5xx: timestamp-match against api log for the concurrent exception
+- For every api `[ItadHttp]`-style external-API warning cluster: match against the consuming cron's `status=` line
+- For every cron duration outlier (≥10× baseline): match against concurrent DB query slowdown or external-API errors
+- For every long request (nginx `$request_time` or api HTTP latency): match to the DB queries or external calls it spawned
+
+### 3a.ii — Write up the sweep (REQUIRED — before drafting stories)
+
+Produce a short analysis summary **per log file** covering every dimension from 3a.i. Even dimensions that are clean get a line — the operator needs to know you actually checked, and a "clean" axis is itself a data point.
+
+Format roughly:
+
+```
+### api.log — <first-ts> → <last-ts>, <N> lines
+- Errors: WARN=<n> ERROR=<n> FATAL=<n>, noisiest module: <module>
+- Top normalized messages:
+  1. "<msg>" × <n> (<module>)
+  2. ...
+- Perf: <top event types>
+- DB: <top tables>; slowest query <n>ms; queries ≥100ms: <n>
+- HTTP: requests ≥500ms: <path/latency>
+- CRON: outliers <service/duration>; any non-completed <list>
+- HEAP: heapUsed <min>-<max> MB, RSS <min>-<max> MB — <stable|growing|oscillating>
+- Cadence: <cron schedules confirmed>
+- Restarts: <yes/no within window>
+
+### nginx-access.log — <n> requests over <window>
+- Status: <distribution>
+- Path mix: <healthcheck share> / <real traffic count>
+- 4xx/5xx paths: <breakdown>
+- Client IPs: <internal vs external>
+- UA diversity: <summary>
+- Hour-by-hour: <peaks / dead periods>
+
+### postgresql.log — <window or "stale/absent">
+- ...
+### redis.log — <window or "stale/absent">
+- ...
+### supervisor.log — <window or "stale/absent">
+- ...
+```
+
+This write-up is for the operator. Keep it tight but complete.
+
+### 3a.iii — Candidate enumeration (all findings, not just stories)
+
+List every observation from 3a.ii that has ANY engineering signal as a candidate. Include even borderline ones. Do not filter yet. Typical candidate classes:
+
+| Pattern | Category | Linear prefix | Area label hint |
+|---|---|---|---|
+| Recurring exception in app code | bug | `fix:` | feature area from stack frame |
+| External API flake swallowed by client (no retry / misleading success) | tech debt / reliability | `tech-debt:` | consuming feature area |
+| Slow query / repeated identical query / N+1 | perf | `perf:` | `Database` or feature module |
+| Chatty endpoint (hot path getting called >10× expected rate) | perf | `perf:` | consuming feature area |
+| Healthcheck doing real work (DB/Redis round-trips) on every poll | tech debt | `tech-debt:` | `Infrastructure` |
+| Heap growth / memory leak signal | bug | `fix:` | feature area |
+| Cron skipped / blocked / silently degraded | bug | `fix:` | feature area |
+| Misleading `status=completed` when batches failed | tech debt / observability | `tech-debt:` | feature area |
+| Deprecation warning, unhandled rejection in non-critical path | tech debt | `tech-debt:` | feature area |
+| Config drift, dead env var, missing optional service | chore | `chore:` | `Infrastructure` |
+| Postgres deadlock / lock contention | bug or tech debt | `fix:` / `tech-debt:` | `Database` |
+| Redis eviction / persistence errors | bug or chore | `fix:` / `chore:` | `Infrastructure` |
+| Supervisor child restart loop | bug | `fix:` | `Infrastructure` |
+| One-off transient (single ETIMEDOUT, single restart, single blip) | noise | — | skip |
+
+**Always exclude:** "reduce logging", "lower log level", "silence noisy logs", "rotate faster", "trim verbose output". The operator explicitly does not want these. If a candidate's only suggested action would be to log less, drop it.
+
+### 3a.iv — Investigate each candidate before drafting (STRICT)
+
+Per `feedback_investigate_before_stories.md`: do NOT write a story from grep output alone. For each candidate from 3a.iii:
+
+- Read the file referenced by the stack frame / module tag. Confirm the behavior is reachable in current `main` (not already fixed).
+- `git log --oneline -10 -- <file>` — scan for a recent fix matching the signal.
+- `mcp__linear__list_issues` (project: Raid Ledger) — search by file name, module name, AND by error keyword. If an open story covers the same root cause, plan to **append evidence as a comment** rather than create a duplicate.
+- Decide severity: Urgent (1) only for production outages or data loss; High (2) for reliability regressions affecting users; Medium (3) for silent degradation / observability gaps / meaningful perf; Low (4) for minor cleanup.
+
+Write the decision per candidate internally before surfacing to the operator: **promote to story / demote to observation / defer (comment on existing story) / drop as noise**. Include a one-line reason for demotions so the operator can override.
+
+### 3a.v — Present full triage summary, wait for approval
+
+Now (and only now) present to the operator. Include:
+
+1. The 3a.ii sweep summary (so the operator can see what you checked).
+2. A table of every **promoted** story candidate: title, category, severity, occurrence count, source files, one-line evidence snippet.
+3. A short list of **demoted** observations (chatty endpoints, minor perf, nice-to-haves) so the operator can green-light any of them.
+4. Any **matched existing stories** where you plan to comment rather than duplicate.
+5. Ask the operator which to create (use `AskUserQuestion` if the list is ≥3 items). Phrase the ask so the operator can approve all, approve a subset, or add a demoted item.
+
+### 3a.vi — Create approved stories
+
+For each approved finding:
+- Title prefix: `fix:` / `perf:` / `tech-debt:` / `chore:`
+- `mcp__linear__save_issue` with: project Raid Ledger, team Roknua's projects, state `Backlog`, priority by severity, **one Area label** (see `area-labels.md` in MEMORY).
+- Body must include: `## What`, `## Evidence` (excerpt + occurrence count + timestamps), `## Root cause` (source file:line + explanation), `## Fix` (concrete approach), `## Acceptance criteria` (bulleted, at least one of the form "no occurrences in fresh log export ≥7 days post-deploy"), and `## Out of scope` if adjacent stories exist.
+- For matched-existing stories: `mcp__linear__save_comment` with the new evidence and timestamps.
+
+Print a final summary listing each created `ROK-NNN` (and any comments appended).
+
+---
+
+## Step 3b — Troubleshoot mode (warm session)
+
+Goal: pull facts out of the log that help with whatever is actively being worked on. Do **not** create Linear stories in this mode unless explicitly asked.
+
+### 3b.i — Build a search dossier from active context
+
+Collect anchors from the conversation:
+- Active branch name + last commit subject.
+- Open `TaskList` titles.
+- Files recently edited or read in this session.
+- Any error message, stack trace, endpoint, or Linear story ID the operator mentioned.
+- If `--query <regex>` was passed, use it verbatim as an extra anchor.
+
+### 3b.ii — Search logs for those anchors
+
+For each anchor, run targeted greps with timestamp context (`grep -nE -C 3`). Prefer:
+- Exact endpoint / route path matches (`GET /api/...`, `POST /api/...`).
+- Class/function names from stack frames (`UsersService.findById`, `EventsController.cancel`).
+- Linear ID in commit messages or feature flags (e.g., `ROK-1065`).
+- Discord interaction IDs / event IDs / signup IDs the operator named.
+
+Cross-reference api ↔ nginx for request-side correlation (match by timestamp + path), and api ↔ postgresql for query-side correlation (match by timestamp + table).
+
+### 3b.iii — Report findings inline
+
+Respond with:
+- A concise narrative of what the logs show that's relevant to the active task.
+- Direct quotes (with line numbers and timestamps) for each material hit.
+- A list of "didn't find" anchors so the operator knows what is absent.
+- Optional: 1–3 follow-up actions (e.g., "the failing assertion in `events.cancel` matches a `null user_id` in the log at 12:04:31 — check the seed data").
+
+Do **not** open Linear stories from troubleshoot mode unless the operator says so.
+
+---
+
+## Step 4 — Cleanup
+
+- If a `.tar.gz` was extracted to a temp dir, delete it.
+- Do NOT delete the original downloaded files in `~/Downloads`; the operator manages those.
+
+---
+
+## Quick reference
+
+```text
+/readlogs                      # auto-detect mode, latest file per service
+/readlogs --triage             # force triage even mid-task
+/readlogs --troubleshoot       # force troubleshoot even on main
+/readlogs --service api        # only the api log
+/readlogs --file "api (30).log"
+/readlogs --since "2026-04-20"
+/readlogs --query "EventsController.cancel"
+```

--- a/api/src/admin/admin.module.ts
+++ b/api/src/admin/admin.module.ts
@@ -21,6 +21,7 @@ import { DemoTestLineupService } from './demo-test-lineup.service';
 import { SlashCommandTestService } from './slash-command-test.service';
 import { LineupsModule } from '../lineups/lineups.module';
 import { AiChatModule } from '../discord-bot/ai-chat/ai-chat.module';
+import { TasteProfileModule } from '../taste-profile/taste-profile.module';
 import { AiChatTestController } from './ai-chat-test.controller';
 
 @Module({
@@ -30,6 +31,7 @@ import { AiChatTestController } from './ai-chat-test.controller';
     IgdbModule,
     LineupsModule,
     AiChatModule,
+    TasteProfileModule,
   ],
   controllers: [
     AdminController,

--- a/api/src/admin/demo-data-gen-taste-profile.spec.ts
+++ b/api/src/admin/demo-data-gen-taste-profile.spec.ts
@@ -1,0 +1,148 @@
+import {
+  TASTE_TIER_PROFILES,
+  currentWeekStart,
+  generateGameActivityRollups,
+  generatePlayhistoryInterests,
+  generateSignalProfiles,
+  type TasteIntensityTier,
+} from './demo-data-gen-taste-profile';
+import { createRng } from './demo-data-rng';
+
+const ALL_TIERS: TasteIntensityTier[] = [
+  'Hardcore',
+  'Dedicated',
+  'Regular',
+  'Casual',
+];
+
+function makeUsernames(count: number): string[] {
+  return Array.from({ length: count }, (_, i) => `demo_user_${i}`);
+}
+
+describe('demo-data-gen-taste-profile (ROK-1083)', () => {
+  describe('generateSignalProfiles', () => {
+    it('covers all four tiers across a realistic population', () => {
+      const rng = createRng(42);
+      const profiles = generateSignalProfiles(rng, makeUsernames(100));
+      const tiers = new Set(profiles.map((p) => p.tier));
+      for (const tier of ALL_TIERS) {
+        expect(tiers.has(tier)).toBe(true);
+      }
+    });
+
+    it('produces weekly hours within each tier profile range', () => {
+      const rng = createRng(99);
+      const profiles = generateSignalProfiles(rng, makeUsernames(200));
+      for (const p of profiles) {
+        const [min, max] = TASTE_TIER_PROFILES[p.tier].weeklyHours;
+        expect(p.weeklyHours).toBeGreaterThanOrEqual(min);
+        expect(p.weeklyHours).toBeLessThanOrEqual(max);
+      }
+    });
+
+    it('picks unique favourite games within the user-specific count range', () => {
+      const rng = createRng(7);
+      const profiles = generateSignalProfiles(rng, makeUsernames(50));
+      for (const p of profiles) {
+        const [min, max] = TASTE_TIER_PROFILES[p.tier].gameCount;
+        expect(p.favouriteIgdbIds.length).toBeGreaterThanOrEqual(min);
+        expect(p.favouriteIgdbIds.length).toBeLessThanOrEqual(max);
+        expect(new Set(p.favouriteIgdbIds).size).toBe(
+          p.favouriteIgdbIds.length,
+        );
+      }
+    });
+
+    it('is deterministic under a fixed seed', () => {
+      const a = generateSignalProfiles(createRng(1234), makeUsernames(20));
+      const b = generateSignalProfiles(createRng(1234), makeUsernames(20));
+      expect(b).toEqual(a);
+    });
+  });
+
+  describe('generateGameActivityRollups', () => {
+    const NOW = new Date('2026-04-22T10:00:00Z');
+
+    it('emits exactly one week-period row per favourite game and 28 daily rows per game', () => {
+      const rng = createRng(11);
+      const profiles = generateSignalProfiles(rng, ['only_user']);
+      const rollups = generateGameActivityRollups(profiles, NOW);
+      const profile = profiles[0];
+      const weekRows = rollups.filter((r) => r.period === 'week');
+      const dayRows = rollups.filter((r) => r.period === 'day');
+      expect(weekRows).toHaveLength(profile.favouriteIgdbIds.length);
+      expect(dayRows.length).toBeGreaterThan(0);
+      for (const igdbId of profile.favouriteIgdbIds) {
+        const dailyForGame = dayRows.filter((r) => r.igdbId === igdbId);
+        expect(dailyForGame.length).toBeLessThanOrEqual(28);
+      }
+    });
+
+    it('weekly totals match the generated user weeklyHours (within rounding)', () => {
+      const rng = createRng(55);
+      const profiles = generateSignalProfiles(rng, ['rounding_user']);
+      const profile = profiles[0];
+      const rollups = generateGameActivityRollups(profiles, NOW);
+      const weekSeconds = rollups
+        .filter((r) => r.period === 'week')
+        .reduce((acc, r) => acc + r.totalSeconds, 0);
+      const expected = profile.weeklyHours * 3600;
+      expect(Math.abs(weekSeconds - expected)).toBeLessThanOrEqual(
+        profile.favouriteIgdbIds.length,
+      );
+    });
+
+    it('sets period_start to the Monday of the current week', () => {
+      const profiles = generateSignalProfiles(createRng(3), ['monday_user']);
+      const rollups = generateGameActivityRollups(profiles, NOW);
+      const weekRow = rollups.find((r) => r.period === 'week');
+      expect(weekRow).toBeDefined();
+      const expectedMonday = currentWeekStart(NOW);
+      expect(weekRow!.periodStart.toISOString()).toBe(
+        expectedMonday.toISOString(),
+      );
+    });
+  });
+
+  describe('generatePlayhistoryInterests', () => {
+    it('emits at least one steam_library row per favourite game', () => {
+      const rng = createRng(17);
+      const profiles = generateSignalProfiles(rng, makeUsernames(10));
+      const interests = generatePlayhistoryInterests(rng, profiles);
+      for (const p of profiles) {
+        const userRows = interests.filter((r) => r.username === p.username);
+        const matchedFavourites = p.favouriteIgdbIds.filter((id) =>
+          userRows.some((r) => r.igdbId === id),
+        );
+        expect(matchedFavourites.length).toBe(p.favouriteIgdbIds.length);
+      }
+    });
+
+    it('scales playtimeForever by the tier lifetimeMultiplier', () => {
+      const rng = createRng(23);
+      const profiles = generateSignalProfiles(rng, ['tier_user']);
+      const profile = profiles[0];
+      const interests = generatePlayhistoryInterests(rng, profiles);
+      const weeklyMinutes = profile.weeklyHours * 60;
+      const expected = Math.round(
+        weeklyMinutes * TASTE_TIER_PROFILES[profile.tier].lifetimeMultiplier,
+      );
+      const favouriteRow = interests.find(
+        (r) =>
+          r.username === profile.username &&
+          r.igdbId === profile.favouriteIgdbIds[0],
+      );
+      expect(favouriteRow).toBeDefined();
+      expect(favouriteRow!.playtimeForever).toBe(expected);
+    });
+
+    it('tags every row with source steam_library', () => {
+      const rng = createRng(31);
+      const profiles = generateSignalProfiles(rng, makeUsernames(5));
+      const interests = generatePlayhistoryInterests(rng, profiles);
+      for (const row of interests) {
+        expect(row.source).toBe('steam_library');
+      }
+    });
+  });
+});

--- a/api/src/admin/demo-data-gen-taste-profile.ts
+++ b/api/src/admin/demo-data-gen-taste-profile.ts
@@ -1,0 +1,281 @@
+/**
+ * Demo-mode taste-profile signal generator (ROK-1083).
+ *
+ * Produces per-user weekly + daily game activity rollups and
+ * steam-library-flavoured game interests so the aggregator pipeline
+ * derives varied intensity tiers (Hardcore / Dedicated / Regular / Casual)
+ * and vector titles across the demo population. Without this step the
+ * demo users have zero playtime signal and everyone resolves to Casual.
+ */
+import type { Rng } from './demo-data-rng';
+import { pickN, randInt, weightedPick } from './demo-data-rng';
+import { IGDB_GAME_WEIGHTS } from './demo-data-generator-templates';
+
+/** Taste-profile intensity tier label (matches contract `IntensityTier`). */
+export type TasteIntensityTier =
+  | 'Hardcore'
+  | 'Dedicated'
+  | 'Regular'
+  | 'Casual';
+
+export interface TasteTierProfile {
+  /** Weekly hours range (inclusive) this tier plays across all games. */
+  weeklyHours: [number, number];
+  /** How many "favourite" games the user plays in a given week. */
+  gameCount: [number, number];
+  /** Unique-ownership multiplier used for playtime_forever (all-time minutes). */
+  lifetimeMultiplier: number;
+}
+
+/**
+ * Per-tier playtime shape. Tuned so the aggregator's intensity-rollup
+ * bucketing lands in the matching tier: Hardcore ≥ 85, Dedicated 60-84,
+ * Regular 35-59, Casual < 35 after the community-relative percentile rank.
+ */
+export const TASTE_TIER_PROFILES: Record<TasteIntensityTier, TasteTierProfile> =
+  {
+    Hardcore: {
+      weeklyHours: [28, 45],
+      gameCount: [3, 5],
+      lifetimeMultiplier: 80,
+    },
+    Dedicated: {
+      weeklyHours: [14, 26],
+      gameCount: [2, 4],
+      lifetimeMultiplier: 40,
+    },
+    Regular: {
+      weeklyHours: [6, 12],
+      gameCount: [2, 3],
+      lifetimeMultiplier: 15,
+    },
+    Casual: {
+      weeklyHours: [1, 4],
+      gameCount: [1, 2],
+      lifetimeMultiplier: 4,
+    },
+  };
+
+/** Weighted tier distribution — hits all four tiers on ~100 demo users. */
+const TIER_WEIGHTS: Array<{ tier: TasteIntensityTier; weight: number }> = [
+  { tier: 'Hardcore', weight: 3 },
+  { tier: 'Dedicated', weight: 6 },
+  { tier: 'Regular', weight: 7 },
+  { tier: 'Casual', weight: 4 },
+];
+
+export interface SignalProfileEntry {
+  username: string;
+  tier: TasteIntensityTier;
+  /** IGDB IDs the user actively plays this week. */
+  favouriteIgdbIds: number[];
+  /** Hours to spread across the favourite games this week. */
+  weeklyHours: number;
+}
+
+export interface GeneratedGameActivityRollup {
+  username: string;
+  igdbId: number;
+  period: 'day' | 'week';
+  periodStart: Date;
+  totalSeconds: number;
+}
+
+export interface GeneratedPlayhistoryInterest {
+  username: string;
+  igdbId: number;
+  source: 'steam_library';
+  playtimeForever: number;
+  playtime2weeks: number;
+}
+
+/** Pick a tier using the community-wide distribution. */
+function pickTier(rng: Rng): TasteIntensityTier {
+  const weights = TIER_WEIGHTS.map((t) => t.weight);
+  return weightedPick(rng, TIER_WEIGHTS, weights).tier;
+}
+
+/**
+ * Assemble a per-user signal profile: tier, chosen games, weekly hours.
+ * The choice of games uses the same weighted pool as other demo flows
+ * so popular MMOs get more volume and genre spread remains believable.
+ */
+export function generateSignalProfiles(
+  rng: Rng,
+  usernames: string[],
+): SignalProfileEntry[] {
+  const gameWeights = IGDB_GAME_WEIGHTS.map((g) => g.weight);
+  const gamePool = IGDB_GAME_WEIGHTS.map((g) => Number(g.igdbId));
+  return usernames.map((username) => {
+    const tier = pickTier(rng);
+    const profile = TASTE_TIER_PROFILES[tier];
+    const gameCount = randInt(rng, profile.gameCount[0], profile.gameCount[1]);
+    const weeklyHours = randInt(
+      rng,
+      profile.weeklyHours[0],
+      profile.weeklyHours[1],
+    );
+    const favouriteIgdbIds = pickWeightedUnique(
+      rng,
+      gamePool,
+      gameWeights,
+      gameCount,
+    );
+    return { username, tier, favouriteIgdbIds, weeklyHours };
+  });
+}
+
+/** Weighted sample without replacement — returns `count` unique IGDB IDs. */
+function pickWeightedUnique(
+  rng: Rng,
+  pool: number[],
+  weights: number[],
+  count: number,
+): number[] {
+  const picked: number[] = [];
+  const remaining = pool.map((id, i) => ({ id, weight: weights[i] }));
+  while (picked.length < count && remaining.length > 0) {
+    const totalWeight = remaining.reduce((acc, r) => acc + r.weight, 0);
+    let roll = rng() * totalWeight;
+    let chosenIdx = 0;
+    for (let i = 0; i < remaining.length; i++) {
+      roll -= remaining[i].weight;
+      if (roll <= 0) {
+        chosenIdx = i;
+        break;
+      }
+    }
+    picked.push(remaining[chosenIdx].id);
+    remaining.splice(chosenIdx, 1);
+  }
+  return picked;
+}
+
+/** Monday-floor date for `game_activity_rollups.period_start` week rows. */
+export function currentWeekStart(now: Date): Date {
+  const d = new Date(now);
+  const day = d.getDay();
+  d.setDate(d.getDate() - day + (day === 0 ? -6 : 1));
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+/** Daily floor (midnight local). */
+function floorDay(d: Date): Date {
+  const out = new Date(d);
+  out.setHours(0, 0, 0, 0);
+  return out;
+}
+
+/**
+ * Produce the current-week rollup plus 28 prior days of daily rollups so
+ * the intensity rollup's `last4wHours` signal is non-zero. Total weekly
+ * hours are spread proportionally across the user's favourite games.
+ */
+export function generateGameActivityRollups(
+  profiles: SignalProfileEntry[],
+  now: Date,
+): GeneratedGameActivityRollup[] {
+  const rows: GeneratedGameActivityRollup[] = [];
+  const weekStart = currentWeekStart(now);
+  for (const p of profiles) {
+    if (p.favouriteIgdbIds.length === 0) continue;
+    const perGameSeconds = splitSecondsAcrossGames(
+      p.weeklyHours * 3600,
+      p.favouriteIgdbIds.length,
+    );
+    p.favouriteIgdbIds.forEach((igdbId, idx) => {
+      const weeklySeconds = perGameSeconds[idx];
+      if (weeklySeconds <= 0) return;
+      rows.push({
+        username: p.username,
+        igdbId,
+        period: 'week',
+        periodStart: weekStart,
+        totalSeconds: weeklySeconds,
+      });
+      rows.push(
+        ...emitDailyRollups(p.username, igdbId, weeklySeconds, weekStart, now),
+      );
+    });
+  }
+  return rows;
+}
+
+/** Split `totalSeconds` across `count` games with a mild front-bias. */
+function splitSecondsAcrossGames(
+  totalSeconds: number,
+  count: number,
+): number[] {
+  if (count === 1) return [totalSeconds];
+  const weights = Array.from({ length: count }, (_, i) => count - i);
+  const weightTotal = weights.reduce((a, b) => a + b, 0);
+  return weights.map((w) => Math.round((totalSeconds * w) / weightTotal));
+}
+
+/** Emit 4 prior weeks of daily-period rollups averaging the weekly total. */
+function emitDailyRollups(
+  username: string,
+  igdbId: number,
+  weeklySeconds: number,
+  weekStart: Date,
+  now: Date,
+): GeneratedGameActivityRollup[] {
+  const rows: GeneratedGameActivityRollup[] = [];
+  const dailySeconds = Math.max(0, Math.round(weeklySeconds / 7));
+  if (dailySeconds === 0) return rows;
+  for (let dayOffset = 1; dayOffset <= 28; dayOffset++) {
+    const day = new Date(weekStart);
+    day.setDate(day.getDate() - dayOffset);
+    if (day >= now) continue;
+    rows.push({
+      username,
+      igdbId,
+      period: 'day',
+      periodStart: floorDay(day),
+      totalSeconds: dailySeconds,
+    });
+  }
+  return rows;
+}
+
+/**
+ * Enrich game interests with steam-library playtime fields so the
+ * aggregator's `steamOwnership` signal path produces non-zero axis values.
+ * Adds 1–3 extra "owned but barely played" games per user to make the
+ * profile feel more like a real library.
+ */
+export function generatePlayhistoryInterests(
+  rng: Rng,
+  profiles: SignalProfileEntry[],
+): GeneratedPlayhistoryInterest[] {
+  const rows: GeneratedPlayhistoryInterest[] = [];
+  const gamePool = IGDB_GAME_WEIGHTS.map((g) => Number(g.igdbId));
+  for (const p of profiles) {
+    const tierProfile = TASTE_TIER_PROFILES[p.tier];
+    const weeklyMinutes = p.weeklyHours * 60;
+    for (const igdbId of p.favouriteIgdbIds) {
+      rows.push({
+        username: p.username,
+        igdbId,
+        source: 'steam_library',
+        playtimeForever: Math.round(
+          weeklyMinutes * tierProfile.lifetimeMultiplier,
+        ),
+        playtime2weeks: weeklyMinutes * 2,
+      });
+    }
+    const owned = pickN(rng, gamePool, randInt(rng, 1, 3));
+    for (const igdbId of owned) {
+      if (p.favouriteIgdbIds.includes(igdbId)) continue;
+      rows.push({
+        username: p.username,
+        igdbId,
+        source: 'steam_library',
+        playtimeForever: randInt(rng, 30, 600),
+        playtime2weeks: 0,
+      });
+    }
+  }
+  return rows;
+}

--- a/api/src/admin/demo-data-generation-steps.ts
+++ b/api/src/admin/demo-data-generation-steps.ts
@@ -12,6 +12,9 @@ import {
   generateNotifications,
   generateNotifPreferences,
   generateGameInterests,
+  generateSignalProfiles,
+  generateGameActivityRollups,
+  generatePlayhistoryInterests,
 } from './demo-data-generator';
 
 type GameRow = typeof schema.games.$inferSelect;
@@ -60,7 +63,23 @@ function generateSupportData(
     .map((g) => g.igdbId)
     .filter((id): id is number => id !== null);
   const interests = generateGameInterests(rng, usernames, allIgdbIds);
-  return { gameTime, avail, notifs, notifPrefs, interests };
+  // ROK-1083: taste-profile signal data — drives intensity tier + vector titles.
+  const signalProfiles = generateSignalProfiles(rng, usernames);
+  const activityRollups = generateGameActivityRollups(signalProfiles, now);
+  const playhistoryInterests = generatePlayhistoryInterests(
+    rng,
+    signalProfiles,
+  );
+  return {
+    gameTime,
+    avail,
+    notifs,
+    notifPrefs,
+    interests,
+    signalProfiles,
+    activityRollups,
+    playhistoryInterests,
+  };
 }
 
 /** Generate all non-DB data structures. */

--- a/api/src/admin/demo-data-generator.ts
+++ b/api/src/admin/demo-data-generator.ts
@@ -57,3 +57,18 @@ export {
   generateGameInterests,
   getAllNotificationTitles,
 } from './demo-data-gen-support';
+
+// ─── Taste-Profile Signal Generators (ROK-1083) ──────────────────────────────
+export type {
+  TasteIntensityTier,
+  TasteTierProfile,
+  SignalProfileEntry,
+  GeneratedGameActivityRollup,
+  GeneratedPlayhistoryInterest,
+} from './demo-data-gen-taste-profile';
+export {
+  TASTE_TIER_PROFILES,
+  generateSignalProfiles,
+  generateGameActivityRollups,
+  generatePlayhistoryInterests,
+} from './demo-data-gen-taste-profile';

--- a/api/src/admin/demo-data-install-core.helpers.ts
+++ b/api/src/admin/demo-data-install-core.helpers.ts
@@ -23,6 +23,9 @@ import {
   generateNotifications,
   generateNotifPreferences,
   generateGameInterests,
+  generateSignalProfiles,
+  generateGameActivityRollups,
+  generatePlayhistoryInterests,
 } from './demo-data-generator';
 
 type Db = PostgresJsDatabase<typeof schema>;
@@ -211,6 +214,10 @@ export function generateAllData(
   const newUsernames = generatedUsernames.slice(ORIGINAL_GAMER_COUNT);
   const chars = generateCharacters(rng, newUsernames);
   const allUsernames = [...generatedUsernames, 'SeedAdmin'];
+  // ROK-1083: signal profiles drive both the new activity rollups and the
+  // playtime-flavoured steam_library game interests so the aggregator
+  // derives varied intensity tiers + vector titles.
+  const signalProfiles = generateSignalProfiles(rng, generatedUsernames);
   return {
     events,
     chars,
@@ -227,6 +234,8 @@ export function generateAllData(
       generatedUsernames,
       extractIgdbIds(allGames),
     ),
+    activityRollups: generateGameActivityRollups(signalProfiles, now),
+    playhistoryInterests: generatePlayhistoryInterests(rng, signalProfiles),
   };
 }
 

--- a/api/src/admin/demo-data-install-taste.helpers.ts
+++ b/api/src/admin/demo-data-install-taste.helpers.ts
@@ -1,0 +1,95 @@
+/**
+ * Install helpers for demo-mode taste-profile signal data (ROK-1083).
+ * Persists weekly + daily game activity rollups and steam-library game
+ * interests so the taste-profile pipelines derive varied intensity tiers
+ * and vector titles across the demo population.
+ */
+import * as schema from '../drizzle/schema';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import type {
+  GeneratedGameActivityRollup,
+  GeneratedPlayhistoryInterest,
+} from './demo-data-gen-taste-profile';
+
+type Db = PostgresJsDatabase<typeof schema>;
+type BatchInsert = (
+  table: Parameters<Db['insert']>[0],
+  rows: Record<string, unknown>[],
+  onConflict?: 'doNothing',
+) => Promise<void>;
+
+type UserMap = Map<string, { id: number }>;
+type GameMap = Map<number | null, number>;
+
+function nonNull<T>(v: T | null): v is T {
+  return v !== null;
+}
+
+/** Format as YYYY-MM-DD for drizzle's date column. */
+function toDateString(d: Date): string {
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Install weekly + daily activity rollups. Uses `doNothing` on conflict so
+ * re-runs never double-count. Rows referring to missing users/games are
+ * dropped silently — missing IGDB IDs happen when the demo game catalogue
+ * hasn't been synced yet.
+ */
+export async function installGameActivityRollups(
+  batchInsert: BatchInsert,
+  userByName: UserMap,
+  igdbIdsByDbId: GameMap,
+  generated: GeneratedGameActivityRollup[],
+): Promise<number> {
+  const values = generated
+    .map((row) => {
+      const user = userByName.get(row.username);
+      const gameId = igdbIdsByDbId.get(row.igdbId);
+      if (!user || !gameId) return null;
+      return {
+        userId: user.id,
+        gameId,
+        period: row.period,
+        periodStart: toDateString(row.periodStart),
+        totalSeconds: row.totalSeconds,
+      };
+    })
+    .filter(nonNull);
+  if (values.length === 0) return 0;
+  await batchInsert(schema.gameActivityRollups, values, 'doNothing');
+  return values.length;
+}
+
+/**
+ * Install steam-library flavoured game interests with playtime fields.
+ * Dedupes by (userId, gameId, source) so the DB unique constraint is
+ * respected on re-runs.
+ */
+export async function installPlayhistoryInterests(
+  batchInsert: BatchInsert,
+  userByName: UserMap,
+  igdbIdsByDbId: GameMap,
+  generated: GeneratedPlayhistoryInterest[],
+): Promise<number> {
+  const dedup = new Map<string, Record<string, unknown>>();
+  for (const row of generated) {
+    const user = userByName.get(row.username);
+    const gameId = igdbIdsByDbId.get(row.igdbId);
+    if (!user || !gameId) continue;
+    const key = `${user.id}:${gameId}:${row.source}`;
+    if (dedup.has(key)) continue;
+    dedup.set(key, {
+      userId: user.id,
+      gameId,
+      source: row.source,
+      playtimeForever: row.playtimeForever,
+      playtime2weeks: row.playtime2weeks,
+      lastSyncedAt: new Date(),
+    });
+  }
+  const values = [...dedup.values()];
+  if (values.length === 0) return 0;
+  await batchInsert(schema.gameInterests, values, 'doNothing');
+  return values.length;
+}

--- a/api/src/admin/demo-data-install-taste.helpers.ts
+++ b/api/src/admin/demo-data-install-taste.helpers.ts
@@ -4,8 +4,10 @@
  * interests so the taste-profile pipelines derive varied intensity tiers
  * and vector titles across the demo population.
  */
+import { eq } from 'drizzle-orm';
 import * as schema from '../drizzle/schema';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { deriveArchetype } from '../taste-profile/archetype.helpers';
 import type {
   GeneratedGameActivityRollup,
   GeneratedPlayhistoryInterest,
@@ -92,4 +94,39 @@ export async function installPlayhistoryInterests(
   if (values.length === 0) return 0;
   await batchInsert(schema.gameInterests, values, 'doNothing');
   return values.length;
+}
+
+/**
+ * Re-derive archetypes for every existing `player_taste_vectors` row.
+ *
+ * The production aggregator short-circuits on matching `signalHash`, so the
+ * post-install sequence (aggregate → weekly intensity → re-aggregate) never
+ * updates archetypes once the hash is stable. This helper exists purely
+ * for demo installs — after `aggregateVectors` has populated vectors and
+ * `weeklyIntensityRollup` has written fresh `intensity_metrics`, we
+ * recompute archetypes bottom-up using the current metrics + dimensions.
+ */
+export async function refreshArchetypesFromCurrentMetrics(
+  db: PostgresJsDatabase<typeof schema>,
+): Promise<number> {
+  const rows = await db
+    .select({
+      userId: schema.playerTasteVectors.userId,
+      dimensions: schema.playerTasteVectors.dimensions,
+      intensityMetrics: schema.playerTasteVectors.intensityMetrics,
+    })
+    .from(schema.playerTasteVectors);
+  let updated = 0;
+  for (const row of rows) {
+    const archetype = deriveArchetype({
+      intensityMetrics: row.intensityMetrics,
+      dimensions: row.dimensions,
+    });
+    await db
+      .update(schema.playerTasteVectors)
+      .set({ archetype })
+      .where(eq(schema.playerTasteVectors.userId, row.userId));
+    updated += 1;
+  }
+  return updated;
 }

--- a/api/src/admin/demo-data.service.ts
+++ b/api/src/admin/demo-data.service.ts
@@ -259,13 +259,25 @@ export class DemoDataService {
 
   /**
    * Run the taste-profile pipelines synchronously after install so the
-   * profile pages render composed archetypes immediately. Failures are
-   * logged and swallowed — install is still considered successful.
+   * profile pages render composed archetypes immediately.
+   *
+   * Order matters:
+   * 1. `aggregateVectors` creates `player_taste_vectors` rows (archetype
+   *    here is stale — intensity_metrics still zero).
+   * 2. `weeklyIntensityRollup` reads `game_activity_rollups` and updates
+   *    `intensity_metrics` on those rows.
+   * 3. `refreshArchetypesFromCurrentMetrics` re-derives archetypes using
+   *    the now-correct intensity metrics. The production aggregator's
+   *    signalHash guard otherwise skips this recompute.
+   *
+   * Failures are logged and swallowed — install is still considered
+   * successful even if aggregation trips up.
    */
   private async runTasteProfileAggregation(): Promise<void> {
     try {
-      await this.tasteProfileService.weeklyIntensityRollup();
       await this.tasteProfileService.aggregateVectors();
+      await this.tasteProfileService.weeklyIntensityRollup();
+      await tasteH.refreshArchetypesFromCurrentMetrics(this.db);
     } catch (err) {
       this.logger.warn(
         `Taste-profile aggregation after demo install failed: ${

--- a/api/src/admin/demo-data.service.ts
+++ b/api/src/admin/demo-data.service.ts
@@ -14,7 +14,9 @@ import { getEventsDefinitions } from './demo-data.constants';
 import * as coreH from './demo-data-install-core.helpers';
 import * as signupsH from './demo-data-install-signups.helpers';
 import * as secondaryH from './demo-data-install-secondary.helpers';
+import * as tasteH from './demo-data-install-taste.helpers';
 import * as clearH from './demo-data-clear.helpers';
+import { TasteProfileService } from '../taste-profile/taste-profile.service';
 
 const BATCH_SIZE = 500;
 
@@ -26,6 +28,7 @@ export class DemoDataService {
     @Inject(DrizzleAsyncProvider)
     private db: PostgresJsDatabase<typeof schema>,
     private readonly settingsService: SettingsService,
+    private readonly tasteProfileService: TasteProfileService,
   ) {}
 
   async getStatus(): Promise<DemoDataStatusDto> {
@@ -120,6 +123,7 @@ export class DemoDataService {
       gen,
     );
     await this.settingsService.setDemoMode(true);
+    await this.runTasteProfileAggregation();
     return { users: allUsers.length, ...core, ...secondary };
   }
 
@@ -232,11 +236,43 @@ export class DemoDataService {
       igdbIdsByDbId,
       gen.interests,
     );
+    // ROK-1083: seed taste-profile signals so the aggregator derives varied
+    // intensity tiers + vector titles. Runs before the aggregator pass below.
+    await tasteH.installGameActivityRollups(
+      bi,
+      userByName,
+      igdbIdsByDbId,
+      gen.activityRollups,
+    );
+    await tasteH.installPlayhistoryInterests(
+      bi,
+      userByName,
+      igdbIdsByDbId,
+      gen.playhistoryInterests,
+    );
     return {
       availability: avail.length,
       gameTimeSlots: gameTime.length,
       notifications: notifs,
     };
+  }
+
+  /**
+   * Run the taste-profile pipelines synchronously after install so the
+   * profile pages render composed archetypes immediately. Failures are
+   * logged and swallowed — install is still considered successful.
+   */
+  private async runTasteProfileAggregation(): Promise<void> {
+    try {
+      await this.tasteProfileService.weeklyIntensityRollup();
+      await this.tasteProfileService.aggregateVectors();
+    } catch (err) {
+      this.logger.warn(
+        `Taste-profile aggregation after demo install failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
   }
 
   private async batchInsert(

--- a/api/src/admin/demo-test-core.controller.spec.ts
+++ b/api/src/admin/demo-test-core.controller.spec.ts
@@ -1,6 +1,8 @@
 import { Test } from '@nestjs/testing';
 import { DemoTestCoreController } from './demo-test-core.controller';
 import { DemoTestService } from './demo-test.service';
+import { TasteProfileService } from '../taste-profile/taste-profile.service';
+import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
 
 function createMockService() {
   return {
@@ -27,7 +29,17 @@ describe('DemoTestCoreController', () => {
 
     const module = await Test.createTestingModule({
       controllers: [DemoTestCoreController],
-      providers: [{ provide: DemoTestService, useValue: mockService }],
+      providers: [
+        { provide: DemoTestService, useValue: mockService },
+        {
+          provide: TasteProfileService,
+          useValue: {
+            aggregateVectors: jest.fn().mockResolvedValue(undefined),
+            weeklyIntensityRollup: jest.fn().mockResolvedValue(undefined),
+          },
+        },
+        { provide: DrizzleAsyncProvider, useValue: {} },
+      ],
     }).compile();
 
     controller = module.get(DemoTestCoreController);

--- a/api/src/admin/demo-test-core.controller.spec.ts
+++ b/api/src/admin/demo-test-core.controller.spec.ts
@@ -1,9 +1,11 @@
 import { Test } from '@nestjs/testing';
+import { ForbiddenException } from '@nestjs/common';
 import { DemoTestCoreController } from './demo-test-core.controller';
 import { DemoTestService } from './demo-test.service';
 import { TasteProfileService } from '../taste-profile/taste-profile.service';
 import { SettingsService } from '../settings/settings.service';
 import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
+import { DEMO_USERNAMES } from './demo-data.constants';
 
 function createMockService() {
   return {
@@ -18,36 +20,71 @@ function createMockService() {
 }
 
 type MockService = ReturnType<typeof createMockService>;
+type MockTasteProfileService = {
+  aggregateVectors: jest.Mock;
+  weeklyIntensityRollup: jest.Mock;
+};
+type MockSettingsService = { getDemoMode: jest.Mock };
 type GetController = () => DemoTestCoreController;
 type GetMockService = () => MockService;
+type GetMockTaste = () => MockTasteProfileService;
+type GetMockSettings = () => MockSettingsService;
+
+/**
+ * Minimal mock of the drizzle select builder. Returns `rows` when
+ * `.from(table)` is eventually awaited. One call per `.select().from()`.
+ */
+function mockDb(rowsByCall: unknown[][]) {
+  let call = 0;
+  const db = {
+    select: jest.fn(() => ({
+      from: jest.fn(() => {
+        const rows = rowsByCall[call] ?? [];
+        call += 1;
+        return Promise.resolve(rows);
+      }),
+    })),
+    insert: jest.fn(() => ({
+      values: jest.fn(() => ({
+        onConflictDoNothing: jest.fn().mockResolvedValue(undefined),
+      })),
+    })),
+  };
+  return db;
+}
 
 describe('DemoTestCoreController', () => {
   let controller: DemoTestCoreController;
   let mockService: MockService;
+  let mockTaste: MockTasteProfileService;
+  let mockSettings: MockSettingsService;
+  const ORIGINAL_DEMO_MODE = process.env.DEMO_MODE;
 
   beforeEach(async () => {
     mockService = createMockService();
+    mockTaste = {
+      aggregateVectors: jest.fn().mockResolvedValue(undefined),
+      weeklyIntensityRollup: jest.fn().mockResolvedValue(undefined),
+    };
+    mockSettings = { getDemoMode: jest.fn().mockResolvedValue(true) };
+    process.env.DEMO_MODE = 'true';
 
     const module = await Test.createTestingModule({
       controllers: [DemoTestCoreController],
       providers: [
         { provide: DemoTestService, useValue: mockService },
-        {
-          provide: TasteProfileService,
-          useValue: {
-            aggregateVectors: jest.fn().mockResolvedValue(undefined),
-            weeklyIntensityRollup: jest.fn().mockResolvedValue(undefined),
-          },
-        },
-        {
-          provide: SettingsService,
-          useValue: { getDemoMode: jest.fn().mockResolvedValue(true) },
-        },
-        { provide: DrizzleAsyncProvider, useValue: {} },
+        { provide: TasteProfileService, useValue: mockTaste },
+        { provide: SettingsService, useValue: mockSettings },
+        { provide: DrizzleAsyncProvider, useValue: mockDb([]) },
       ],
     }).compile();
 
     controller = module.get(DemoTestCoreController);
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_DEMO_MODE === undefined) delete process.env.DEMO_MODE;
+    else process.env.DEMO_MODE = ORIGINAL_DEMO_MODE;
   });
 
   describe('linkDiscord', () => {
@@ -97,6 +134,18 @@ describe('DemoTestCoreController', () => {
       () => controller,
       () => mockService,
     );
+  });
+
+  describe('rebuildTasteProfiles (ROK-1083)', () => {
+    rebuildTasteProfilesTests(
+      () => controller,
+      () => mockTaste,
+      () => mockSettings,
+    );
+  });
+
+  describe('reseedTasteProfiles (ROK-1083)', () => {
+    reseedTasteProfilesTests(() => mockSettings);
   });
 });
 
@@ -226,5 +275,123 @@ function clearGameTimeConfirmationTests(
     const result = await getController().clearGameTimeConfirmationForTest(req);
     expect(result).toEqual({ success: true });
     expect(getMock().clearGameTimeConfirmationForTest).toHaveBeenCalledWith(1);
+  });
+}
+
+/**
+ * Helper: build a controller instance with a custom db mock so the
+ * reseed-taste-profiles flow can be exercised (its select->filter->insert
+ * pipeline reads from two tables).
+ */
+async function buildController(overrides: {
+  demoMode?: boolean;
+  envDemo?: boolean;
+  dbRows?: unknown[][];
+}): Promise<{ controller: DemoTestCoreController; taste: MockTasteProfileService }> {
+  const prevEnv = process.env.DEMO_MODE;
+  process.env.DEMO_MODE = overrides.envDemo === false ? 'false' : 'true';
+  const taste = {
+    aggregateVectors: jest.fn().mockResolvedValue(undefined),
+    weeklyIntensityRollup: jest.fn().mockResolvedValue(undefined),
+  };
+  const settings = {
+    getDemoMode: jest.fn().mockResolvedValue(overrides.demoMode ?? true),
+  };
+  const db = mockDb(overrides.dbRows ?? []);
+  const module = await Test.createTestingModule({
+    controllers: [DemoTestCoreController],
+    providers: [
+      { provide: DemoTestService, useValue: createMockService() },
+      { provide: TasteProfileService, useValue: taste },
+      { provide: SettingsService, useValue: settings },
+      { provide: DrizzleAsyncProvider, useValue: db },
+    ],
+  }).compile();
+  const controller = module.get(DemoTestCoreController);
+  // Restore DEMO_MODE after the controller is built; the handler reads it
+  // at call time so the tests below re-set it as needed.
+  if (prevEnv === undefined) delete process.env.DEMO_MODE;
+  else process.env.DEMO_MODE = prevEnv;
+  return { controller, taste };
+}
+
+function rebuildTasteProfilesTests(
+  getController: GetController,
+  getTaste: GetMockTaste,
+  getSettings: GetMockSettings,
+) {
+  it('runs aggregate → weekly-intensity → archetype-refresh in order', async () => {
+    const order: string[] = [];
+    getTaste().aggregateVectors.mockImplementation(async () => {
+      order.push('aggregate');
+    });
+    getTaste().weeklyIntensityRollup.mockImplementation(async () => {
+      order.push('weekly');
+    });
+    const result = await getController().rebuildTasteProfilesForTest();
+    expect(order).toEqual(['aggregate', 'weekly']);
+    expect(result.success).toBe(true);
+  });
+
+  it('throws ForbiddenException when DB demoMode is false', async () => {
+    getSettings().getDemoMode.mockResolvedValueOnce(false);
+    await expect(
+      getController().rebuildTasteProfilesForTest(),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(getTaste().aggregateVectors).not.toHaveBeenCalled();
+    expect(getTaste().weeklyIntensityRollup).not.toHaveBeenCalled();
+  });
+
+  it('throws ForbiddenException when env DEMO_MODE !== "true"', async () => {
+    process.env.DEMO_MODE = 'false';
+    await expect(
+      getController().rebuildTasteProfilesForTest(),
+    ).rejects.toBeInstanceOf(ForbiddenException);
+    expect(getTaste().aggregateVectors).not.toHaveBeenCalled();
+  });
+}
+
+function reseedTasteProfilesTests(getSettings: GetMockSettings) {
+  it('scopes seed to DEMO_USERNAMES and never touches real accounts', async () => {
+    const demoName = DEMO_USERNAMES[0];
+    const dbRows: unknown[][] = [
+      [
+        { id: 1, username: 'roknua' }, // real operator — must NOT be seeded
+        { id: 2, username: demoName }, // demo — should be seeded
+      ],
+      [{ id: 100, igdbId: 1942 }],
+    ];
+    const { controller, taste } = await buildController({ dbRows });
+    const result = await controller.reseedTasteProfilesForTest();
+    expect(result.success).toBe(true);
+    // Only 1 demo user was eligible, so seededUsers must be 1.
+    expect(result.seededUsers).toBe(1);
+    expect(taste.aggregateVectors).toHaveBeenCalledTimes(1);
+    expect(taste.weeklyIntensityRollup).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws ForbiddenException before any DB read when demoMode is off', async () => {
+    const { controller, taste } = await buildController({ demoMode: false });
+    await expect(controller.reseedTasteProfilesForTest()).rejects.toBeInstanceOf(
+      ForbiddenException,
+    );
+    expect(taste.aggregateVectors).not.toHaveBeenCalled();
+    // settings was called by the gate check, but db.select should not have been
+    // triggered — if it was, the gate ran too late.
+    expect(getSettings()).toBeDefined(); // sanity
+  });
+
+  it('throws ForbiddenException when env DEMO_MODE !== "true"', async () => {
+    const { controller, taste } = await buildController({});
+    // Flip env AFTER the controller is built — the handler reads it at call time.
+    process.env.DEMO_MODE = 'false';
+    try {
+      await expect(
+        controller.reseedTasteProfilesForTest(),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+      expect(taste.aggregateVectors).not.toHaveBeenCalled();
+    } finally {
+      process.env.DEMO_MODE = 'true';
+    }
   });
 }

--- a/api/src/admin/demo-test-core.controller.spec.ts
+++ b/api/src/admin/demo-test-core.controller.spec.ts
@@ -287,7 +287,10 @@ async function buildController(overrides: {
   demoMode?: boolean;
   envDemo?: boolean;
   dbRows?: unknown[][];
-}): Promise<{ controller: DemoTestCoreController; taste: MockTasteProfileService }> {
+}): Promise<{
+  controller: DemoTestCoreController;
+  taste: MockTasteProfileService;
+}> {
   const prevEnv = process.env.DEMO_MODE;
   process.env.DEMO_MODE = overrides.envDemo === false ? 'false' : 'true';
   const taste = {
@@ -322,11 +325,13 @@ function rebuildTasteProfilesTests(
 ) {
   it('runs aggregate → weekly-intensity → archetype-refresh in order', async () => {
     const order: string[] = [];
-    getTaste().aggregateVectors.mockImplementation(async () => {
+    getTaste().aggregateVectors.mockImplementation(() => {
       order.push('aggregate');
+      return Promise.resolve();
     });
-    getTaste().weeklyIntensityRollup.mockImplementation(async () => {
+    getTaste().weeklyIntensityRollup.mockImplementation(() => {
       order.push('weekly');
+      return Promise.resolve();
     });
     const result = await getController().rebuildTasteProfilesForTest();
     expect(order).toEqual(['aggregate', 'weekly']);
@@ -372,9 +377,9 @@ function reseedTasteProfilesTests(getSettings: GetMockSettings) {
 
   it('throws ForbiddenException before any DB read when demoMode is off', async () => {
     const { controller, taste } = await buildController({ demoMode: false });
-    await expect(controller.reseedTasteProfilesForTest()).rejects.toBeInstanceOf(
-      ForbiddenException,
-    );
+    await expect(
+      controller.reseedTasteProfilesForTest(),
+    ).rejects.toBeInstanceOf(ForbiddenException);
     expect(taste.aggregateVectors).not.toHaveBeenCalled();
     // settings was called by the gate check, but db.select should not have been
     // triggered — if it was, the gate ran too late.

--- a/api/src/admin/demo-test-core.controller.spec.ts
+++ b/api/src/admin/demo-test-core.controller.spec.ts
@@ -2,6 +2,7 @@ import { Test } from '@nestjs/testing';
 import { DemoTestCoreController } from './demo-test-core.controller';
 import { DemoTestService } from './demo-test.service';
 import { TasteProfileService } from '../taste-profile/taste-profile.service';
+import { SettingsService } from '../settings/settings.service';
 import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
 
 function createMockService() {
@@ -37,6 +38,10 @@ describe('DemoTestCoreController', () => {
             aggregateVectors: jest.fn().mockResolvedValue(undefined),
             weeklyIntensityRollup: jest.fn().mockResolvedValue(undefined),
           },
+        },
+        {
+          provide: SettingsService,
+          useValue: { getDemoMode: jest.fn().mockResolvedValue(true) },
         },
         { provide: DrizzleAsyncProvider, useValue: {} },
       ],

--- a/api/src/admin/demo-test-core.controller.ts
+++ b/api/src/admin/demo-test-core.controller.ts
@@ -190,47 +190,77 @@ export class DemoTestCoreController {
     refreshed: number;
   }> {
     await this.assertDemoMode();
-    const users = await this.db
-      .select({ id: schema.users.id, username: schema.users.username })
-      .from(schema.users);
-    const games = await this.db
-      .select({ id: schema.games.id, igdbId: schema.games.igdbId })
-      .from(schema.games);
-    // Scope to DEMO_USERNAMES only — real operator accounts (e.g. roknua)
-    // are never touched, even in DEMO_MODE.
-    const demoSet = new Set<string>(DEMO_USERNAMES as readonly string[]);
-    const demoUsers = users.filter((u) => demoSet.has(u.username));
-    const userByName = new Map(demoUsers.map((u) => [u.username, { id: u.id }]));
-    const igdbIdsByDbId = new Map(games.map((g) => [g.igdbId, g.id]));
-    const rng = createRng();
-    const usernames = demoUsers.map((u) => u.username);
-    const profiles = generateSignalProfiles(rng, usernames);
-    const activityRollups = generateGameActivityRollups(profiles, new Date());
-    const playhistoryInterests = generatePlayhistoryInterests(rng, profiles);
-    const batchInsert = async (
-      table: Parameters<typeof this.db.insert>[0],
-      rows: Record<string, unknown>[],
-      onConflict?: 'doNothing',
-    ) => {
-      if (rows.length === 0) return;
-      const q = this.db.insert(table).values(rows as never);
-      await (onConflict === 'doNothing' ? q.onConflictDoNothing() : q);
-    };
-    await installGameActivityRollups(
-      batchInsert,
-      userByName,
-      igdbIdsByDbId,
-      activityRollups,
-    );
-    await installPlayhistoryInterests(
-      batchInsert,
-      userByName,
-      igdbIdsByDbId,
-      playhistoryInterests,
-    );
+    const { userByName, igdbIdsByDbId } = await loadDemoMaps(this.db);
+    const profiles = await seedDemoSignals(this.db, userByName, igdbIdsByDbId);
     await this.tasteProfileService.aggregateVectors();
     await this.tasteProfileService.weeklyIntensityRollup();
     const refreshed = await refreshArchetypesFromCurrentMetrics(this.db);
     return { success: true, seededUsers: profiles.length, refreshed };
   }
+}
+
+type Db = PostgresJsDatabase<typeof schema>;
+
+/**
+ * Scoped to DEMO_USERNAMES — real operator accounts (e.g. roknua) are
+ * never included in the returned maps, which is the structural guarantee
+ * the reseed flow leans on.
+ */
+async function loadDemoMaps(db: Db): Promise<{
+  userByName: Map<string, { id: number }>;
+  igdbIdsByDbId: Map<number | null, number>;
+}> {
+  const users = await db
+    .select({ id: schema.users.id, username: schema.users.username })
+    .from(schema.users);
+  const games = await db
+    .select({ id: schema.games.id, igdbId: schema.games.igdbId })
+    .from(schema.games);
+  const demoSet = new Set<string>(DEMO_USERNAMES as readonly string[]);
+  const demoUsers = users.filter((u) => demoSet.has(u.username));
+  return {
+    userByName: new Map(demoUsers.map((u) => [u.username, { id: u.id }])),
+    igdbIdsByDbId: new Map(games.map((g) => [g.igdbId, g.id])),
+  };
+}
+
+/** Build inline batch-insert (mirrors `demo-data.service.batchInsert`). */
+function makeBatchInsert(db: Db) {
+  return async (
+    table: Parameters<Db['insert']>[0],
+    rows: Record<string, unknown>[],
+    onConflict?: 'doNothing',
+  ) => {
+    if (rows.length === 0) return;
+    const q = db.insert(table).values(rows as never);
+    await (onConflict === 'doNothing' ? q.onConflictDoNothing() : q);
+  };
+}
+
+/** Generate + persist signal data for the scoped demo users; returns the
+ *  raw profiles so the caller can report `seededUsers`. */
+async function seedDemoSignals(
+  db: Db,
+  userByName: Map<string, { id: number }>,
+  igdbIdsByDbId: Map<number | null, number>,
+): Promise<ReturnType<typeof generateSignalProfiles>> {
+  const rng = createRng();
+  const usernames = [...userByName.keys()];
+  const profiles = generateSignalProfiles(rng, usernames);
+  const activityRollups = generateGameActivityRollups(profiles, new Date());
+  const playhistoryInterests = generatePlayhistoryInterests(rng, profiles);
+  const batchInsert = makeBatchInsert(db);
+  await installGameActivityRollups(
+    batchInsert,
+    userByName,
+    igdbIdsByDbId,
+    activityRollups,
+  );
+  await installPlayhistoryInterests(
+    batchInsert,
+    userByName,
+    igdbIdsByDbId,
+    playhistoryInterests,
+  );
+  return profiles;
 }

--- a/api/src/admin/demo-test-core.controller.ts
+++ b/api/src/admin/demo-test-core.controller.ts
@@ -10,35 +10,35 @@ import {
   HttpStatus,
   BadRequestException,
   ForbiddenException,
+  Inject,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { SkipThrottle } from '@nestjs/throttler';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { AdminGuard } from '../auth/admin.guard';
+import type { AuthenticatedRequest } from '../auth/types';
+import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
+import * as schema from '../drizzle/schema';
 import { SettingsService } from '../settings/settings.service';
-import { DemoTestService } from './demo-test.service';
-import { DEMO_USERNAMES } from './demo-data.constants';
 import { TasteProfileService } from '../taste-profile/taste-profile.service';
-import {
-  installGameActivityRollups,
-  installPlayhistoryInterests,
-  refreshArchetypesFromCurrentMetrics,
-} from './demo-data-install-taste.helpers';
+import { DEMO_USERNAMES } from './demo-data.constants';
 import {
   createRng,
   generateSignalProfiles,
   generateGameActivityRollups,
   generatePlayhistoryInterests,
 } from './demo-data-generator';
-import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
-import { Inject } from '@nestjs/common';
-import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
-import * as schema from '../drizzle/schema';
-import type { AuthenticatedRequest } from '../auth/types';
+import {
+  installGameActivityRollups,
+  installPlayhistoryInterests,
+  refreshArchetypesFromCurrentMetrics,
+} from './demo-data-install-taste.helpers';
 import {
   LinkDiscordSchema,
   EnableNotificationsSchema,
   AwaitProcessingSchema,
 } from './demo-test.schemas';
+import { DemoTestService } from './demo-test.service';
 import { parseDemoBody } from './demo-test.utils';
 
 /**

--- a/api/src/admin/demo-test-core.controller.ts
+++ b/api/src/admin/demo-test-core.controller.ts
@@ -9,11 +9,14 @@ import {
   HttpCode,
   HttpStatus,
   BadRequestException,
+  ForbiddenException,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { SkipThrottle } from '@nestjs/throttler';
 import { AdminGuard } from '../auth/admin.guard';
+import { SettingsService } from '../settings/settings.service';
 import { DemoTestService } from './demo-test.service';
+import { DEMO_USERNAMES } from './demo-data.constants';
 import { TasteProfileService } from '../taste-profile/taste-profile.service';
 import {
   installGameActivityRollups,
@@ -49,9 +52,25 @@ export class DemoTestCoreController {
   constructor(
     private readonly demoTestService: DemoTestService,
     private readonly tasteProfileService: TasteProfileService,
+    private readonly settingsService: SettingsService,
     @Inject(DrizzleAsyncProvider)
     private readonly db: PostgresJsDatabase<typeof schema>,
   ) {}
+
+  /**
+   * Gate — throws if DEMO_MODE is off. Mirrors DemoTestService.assertDemoMode
+   * but the check lives here because the rebuild/reseed endpoints live on
+   * this controller and the guard must fire BEFORE pipeline calls run.
+   */
+  private async assertDemoMode(): Promise<void> {
+    if (process.env.DEMO_MODE !== 'true') {
+      throw new ForbiddenException('Only available in DEMO_MODE');
+    }
+    const demoMode = await this.settingsService.getDemoMode();
+    if (!demoMode) {
+      throw new ForbiddenException('Only available in DEMO_MODE');
+    }
+  }
 
   /** Link a Discord ID to a user -- DEMO_MODE only (smoke tests). */
   @Post('link-discord')
@@ -149,6 +168,7 @@ export class DemoTestCoreController {
     success: boolean;
     refreshed: number;
   }> {
+    await this.assertDemoMode();
     await this.tasteProfileService.aggregateVectors();
     await this.tasteProfileService.weeklyIntensityRollup();
     const refreshed = await refreshArchetypesFromCurrentMetrics(this.db);
@@ -169,16 +189,21 @@ export class DemoTestCoreController {
     seededUsers: number;
     refreshed: number;
   }> {
+    await this.assertDemoMode();
     const users = await this.db
       .select({ id: schema.users.id, username: schema.users.username })
       .from(schema.users);
     const games = await this.db
       .select({ id: schema.games.id, igdbId: schema.games.igdbId })
       .from(schema.games);
-    const userByName = new Map(users.map((u) => [u.username, { id: u.id }]));
+    // Scope to DEMO_USERNAMES only — real operator accounts (e.g. roknua)
+    // are never touched, even in DEMO_MODE.
+    const demoSet = new Set<string>(DEMO_USERNAMES as readonly string[]);
+    const demoUsers = users.filter((u) => demoSet.has(u.username));
+    const userByName = new Map(demoUsers.map((u) => [u.username, { id: u.id }]));
     const igdbIdsByDbId = new Map(games.map((g) => [g.igdbId, g.id]));
     const rng = createRng();
-    const usernames = users.map((u) => u.username);
+    const usernames = demoUsers.map((u) => u.username);
     const profiles = generateSignalProfiles(rng, usernames);
     const activityRollups = generateGameActivityRollups(profiles, new Date());
     const playhistoryInterests = generatePlayhistoryInterests(rng, profiles);

--- a/api/src/admin/demo-test-core.controller.ts
+++ b/api/src/admin/demo-test-core.controller.ts
@@ -15,11 +15,21 @@ import { SkipThrottle } from '@nestjs/throttler';
 import { AdminGuard } from '../auth/admin.guard';
 import { DemoTestService } from './demo-test.service';
 import { TasteProfileService } from '../taste-profile/taste-profile.service';
-import { refreshArchetypesFromCurrentMetrics } from './demo-data-install-taste.helpers';
+import {
+  installGameActivityRollups,
+  installPlayhistoryInterests,
+  refreshArchetypesFromCurrentMetrics,
+} from './demo-data-install-taste.helpers';
+import {
+  createRng,
+  generateSignalProfiles,
+  generateGameActivityRollups,
+  generatePlayhistoryInterests,
+} from './demo-data-generator';
 import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
 import { Inject } from '@nestjs/common';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
-import type * as schema from '../drizzle/schema';
+import * as schema from '../drizzle/schema';
 import type { AuthenticatedRequest } from '../auth/types';
 import {
   LinkDiscordSchema,
@@ -143,5 +153,59 @@ export class DemoTestCoreController {
     await this.tasteProfileService.weeklyIntensityRollup();
     const refreshed = await refreshArchetypesFromCurrentMetrics(this.db);
     return { success: true, refreshed };
+  }
+
+  /**
+   * Seed taste-profile signal data (game_activity_rollups +
+   * game_interests with playtime) against ALL current users who lack it,
+   * then rebuild taste profiles (ROK-1083). Additive — no deletes — so
+   * existing real signal data is preserved. Intended for demo
+   * environments that predate the ROK-1083 seed code.
+   */
+  @Post('reseed-taste-profiles')
+  @HttpCode(HttpStatus.OK)
+  async reseedTasteProfilesForTest(): Promise<{
+    success: boolean;
+    seededUsers: number;
+    refreshed: number;
+  }> {
+    const users = await this.db
+      .select({ id: schema.users.id, username: schema.users.username })
+      .from(schema.users);
+    const games = await this.db
+      .select({ id: schema.games.id, igdbId: schema.games.igdbId })
+      .from(schema.games);
+    const userByName = new Map(users.map((u) => [u.username, { id: u.id }]));
+    const igdbIdsByDbId = new Map(games.map((g) => [g.igdbId, g.id]));
+    const rng = createRng();
+    const usernames = users.map((u) => u.username);
+    const profiles = generateSignalProfiles(rng, usernames);
+    const activityRollups = generateGameActivityRollups(profiles, new Date());
+    const playhistoryInterests = generatePlayhistoryInterests(rng, profiles);
+    const batchInsert = async (
+      table: Parameters<typeof this.db.insert>[0],
+      rows: Record<string, unknown>[],
+      onConflict?: 'doNothing',
+    ) => {
+      if (rows.length === 0) return;
+      const q = this.db.insert(table).values(rows as never);
+      await (onConflict === 'doNothing' ? q.onConflictDoNothing() : q);
+    };
+    await installGameActivityRollups(
+      batchInsert,
+      userByName,
+      igdbIdsByDbId,
+      activityRollups,
+    );
+    await installPlayhistoryInterests(
+      batchInsert,
+      userByName,
+      igdbIdsByDbId,
+      playhistoryInterests,
+    );
+    await this.tasteProfileService.aggregateVectors();
+    await this.tasteProfileService.weeklyIntensityRollup();
+    const refreshed = await refreshArchetypesFromCurrentMetrics(this.db);
+    return { success: true, seededUsers: profiles.length, refreshed };
   }
 }

--- a/api/src/admin/demo-test-core.controller.ts
+++ b/api/src/admin/demo-test-core.controller.ts
@@ -14,6 +14,12 @@ import { AuthGuard } from '@nestjs/passport';
 import { SkipThrottle } from '@nestjs/throttler';
 import { AdminGuard } from '../auth/admin.guard';
 import { DemoTestService } from './demo-test.service';
+import { TasteProfileService } from '../taste-profile/taste-profile.service';
+import { refreshArchetypesFromCurrentMetrics } from './demo-data-install-taste.helpers';
+import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
+import { Inject } from '@nestjs/common';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import type * as schema from '../drizzle/schema';
 import type { AuthenticatedRequest } from '../auth/types';
 import {
   LinkDiscordSchema,
@@ -30,7 +36,12 @@ import { parseDemoBody } from './demo-test.utils';
 @SkipThrottle()
 @UseGuards(AuthGuard('jwt'), AdminGuard)
 export class DemoTestCoreController {
-  constructor(private readonly demoTestService: DemoTestService) {}
+  constructor(
+    private readonly demoTestService: DemoTestService,
+    private readonly tasteProfileService: TasteProfileService,
+    @Inject(DrizzleAsyncProvider)
+    private readonly db: PostgresJsDatabase<typeof schema>,
+  ) {}
 
   /** Link a Discord ID to a user -- DEMO_MODE only (smoke tests). */
   @Post('link-discord')
@@ -113,5 +124,24 @@ export class DemoTestCoreController {
   ): Promise<{ success: boolean }> {
     await this.demoTestService.clearGameTimeConfirmationForTest(req.user.id);
     return { success: true };
+  }
+
+  /**
+   * Rebuild taste-profile vectors + intensity + archetypes for every user
+   * (ROK-1083). Runs aggregate-vectors → weekly-intensity → archetype
+   * refresh in the same order the demo installer uses, so existing
+   * DB state reflects the latest archetype composition without a full
+   * re-install.
+   */
+  @Post('rebuild-taste-profiles')
+  @HttpCode(HttpStatus.OK)
+  async rebuildTasteProfilesForTest(): Promise<{
+    success: boolean;
+    refreshed: number;
+  }> {
+    await this.tasteProfileService.aggregateVectors();
+    await this.tasteProfileService.weeklyIntensityRollup();
+    const refreshed = await refreshArchetypesFromCurrentMetrics(this.db);
+    return { success: true, refreshed };
   }
 }

--- a/api/src/ai/context-builders/taste-profile-context.builder.spec.ts
+++ b/api/src/ai/context-builders/taste-profile-context.builder.spec.ts
@@ -10,10 +10,12 @@
  * - AC 8: Unit tests exist
  */
 import { Test } from '@nestjs/testing';
+import type { ArchetypeDto } from '@raid-ledger/contract';
 import type {
   CoPlayPartnerRow,
   TasteProfileResult,
 } from '../../taste-profile/queries/taste-profile-queries';
+import { TIER_DESCRIPTIONS } from '../../taste-profile/archetype-copy';
 import { TasteProfileService } from '../../taste-profile/taste-profile.service';
 import { TasteProfileContextBuilder } from './taste-profile-context.builder';
 
@@ -24,11 +26,24 @@ import { TasteProfileContextBuilder } from './taste-profile-context.builder';
  * doesn't care which values we pick — the builder should read
  * `dimensions` and `intensityMetrics` verbatim from this source.
  */
+/**
+ * Default composed archetype used by the fixture when a test does not
+ * pin a specific shape — Dedicated tier, no vector titles.
+ */
+const DEFAULT_ARCHETYPE: ArchetypeDto = {
+  intensityTier: 'Dedicated',
+  vectorTitles: [],
+  descriptions: {
+    tier: TIER_DESCRIPTIONS.Dedicated,
+    titles: [],
+  },
+};
+
 function buildProfile(overrides: {
   userId: number;
   dimensions?: Record<string, number>;
   coPlayPartners?: CoPlayPartnerRow[];
-  archetype?: TasteProfileResult['archetype'];
+  archetype?: ArchetypeDto;
   intensityMetrics?: TasteProfileResult['intensityMetrics'];
 }): TasteProfileResult {
   // Use the full pool but we only need *some* values non-zero to test sort.
@@ -70,7 +85,7 @@ function buildProfile(overrides: {
       breadth: 55,
       consistency: 70,
     },
-    archetype: overrides.archetype ?? 'Explorer',
+    archetype: overrides.archetype ?? DEFAULT_ARCHETYPE,
     coPlayPartners: overrides.coPlayPartners ?? [],
     computedAt: new Date('2026-04-01T00:00:00Z').toISOString(),
   };
@@ -190,10 +205,18 @@ describe('TasteProfileContextBuilder', () => {
     });
 
     it('passes archetype and intensityMetrics through from source (AC 3 anchor)', async () => {
+      const archetype: ArchetypeDto = {
+        intensityTier: 'Dedicated',
+        vectorTitles: ['Raider', 'Hero'],
+        descriptions: {
+          tier: TIER_DESCRIPTIONS.Dedicated,
+          titles: ['MMO group content is home base', 'Fantasy RPG lead'],
+        },
+      };
       mockTasteProfileService.getTasteProfile.mockResolvedValueOnce(
         buildProfile({
           userId: 1,
-          archetype: 'Dedicated',
+          archetype,
           intensityMetrics: {
             intensity: 85,
             focus: 70,
@@ -205,7 +228,7 @@ describe('TasteProfileContextBuilder', () => {
 
       const result = await builder.build([1]);
       const ctx = result.contexts[0];
-      expect(ctx.archetype).toBe('Dedicated');
+      expect(ctx.archetype).toEqual(archetype);
       expect(ctx.intensityMetrics).toEqual({
         intensity: 85,
         focus: 70,

--- a/api/src/drizzle/migrations/0127_player_taste_archetype_jsonb.sql
+++ b/api/src/drizzle/migrations/0127_player_taste_archetype_jsonb.sql
@@ -1,0 +1,10 @@
+-- ROK-1083: migrate player_taste_vectors.archetype from text -> jsonb.
+-- Drizzle-kit's generated output omits the `USING` clause, which is
+-- required when converting between incompatible Postgres types. We set
+-- USING NULL intentionally: the old text enum cannot be safely mapped
+-- to the new composed shape from the migration alone (the mapping
+-- needs intensity_metrics signal only the cron has), so we null out
+-- and let `runAggregateVectors` repopulate every row on the next tick.
+-- Architect decision: ROK-1083 architect guidance, section 1.
+ALTER TABLE "player_taste_vectors" ALTER COLUMN "archetype" DROP NOT NULL;--> statement-breakpoint
+ALTER TABLE "player_taste_vectors" ALTER COLUMN "archetype" SET DATA TYPE jsonb USING NULL;

--- a/api/src/drizzle/migrations/meta/0127_snapshot.json
+++ b/api/src/drizzle/migrations/meta/0127_snapshot.json
@@ -1,0 +1,6939 @@
+{
+  "id": "16d25841-58a0-4227-a6b1-a857ec7c3a35",
+  "prevId": "6122a5a5-673c-48c2-9247-3d5f691d1a01",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_id": {
+          "name": "steam_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_avatar_url": {
+          "name": "custom_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_time_confirmed_at": {
+          "name": "game_time_confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_discord_id_unique": {
+          "name": "users_discord_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_id"
+          ]
+        },
+        "users_steam_id_unique": {
+          "name": "users_steam_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "steam_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "display_name_length": {
+          "name": "display_name_length",
+          "value": "\"users\".\"display_name\" IS NULL OR (LENGTH(\"users\".\"display_name\") >= 2 AND LENGTH(\"users\".\"display_name\") <= 30)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "tsrange",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_config": {
+          "name": "slot_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_attendees": {
+          "name": "max_attendees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_unbench": {
+          "name": "auto_unbench",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "recurrence_group_id": {
+          "name": "recurrence_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_rule": {
+          "name": "recurrence_rule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_instances": {
+          "name": "content_instances",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_15min": {
+          "name": "reminder_15min",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_1hour": {
+          "name": "reminder_1hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_24hour": {
+          "name": "reminder_24hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_ad_hoc": {
+          "name": "is_ad_hoc",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ad_hoc_status": {
+          "name": "ad_hoc_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_binding_id": {
+          "name": "channel_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_scheduled_event_id": {
+          "name": "discord_scheduled_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extended_until": {
+          "name": "extended_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_channel_override": {
+          "name": "notification_channel_override",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rescheduling_poll_id": {
+          "name": "rescheduling_poll_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_events_creator_id": {
+          "name": "idx_events_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_game_id": {
+          "name": "idx_events_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_ad_hoc_binding": {
+          "name": "idx_events_ad_hoc_binding",
+          "columns": [
+            {
+              "expression": "channel_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_ad_hoc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_recurrence_group_id": {
+          "name": "idx_events_recurrence_group_id",
+          "columns": [
+            {
+              "expression": "recurrence_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_cancelled_at": {
+          "name": "idx_events_cancelled_at",
+          "columns": [
+            {
+              "expression": "cancelled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_discord_scheduled_event_id": {
+          "name": "idx_events_discord_scheduled_event_id",
+          "columns": [
+            {
+              "expression": "discord_scheduled_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_game_id_games_id_fk": {
+          "name": "events_game_id_games_id_fk",
+          "tableFrom": "events",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_creator_id_users_id_fk": {
+          "name": "events_creator_id_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_channel_binding_id_channel_bindings_id_fk": {
+          "name": "events_channel_binding_id_channel_bindings_id_fk",
+          "tableFrom": "events",
+          "tableTo": "channel_bindings",
+          "columnsFrom": [
+            "channel_binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_types": {
+      "name": "event_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_player_cap": {
+          "name": "default_player_cap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_duration_minutes": {
+          "name": "default_duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_composition": {
+          "name": "requires_composition",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_event_types_game_id": {
+          "name": "idx_event_types_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_types_game_id_games_id_fk": {
+          "name": "event_types_game_id_games_id_fk",
+          "tableFrom": "event_types",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_types_game_slug_unique": {
+          "name": "event_types_game_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "game_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "igdb_id": {
+          "name": "igdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregated_rating": {
+          "name": "aggregated_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "popularity": {
+          "name": "popularity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_modes": {
+          "name": "game_modes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "themes": {
+          "name": "themes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "platforms": {
+          "name": "platforms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "screenshots": {
+          "name": "screenshots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "videos": {
+          "name": "videos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "first_release_date": {
+          "name": "first_release_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_count": {
+          "name": "player_count",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitch_game_id": {
+          "name": "twitch_game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_app_id": {
+          "name": "steam_app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crossplay": {
+          "name": "crossplay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color_hex": {
+          "name": "color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_roles": {
+          "name": "has_roles",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_specs": {
+          "name": "has_specs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "itad_game_id": {
+          "name": "itad_game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_boxart_url": {
+          "name": "itad_boxart_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_tags": {
+          "name": "itad_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "max_characters_per_user": {
+          "name": "max_characters_per_user",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "api_namespace_prefix": {
+          "name": "api_namespace_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_current_price": {
+          "name": "itad_current_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_current_cut": {
+          "name": "itad_current_cut",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_current_shop": {
+          "name": "itad_current_shop",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_current_url": {
+          "name": "itad_current_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_lowest_price": {
+          "name": "itad_lowest_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_lowest_cut": {
+          "name": "itad_lowest_cut",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_price_updated_at": {
+          "name": "itad_price_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "early_access": {
+          "name": "early_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "igdb_enrichment_status": {
+          "name": "igdb_enrichment_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "igdb_enrichment_retry_count": {
+          "name": "igdb_enrichment_retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "games_igdb_id_unique": {
+          "name": "games_igdb_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "igdb_id"
+          ]
+        },
+        "games_slug_unique": {
+          "name": "games_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "games_itad_game_id_unique": {
+          "name": "games_itad_game_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "itad_game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_signups": {
+      "name": "event_signups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_avatar_hash": {
+          "name": "discord_avatar_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation_status": {
+          "name": "confirmation_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'signed_up'"
+        },
+        "preferred_roles": {
+          "name": "preferred_roles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attendance_status": {
+          "name": "attendance_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attendance_recorded_at": {
+          "name": "attendance_recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roached_out_at": {
+          "name": "roached_out_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_up_at": {
+          "name": "signed_up_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_event_signups_event_id": {
+          "name": "idx_event_signups_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_signups_discord_user_id": {
+          "name": "idx_event_signups_discord_user_id",
+          "columns": [
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_signups_user_id": {
+          "name": "idx_event_signups_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_signups_event_id_status": {
+          "name": "idx_event_signups_event_id_status",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_signups_event_id_events_id_fk": {
+          "name": "event_signups_event_id_events_id_fk",
+          "tableFrom": "event_signups",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_signups_user_id_users_id_fk": {
+          "name": "event_signups_user_id_users_id_fk",
+          "tableFrom": "event_signups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_signups_character_id_characters_id_fk": {
+          "name": "event_signups_character_id_characters_id_fk",
+          "tableFrom": "event_signups",
+          "tableTo": "characters",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_user": {
+          "name": "unique_event_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id"
+          ]
+        },
+        "unique_event_discord_user": {
+          "name": "unique_event_discord_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "discord_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_or_discord": {
+          "name": "user_or_discord",
+          "value": "\"event_signups\".\"user_id\" IS NOT NULL OR \"event_signups\".\"discord_user_id\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.characters": {
+      "name": "characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "realm": {
+          "name": "realm",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class": {
+          "name": "class",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_override": {
+          "name": "role_override",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_main": {
+          "name": "is_main",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "item_level": {
+          "name": "item_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "render_url": {
+          "name": "render_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "race": {
+          "name": "race",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faction": {
+          "name": "faction",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_url": {
+          "name": "profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_variant": {
+          "name": "game_variant",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "equipment": {
+          "name": "equipment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "talents": {
+          "name": "talents",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_one_main_per_game": {
+          "name": "idx_one_main_per_game",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"characters\".\"is_main\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_characters_user_id": {
+          "name": "idx_characters_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_characters_user_id_name": {
+          "name": "idx_characters_user_id_name",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "characters_user_id_users_id_fk": {
+          "name": "characters_user_id_users_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "characters_game_id_games_id_fk": {
+          "name": "characters_game_id_games_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_game_character": {
+          "name": "unique_user_game_character",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id",
+            "name",
+            "realm"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.local_credentials": {
+      "name": "local_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "local_credentials_user_id_users_id_fk": {
+          "name": "local_credentials_user_id_users_id_fk",
+          "tableFrom": "local_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "local_credentials_email_unique": {
+          "name": "local_credentials_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.availability": {
+      "name": "availability",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_range": {
+          "name": "time_range",
+          "type": "tsrange",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_availability_user_id": {
+          "name": "idx_availability_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "availability_user_id_users_id_fk": {
+          "name": "availability_user_id_users_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "availability_game_id_games_id_fk": {
+          "name": "availability_game_id_games_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "availability_source_event_id_events_id_fk": {
+          "name": "availability_source_event_id_events_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "events",
+          "columnsFrom": [
+            "source_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roster_assignments": {
+      "name": "roster_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signup_id": {
+          "name": "signup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "is_override": {
+          "name": "is_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_roster_assignments_event_id": {
+          "name": "idx_roster_assignments_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_roster_assignments_signup_id": {
+          "name": "idx_roster_assignments_signup_id",
+          "columns": [
+            {
+              "expression": "signup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roster_assignments_event_id_events_id_fk": {
+          "name": "roster_assignments_event_id_events_id_fk",
+          "tableFrom": "roster_assignments",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "roster_assignments_signup_id_event_signups_id_fk": {
+          "name": "roster_assignments_signup_id_event_signups_id_fk",
+          "tableFrom": "roster_assignments",
+          "tableTo": "event_signups",
+          "columnsFrom": [
+            "signup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_signup": {
+          "name": "unique_event_signup",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "signup_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_settings_key_unique": {
+          "name": "app_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_expires_at": {
+          "name": "idx_notifications_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_preferences": {
+      "name": "user_notification_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_prefs": {
+          "name": "channel_prefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"slot_vacated\":{\"inApp\":true,\"push\":true,\"discord\":true},\"event_reminder\":{\"inApp\":true,\"push\":true,\"discord\":true},\"new_event\":{\"inApp\":true,\"push\":true,\"discord\":true},\"subscribed_game\":{\"inApp\":true,\"push\":true,\"discord\":true},\"achievement_unlocked\":{\"inApp\":true,\"push\":false,\"discord\":false},\"level_up\":{\"inApp\":true,\"push\":false,\"discord\":false},\"missed_event_nudge\":{\"inApp\":true,\"push\":true,\"discord\":true},\"event_rescheduled\":{\"inApp\":true,\"push\":true,\"discord\":true},\"bench_promoted\":{\"inApp\":true,\"push\":true,\"discord\":true},\"event_cancelled\":{\"inApp\":true,\"push\":true,\"discord\":true},\"roster_reassigned\":{\"inApp\":true,\"push\":true,\"discord\":true},\"tentative_displaced\":{\"inApp\":true,\"push\":true,\"discord\":true},\"member_returned\":{\"inApp\":true,\"push\":true,\"discord\":true},\"recruitment_reminder\":{\"inApp\":true,\"push\":true,\"discord\":true},\"role_gap_alert\":{\"inApp\":true,\"push\":true,\"discord\":true},\"lineup_steam_nudge\":{\"inApp\":true,\"push\":false,\"discord\":true},\"community_lineup\":{\"inApp\":true,\"push\":true,\"discord\":true},\"system\":{\"inApp\":true,\"push\":false,\"discord\":false}}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_preferences_user_id_users_id_fk": {
+          "name": "user_notification_preferences_user_id_users_id_fk",
+          "tableFrom": "user_notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_preference_key": {
+          "name": "unique_user_preference_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_time_templates": {
+      "name": "game_time_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_hour": {
+          "name": "start_hour",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_time_templates_user_id_idx": {
+          "name": "game_time_templates_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_time_templates_user_id_users_id_fk": {
+          "name": "game_time_templates_user_id_users_id_fk",
+          "tableFrom": "game_time_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_game_time_slot": {
+          "name": "unique_user_game_time_slot",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "day_of_week",
+            "start_hour"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_time_absences": {
+      "name": "game_time_absences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_time_absences_user_id_idx": {
+          "name": "game_time_absences_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_time_absences_user_id_users_id_fk": {
+          "name": "game_time_absences_user_id_users_id_fk",
+          "tableFrom": "game_time_absences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_time_overrides": {
+      "name": "game_time_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hour": {
+          "name": "hour",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_time_overrides_user_id_idx": {
+          "name": "game_time_overrides_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_time_overrides_user_id_users_id_fk": {
+          "name": "game_time_overrides_user_id_users_id_fk",
+          "tableFrom": "game_time_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_override_date_hour": {
+          "name": "unique_user_override_date_hour",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "date",
+            "hour"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_interests": {
+      "name": "game_interests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "playtime_forever": {
+          "name": "playtime_forever",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playtime_2weeks": {
+          "name": "playtime_2weeks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_game_interests_game_id": {
+          "name": "idx_game_interests_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_interests_user_id_users_id_fk": {
+          "name": "game_interests_user_id_users_id_fk",
+          "tableFrom": "game_interests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_interests_game_id_games_id_fk": {
+          "name": "game_interests_game_id_games_id_fk",
+          "tableFrom": "game_interests",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_user_game_interest_source": {
+          "name": "uq_user_game_interest_source",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id",
+            "source"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_reminders_sent": {
+      "name": "event_reminders_sent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reminder_type": {
+          "name": "reminder_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_reminders_sent_event_id_events_id_fk": {
+          "name": "event_reminders_sent_event_id_events_id_fk",
+          "tableFrom": "event_reminders_sent",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_reminders_sent_user_id_users_id_fk": {
+          "name": "event_reminders_sent_user_id_users_id_fk",
+          "tableFrom": "event_reminders_sent",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_user_reminder": {
+          "name": "unique_event_user_reminder",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id",
+            "reminder_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_templates": {
+      "name": "event_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_templates_user_id_users_id_fk": {
+          "name": "event_templates_user_id_users_id_fk",
+          "tableFrom": "event_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plugins": {
+      "name": "plugins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config_json": {
+          "name": "config_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plugins_slug_unique": {
+          "name": "plugins_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_user_id_users_id_fk": {
+          "name": "feedback_user_id_users_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pug_slots": {
+      "name": "pug_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_avatar_hash": {
+          "name": "discord_avatar_hash",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class": {
+          "name": "class",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "server_invite_url": {
+          "name": "server_invite_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_event_pug": {
+          "name": "unique_event_pug",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pug_slots\".\"discord_username\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_invite_code": {
+          "name": "unique_invite_code",
+          "columns": [
+            {
+              "expression": "invite_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pug_slots\".\"invite_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pug_slots_event_id_events_id_fk": {
+          "name": "pug_slots_event_id_events_id_fk",
+          "tableFrom": "pug_slots",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pug_slots_claimed_by_user_id_users_id_fk": {
+          "name": "pug_slots_claimed_by_user_id_users_id_fk",
+          "tableFrom": "pug_slots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "claimed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pug_slots_created_by_users_id_fk": {
+          "name": "pug_slots_created_by_users_id_fk",
+          "tableFrom": "pug_slots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cron_jobs": {
+      "name": "cron_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_slug": {
+          "name": "plugin_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Other'"
+        },
+        "paused": {
+          "name": "paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cron_jobs_name_unique": {
+          "name": "cron_jobs_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cron_job_executions": {
+      "name": "cron_job_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cron_job_id": {
+          "name": "cron_job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cron_job_executions_job_started_idx": {
+          "name": "cron_job_executions_job_started_idx",
+          "columns": [
+            {
+              "expression": "cron_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cron_job_executions_cron_job_id_cron_jobs_id_fk": {
+          "name": "cron_job_executions_cron_job_id_cron_jobs_id_fk",
+          "tableFrom": "cron_job_executions",
+          "tableTo": "cron_jobs",
+          "columnsFrom": [
+            "cron_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_event_messages": {
+      "name": "discord_event_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embed_state": {
+          "name": "embed_state",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'posted'"
+        },
+        "bump_message_id": {
+          "name": "bump_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_discord_event_messages_event": {
+          "name": "idx_discord_event_messages_event",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_discord_event_messages_message": {
+          "name": "idx_discord_event_messages_message",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_event_messages_event_id_events_id_fk": {
+          "name": "discord_event_messages_event_id_events_id_fk",
+          "tableFrom": "discord_event_messages",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_channel_message": {
+          "name": "unique_event_channel_message",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "channel_id",
+            "message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_bindings": {
+      "name": "channel_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding_purpose": {
+          "name": "binding_purpose",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_group_id": {
+          "name": "recurrence_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_bindings_guild_channel_series_unique": {
+          "name": "channel_bindings_guild_channel_series_unique",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurrence_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_bindings_guild": {
+          "name": "idx_channel_bindings_guild",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_bindings_game": {
+          "name": "idx_channel_bindings_game",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_bindings_recurrence_group": {
+          "name": "idx_channel_bindings_recurrence_group",
+          "columns": [
+            {
+              "expression": "recurrence_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_bindings_game_id_games_id_fk": {
+          "name": "channel_bindings_game_id_games_id_fk",
+          "tableFrom": "channel_bindings",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_event_reminders_sent": {
+      "name": "post_event_reminders_sent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pug_slot_id": {
+          "name": "pug_slot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_event_reminders_sent_event_id_events_id_fk": {
+          "name": "post_event_reminders_sent_event_id_events_id_fk",
+          "tableFrom": "post_event_reminders_sent",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_event_reminders_sent_pug_slot_id_pug_slots_id_fk": {
+          "name": "post_event_reminders_sent_pug_slot_id_pug_slots_id_fk",
+          "tableFrom": "post_event_reminders_sent",
+          "tableTo": "pug_slots",
+          "columnsFrom": [
+            "pug_slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_post_event_pug_reminder": {
+          "name": "unique_post_event_pug_reminder",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "pug_slot_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_plans": {
+      "name": "event_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slot_config": {
+          "name": "slot_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_attendees": {
+          "name": "max_attendees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_unbench": {
+          "name": "auto_unbench",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_options": {
+          "name": "poll_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_duration_hours": {
+          "name": "poll_duration_hours",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_mode": {
+          "name": "poll_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "poll_round": {
+          "name": "poll_round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "poll_channel_id": {
+          "name": "poll_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_message_id": {
+          "name": "poll_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "winning_option": {
+          "name": "winning_option",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_event_id": {
+          "name": "created_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_instances": {
+          "name": "content_instances",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_15min": {
+          "name": "reminder_15min",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_1hour": {
+          "name": "reminder_1hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_24hour": {
+          "name": "reminder_24hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "poll_started_at": {
+          "name": "poll_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_ends_at": {
+          "name": "poll_ends_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_event_plans_creator_id": {
+          "name": "idx_event_plans_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_plans_status": {
+          "name": "idx_event_plans_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_plans_creator_id_users_id_fk": {
+          "name": "event_plans_creator_id_users_id_fk",
+          "tableFrom": "event_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_plans_game_id_games_id_fk": {
+          "name": "event_plans_game_id_games_id_fk",
+          "tableFrom": "event_plans",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "event_plans_created_event_id_events_id_fk": {
+          "name": "event_plans_created_event_id_events_id_fk",
+          "tableFrom": "event_plans",
+          "tableTo": "events",
+          "columnsFrom": [
+            "created_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_dungeon_quests": {
+      "name": "wow_classic_dungeon_quests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dungeon_instance_id": {
+          "name": "dungeon_instance_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quest_level": {
+          "name": "quest_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_level": {
+          "name": "required_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expansion": {
+          "name": "expansion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quest_giver_npc": {
+          "name": "quest_giver_npc",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quest_giver_zone": {
+          "name": "quest_giver_zone",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_quest_id": {
+          "name": "prev_quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_quest_id": {
+          "name": "next_quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewards_json": {
+          "name": "rewards_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objectives": {
+          "name": "objectives",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_restriction": {
+          "name": "class_restriction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "race_restriction": {
+          "name": "race_restriction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_inside_dungeon": {
+          "name": "starts_inside_dungeon",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sharable": {
+          "name": "sharable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reward_xp": {
+          "name": "reward_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_gold": {
+          "name": "reward_gold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_type": {
+          "name": "reward_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wow_classic_dungeon_quests_quest_id_unique": {
+          "name": "wow_classic_dungeon_quests_quest_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "quest_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_boss_loot": {
+      "name": "wow_classic_boss_loot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "boss_id": {
+          "name": "boss_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot": {
+          "name": "slot",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality": {
+          "name": "quality",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_level": {
+          "name": "item_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drop_rate": {
+          "name": "drop_rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expansion": {
+          "name": "expansion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_restrictions": {
+          "name": "class_restrictions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_subclass": {
+          "name": "item_subclass",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wow_classic_boss_loot_boss_id_wow_classic_bosses_id_fk": {
+          "name": "wow_classic_boss_loot_boss_id_wow_classic_bosses_id_fk",
+          "tableFrom": "wow_classic_boss_loot",
+          "tableTo": "wow_classic_bosses",
+          "columnsFrom": [
+            "boss_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_loot_boss_item_expansion": {
+          "name": "uq_loot_boss_item_expansion",
+          "nullsNotDistinct": false,
+          "columns": [
+            "boss_id",
+            "item_id",
+            "expansion"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_bosses": {
+      "name": "wow_classic_bosses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expansion": {
+          "name": "expansion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sod_modified": {
+          "name": "sod_modified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_boss_instance_name_expansion": {
+          "name": "uq_boss_instance_name_expansion",
+          "nullsNotDistinct": false,
+          "columns": [
+            "instance_id",
+            "name",
+            "expansion"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_quest_progress": {
+      "name": "wow_classic_quest_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picked_up": {
+          "name": "picked_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wow_classic_quest_progress_event_id_events_id_fk": {
+          "name": "wow_classic_quest_progress_event_id_events_id_fk",
+          "tableFrom": "wow_classic_quest_progress",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wow_classic_quest_progress_user_id_users_id_fk": {
+          "name": "wow_classic_quest_progress_user_id_users_id_fk",
+          "tableFrom": "wow_classic_quest_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_quest_progress_event_user_quest": {
+          "name": "uq_quest_progress_event_user_quest",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id",
+            "quest_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_activity_sessions": {
+      "name": "game_activity_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_activity_name": {
+          "name": "discord_activity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "game_activity_sessions_user_game_started_idx": {
+          "name": "game_activity_sessions_user_game_started_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "game_activity_sessions_game_started_idx": {
+          "name": "game_activity_sessions_game_started_idx",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_activity_sessions_user_id_users_id_fk": {
+          "name": "game_activity_sessions_user_id_users_id_fk",
+          "tableFrom": "game_activity_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_activity_sessions_game_id_games_id_fk": {
+          "name": "game_activity_sessions_game_id_games_id_fk",
+          "tableFrom": "game_activity_sessions",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_activity_rollups": {
+      "name": "game_activity_rollups",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period": {
+          "name": "period",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_seconds": {
+          "name": "total_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "game_activity_rollups_game_period_start_idx": {
+          "name": "game_activity_rollups_game_period_start_idx",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_activity_rollups_user_id_users_id_fk": {
+          "name": "game_activity_rollups_user_id_users_id_fk",
+          "tableFrom": "game_activity_rollups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_activity_rollups_game_id_games_id_fk": {
+          "name": "game_activity_rollups_game_id_games_id_fk",
+          "tableFrom": "game_activity_rollups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "game_activity_rollups_user_game_period_unique": {
+          "name": "game_activity_rollups_user_game_period_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id",
+            "period",
+            "period_start"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_game_mappings": {
+      "name": "discord_game_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "discord_activity_name": {
+          "name": "discord_activity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "discord_game_mappings_game_id_games_id_fk": {
+          "name": "discord_game_mappings_game_id_games_id_fk",
+          "tableFrom": "discord_game_mappings",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_game_mappings_discord_activity_name_unique": {
+          "name": "discord_game_mappings_discord_activity_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_activity_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ad_hoc_participants": {
+      "name": "ad_hoc_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_avatar_hash": {
+          "name": "discord_avatar_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_duration_seconds": {
+          "name": "total_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "ad_hoc_participants_event_discord_user_unique": {
+          "name": "ad_hoc_participants_event_discord_user_unique",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ad_hoc_participants_event": {
+          "name": "idx_ad_hoc_participants_event",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ad_hoc_participants_user": {
+          "name": "idx_ad_hoc_participants_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ad_hoc_participants_event_id_events_id_fk": {
+          "name": "ad_hoc_participants_event_id_events_id_fk",
+          "tableFrom": "ad_hoc_participants",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ad_hoc_participants_user_id_users_id_fk": {
+          "name": "ad_hoc_participants_user_id_users_id_fk",
+          "tableFrom": "ad_hoc_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_interest_suppressions": {
+      "name": "game_interest_suppressions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suppressed_at": {
+          "name": "suppressed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_interest_suppressions_user_id_users_id_fk": {
+          "name": "game_interest_suppressions_user_id_users_id_fk",
+          "tableFrom": "game_interest_suppressions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_interest_suppressions_game_id_games_id_fk": {
+          "name": "game_interest_suppressions_game_id_games_id_fk",
+          "tableFrom": "game_interest_suppressions",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_user_game_suppression": {
+          "name": "uq_user_game_suppression",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_voice_sessions": {
+      "name": "event_voice_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_join_at": {
+          "name": "first_join_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_leave_at": {
+          "name": "last_leave_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_duration_sec": {
+          "name": "total_duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "segments": {
+          "name": "segments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "event_voice_sessions_event_discord_user_unique": {
+          "name": "event_voice_sessions_event_discord_user_unique",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_voice_sessions_event": {
+          "name": "idx_event_voice_sessions_event",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_voice_sessions_event_id_events_id_fk": {
+          "name": "event_voice_sessions_event_id_events_id_fk",
+          "tableFrom": "event_voice_sessions",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_voice_sessions_user_id_users_id_fk": {
+          "name": "event_voice_sessions_user_id_users_id_fk",
+          "tableFrom": "event_voice_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrichments": {
+      "name": "enrichments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enricher_key": {
+          "name": "enricher_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_enrichments_entity": {
+          "name": "idx_enrichments_entity",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_entity_enricher": {
+          "name": "unique_entity_enricher",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "enricher_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_request_logs": {
+      "name": "ai_request_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "feature": {
+          "name": "feature",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ai_request_logs_created_at": {
+          "name": "idx_ai_request_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_request_logs_feature_created_at": {
+          "name": "idx_ai_request_logs_feature_created_at",
+          "columns": [
+            {
+              "expression": "feature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_request_logs_user_id_users_id_fk": {
+          "name": "ai_request_logs_user_id_users_id_fk",
+          "tableFrom": "ai_request_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_entries": {
+      "name": "community_lineup_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nominated_by": {
+          "name": "nominated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carried_over_from": {
+          "name": "carried_over_from",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_entries_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_entries_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_entries",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_entries_game_id_games_id_fk": {
+          "name": "community_lineup_entries_game_id_games_id_fk",
+          "tableFrom": "community_lineup_entries",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_entries_nominated_by_users_id_fk": {
+          "name": "community_lineup_entries_nominated_by_users_id_fk",
+          "tableFrom": "community_lineup_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "nominated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_entries_carried_over_from_community_lineups_id_fk": {
+          "name": "community_lineup_entries_carried_over_from_community_lineups_id_fk",
+          "tableFrom": "community_lineup_entries",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "carried_over_from"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lineup_entry_game": {
+          "name": "uq_lineup_entry_game",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineup_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_invitees": {
+      "name": "community_lineup_invitees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_invitees_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_invitees_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_invitees",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_invitees_user_id_users_id_fk": {
+          "name": "community_lineup_invitees_user_id_users_id_fk",
+          "tableFrom": "community_lineup_invitees",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lineup_invitee_user": {
+          "name": "uq_lineup_invitee_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineup_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_votes": {
+      "name": "community_lineup_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_votes_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_votes_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_votes",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_votes_user_id_users_id_fk": {
+          "name": "community_lineup_votes_user_id_users_id_fk",
+          "tableFrom": "community_lineup_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_votes_game_id_games_id_fk": {
+          "name": "community_lineup_votes_game_id_games_id_fk",
+          "tableFrom": "community_lineup_votes",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lineup_vote_user_game": {
+          "name": "uq_lineup_vote_user_game",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineup_id",
+            "user_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineups": {
+      "name": "community_lineups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'building'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_game_id": {
+          "name": "decided_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_event_id": {
+          "name": "linked_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voting_deadline": {
+          "name": "voting_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase_deadline": {
+          "name": "phase_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase_duration_override": {
+          "name": "phase_duration_override",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_threshold": {
+          "name": "match_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 35
+        },
+        "max_votes_per_player": {
+          "name": "max_votes_per_player",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "default_tiebreaker_mode": {
+          "name": "default_tiebreaker_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_tiebreaker_id": {
+          "name": "active_tiebreaker_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_created_channel_id": {
+          "name": "discord_created_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_created_message_id": {
+          "name": "discord_created_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_override_id": {
+          "name": "channel_override_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineups_decided_game_id_games_id_fk": {
+          "name": "community_lineups_decided_game_id_games_id_fk",
+          "tableFrom": "community_lineups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "decided_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_lineups_linked_event_id_events_id_fk": {
+          "name": "community_lineups_linked_event_id_events_id_fk",
+          "tableFrom": "community_lineups",
+          "tableTo": "events",
+          "columnsFrom": [
+            "linked_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_lineups_created_by_users_id_fk": {
+          "name": "community_lineups_created_by_users_id_fk",
+          "tableFrom": "community_lineups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_tiebreaker_bracket_matchups": {
+      "name": "community_lineup_tiebreaker_bracket_matchups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tiebreaker_id": {
+          "name": "tiebreaker_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_a_id": {
+          "name": "game_a_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_b_id": {
+          "name": "game_b_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "winner_game_id": {
+          "name": "winner_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bye": {
+          "name": "is_bye",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_tiebreaker_bracket_matchups_tiebreaker_id_community_lineup_tiebreakers_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_matchups_tiebreaker_id_community_lineup_tiebreakers_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_matchups",
+          "tableTo": "community_lineup_tiebreakers",
+          "columnsFrom": [
+            "tiebreaker_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_matchups_game_a_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_matchups_game_a_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_matchups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_matchups_game_b_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_matchups_game_b_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_matchups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_matchups_winner_game_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_matchups_winner_game_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_matchups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "winner_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_tiebreaker_matchup_round_pos": {
+          "name": "uq_tiebreaker_matchup_round_pos",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tiebreaker_id",
+            "round",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_tiebreaker_bracket_votes": {
+      "name": "community_lineup_tiebreaker_bracket_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "matchup_id": {
+          "name": "matchup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_tiebreaker_bracket_votes_matchup_id_community_lineup_tiebreaker_bracket_matchups_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_votes_matchup_id_community_lineup_tiebreaker_bracket_matchups_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_votes",
+          "tableTo": "community_lineup_tiebreaker_bracket_matchups",
+          "columnsFrom": [
+            "matchup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_votes_user_id_users_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_votes_user_id_users_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_votes_game_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_votes_game_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_votes",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_tiebreaker_bracket_vote": {
+          "name": "uq_tiebreaker_bracket_vote",
+          "nullsNotDistinct": false,
+          "columns": [
+            "matchup_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_tiebreaker_vetoes": {
+      "name": "community_lineup_tiebreaker_vetoes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tiebreaker_id": {
+          "name": "tiebreaker_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revealed": {
+          "name": "revealed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_tiebreaker_vetoes_tiebreaker_id_community_lineup_tiebreakers_id_fk": {
+          "name": "community_lineup_tiebreaker_vetoes_tiebreaker_id_community_lineup_tiebreakers_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_vetoes",
+          "tableTo": "community_lineup_tiebreakers",
+          "columnsFrom": [
+            "tiebreaker_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_vetoes_user_id_users_id_fk": {
+          "name": "community_lineup_tiebreaker_vetoes_user_id_users_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_vetoes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_vetoes_game_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_vetoes_game_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_vetoes",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_tiebreaker_veto_user": {
+          "name": "uq_tiebreaker_veto_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tiebreaker_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_tiebreakers": {
+      "name": "community_lineup_tiebreakers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "tied_game_ids": {
+          "name": "tied_game_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_vote_count": {
+          "name": "original_vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "winner_game_id": {
+          "name": "winner_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round_deadline": {
+          "name": "round_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_tiebreakers_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_tiebreakers_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_tiebreakers",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreakers_winner_game_id_games_id_fk": {
+          "name": "community_lineup_tiebreakers_winner_game_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreakers",
+          "tableTo": "games",
+          "columnsFrom": [
+            "winner_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_match_members": {
+      "name": "community_lineup_match_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_match_members_match_id_community_lineup_matches_id_fk": {
+          "name": "community_lineup_match_members_match_id_community_lineup_matches_id_fk",
+          "tableFrom": "community_lineup_match_members",
+          "tableTo": "community_lineup_matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_match_members_user_id_users_id_fk": {
+          "name": "community_lineup_match_members_user_id_users_id_fk",
+          "tableFrom": "community_lineup_match_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_match_member_user": {
+          "name": "uq_match_member_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_matches": {
+      "name": "community_lineup_matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'suggested'"
+        },
+        "threshold_met": {
+          "name": "threshold_met",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "vote_percentage": {
+          "name": "vote_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fit_type": {
+          "name": "fit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_event_id": {
+          "name": "linked_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_message_id": {
+          "name": "embed_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_channel_id": {
+          "name": "embed_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_vote_threshold": {
+          "name": "min_vote_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threshold_notified_at": {
+          "name": "threshold_notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_matches_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_matches_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_matches",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_matches_game_id_games_id_fk": {
+          "name": "community_lineup_matches_game_id_games_id_fk",
+          "tableFrom": "community_lineup_matches",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_matches_linked_event_id_events_id_fk": {
+          "name": "community_lineup_matches_linked_event_id_events_id_fk",
+          "tableFrom": "community_lineup_matches",
+          "tableTo": "events",
+          "columnsFrom": [
+            "linked_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lineup_match_game": {
+          "name": "uq_lineup_match_game",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineup_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_schedule_slots": {
+      "name": "community_lineup_schedule_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_time": {
+          "name": "proposed_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overlap_score": {
+          "name": "overlap_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_by": {
+          "name": "suggested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_schedule_slots_match_id_community_lineup_matches_id_fk": {
+          "name": "community_lineup_schedule_slots_match_id_community_lineup_matches_id_fk",
+          "tableFrom": "community_lineup_schedule_slots",
+          "tableTo": "community_lineup_matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_schedule_votes": {
+      "name": "community_lineup_schedule_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slot_id": {
+          "name": "slot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_schedule_votes_slot_id_community_lineup_schedule_slots_id_fk": {
+          "name": "community_lineup_schedule_votes_slot_id_community_lineup_schedule_slots_id_fk",
+          "tableFrom": "community_lineup_schedule_votes",
+          "tableTo": "community_lineup_schedule_slots",
+          "columnsFrom": [
+            "slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_schedule_votes_user_id_users_id_fk": {
+          "name": "community_lineup_schedule_votes_user_id_users_id_fk",
+          "tableFrom": "community_lineup_schedule_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_schedule_vote_user": {
+          "name": "uq_schedule_vote_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slot_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_activity_log_entity": {
+          "name": "idx_activity_log_entity",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_actor_id_users_id_fk": {
+          "name": "activity_log_actor_id_users_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_dedup": {
+      "name": "notification_dedup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_notification_dedup_key": {
+          "name": "uq_notification_dedup_key",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_dedup_expires_at": {
+          "name": "idx_notification_dedup_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consumed_intent_tokens": {
+      "name": "consumed_intent_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_consumed_intent_tokens_consumed_at": {
+          "name": "idx_consumed_intent_tokens_consumed_at",
+          "columns": [
+            {
+              "expression": "consumed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "consumed_intent_tokens_token_hash_unique": {
+          "name": "consumed_intent_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_taste_vectors": {
+      "name": "player_taste_vectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vector": {
+          "name": "vector",
+          "type": "vector(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intensity_metrics": {
+          "name": "intensity_metrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archetype": {
+          "name": "archetype",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "signal_hash": {
+          "name": "signal_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "player_taste_vectors_computed_at_idx": {
+          "name": "player_taste_vectors_computed_at_idx",
+          "columns": [
+            {
+              "expression": "computed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "player_taste_vectors_user_id_users_id_fk": {
+          "name": "player_taste_vectors_user_id_users_id_fk",
+          "tableFrom": "player_taste_vectors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "player_taste_vectors_user_id_unique": {
+          "name": "player_taste_vectors_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_intensity_snapshots": {
+      "name": "player_intensity_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_start": {
+          "name": "week_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_hours": {
+          "name": "total_hours",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_breakdown": {
+          "name": "game_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unique_games": {
+          "name": "unique_games",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longest_session_hours": {
+          "name": "longest_session_hours",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longest_session_game_id": {
+          "name": "longest_session_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "player_intensity_snapshots_week_start_idx": {
+          "name": "player_intensity_snapshots_week_start_idx",
+          "columns": [
+            {
+              "expression": "week_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "player_intensity_snapshots_user_id_users_id_fk": {
+          "name": "player_intensity_snapshots_user_id_users_id_fk",
+          "tableFrom": "player_intensity_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "player_intensity_snapshots_longest_session_game_id_games_id_fk": {
+          "name": "player_intensity_snapshots_longest_session_game_id_games_id_fk",
+          "tableFrom": "player_intensity_snapshots",
+          "tableTo": "games",
+          "columnsFrom": [
+            "longest_session_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_player_intensity_user_week": {
+          "name": "uq_player_intensity_user_week",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "week_start"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_co_play": {
+      "name": "player_co_play",
+      "schema": "",
+      "columns": {
+        "user_id_a": {
+          "name": "user_id_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id_b": {
+          "name": "user_id_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_minutes": {
+          "name": "total_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_played_at": {
+          "name": "last_played_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "games_played": {
+          "name": "games_played",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "player_co_play_user_id_a_users_id_fk": {
+          "name": "player_co_play_user_id_a_users_id_fk",
+          "tableFrom": "player_co_play",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id_a"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "player_co_play_user_id_b_users_id_fk": {
+          "name": "player_co_play_user_id_b_users_id_fk",
+          "tableFrom": "player_co_play",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id_b"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "player_co_play_user_id_a_user_id_b_pk": {
+          "name": "player_co_play_user_id_a_user_id_b_pk",
+          "columns": [
+            "user_id_a",
+            "user_id_b"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_player_co_play_canonical_order": {
+          "name": "chk_player_co_play_canonical_order",
+          "value": "\"player_co_play\".\"user_id_a\" < \"player_co_play\".\"user_id_b\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.game_taste_vectors": {
+      "name": "game_taste_vectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vector": {
+          "name": "vector",
+          "type": "vector(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "signal_hash": {
+          "name": "signal_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "game_taste_vectors_computed_at_idx": {
+          "name": "game_taste_vectors_computed_at_idx",
+          "columns": [
+            {
+              "expression": "computed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_taste_vectors_game_id_games_id_fk": {
+          "name": "game_taste_vectors_game_id_games_id_fk",
+          "tableFrom": "game_taste_vectors",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "game_taste_vectors_game_id_unique": {
+          "name": "game_taste_vectors_game_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/src/drizzle/migrations/meta/_journal.json
+++ b/api/src/drizzle/migrations/meta/_journal.json
@@ -890,6 +890,13 @@
       "when": 1776804310878,
       "tag": "0126_eminent_naoko",
       "breakpoints": true
+    },
+    {
+      "idx": 127,
+      "version": "7",
+      "when": 1776831898605,
+      "tag": "0127_player_taste_archetype_jsonb",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/drizzle/schema/player-taste-vectors.ts
+++ b/api/src/drizzle/schema/player-taste-vectors.ts
@@ -10,7 +10,7 @@ import {
 } from 'drizzle-orm/pg-core';
 import { users } from './users';
 import type {
-  TasteProfileArchetype,
+  ArchetypeDto,
   TasteProfileDimensionsDto,
   IntensityMetricsDto,
 } from '@raid-ledger/contract';
@@ -55,7 +55,7 @@ export const playerTasteVectors = pgTable(
     intensityMetrics: jsonb('intensity_metrics')
       .$type<IntensityMetricsDto>()
       .notNull(),
-    archetype: text('archetype').$type<TasteProfileArchetype>().notNull(),
+    archetype: jsonb('archetype').$type<ArchetypeDto | null>(),
     computedAt: timestamp('computed_at').defaultNow().notNull(),
     signalHash: text('signal_hash').notNull(),
   },

--- a/api/src/game-taste/game-taste.integration.spec.ts
+++ b/api/src/game-taste/game-taste.integration.spec.ts
@@ -26,8 +26,21 @@ import {
   loginAsAdmin,
 } from '../common/testing/integration-helpers';
 import * as schema from '../drizzle/schema';
+import { TIER_DESCRIPTIONS } from '../taste-profile/archetype-copy';
 import { GameTasteService } from './game-taste.service';
 import { runAggregateGameVectors } from './pipelines/aggregate-game-vectors';
+
+/**
+ * ROK-1083: `player_taste_vectors.archetype` moved from `text` to
+ * nullable `jsonb`. The three raw-SQL fixture INSERTs below need a jsonb
+ * literal — this constant is the composed-shape default, pre-escaped for
+ * safe substitution into a `sql` template.
+ */
+const STUB_ARCHETYPE_JSON = `'${JSON.stringify({
+  intensityTier: 'Regular',
+  vectorTitles: [],
+  descriptions: { tier: TIER_DESCRIPTIONS.Regular, titles: [] },
+}).replace(/'/g, "''")}'::jsonb`;
 
 describe('Game Taste Vectors (ROK-1082)', () => {
   let testApp: TestApp;
@@ -210,7 +223,7 @@ describe('Game Taste Vectors (ROK-1082)', () => {
           '[0.1,0.1,0.9,0.1,0.1,0.1,0.1]'::vector,
           '{"co_op":10,"pvp":10,"rpg":90,"survival":10,"strategy":10,"social":10,"mmo":10}'::jsonb,
           '{"intensity":50,"focus":50,"breadth":50,"consistency":50}'::jsonb,
-          'Specialist',
+          ${sql.raw(STUB_ARCHETYPE_JSON)},
           NOW(),
           'test-hash-1'
         )
@@ -252,11 +265,11 @@ describe('Game Taste Vectors (ROK-1082)', () => {
           (${a}, '[0.1,0.1,0.9,0.1,0.1,0.1,0.1]'::vector,
            '{"co_op":10,"pvp":10,"rpg":90,"survival":10,"strategy":10,"social":10,"mmo":10}'::jsonb,
            '{"intensity":50,"focus":50,"breadth":50,"consistency":50}'::jsonb,
-           'Specialist', NOW(), 'gt-hash-a'),
+           ${sql.raw(STUB_ARCHETYPE_JSON)}, NOW(), 'gt-hash-a'),
           (${b}, '[0.1,0.1,0.8,0.2,0.1,0.1,0.1]'::vector,
            '{"co_op":10,"pvp":10,"rpg":80,"survival":20,"strategy":10,"social":10,"mmo":10}'::jsonb,
            '{"intensity":50,"focus":50,"breadth":50,"consistency":50}'::jsonb,
-           'Specialist', NOW(), 'gt-hash-b')
+           ${sql.raw(STUB_ARCHETYPE_JSON)}, NOW(), 'gt-hash-b')
       `);
 
       await runAggregateGameVectors(testApp.db);

--- a/api/src/lineups/common-ground-taste.integration.spec.ts
+++ b/api/src/lineups/common-ground-taste.integration.spec.ts
@@ -12,6 +12,7 @@
  * - AC 7: Graceful degradation — zero voters, voter missing a taste vector
  */
 import { sql } from 'drizzle-orm';
+import type { ArchetypeDto } from '@raid-ledger/contract';
 import { getTestApp, type TestApp } from '../common/testing/test-app';
 import {
   truncateAllTables,
@@ -19,7 +20,18 @@ import {
 } from '../common/testing/integration-helpers';
 import * as schema from '../drizzle/schema';
 import { SettingsService } from '../settings/settings.service';
+import { TIER_DESCRIPTIONS } from '../taste-profile/archetype-copy';
 import { SETTING_KEYS } from '../drizzle/schema/app-settings';
+
+/** Default composed archetype for test fixtures (ROK-1083 jsonb shape). */
+const DEFAULT_TEST_ARCHETYPE: ArchetypeDto = {
+  intensityTier: 'Regular',
+  vectorTitles: [],
+  descriptions: {
+    tier: TIER_DESCRIPTIONS.Regular,
+    titles: [],
+  },
+};
 
 function describeCommonGroundTaste() {
   let testApp: TestApp;
@@ -104,7 +116,7 @@ function describeCommonGroundTaste() {
     userId: number,
     opts: {
       axisScores: Partial<Record<string, number>>;
-      archetype?: string;
+      archetype?: ArchetypeDto | Partial<ArchetypeDto>;
       intensity?: number;
     },
   ): Promise<void> {
@@ -146,6 +158,10 @@ function describeCommonGroundTaste() {
       dimensions.social,
       dimensions.mmo,
     ];
+    const archetype: ArchetypeDto = {
+      ...DEFAULT_TEST_ARCHETYPE,
+      ...(opts.archetype ?? {}),
+    } as ArchetypeDto;
     await testApp.db.insert(schema.playerTasteVectors).values({
       userId,
       vector,
@@ -159,7 +175,8 @@ function describeCommonGroundTaste() {
         consistency: 50,
       } as any,
 
-      archetype: (opts.archetype ?? 'Explorer') as any,
+      // ROK-1083: jsonb column accepts the composed archetype object directly.
+      archetype,
       signalHash: `test-${userId}-${Date.now()}`,
     });
   }

--- a/api/src/taste-profile/archetype-copy.ts
+++ b/api/src/taste-profile/archetype-copy.ts
@@ -1,0 +1,98 @@
+/**
+ * Archetype server-side copy tables (ROK-1083).
+ *
+ * These strings are owned by the server and shipped to the UI via the
+ * taste-profile response payload (see `ArchetypeSchema.descriptions` in
+ * `@raid-ledger/contract`). Keeping copy server-side means text changes
+ * don't force a contract rebuild + redeploy cascade, and the LLM context
+ * builder reuses the same descriptions when constructing prompts.
+ *
+ * - `TIER_DESCRIPTIONS`: one short phrase per intensity tier.
+ * - `VECTOR_TITLE_DESCRIPTIONS`: one phrase per vector title.
+ * - `VECTOR_TITLE_AXES`: which pool axis (or axes, for multi-axis combo
+ *   titles) feed each vector-title score. Multi-axis titles use the
+ *   max of their components (see `archetype.helpers.ts`).
+ */
+import type {
+  IntensityTier,
+  TasteProfilePoolAxis,
+  VectorTitle,
+} from '@raid-ledger/contract';
+
+/**
+ * Short human-readable description per intensity tier. Shipped inside
+ * `ArchetypeDto.descriptions.tier` so the UI (and LLM prompts) render
+ * the same copy everywhere.
+ */
+export const TIER_DESCRIPTIONS: Record<IntensityTier, string> = {
+  Hardcore: 'Plays nearly daily, many hours per week',
+  Dedicated: 'Shows up several times a week',
+  Regular: 'A few sessions a week',
+  Casual: 'Drops in once or twice a week',
+} as const;
+
+/**
+ * Short human-readable description per vector title. The order of
+ * strings in `ArchetypeDto.descriptions.titles` mirrors the order of
+ * entries in `ArchetypeDto.vectorTitles`.
+ */
+export const VECTOR_TITLE_DESCRIPTIONS: Record<VectorTitle, string> = {
+  Duelist: 'Lives for PvP and one-on-one fights',
+  Brawler: 'Thrives on fast-paced fighting games',
+  'Last One Standing': 'Battle-royale devotee — last squad wins',
+  Tactician: 'Reads the map, calls the shots in MOBAs',
+  Marksman: 'Sharp aim and reflexes in shooters',
+  Companion: 'Plays best shoulder-to-shoulder in co-op',
+  Raider: 'MMO group content is home base',
+  Socialite: 'Here for the people as much as the games',
+  Hero: 'Drawn to story-driven RPGs and fantasy worlds',
+  Spacefarer: 'Explores science-fiction frontiers',
+  Wayfarer: 'Chases adventure and discovery',
+  Architect: 'Builds, automates, and shapes sandboxes',
+  Strategist: 'Out-thinks opponents in strategy titles',
+  Survivor: 'Scrapes by in survival games and lives to tell it',
+  Nightcrawler: 'Drawn to horror and the uncanny',
+  'Risk Taker': 'Rolls the dice on roguelike runs',
+  Operative: 'Moves in the shadows — stealth specialist',
+  Puzzler: 'Loves unraveling puzzles',
+  Acrobat: 'Leaps and lands platformer challenges',
+  Racer: 'Lives for speed and the perfect racing line',
+  Athlete: 'Competes on the virtual field in sports titles',
+} as const;
+
+/**
+ * Vector-title → axis(es) mapping. Single-axis titles score on the raw
+ * axis value; multi-axis titles score via `max(...component axes)`
+ * (per ROK-1083 locked decision — see `archetype.helpers.ts` doc).
+ *
+ * Axis order inside each tuple matters for tie-break: the FIRST axis in
+ * the tuple is the title's "primary" axis, and primary-axis position
+ * inside `TASTE_PROFILE_AXIS_POOL` is the secondary sort key when
+ * titles share a score.
+ */
+export const VECTOR_TITLE_AXES: Record<
+  VectorTitle,
+  readonly TasteProfilePoolAxis[]
+> = {
+  Duelist: ['pvp'],
+  Brawler: ['fighting'],
+  'Last One Standing': ['battle_royale'],
+  Tactician: ['moba'],
+  Marksman: ['shooter'],
+  Companion: ['co_op'],
+  Raider: ['mmo'],
+  Socialite: ['social'],
+  Hero: ['rpg', 'fantasy'],
+  Spacefarer: ['sci_fi'],
+  Wayfarer: ['adventure'],
+  Architect: ['crafting', 'automation', 'sandbox'],
+  Strategist: ['strategy'],
+  Survivor: ['survival'],
+  Nightcrawler: ['horror'],
+  'Risk Taker': ['roguelike'],
+  Operative: ['stealth'],
+  Puzzler: ['puzzle'],
+  Acrobat: ['platformer'],
+  Racer: ['racing'],
+  Athlete: ['sports'],
+} as const;

--- a/api/src/taste-profile/archetype.helpers.spec.ts
+++ b/api/src/taste-profile/archetype.helpers.spec.ts
@@ -141,10 +141,7 @@ describe('deriveArchetype (ROK-1083 composed shape)', () => {
         dimensions: makeDimensions({ pvp: 80, mmo: 72 }),
       });
 
-      expect(result.vectorTitles).toEqual<VectorTitle[]>([
-        'Duelist',
-        'Raider',
-      ]);
+      expect(result.vectorTitles).toEqual<VectorTitle[]>(['Duelist', 'Raider']);
     });
 
     it('emits a single title when diff > 10', () => {
@@ -165,10 +162,7 @@ describe('deriveArchetype (ROK-1083 composed shape)', () => {
       });
 
       expect(result.vectorTitles).toHaveLength(2);
-      expect(result.vectorTitles).toEqual<VectorTitle[]>([
-        'Duelist',
-        'Raider',
-      ]);
+      expect(result.vectorTitles).toEqual<VectorTitle[]>(['Duelist', 'Raider']);
       expect(result.vectorTitles).not.toContain<VectorTitle>('Hero');
     });
   });
@@ -181,10 +175,7 @@ describe('deriveArchetype (ROK-1083 composed shape)', () => {
         dimensions: makeDimensions({ pvp: 70, mmo: 70 }),
       });
 
-      expect(result.vectorTitles).toEqual<VectorTitle[]>([
-        'Duelist',
-        'Raider',
-      ]);
+      expect(result.vectorTitles).toEqual<VectorTitle[]>(['Duelist', 'Raider']);
     });
 
     it('resolves equal scores at the cap boundary (3-way tie → pvp + mmo, rpg dropped)', () => {
@@ -194,10 +185,7 @@ describe('deriveArchetype (ROK-1083 composed shape)', () => {
         dimensions: makeDimensions({ pvp: 70, mmo: 70, rpg: 70 }),
       });
 
-      expect(result.vectorTitles).toEqual<VectorTitle[]>([
-        'Duelist',
-        'Raider',
-      ]);
+      expect(result.vectorTitles).toEqual<VectorTitle[]>(['Duelist', 'Raider']);
     });
   });
 

--- a/api/src/taste-profile/archetype.helpers.spec.ts
+++ b/api/src/taste-profile/archetype.helpers.spec.ts
@@ -1,64 +1,283 @@
 /**
- * Archetype derivation unit tests (ROK-948 AC 7).
+ * Archetype derivation unit tests (ROK-1083 — new two-layer shape).
  *
- * Thresholds from the enriched spec (first match wins):
- *   Dedicated       — intensity ≥ 75 AND consistency ≥ 60
- *   Specialist      — focus ≥ 80
- *   Explorer        — breadth ≥ 70 AND focus < 50
- *   Social Drifter  — intensity < 50 AND coPlayPartners ≥ 3
- *   Casual          — default
+ * The helper replaces the old 5-value enum ladder with a composed
+ * {intensityTier, vectorTitles, descriptions} shape.
+ *
+ * Tier thresholds (inclusive on the lower bound):
+ *   intensity < 35            -> Casual
+ *   35 ≤ intensity < 60       -> Regular
+ *   60 ≤ intensity < 85       -> Dedicated
+ *   85 ≤ intensity            -> Hardcore
+ *
+ * Vector-title composition:
+ *   - score per title uses raw axis value (single-axis) or max of
+ *     component axes (multi-axis: Hero = max(rpg, fantasy);
+ *     Architect = max(crafting, automation, sandbox))
+ *   - top-axis floor: if the top score < 30, vectorTitles = []
+ *   - close window: if second score ≥ 30 AND (first - second) ≤ 10,
+ *     emit both titles; else one
+ *   - cap at 2
+ *   - tie-break by TASTE_PROFILE_AXIS_POOL order (earlier wins)
  */
+import {
+  INTENSITY_TIERS,
+  TASTE_PROFILE_AXIS_POOL,
+  VECTOR_TITLES,
+  type ArchetypeDto,
+  type IntensityMetricsDto,
+  type IntensityTier,
+  type TasteProfileDimensionsDto,
+  type VectorTitle,
+} from '@raid-ledger/contract';
 import { deriveArchetype } from './archetype.helpers';
 
-describe('archetype derivation (ROK-948 AC 7)', () => {
-  const base = {
-    intensity: 50,
-    focus: 50,
-    breadth: 50,
-    consistency: 50,
-    coPlayPartners: 0,
+function makeDimensions(
+  overrides: Partial<TasteProfileDimensionsDto> = {},
+): TasteProfileDimensionsDto {
+  const base = Object.fromEntries(
+    TASTE_PROFILE_AXIS_POOL.map((axis) => [axis, 0]),
+  ) as TasteProfileDimensionsDto;
+  return { ...base, ...overrides };
+}
+
+function makeMetrics(
+  overrides: Partial<IntensityMetricsDto> = {},
+): IntensityMetricsDto {
+  return {
+    intensity: 0,
+    focus: 0,
+    breadth: 0,
+    consistency: 0,
+    ...overrides,
   };
+}
 
-  it("returns 'Dedicated' at the boundary", () => {
-    expect(deriveArchetype({ ...base, intensity: 75, consistency: 60 })).toBe(
-      'Dedicated',
-    );
+describe('deriveArchetype (ROK-1083 composed shape)', () => {
+  describe('AC regression — high intensity is never Casual', () => {
+    it('returns Hardcore for intensity 95 / focus 77 / breadth 20 / consistency 0 (old AC-1 regression)', () => {
+      const result: ArchetypeDto = deriveArchetype({
+        intensityMetrics: makeMetrics({
+          intensity: 95,
+          focus: 77,
+          breadth: 20,
+          consistency: 0,
+        }),
+        dimensions: makeDimensions(),
+      });
+
+      expect(result.intensityTier).toBe('Hardcore');
+      expect(result.intensityTier).not.toBe('Casual');
+    });
+
+    it('returns Casual for intensity 34 with all other signals zero (AC 2)', () => {
+      const result = deriveArchetype({
+        intensityMetrics: makeMetrics({ intensity: 34 }),
+        dimensions: makeDimensions(),
+      });
+
+      expect(result.intensityTier).toBe('Casual');
+    });
+
+    it('returns Hardcore with empty vectorTitles for high-intensity / low axis player (AC 3)', () => {
+      const result = deriveArchetype({
+        intensityMetrics: makeMetrics({
+          intensity: 90,
+          focus: 10,
+          breadth: 10,
+          consistency: 0,
+        }),
+        dimensions: makeDimensions(),
+      });
+
+      expect(result.intensityTier).toBe('Hardcore');
+      expect(result.vectorTitles).toEqual([]);
+    });
   });
 
-  it("returns 'Specialist' at the focus boundary", () => {
-    expect(deriveArchetype({ ...base, focus: 80 })).toBe('Specialist');
+  describe('intensity tier boundaries (AC 4)', () => {
+    it.each<[number, IntensityTier]>([
+      [34, 'Casual'],
+      [35, 'Regular'],
+      [59, 'Regular'],
+      [60, 'Dedicated'],
+      [84, 'Dedicated'],
+      [85, 'Hardcore'],
+    ])('intensity=%i → %s', (intensity, expectedTier) => {
+      const result = deriveArchetype({
+        intensityMetrics: makeMetrics({ intensity }),
+        dimensions: makeDimensions(),
+      });
+
+      expect(result.intensityTier).toBe(expectedTier);
+    });
   });
 
-  it("prefers 'Dedicated' over 'Specialist' when both apply", () => {
-    expect(
-      deriveArchetype({
-        ...base,
-        intensity: 90,
-        consistency: 80,
-        focus: 90,
-      }),
-    ).toBe('Dedicated');
+  describe('top-axis floor (AC 5)', () => {
+    it('emits no vectorTitles when the top score is 29', () => {
+      const result = deriveArchetype({
+        intensityMetrics: makeMetrics({ intensity: 50 }),
+        dimensions: makeDimensions({ pvp: 29 }),
+      });
+
+      expect(result.vectorTitles).toEqual([]);
+    });
+
+    it('emits a single vectorTitle when the top score is exactly 30', () => {
+      const result = deriveArchetype({
+        intensityMetrics: makeMetrics({ intensity: 50 }),
+        dimensions: makeDimensions({ pvp: 30 }),
+      });
+
+      expect(result.vectorTitles).toHaveLength(1);
+      expect(result.vectorTitles[0]).toBe<VectorTitle>('Duelist');
+    });
   });
 
-  it("returns 'Explorer' when breadth ≥ 70 and focus < 50", () => {
-    expect(deriveArchetype({ ...base, breadth: 70, focus: 49 })).toBe(
-      'Explorer',
-    );
+  describe('close-window (AC 6)', () => {
+    it('emits both titles when diff ≤ 10 and both ≥ 30 (higher score first)', () => {
+      const result = deriveArchetype({
+        intensityMetrics: makeMetrics({ intensity: 50 }),
+        dimensions: makeDimensions({ pvp: 80, mmo: 72 }),
+      });
+
+      expect(result.vectorTitles).toEqual<VectorTitle[]>([
+        'Duelist',
+        'Raider',
+      ]);
+    });
+
+    it('emits a single title when diff > 10', () => {
+      const result = deriveArchetype({
+        intensityMetrics: makeMetrics({ intensity: 50 }),
+        dimensions: makeDimensions({ pvp: 80, mmo: 69 }),
+      });
+
+      expect(result.vectorTitles).toEqual<VectorTitle[]>(['Duelist']);
+    });
   });
 
-  it("does not return 'Explorer' when focus is 50 or higher", () => {
-    expect(deriveArchetype({ ...base, breadth: 80, focus: 50 })).not.toBe(
-      'Explorer',
-    );
+  describe('cap at 2 (AC 8)', () => {
+    it('never emits more than two titles even when 3+ scores are within the window', () => {
+      const result = deriveArchetype({
+        intensityMetrics: makeMetrics({ intensity: 50 }),
+        dimensions: makeDimensions({ pvp: 80, mmo: 78, rpg: 76 }),
+      });
+
+      expect(result.vectorTitles).toHaveLength(2);
+      expect(result.vectorTitles).toEqual<VectorTitle[]>([
+        'Duelist',
+        'Raider',
+      ]);
+      expect(result.vectorTitles).not.toContain<VectorTitle>('Hero');
+    });
   });
 
-  it("returns 'Social Drifter' when intensity < 50 and coPlayPartners ≥ 3", () => {
-    expect(deriveArchetype({ ...base, intensity: 49, coPlayPartners: 3 })).toBe(
-      'Social Drifter',
-    );
+  describe('tie-break determinism (AC 7)', () => {
+    it('resolves equal scores by TASTE_PROFILE_AXIS_POOL order (pvp before mmo)', () => {
+      // pvp is index 1, mmo is index 3 in TASTE_PROFILE_AXIS_POOL — pvp wins slot 0
+      const result = deriveArchetype({
+        intensityMetrics: makeMetrics({ intensity: 50 }),
+        dimensions: makeDimensions({ pvp: 70, mmo: 70 }),
+      });
+
+      expect(result.vectorTitles).toEqual<VectorTitle[]>([
+        'Duelist',
+        'Raider',
+      ]);
+    });
+
+    it('resolves equal scores at the cap boundary (3-way tie → pvp + mmo, rpg dropped)', () => {
+      // pool order: pvp(1) < mmo(3) < rpg(9) — first two win, third dropped by cap
+      const result = deriveArchetype({
+        intensityMetrics: makeMetrics({ intensity: 50 }),
+        dimensions: makeDimensions({ pvp: 70, mmo: 70, rpg: 70 }),
+      });
+
+      expect(result.vectorTitles).toEqual<VectorTitle[]>([
+        'Duelist',
+        'Raider',
+      ]);
+    });
   });
 
-  it("falls back to 'Casual' when nothing else matches", () => {
-    expect(deriveArchetype(base)).toBe('Casual');
+  describe('multi-axis scoring (max of components)', () => {
+    it('Hero uses max(rpg, fantasy) and beats lone single-axis competitors', () => {
+      // Hero score = max(50, 40) = 50, beats any other axis (all 0)
+      const result = deriveArchetype({
+        intensityMetrics: makeMetrics({ intensity: 50 }),
+        dimensions: makeDimensions({ rpg: 50, fantasy: 40 }),
+      });
+
+      expect(result.vectorTitles).toEqual<VectorTitle[]>(['Hero']);
+    });
+
+    it('Architect uses max(crafting, automation, sandbox)', () => {
+      const result = deriveArchetype({
+        intensityMetrics: makeMetrics({ intensity: 50 }),
+        dimensions: makeDimensions({
+          crafting: 45,
+          automation: 30,
+          sandbox: 0,
+        }),
+      });
+
+      expect(result.vectorTitles).toEqual<VectorTitle[]>(['Architect']);
+    });
+  });
+
+  describe('descriptions shape', () => {
+    it('returns a non-empty tier description and one description per vector title', () => {
+      const result = deriveArchetype({
+        intensityMetrics: makeMetrics({ intensity: 90 }),
+        dimensions: makeDimensions({ pvp: 80, mmo: 72 }),
+      });
+
+      expect(typeof result.descriptions.tier).toBe('string');
+      expect(result.descriptions.tier.length).toBeGreaterThan(0);
+      expect(result.descriptions.titles).toHaveLength(
+        result.vectorTitles.length,
+      );
+      for (const description of result.descriptions.titles) {
+        expect(typeof description).toBe('string');
+        expect(description.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('returns empty titles description array when vectorTitles is empty', () => {
+      const result = deriveArchetype({
+        intensityMetrics: makeMetrics({ intensity: 90 }),
+        dimensions: makeDimensions(),
+      });
+
+      expect(result.vectorTitles).toEqual([]);
+      expect(result.descriptions.titles).toEqual([]);
+      expect(typeof result.descriptions.tier).toBe('string');
+      expect(result.descriptions.tier.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('contract sanity', () => {
+    it('only returns tiers enumerated in INTENSITY_TIERS', () => {
+      for (const intensity of [0, 34, 35, 59, 60, 84, 85, 100]) {
+        const result = deriveArchetype({
+          intensityMetrics: makeMetrics({ intensity }),
+          dimensions: makeDimensions(),
+        });
+
+        expect(INTENSITY_TIERS).toContain(result.intensityTier);
+      }
+    });
+
+    it('only returns titles enumerated in VECTOR_TITLES', () => {
+      const result = deriveArchetype({
+        intensityMetrics: makeMetrics({ intensity: 50 }),
+        dimensions: makeDimensions({ pvp: 80, mmo: 72 }),
+      });
+
+      for (const title of result.vectorTitles) {
+        expect(VECTOR_TITLES).toContain(title);
+      }
+    });
   });
 });

--- a/api/src/taste-profile/archetype.helpers.ts
+++ b/api/src/taste-profile/archetype.helpers.ts
@@ -1,25 +1,145 @@
-import type { TasteProfileArchetype } from '@raid-ledger/contract';
+/**
+ * Archetype derivation (ROK-1083 composed shape).
+ *
+ * The player archetype is a two-layer object:
+ *   - `intensityTier` — always present, derived from
+ *     `intensityMetrics.intensity` via a threshold ladder.
+ *   - `vectorTitles` — 0-2 entries, picked from the strongest pool-axis
+ *     scores in `dimensions` via the composition rules below.
+ *   - `descriptions` — matching server-owned copy (see
+ *     `archetype-copy.ts`). `descriptions.titles[i]` pairs with
+ *     `vectorTitles[i]`.
+ *
+ * Combo scoring rule (locked ROK-1083 decision): multi-axis titles
+ * score by `max(...component axes)`. E.g. `Hero = max(rpg, fantasy)`;
+ * `Architect = max(crafting, automation, sandbox)`. Single-axis titles
+ * use the raw axis value. We chose `max` over `mean`/`sum` so a player
+ * who is strong in exactly one facet of a combo title still earns the
+ * title — the combo axes express "any of these flavors".
+ *
+ * Composition rules (applied after scoring):
+ *   1. Top-axis floor: if the top title's score is `< 30`, emit no
+ *      vector titles (intensity-only badge, e.g. "Hardcore Player").
+ *   2. Close window: if the second title's score is `>= 30` and the
+ *      gap `top - second <= 10`, emit both titles; else emit one.
+ *   3. Cap at 2 — never emit 3+ titles.
+ *   4. Tie-break: equal scores resolve by each title's primary-axis
+ *      position in `TASTE_PROFILE_AXIS_POOL` (earlier index wins).
+ */
+import {
+  TASTE_PROFILE_AXIS_POOL,
+  type ArchetypeDto,
+  type IntensityMetricsDto,
+  type IntensityTier,
+  type TasteProfileDimensionsDto,
+  type VectorTitle,
+} from '@raid-ledger/contract';
+import {
+  TIER_DESCRIPTIONS,
+  VECTOR_TITLE_AXES,
+  VECTOR_TITLE_DESCRIPTIONS,
+} from './archetype-copy';
 
-export interface ArchetypeInputs {
-  intensity: number;
-  focus: number;
-  breadth: number;
-  consistency: number;
-  coPlayPartners: number;
+/** Minimum axis score required to earn any vector title. */
+const TOP_AXIS_FLOOR = 30;
+
+/** Max gap between first and second title score for both to be kept. */
+const CLOSE_WINDOW = 10;
+
+/** Maximum number of vector titles ever attached to an archetype. */
+const TITLE_CAP = 2;
+
+/** Inputs for `deriveArchetype`. */
+export interface ArchetypeDerivationInputs {
+  intensityMetrics: IntensityMetricsDto;
+  dimensions: TasteProfileDimensionsDto;
+}
+
+interface VectorTitleScore {
+  title: VectorTitle;
+  score: number;
+  /** Index of the title's primary axis inside TASTE_PROFILE_AXIS_POOL. */
+  primaryAxisIndex: number;
 }
 
 /**
- * Derive a player archetype from their intensity metrics (ROK-948 AC 7).
- * Rules evaluate top-to-bottom — first match wins.
+ * Map an intensity score (0-100) to its tier. Thresholds are inclusive
+ * on the lower bound (35 -> Regular, 60 -> Dedicated, 85 -> Hardcore).
+ */
+export function deriveTier(intensity: number): IntensityTier {
+  if (intensity >= 85) return 'Hardcore';
+  if (intensity >= 60) return 'Dedicated';
+  if (intensity >= 35) return 'Regular';
+  return 'Casual';
+}
+
+/**
+ * Score every vector title. Single-axis titles take the raw axis score;
+ * multi-axis titles take `max(...component axes)` per the locked combo
+ * scoring decision. `primaryAxisIndex` is used as a stable tie-break.
+ */
+export function computeVectorTitleScores(
+  dimensions: TasteProfileDimensionsDto,
+): VectorTitleScore[] {
+  const entries = Object.entries(VECTOR_TITLE_AXES) as Array<
+    [VectorTitle, (typeof VECTOR_TITLE_AXES)[VectorTitle]]
+  >;
+  return entries.map(([title, axes]) => {
+    const score = Math.max(...axes.map((axis) => dimensions[axis]));
+    const primaryAxisIndex = TASTE_PROFILE_AXIS_POOL.indexOf(axes[0]);
+    return { title, score, primaryAxisIndex };
+  });
+}
+
+/**
+ * Apply top-axis floor, close-window, and cap-at-2 rules to produce the
+ * ordered list of vector titles for an archetype. Equal-scored titles
+ * are resolved by primary-axis position in `TASTE_PROFILE_AXIS_POOL`.
+ */
+export function pickTopTitles(scores: VectorTitleScore[]): VectorTitle[] {
+  const sorted = [...scores].sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return a.primaryAxisIndex - b.primaryAxisIndex;
+  });
+  const top = sorted[0];
+  if (!top || top.score < TOP_AXIS_FLOOR) return [];
+
+  const second = sorted[1];
+  const keepSecond =
+    !!second &&
+    second.score >= TOP_AXIS_FLOOR &&
+    top.score - second.score <= CLOSE_WINDOW;
+
+  const picks = keepSecond ? [top.title, second.title] : [top.title];
+  return picks.slice(0, TITLE_CAP);
+}
+
+/**
+ * Look up tier + per-title descriptions from the server-owned copy
+ * tables. The returned `titles` array is positionally aligned with the
+ * input `titles` list.
+ */
+export function buildDescriptions(
+  tier: IntensityTier,
+  titles: VectorTitle[],
+): ArchetypeDto['descriptions'] {
+  return {
+    tier: TIER_DESCRIPTIONS[tier],
+    titles: titles.map((title) => VECTOR_TITLE_DESCRIPTIONS[title]),
+  };
+}
+
+/**
+ * Derive the composed archetype for a player from their intensity
+ * metrics and dimensions. Composes the helpers above; see the file
+ * header for the full rule set.
  */
 export function deriveArchetype(
-  inputs: ArchetypeInputs,
-): TasteProfileArchetype {
-  const { intensity, focus, breadth, consistency, coPlayPartners } = inputs;
-
-  if (intensity >= 75 && consistency >= 60) return 'Dedicated';
-  if (focus >= 80) return 'Specialist';
-  if (breadth >= 70 && focus < 50) return 'Explorer';
-  if (intensity < 50 && coPlayPartners >= 3) return 'Social Drifter';
-  return 'Casual';
+  inputs: ArchetypeDerivationInputs,
+): ArchetypeDto {
+  const intensityTier = deriveTier(inputs.intensityMetrics.intensity);
+  const scores = computeVectorTitleScores(inputs.dimensions);
+  const vectorTitles = pickTopTitles(scores);
+  const descriptions = buildDescriptions(intensityTier, vectorTitles);
+  return { intensityTier, vectorTitles, descriptions };
 }

--- a/api/src/taste-profile/pipelines/aggregate-vectors.ts
+++ b/api/src/taste-profile/pipelines/aggregate-vectors.ts
@@ -12,7 +12,6 @@ import { computeSignalHash } from '../signal-hash.helpers';
 import {
   groupBy,
   groupMap,
-  loadCoPlayCounts,
   loadGameMetadata,
   loadSignalHashComponents,
 } from './aggregate-vectors-loaders';
@@ -25,7 +24,6 @@ interface BatchedInputs {
     number,
     { signalHash: string; intensityMetrics: NonNullable<unknown> }
   >;
-  coPlayCounts: Map<number, number>;
   eventGameId: Map<number, number>;
   interestsByUser: Map<number, Array<typeof schema.gameInterests.$inferSelect>>;
   presenceByUser: Map<
@@ -87,8 +85,9 @@ async function upsertVector(
     breadth: 0,
     consistency: 0,
   };
-  const coPlayPartners = batch.coPlayCounts.get(userId) ?? 0;
-  const archetype = deriveArchetype({ ...intensityMetrics, coPlayPartners });
+  // ROK-1083: deriveArchetype now returns a composed ArchetypeDto. The
+  // jsonb column persists it as-is (Drizzle handles jsonb serialization).
+  const archetype = deriveArchetype({ intensityMetrics, dimensions });
 
   await db
     .insert(schema.playerTasteVectors)
@@ -122,7 +121,6 @@ async function loadBatch(db: Db): Promise<BatchedInputs> {
     voice,
     events,
     existingVectors,
-    coPlayRows,
     hashComponents,
   ] = await Promise.all([
     db.select().from(schema.gameInterests),
@@ -153,7 +151,6 @@ async function loadBatch(db: Db): Promise<BatchedInputs> {
       .select({ id: schema.events.id, gameId: schema.events.gameId })
       .from(schema.events),
     db.select().from(schema.playerTasteVectors),
-    loadCoPlayCounts(db),
     loadSignalHashComponents(db),
   ]);
 
@@ -192,7 +189,6 @@ async function loadBatch(db: Db): Promise<BatchedInputs> {
   return {
     gameMap,
     existingByUser,
-    coPlayCounts: coPlayRows,
     eventGameId,
     interestsByUser,
     presenceByUser,

--- a/api/src/taste-profile/queries/taste-profile-queries.ts
+++ b/api/src/taste-profile/queries/taste-profile-queries.ts
@@ -2,12 +2,14 @@ import { eq, inArray, sql } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import * as schema from '../../drizzle/schema';
 import type {
+  ArchetypeDto,
   IntensityMetricsDto,
-  TasteProfileArchetype,
+  IntensityTier,
   TasteProfileDimensionsDto,
   TasteProfilePoolAxis,
 } from '@raid-ledger/contract';
 import { TASTE_PROFILE_AXIS_POOL } from '@raid-ledger/contract';
+import { TIER_DESCRIPTIONS } from '../archetype-copy';
 
 type Db = PostgresJsDatabase<typeof schema>;
 
@@ -29,7 +31,7 @@ export interface TasteProfileResult {
     breadth: number;
     consistency: number;
   };
-  archetype: TasteProfileArchetype;
+  archetype: ArchetypeDto;
   coPlayPartners: CoPlayPartnerRow[];
   computedAt: string;
 }
@@ -38,8 +40,25 @@ export interface SimilarPlayerRow {
   userId: number;
   username: string;
   avatar: string | null;
-  archetype: TasteProfileArchetype;
+  intensityTier: IntensityTier;
   similarity: number;
+}
+
+/**
+ * Default archetype for users without a computed taste vector (or whose
+ * jsonb archetype is still NULL immediately after the 0127 migration).
+ * Matches the composed `ArchetypeDto` shape with no vector titles so the
+ * UI renders an intensity-only badge ("Casual Player").
+ */
+function emptyArchetype(): ArchetypeDto {
+  return {
+    intensityTier: 'Casual',
+    vectorTitles: [],
+    descriptions: {
+      tier: TIER_DESCRIPTIONS.Casual,
+      titles: [],
+    },
+  };
 }
 
 export async function getTasteProfile(
@@ -67,7 +86,7 @@ export async function getTasteProfile(
       userId,
       dimensions: zeroedDimensions(),
       intensityMetrics: { intensity: 0, focus: 0, breadth: 0, consistency: 0 },
-      archetype: 'Casual',
+      archetype: emptyArchetype(),
       coPlayPartners,
       computedAt: now,
     };
@@ -78,7 +97,10 @@ export async function getTasteProfile(
     userId,
     dimensions: row.dimensions,
     intensityMetrics: row.intensityMetrics,
-    archetype: row.archetype,
+    // ROK-1083: archetype column is nullable jsonb post-migration; a NULL
+    // value means the cron has not yet rebuilt the row. Fall through to
+    // the composed Casual default until the next `runAggregateVectors`.
+    archetype: row.archetype ?? emptyArchetype(),
     coPlayPartners,
     computedAt: row.computedAt.toISOString(),
   };
@@ -98,14 +120,18 @@ export async function findSimilarPlayers(
   if (anchor.length === 0) return [];
 
   const anchorVector = `[${anchor[0].vector.join(',')}]`;
+  // ROK-1083: archetype is now jsonb — extract intensityTier via
+  // `->>'intensityTier'` so we still ship the compact tier string on
+  // similar-player cards without parsing the whole payload client-side.
   const rows = await db.execute<{
     user_id: number;
     username: string;
     avatar: string | null;
-    archetype: TasteProfileArchetype;
+    intensity_tier: IntensityTier | null;
     distance: string;
   }>(sql`
-    SELECT v.user_id, u.username, u.avatar, v.archetype,
+    SELECT v.user_id, u.username, u.avatar,
+           (v.archetype->>'intensityTier')::text AS intensity_tier,
            (v.vector <=> ${anchorVector}::vector) AS distance
     FROM player_taste_vectors v
     JOIN users u ON u.id = v.user_id
@@ -118,7 +144,7 @@ export async function findSimilarPlayers(
     userId: r.user_id,
     username: r.username,
     avatar: r.avatar,
-    archetype: r.archetype,
+    intensityTier: r.intensity_tier ?? 'Casual',
     similarity: Math.max(0, 1 - Number(r.distance)),
   }));
 }

--- a/api/src/taste-profile/taste-profile.integration.spec.ts
+++ b/api/src/taste-profile/taste-profile.integration.spec.ts
@@ -13,12 +13,14 @@
  * - AC 10: GET /users/:id/similar-players
  */
 import { sql } from 'drizzle-orm';
+import { INTENSITY_TIERS } from '@raid-ledger/contract';
 import { getTestApp, type TestApp } from '../common/testing/test-app';
 import {
   truncateAllTables,
   loginAsAdmin,
 } from '../common/testing/integration-helpers';
 import * as schema from '../drizzle/schema';
+import { TIER_DESCRIPTIONS } from './archetype-copy';
 import { TasteProfileService } from './taste-profile.service';
 
 describe('Taste Profile (ROK-948)', () => {
@@ -81,6 +83,41 @@ describe('Taste Profile (ROK-948)', () => {
       source,
       playtimeForever: playtimeForever ?? null,
     });
+  }
+
+  /**
+   * Build a zeroed dimensions record for every axis in the pool. Used
+   * when seeding player_taste_vectors directly so we don't trip a NOT
+   * NULL jsonb constraint when a test doesn't care about axis shape.
+   */
+  function zeroPoolDimensions(): Record<string, number> {
+    const axes = [
+      'co_op',
+      'pvp',
+      'battle_royale',
+      'mmo',
+      'moba',
+      'fighting',
+      'shooter',
+      'racing',
+      'sports',
+      'rpg',
+      'fantasy',
+      'sci_fi',
+      'adventure',
+      'strategy',
+      'survival',
+      'crafting',
+      'automation',
+      'sandbox',
+      'horror',
+      'social',
+      'roguelike',
+      'puzzle',
+      'platformer',
+      'stealth',
+    ];
+    return Object.fromEntries(axes.map((a) => [a, 0]));
   }
 
   // ─── AC 2: schema ───────────────────────────────────────────────
@@ -371,28 +408,90 @@ describe('Taste Profile (ROK-948)', () => {
             breadth: expect.any(Number),
             consistency: expect.any(Number),
           }),
-          archetype: expect.stringMatching(
-            /^(Dedicated|Specialist|Explorer|Social Drifter|Casual)$/,
-          ),
+          archetype: expect.objectContaining({
+            intensityTier: expect.stringMatching(
+              /^(Hardcore|Dedicated|Regular|Casual)$/,
+            ),
+            vectorTitles: expect.any(Array),
+            descriptions: expect.objectContaining({
+              tier: expect.any(String),
+              titles: expect.any(Array),
+            }),
+          }),
           coPlayPartners: expect.any(Array),
           computedAt: expect.any(String),
         }),
       );
+      // vectorTitles cap is 2 — descriptions.titles must mirror length.
+      expect(res.body.archetype.vectorTitles.length).toBeLessThanOrEqual(2);
+      expect(res.body.archetype.descriptions.titles.length).toBe(
+        res.body.archetype.vectorTitles.length,
+      );
+      expect(INTENSITY_TIERS).toContain(res.body.archetype.intensityTier);
       expect(res.body.coPlayPartners.length).toBeLessThanOrEqual(10);
     });
 
-    it('returns zeroed dimensions + Casual for a user with no vector', async () => {
+    it('returns zeroed dimensions + composed Casual archetype for a user with no vector', async () => {
       const userId = await seedUser('d:prof2', 'prof2');
       const res = await testApp.request
         .get(`/users/${userId}/taste-profile`)
         .set('Authorization', `Bearer ${adminToken}`);
       expect(res.status).toBe(200);
-      expect(res.body.archetype).toBe('Casual');
+      expect(res.body.archetype.intensityTier).toBe('Casual');
+      expect(res.body.archetype.vectorTitles).toEqual([]);
+      expect(res.body.archetype.descriptions.tier).toBe(
+        TIER_DESCRIPTIONS.Casual,
+      );
+      expect(res.body.archetype.descriptions.titles).toEqual([]);
       for (const axis of Object.values(
         res.body.dimensions as Record<string, number>,
       )) {
         expect(axis).toBe(0);
       }
+    });
+
+    it('AC 1 regression: high-intensity specialist earns the Hardcore tier, not Casual', async () => {
+      // Seed a user whose intensityMetrics lands in the Hardcore tier
+      // (intensity >= 85). This is the ROK-1083 bug anchor — the old
+      // 5-value enum dropped this shape to 'Casual' because the player's
+      // focus/breadth didn't match the 'Specialist' branch exactly.
+      const userId = await seedUser('d:hardcore-regression', 'hardcore');
+      const game = await seedGame('Hardcore Seed', [12], [1], []);
+      await seedInterest(userId, game, 'steam_library', 9000);
+
+      // Pre-seed the row with pinned intensityMetrics + archetype=null so
+      // the pipeline exercises the post-migration rebuild path. Dimensions
+      // stay zeroed so no vector-title floor is crossed — this isolates
+      // the assertion to the tier derivation.
+      const zeroDims = zeroPoolDimensions();
+      await testApp.db.insert(schema.playerTasteVectors).values({
+        userId,
+        vector: [0, 0, 0, 0, 0, 0, 0],
+        dimensions: zeroDims as never,
+        intensityMetrics: {
+          intensity: 95,
+          focus: 77,
+          breadth: 20,
+          consistency: 0,
+        } as never,
+        archetype: null,
+        // Hash intentionally stale so the pipeline reruns upsertVector for
+        // this user instead of skipping on the `existing.signalHash` check.
+        signalHash: `stale-${userId}`,
+      });
+
+      await service.aggregateVectors();
+
+      const res = await testApp.request
+        .get(`/users/${userId}/taste-profile`)
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.archetype.intensityTier).toBe('Hardcore');
+      expect(res.body.archetype.intensityTier).not.toBe('Casual');
+      expect(res.body.archetype.descriptions.tier).toBe(
+        TIER_DESCRIPTIONS.Hardcore,
+      );
     });
 
     it('returns 404 for a nonexistent user', async () => {
@@ -440,6 +539,9 @@ describe('Taste Profile (ROK-948)', () => {
       for (const s of res.body.similar) {
         expect(s.userId).not.toBe(anchor);
         expect(typeof s.similarity).toBe('number');
+        // ROK-1083: similar-player cards expose the composed archetype's
+        // intensityTier only (no vector titles on compact cards).
+        expect(INTENSITY_TIERS).toContain(s.intensityTier);
       }
       // Sorted by similarity — higher first (or distance lower first)
       for (let i = 1; i < res.body.similar.length; i++) {

--- a/packages/contract/src/taste-profile.schema.ts
+++ b/packages/contract/src/taste-profile.schema.ts
@@ -54,15 +54,76 @@ export const TASTE_PROFILE_AXIS_POOL = [
 
 export type TasteProfilePoolAxis = (typeof TASTE_PROFILE_AXIS_POOL)[number];
 
-export const TASTE_PROFILE_ARCHETYPES = [
+/**
+ * Intensity tier enum (ROK-1083). Always present on every archetype —
+ * derived from `intensityMetrics.intensity` via a threshold ladder.
+ * Ordered from most to least intense.
+ */
+export const INTENSITY_TIERS = [
+  'Hardcore',
   'Dedicated',
-  'Specialist',
-  'Explorer',
-  'Social Drifter',
+  'Regular',
   'Casual',
 ] as const;
 
-export type TasteProfileArchetype = (typeof TASTE_PROFILE_ARCHETYPES)[number];
+export type IntensityTier = (typeof INTENSITY_TIERS)[number];
+
+export const IntensityTierSchema = z.enum(INTENSITY_TIERS);
+
+/**
+ * Vector title enum (ROK-1083). 0–2 of these may be attached to an
+ * archetype based on the player's strongest axis scores. Single-axis
+ * titles take the raw axis score; multi-axis titles take the max of
+ * their component axes (e.g. `Hero = max(rpg, fantasy)`,
+ * `Architect = max(crafting, automation, sandbox)`).
+ */
+export const VECTOR_TITLES = [
+  'Duelist',
+  'Brawler',
+  'Last One Standing',
+  'Tactician',
+  'Marksman',
+  'Companion',
+  'Raider',
+  'Socialite',
+  'Hero',
+  'Spacefarer',
+  'Wayfarer',
+  'Architect',
+  'Strategist',
+  'Survivor',
+  'Nightcrawler',
+  'Risk Taker',
+  'Operative',
+  'Puzzler',
+  'Acrobat',
+  'Racer',
+  'Athlete',
+] as const;
+
+export type VectorTitle = (typeof VECTOR_TITLES)[number];
+
+export const VectorTitleSchema = z.enum(VECTOR_TITLES);
+
+/**
+ * Composed archetype shape (ROK-1083) — replaces the old 5-value enum.
+ * `intensityTier` is always present; `vectorTitles` may be 0–2 entries;
+ * `descriptions.titles` has the same length/order as `vectorTitles`.
+ *
+ * Description text is owned by the server (see `api/src/taste-profile/
+ * archetype-copy.ts`) and shipped to the UI in the response payload so
+ * copy changes don't force a contract rebuild cascade.
+ */
+export const ArchetypeSchema = z.object({
+  intensityTier: IntensityTierSchema,
+  vectorTitles: z.array(VectorTitleSchema).max(2),
+  descriptions: z.object({
+    tier: z.string(),
+    titles: z.array(z.string()).max(2),
+  }),
+});
+
+export type ArchetypeDto = z.infer<typeof ArchetypeSchema>;
 
 /**
  * Dimensions object — strict shape keyed by the full axis pool.
@@ -97,7 +158,7 @@ export const TasteProfileResponseSchema = z.object({
   userId: z.number().int(),
   dimensions: TasteProfileDimensionsSchema,
   intensityMetrics: IntensityMetricsSchema,
-  archetype: z.enum(TASTE_PROFILE_ARCHETYPES),
+  archetype: ArchetypeSchema,
   coPlayPartners: z.array(CoPlayPartnerSchema).max(10),
   computedAt: z.string(),
 });
@@ -106,7 +167,7 @@ export const SimilarPlayerSchema = z.object({
   userId: z.number().int(),
   username: z.string(),
   avatar: z.string().nullable(),
-  archetype: z.enum(TASTE_PROFILE_ARCHETYPES),
+  intensityTier: IntensityTierSchema,
   similarity: z.number(),
 });
 
@@ -159,13 +220,15 @@ export type CoPlayPartnerContextDto = z.infer<
 
 /**
  * Per-user taste context bundle — shape consumed by LLM prompt builders.
- * Archetype + intensity metrics + top axes (≤5) + low axes (≤3) + co-play
- * partners (each with their own top axes).
+ * Archetype (composed — tier + vector titles + descriptions) + intensity
+ * metrics + top axes (≤5) + low axes (≤3) + co-play partners (each with
+ * their own top axes). The LLM receives both the intensity tier and the
+ * vector titles so the prompt retains the full signal.
  */
 export const TasteProfileContextSchema = z.object({
     userId: z.number().int(),
     username: z.string(),
-    archetype: z.enum(TASTE_PROFILE_ARCHETYPES),
+    archetype: ArchetypeSchema,
     intensityMetrics: IntensityMetricsSchema,
     topAxes: z.array(TopAxisSchema).max(5),
     lowAxes: z.array(TopAxisSchema).max(3),

--- a/scripts/smoke/user-profile-taste.smoke.spec.ts
+++ b/scripts/smoke/user-profile-taste.smoke.spec.ts
@@ -15,13 +15,7 @@
  */
 import { test, expect } from './base';
 
-const ARCHETYPE_NAMES = [
-    'Dedicated',
-    'Specialist',
-    'Explorer',
-    'Social Drifter',
-    'Casual',
-];
+const INTENSITY_TIER_NAMES = ['Hardcore', 'Dedicated', 'Regular', 'Casual'];
 
 /**
  * Navigate to the Players page and follow a user link to reach another
@@ -120,10 +114,10 @@ test.describe('User profile taste section', () => {
             'Not enough data yet — play more games!',
             { exact: false },
         );
-        const archetypeRegex = new RegExp(
-            `\\b(${ARCHETYPE_NAMES.join('|')})\\b`,
+        const tierRegex = new RegExp(
+            `\\b(${INTENSITY_TIER_NAMES.join('|')})\\b`,
         );
-        const archetypeText = page.getByText(archetypeRegex).first();
+        const archetypeText = page.getByText(tierRegex).first();
         await expect(emptyState.or(archetypeText)).toBeVisible({
             timeout: 15_000,
         });
@@ -139,9 +133,9 @@ test.describe('User profile taste section', () => {
             return;
         }
 
-        // Non-empty: exactly one of the 5 archetype names must be on the
-        // page.  We look for the regex union so the test is robust to the
-        // pill's exact DOM structure (span / badge / pill component).
+        // Non-empty: exactly one of the 4 intensity tiers must appear in the
+        // stacked label (e.g. "Hardcore Raider"). Regex union keeps the
+        // test robust to the pill's exact DOM structure (span/badge/pill).
         await expect(archetypeText).toBeVisible({ timeout: 10_000 });
     });
 

--- a/web/src/components/taste-profile/ArchetypePill.tsx
+++ b/web/src/components/taste-profile/ArchetypePill.tsx
@@ -1,39 +1,41 @@
 import type { JSX } from "react";
-import type { TasteProfileArchetype } from "@raid-ledger/contract";
+import type { ArchetypeDto } from "@raid-ledger/contract";
+import { composeArchetypeLabel } from "./taste-profile-helpers";
 
 type Size = "sm" | "lg";
 
 interface ArchetypePillProps {
-    archetype: TasteProfileArchetype;
+    archetype: ArchetypeDto;
     /** Pill (`sm`) for header use, hero title (`lg`) for radar overlay. */
     size?: Size;
     className?: string;
 }
 
-function toVariant(archetype: TasteProfileArchetype): string {
-    // Normalise to a kebab-case CSS token: "Social Drifter" -> "social-drifter".
-    return archetype.toLowerCase().replace(/\s+/g, "-");
-}
-
 /**
  * Archetype badge shown next to usernames AND above the radar chart.
- * Colour variants are driven by CSS (`taste-profile-section.css`) so the
- * component stays pure and testable.
+ *
+ * ROK-1083: the pill renders the composed stacked label
+ * (`"Hardcore Raider"`, `"Hardcore Hero & Raider"`, or `"Hardcore Player"`
+ * when no titles apply). Colour variants are driven by CSS keyed off the
+ * intensity tier (`taste-profile-section.css`) so the component stays
+ * pure and testable.
  */
 export function ArchetypePill({
     archetype,
     size = "sm",
     className = "",
 }: ArchetypePillProps): JSX.Element {
-    const variant = toVariant(archetype);
+    const tierClass = `archetype-pill--tier-${archetype.intensityTier.toLowerCase()}`;
     const sizeClass =
         size === "lg" ? "archetype-pill--lg" : "archetype-pill--sm";
+    const label = composeArchetypeLabel(archetype);
     return (
         <span
-            className={`archetype-pill archetype-pill--${variant} ${sizeClass} ${className}`.trim()}
-            data-archetype={archetype}
+            className={`archetype-pill ${tierClass} ${sizeClass} ${className}`.trim()}
+            data-tier={archetype.intensityTier}
+            data-vector-titles={archetype.vectorTitles.join(",")}
         >
-            {archetype}
+            {label}
         </span>
     );
 }

--- a/web/src/components/taste-profile/TasteRadarChart.tsx
+++ b/web/src/components/taste-profile/TasteRadarChart.tsx
@@ -8,17 +8,22 @@ import {
     ResponsiveContainer,
 } from "recharts";
 import type {
+    ArchetypeDto,
     IntensityMetricsDto,
-    TasteProfileArchetype,
     TasteProfileDimensionsDto,
 } from "@raid-ledger/contract";
 import { ArchetypePill } from "./ArchetypePill";
-import { axisLabel, topAxes, type AxisScore } from "./taste-profile-helpers";
+import {
+    axisLabel,
+    composeArchetypeLabel,
+    topAxes,
+    type AxisScore,
+} from "./taste-profile-helpers";
 
 interface TasteRadarChartProps {
-    /** Optional archetype hero title. When omitted the title row is skipped
+    /** Optional composed archetype. When omitted the title row is skipped
      *  — used by callers (e.g. game taste profile) that have no archetype. */
-    archetype?: TasteProfileArchetype;
+    archetype?: ArchetypeDto;
     dimensions: TasteProfileDimensionsDto;
     intensityMetrics?: IntensityMetricsDto;
     /** Override the root element's `data-testid`. Defaults to `taste-radar-chart`. */
@@ -26,13 +31,14 @@ interface TasteRadarChartProps {
 }
 
 /**
- * Screen-reader summary of the radar (AC7). Includes the archetype (when
- * present), every rendered axis with its score, and — when available —
- * the top-level intensity/focus/breadth numbers so non-sighted users get
- * the same at-a-glance picture the chart provides visually.
+ * Screen-reader summary of the radar (AC7). Includes the composed
+ * archetype label (when present), every rendered axis with its score,
+ * and — when available — the top-level intensity/focus/breadth numbers
+ * so non-sighted users get the same at-a-glance picture the chart
+ * provides visually.
  */
 function buildAriaLabel(
-    archetype: TasteProfileArchetype | undefined,
+    archetype: ArchetypeDto | undefined,
     scores: AxisScore[],
     metrics?: IntensityMetricsDto,
 ): string {
@@ -40,7 +46,7 @@ function buildAriaLabel(
         .map((s) => `${axisLabel(s.axis)} ${s.value}`)
         .join(", ");
     const header = archetype
-        ? `Taste profile for ${archetype}`
+        ? `Taste profile for ${composeArchetypeLabel(archetype)}`
         : "Taste profile";
     if (!metrics) return `${header}: ${axes}.`;
     return (

--- a/web/src/components/taste-profile/taste-profile-helpers.test.ts
+++ b/web/src/components/taste-profile/taste-profile-helpers.test.ts
@@ -2,12 +2,14 @@ import { describe, it, expect } from "vitest";
 import {
     isEmptyTasteProfile,
     axisLabel,
+    composeArchetypeLabel,
     formatFocusIndicator,
     formatIntensity,
     topAxes,
 } from "./taste-profile-helpers";
 import {
     TASTE_PROFILE_AXIS_POOL,
+    type ArchetypeDto,
     type TasteProfileResponseDto,
 } from "@raid-ledger/contract";
 
@@ -15,6 +17,15 @@ function zeroPool(): TasteProfileResponseDto["dimensions"] {
     const dims: Record<string, number> = {};
     for (const axis of TASTE_PROFILE_AXIS_POOL) dims[axis] = 0;
     return dims as TasteProfileResponseDto["dimensions"];
+}
+
+function makeArchetype(overrides?: Partial<ArchetypeDto>): ArchetypeDto {
+    return {
+        intensityTier: "Casual",
+        vectorTitles: [],
+        descriptions: { tier: "Drops in once or twice a week", titles: [] },
+        ...overrides,
+    };
 }
 
 function makeProfile(
@@ -30,7 +41,7 @@ function makeProfile(
             breadth: 0,
             consistency: 0,
         },
-        archetype: "Casual",
+        archetype: makeArchetype(),
         coPlayPartners: [],
         computedAt: "2026-04-16T00:00:00.000Z",
     };
@@ -134,5 +145,58 @@ describe("formatIntensity", () => {
     it("formats intensity as an /100 score", () => {
         expect(formatIntensity(0)).toBe("Intensity: 0/100");
         expect(formatIntensity(82)).toBe("Intensity: 82/100");
+    });
+});
+
+describe("composeArchetypeLabel", () => {
+    it("returns '{Tier} Player' when there are no vector titles", () => {
+        const archetype = makeArchetype({
+            intensityTier: "Hardcore",
+            vectorTitles: [],
+        });
+        expect(composeArchetypeLabel(archetype)).toBe("Hardcore Player");
+    });
+
+    it("returns '{Tier} {Title}' for one vector title", () => {
+        const archetype = makeArchetype({
+            intensityTier: "Hardcore",
+            vectorTitles: ["Raider"],
+            descriptions: {
+                tier: "Plays nearly daily, many hours per week",
+                titles: ["MMO group content is home base"],
+            },
+        });
+        expect(composeArchetypeLabel(archetype)).toBe("Hardcore Raider");
+    });
+
+    it("returns '{Tier} {Title1} & {Title2}' for two vector titles", () => {
+        const archetype = makeArchetype({
+            intensityTier: "Hardcore",
+            vectorTitles: ["Hero", "Raider"],
+            descriptions: {
+                tier: "Plays nearly daily, many hours per week",
+                titles: [
+                    "Drawn to story-driven RPGs and fantasy worlds",
+                    "MMO group content is home base",
+                ],
+            },
+        });
+        expect(composeArchetypeLabel(archetype)).toBe(
+            "Hardcore Hero & Raider",
+        );
+    });
+
+    it("composes labels for non-hardcore tiers", () => {
+        const dedicated = makeArchetype({
+            intensityTier: "Dedicated",
+            vectorTitles: ["Duelist"],
+        });
+        expect(composeArchetypeLabel(dedicated)).toBe("Dedicated Duelist");
+
+        const casual = makeArchetype({
+            intensityTier: "Casual",
+            vectorTitles: [],
+        });
+        expect(composeArchetypeLabel(casual)).toBe("Casual Player");
     });
 });

--- a/web/src/components/taste-profile/taste-profile-helpers.ts
+++ b/web/src/components/taste-profile/taste-profile-helpers.ts
@@ -1,11 +1,12 @@
 /**
- * Pure helpers for the taste-profile UI (ROK-949).
+ * Pure helpers for the taste-profile UI (ROK-949, ROK-1083).
  *
  * All functions are side-effect free so they can be unit-tested without
  * any rendering or network calls.
  */
 import {
     TASTE_PROFILE_AXIS_POOL,
+    type ArchetypeDto,
     type TasteProfilePoolAxis,
     type TasteProfileResponseDto,
 } from "@raid-ledger/contract";
@@ -124,4 +125,23 @@ export function formatFocusIndicator(
  */
 export function formatIntensity(intensity: number): string {
     return `Intensity: ${intensity}/100`;
+}
+
+/**
+ * Composes the stacked archetype label (ROK-1083).
+ *
+ *  - 0 titles  → `"{Tier} Player"` (e.g. "Hardcore Player")
+ *  - 1 title   → `"{Tier} {Title}"` (e.g. "Hardcore Raider")
+ *  - 2 titles  → `"{Tier} {Title1} & {Title2}"` (e.g. "Hardcore Hero & Raider")
+ *
+ * Reused by the archetype pill and by the radar chart's `aria-label` so
+ * the spoken and visual summary stay in sync.
+ */
+export function composeArchetypeLabel(archetype: ArchetypeDto): string {
+    const { intensityTier, vectorTitles } = archetype;
+    if (vectorTitles.length === 0) return `${intensityTier} Player`;
+    if (vectorTitles.length === 1) {
+        return `${intensityTier} ${vectorTitles[0]}`;
+    }
+    return `${intensityTier} ${vectorTitles[0]} & ${vectorTitles[1]}`;
 }

--- a/web/src/components/taste-profile/taste-profile-section.css
+++ b/web/src/components/taste-profile/taste-profile-section.css
@@ -79,31 +79,27 @@
     padding: 0.25rem 0.875rem;
 }
 
-.archetype-pill--dedicated {
+/* Pill colour variants keyed off intensity tier (ROK-1083). */
+
+.archetype-pill--tier-hardcore {
+    color: #ef4444;
+    background: rgba(239, 68, 68, 0.12);
+    border-color: rgba(239, 68, 68, 0.35);
+}
+
+.archetype-pill--tier-dedicated {
     color: #f472b6;
     background: rgba(244, 114, 182, 0.12);
     border-color: rgba(244, 114, 182, 0.35);
 }
 
-.archetype-pill--specialist {
-    color: #a78bfa;
-    background: rgba(167, 139, 250, 0.12);
-    border-color: rgba(167, 139, 250, 0.35);
-}
-
-.archetype-pill--explorer {
+.archetype-pill--tier-regular {
     color: #34d399;
     background: rgba(52, 211, 153, 0.12);
     border-color: rgba(52, 211, 153, 0.35);
 }
 
-.archetype-pill--social-drifter {
-    color: #60a5fa;
-    background: rgba(96, 165, 250, 0.12);
-    border-color: rgba(96, 165, 250, 0.35);
-}
-
-.archetype-pill--casual {
+.archetype-pill--tier-casual {
     color: #a1a1aa;
     background: rgba(161, 161, 170, 0.12);
     border-color: rgba(161, 161, 170, 0.3);

--- a/web/src/pages/user-profile-page.tsx
+++ b/web/src/pages/user-profile-page.tsx
@@ -18,7 +18,7 @@ import { UserEventSignups } from "../components/profile/UserEventSignups";
 import type {
   UserProfileDto,
   ItadGamePricingDto,
-  TasteProfileArchetype,
+  ArchetypeDto,
 } from "@raid-ledger/contract";
 import {
   HeartedGameCard,
@@ -152,7 +152,7 @@ function ProfileSections({
  */
 function useHeaderArchetype(
   tasteProfile: ReturnType<typeof useTasteProfile>,
-): TasteProfileArchetype | null {
+): ArchetypeDto | null {
   if (!tasteProfile.data) return null;
   if (isEmptyTasteProfile(tasteProfile.data)) return null;
   return tasteProfile.data.archetype;
@@ -237,7 +237,7 @@ function ProfileHeader({
   profile: { username: string };
   profileAvatar: { url: string | null };
   memberSince: string;
-  archetype: TasteProfileArchetype | null;
+  archetype: ArchetypeDto | null;
 }): JSX.Element {
   return (
     <div className="user-profile-header">

--- a/web/src/pages/user-profile/taste-profile/IntensityBadge.tsx
+++ b/web/src/pages/user-profile/taste-profile/IntensityBadge.tsx
@@ -1,28 +1,32 @@
 import type { JSX } from "react";
 import type {
+    ArchetypeDto,
     IntensityMetricsDto,
-    TasteProfileArchetype,
 } from "@raid-ledger/contract";
 import {
+    composeArchetypeLabel,
     formatFocusIndicator,
     formatIntensity,
 } from "../../../components/taste-profile/taste-profile-helpers";
 
 interface IntensityBadgeProps {
-    archetype: TasteProfileArchetype;
+    archetype: ArchetypeDto;
     metrics: IntensityMetricsDto;
 }
 
 /**
- * Two-row summary:
- *   Row 1: `{intensity}/100 · {archetype}`
- *   Row 2: focus / varied indicator (hidden when neither threshold hit)
+ * Multi-row summary (ROK-1083):
+ *   Row 1: `{intensity}/100 · {Tier} {Title1} [& {Title2}]`
+ *   Row 2: tier description (e.g. "Plays nearly daily, many hours per week")
+ *   Row 3+: one line per vector-title description
+ *   Row N: focus / varied indicator (hidden when neither threshold hit)
  */
 export function IntensityBadge({
     archetype,
     metrics,
 }: IntensityBadgeProps): JSX.Element {
     const intensityText = formatIntensity(metrics.intensity);
+    const label = composeArchetypeLabel(archetype);
     const focusLine = formatFocusIndicator(metrics.focus, metrics.breadth);
     return (
         <div className="intensity-badge" data-testid="intensity-badge">
@@ -33,11 +37,39 @@ export function IntensityBadge({
                 <span className="intensity-badge__sep" aria-hidden="true">
                     {" · "}
                 </span>
-                <span className="intensity-badge__archetype">{archetype}</span>
+                <span className="intensity-badge__archetype">{label}</span>
             </p>
+            <ArchetypeDescriptions archetype={archetype} />
             {focusLine && (
                 <p className="intensity-badge__focus">{focusLine}</p>
             )}
         </div>
+    );
+}
+
+/**
+ * Description lines: tier blurb first, then one line per vector-title
+ * blurb (same order as `vectorTitles`). Renders nothing when all copy
+ * strings are empty.
+ */
+function ArchetypeDescriptions({
+    archetype,
+}: {
+    archetype: ArchetypeDto;
+}): JSX.Element | null {
+    const { tier, titles } = archetype.descriptions;
+    const lines = [tier, ...titles].filter((line) => line.trim().length > 0);
+    if (lines.length === 0) return null;
+    return (
+        <>
+            {lines.map((line, idx) => (
+                <p
+                    key={`${idx}-${line}`}
+                    className="intensity-badge__description"
+                >
+                    {line}
+                </p>
+            ))}
+        </>
     );
 }

--- a/web/src/pages/user-profile/taste-profile/TasteProfileSection.test.tsx
+++ b/web/src/pages/user-profile/taste-profile/TasteProfileSection.test.tsx
@@ -166,6 +166,9 @@ describe("<TasteProfileSection> (content)", () => {
         ).toBeInTheDocument();
     });
 
+});
+
+describe("<TasteProfileSection> (labels)", () => {
     it("renders the two-title stacked label (Hardcore Hero & Raider)", () => {
         const profile = makeProfile({
             archetype: makeArchetype({
@@ -208,7 +211,9 @@ describe("<TasteProfileSection> (content)", () => {
             screen.getAllByText(/Hardcore Player/i).length,
         ).toBeGreaterThan(0);
     });
+});
 
+describe("<TasteProfileSection> (interactions)", () => {
     it("opens the partners modal when 'Show all' is clicked", async () => {
         const partners = Array.from({ length: 5 }, (_, i) => ({
             userId: 100 + i,

--- a/web/src/pages/user-profile/taste-profile/TasteProfileSection.test.tsx
+++ b/web/src/pages/user-profile/taste-profile/TasteProfileSection.test.tsx
@@ -2,7 +2,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { UseQueryResult } from "@tanstack/react-query";
-import type { TasteProfileResponseDto } from "@raid-ledger/contract";
+import type {
+    ArchetypeDto,
+    TasteProfileResponseDto,
+} from "@raid-ledger/contract";
 import { renderWithProviders } from "../../../test/render-helpers";
 import { TasteProfileSection } from "./TasteProfileSection";
 
@@ -29,19 +32,29 @@ function makeResult(
     } as unknown as UseQueryResult<TasteProfileResponseDto, Error>;
 }
 
+function makeArchetype(overrides?: Partial<ArchetypeDto>): ArchetypeDto {
+    return {
+        intensityTier: "Dedicated",
+        vectorTitles: ["Raider"],
+        descriptions: {
+            tier: "Shows up several times a week",
+            titles: ["MMO group content is home base"],
+        },
+        ...overrides,
+    };
+}
+
 function makeProfile(
     overrides?: Partial<TasteProfileResponseDto>,
 ): TasteProfileResponseDto {
     return {
         userId: 42,
         dimensions: {
-            co_op: 60,
-            pvp: 10,
-            rpg: 35,
-            survival: 20,
-            strategy: 45,
-            social: 50,
-            mmo: 5,
+            co_op: 60, pvp: 10, battle_royale: 0, mmo: 70, moba: 0,
+            fighting: 0, shooter: 0, racing: 0, sports: 0, rpg: 35,
+            fantasy: 0, sci_fi: 0, adventure: 0, strategy: 45, survival: 20,
+            crafting: 0, automation: 0, sandbox: 0, horror: 0, social: 50,
+            roguelike: 0, puzzle: 0, platformer: 0, stealth: 0,
         },
         intensityMetrics: {
             intensity: 72,
@@ -49,10 +62,20 @@ function makeProfile(
             breadth: 20,
             consistency: 55,
         },
-        archetype: "Specialist",
+        archetype: makeArchetype(),
         coPlayPartners: [],
         computedAt: "2026-04-16T00:00:00.000Z",
         ...overrides,
+    };
+}
+
+function emptyDimensions(): TasteProfileResponseDto["dimensions"] {
+    return {
+        co_op: 0, pvp: 0, battle_royale: 0, mmo: 0, moba: 0,
+        fighting: 0, shooter: 0, racing: 0, sports: 0, rpg: 0,
+        fantasy: 0, sci_fi: 0, adventure: 0, strategy: 0, survival: 0,
+        crafting: 0, automation: 0, sandbox: 0, horror: 0, social: 0,
+        roguelike: 0, puzzle: 0, platformer: 0, stealth: 0,
     };
 }
 
@@ -72,17 +95,7 @@ describe("<TasteProfileSection> (states)", () => {
     });
 
     it("renders the empty-state message when all dimensions are zero", () => {
-        const profile = makeProfile({
-            dimensions: {
-                co_op: 0,
-                pvp: 0,
-                rpg: 0,
-                survival: 0,
-                strategy: 0,
-                social: 0,
-                mmo: 0,
-            },
-        });
+        const profile = makeProfile({ dimensions: emptyDimensions() });
         mockUseTasteProfile.mockReturnValue(
             makeResult({ data: profile, isLoading: false }),
         );
@@ -126,7 +139,7 @@ describe("<TasteProfileSection> (states)", () => {
 });
 
 describe("<TasteProfileSection> (content)", () => {
-    it("renders intensity badge + archetype + focus line for populated profiles", () => {
+    it("renders intensity badge + composed label + descriptions for populated profiles", () => {
         const profile = makeProfile();
         mockUseTasteProfile.mockReturnValue(
             makeResult({ data: profile, isLoading: false }),
@@ -139,8 +152,61 @@ describe("<TasteProfileSection> (content)", () => {
         expect(
             screen.getByText(/Focused play \(75%\)/),
         ).toBeInTheDocument();
-        // Archetype appears somewhere on the page (pill overlay + badge).
-        expect(screen.getAllByText("Specialist").length).toBeGreaterThan(0);
+        // Composed label ("Dedicated Raider") appears somewhere on the
+        // page — the pill overlay and the intensity badge both render it.
+        expect(
+            screen.getAllByText(/Dedicated Raider/i).length,
+        ).toBeGreaterThan(0);
+        // Descriptions (tier + title) surface alongside the label.
+        expect(
+            screen.getByText(/Shows up several times a week/i),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(/MMO group content is home base/i),
+        ).toBeInTheDocument();
+    });
+
+    it("renders the two-title stacked label (Hardcore Hero & Raider)", () => {
+        const profile = makeProfile({
+            archetype: makeArchetype({
+                intensityTier: "Hardcore",
+                vectorTitles: ["Hero", "Raider"],
+                descriptions: {
+                    tier: "Plays nearly daily, many hours per week",
+                    titles: [
+                        "Drawn to story-driven RPGs and fantasy worlds",
+                        "MMO group content is home base",
+                    ],
+                },
+            }),
+        });
+        mockUseTasteProfile.mockReturnValue(
+            makeResult({ data: profile, isLoading: false }),
+        );
+        renderWithProviders(<TasteProfileSection userId={1} />);
+        expect(
+            screen.getAllByText(/Hardcore Hero & Raider/i).length,
+        ).toBeGreaterThan(0);
+    });
+
+    it("renders '{Tier} Player' when the profile has no vector titles", () => {
+        const profile = makeProfile({
+            archetype: makeArchetype({
+                intensityTier: "Hardcore",
+                vectorTitles: [],
+                descriptions: {
+                    tier: "Plays nearly daily, many hours per week",
+                    titles: [],
+                },
+            }),
+        });
+        mockUseTasteProfile.mockReturnValue(
+            makeResult({ data: profile, isLoading: false }),
+        );
+        renderWithProviders(<TasteProfileSection userId={1} />);
+        expect(
+            screen.getAllByText(/Hardcore Player/i).length,
+        ).toBeGreaterThan(0);
     });
 
     it("opens the partners modal when 'Show all' is clicked", async () => {

--- a/web/src/test/mocks/handlers.ts
+++ b/web/src/test/mocks/handlers.ts
@@ -138,7 +138,14 @@ export const handlers = [
             intensityMetrics: {
                 intensity: 0, focus: 0, breadth: 0, consistency: 0,
             },
-            archetype: 'Casual',
+            archetype: {
+                intensityTier: 'Casual',
+                vectorTitles: [],
+                descriptions: {
+                    tier: 'Drops in once or twice a week',
+                    titles: [],
+                },
+            },
             coPlayPartners: [],
             computedAt: '2026-04-17T00:00:00.000Z',
         });


### PR DESCRIPTION
## Summary

- **Fix** the archetype rule-ladder bug: high-intensity players no longer fall through to `Casual`. Replaces the 5-value enum with a composed shape `{ intensityTier, vectorTitles[0-2], descriptions }` across contract + api + web.
- **New tier logic:** `intensity >= 85 → Hardcore`, `60-84 → Dedicated`, `35-59 → Regular`, `< 35 → Casual`. Casual becomes a strict bucket, not a fallback.
- **21 vector titles** (Duelist, Raider, Hero, Architect, etc.) scored from top 2 dominant axes with max-combo scoring (`Hero = max(rpg, fantasy)`), floor (30) / close-window (10) / cap (2) / tie-break by `TASTE_PROFILE_AXIS_POOL` order.
- **Migration 0127** drops NOT NULL and moves `player_taste_vectors.archetype` from `text → jsonb`. Nullable transition; cron rebuilds on next run; `getTasteProfile` fallback handles null rows.
- **Demo-mode signal seed** (new): `generateSignalProfiles` + `generateGameActivityRollups` + `generatePlayhistoryInterests` produce tier-weighted play history so the aggregator derives varied tiers + vector titles across the demo population. Scoped to `DEMO_USERNAMES` — real operator accounts structurally unreachable. Install sequence: `aggregate-vectors → weekly-intensity → archetype-refresh`.
- **Admin test endpoints** (new, DEMO_MODE-gated): `/admin/test/rebuild-taste-profiles` and `/admin/test/reseed-taste-profiles` — for DB-restore recovery and demo environments predating the seed code. Both call `assertDemoMode()` (env AND DB) before any DB op.

## Linear

[ROK-1083](https://linear.app/roknua-projects/issue/ROK-1083)

Follow-up filed: **ROK-1104** — tech-debt: integration test suite flakes under `runInBand` (unrelated; surfaced during full CI).

## Test plan

- [x] 22 new unit tests in `archetype.helpers.spec.ts` (tier boundaries, floor, close-window, cap, tie-break, max-combo, descriptions)
- [x] 10 new unit tests in `demo-data-gen-taste-profile.spec.ts` (tier distribution, weekly hours, game-count per-tier, determinism)
- [x] 6 new controller tests in `demo-test-core.controller.spec.ts` (pipeline order, DEMO_USERNAMES scoping, DEMO_MODE gate for both new endpoints)
- [x] API integration tests updated for composed shape + null-fallback + similar-players `intensityTier` projection
- [x] LLM context builder spec updated for composed shape
- [x] Web: `ArchetypePill` / `IntensityBadge` / `TasteRadarChart` / helpers tests updated; MSW handler emits composed shape
- [x] Smoke: `user-profile-taste.smoke.spec.ts` matches 4 intensity tier names instead of 5 old archetypes
- [x] Operator browser-verified all 4 tiers rendering (Hardcore, Dedicated, Regular, Casual) across multiple demo users
- [x] Local full CI passed (5519/5519 api unit, 2903/2903 web vitest, typecheck + lint + build clean)
- [x] Code review passed (3 parallel slices: security+correctness, tests+contract, perf+style; all findings addressed)
- [x] Architect POST_REVIEW APPROVED

Piggyback: `.claude/skills/build/` updates (no-push-before-review rule) + new `.claude/skills/readlogs/` skill. Per operator convention, skill changes ship with the next outgoing PR.