### PR TITLE
chore: batch 2026-04-22 (ROK-1086, ROK-1088, ROK-1107)

### DIFF
--- a/api/src/ai/ai.module.ts
+++ b/api/src/ai/ai.module.ts
@@ -3,6 +3,7 @@ import { SettingsModule } from '../settings/settings.module';
 import { DrizzleModule } from '../drizzle/drizzle.module';
 import { PluginRegistryService } from '../plugins/plugin-host/plugin-registry.service';
 import { TasteProfileModule } from '../taste-profile/taste-profile.module';
+import { UsersModule } from '../users/users.module';
 import { AiAdminController } from './ai-admin.controller';
 import { AiProvidersController } from './ai-providers.controller';
 import { LlmProviderRegistry } from './llm-provider-registry';
@@ -24,7 +25,7 @@ import { TasteProfileContextBuilder } from './context-builders/taste-profile-con
  * the LLM provider infrastructure for all 4 providers.
  */
 @Module({
-  imports: [SettingsModule, DrizzleModule, TasteProfileModule],
+  imports: [SettingsModule, DrizzleModule, TasteProfileModule, UsersModule],
   controllers: [AiAdminController, AiProvidersController],
   providers: [
     LlmProviderRegistry,

--- a/api/src/ai/context-builders/taste-profile-context.builder.spec.ts
+++ b/api/src/ai/context-builders/taste-profile-context.builder.spec.ts
@@ -17,6 +17,7 @@ import type {
 } from '../../taste-profile/queries/taste-profile-queries';
 import { TIER_DESCRIPTIONS } from '../../taste-profile/archetype-copy';
 import { TasteProfileService } from '../../taste-profile/taste-profile.service';
+import { UsersService } from '../../users/users.service';
 import { TasteProfileContextBuilder } from './taste-profile-context.builder';
 
 // ─── Helpers ─────────────────────────────────────────────────────
@@ -112,10 +113,21 @@ describe('TasteProfileContextBuilder', () => {
   let mockTasteProfileService: {
     getTasteProfile: jest.Mock<Promise<TasteProfileResult | null>, [number]>;
   };
+  let mockUsersService: {
+    findByIds: jest.Mock<
+      Promise<Array<{ id: number; username: string }>>,
+      [number[]]
+    >;
+  };
 
   beforeEach(async () => {
     mockTasteProfileService = {
       getTasteProfile: jest.fn(),
+    };
+    mockUsersService = {
+      findByIds: jest.fn((ids: number[]) =>
+        Promise.resolve(ids.map((id) => ({ id, username: `user${id}` }))),
+      ),
     };
 
     const module = await Test.createTestingModule({
@@ -124,6 +136,10 @@ describe('TasteProfileContextBuilder', () => {
         {
           provide: TasteProfileService,
           useValue: mockTasteProfileService,
+        },
+        {
+          provide: UsersService,
+          useValue: mockUsersService,
         },
       ],
     }).compile();
@@ -267,6 +283,50 @@ describe('TasteProfileContextBuilder', () => {
       expect(result.contexts[0].userId).toBe(1);
       expect(result.missingUserIds).toEqual(expect.arrayContaining([2, 3]));
       expect(result.missingUserIds).toHaveLength(2);
+    });
+  });
+
+  // ─── Username resolution (ROK-1088) ─────────────────────
+
+  describe('username resolution (ROK-1088)', () => {
+    it('resolves real usernames from UsersService and includes them in the context', async () => {
+      mockTasteProfileService.getTasteProfile.mockResolvedValueOnce(
+        buildProfile({ userId: 1, dimensions: { rpg: 80 } }),
+      );
+      mockUsersService.findByIds.mockResolvedValueOnce([
+        { id: 1, username: 'Aragorn' },
+      ]);
+
+      const result = await builder.build([1]);
+
+      expect(result.contexts[0].username).toBe('Aragorn');
+    });
+
+    it('falls back to "Unknown player" when a user is hard-deleted (not returned by findByIds)', async () => {
+      mockTasteProfileService.getTasteProfile.mockResolvedValueOnce(
+        buildProfile({ userId: 42, dimensions: { rpg: 80 } }),
+      );
+      mockUsersService.findByIds.mockResolvedValueOnce([]);
+
+      const result = await builder.build([42]);
+
+      expect(result.contexts[0].username).toBe('Unknown player');
+    });
+
+    it('calls UsersService.findByIds once with the resolved (non-missing) userIds', async () => {
+      mockTasteProfileService.getTasteProfile.mockImplementation(
+        (id: number) => {
+          if (id === 2) return Promise.resolve(null);
+          return Promise.resolve(
+            buildProfile({ userId: id, dimensions: { rpg: 80 } }),
+          );
+        },
+      );
+
+      await builder.build([1, 2, 3]);
+
+      expect(mockUsersService.findByIds).toHaveBeenCalledTimes(1);
+      expect(mockUsersService.findByIds).toHaveBeenCalledWith([1, 3]);
     });
   });
 

--- a/api/src/ai/context-builders/taste-profile-context.builder.ts
+++ b/api/src/ai/context-builders/taste-profile-context.builder.ts
@@ -20,6 +20,7 @@ import type {
   TasteProfileResult,
 } from '../../taste-profile/queries/taste-profile-queries';
 import { TasteProfileService } from '../../taste-profile/taste-profile.service';
+import { UsersService } from '../../users/users.service';
 
 const MAX_TOP_AXES = 5;
 const MAX_LOW_AXES = 3;
@@ -28,7 +29,10 @@ const MAX_PARTNER_AXES = 3;
 
 @Injectable()
 export class TasteProfileContextBuilder {
-  constructor(private readonly tasteProfile: TasteProfileService) {}
+  constructor(
+    private readonly tasteProfile: TasteProfileService,
+    private readonly users: UsersService,
+  ) {}
 
   /**
    * Build taste context bundles for the given user IDs. Users without a
@@ -49,15 +53,20 @@ export class TasteProfileContextBuilder {
       (p): p is TasteProfileResult => p !== null,
     );
 
-    const partnerLists = await Promise.all(
-      resolved.map((profile) =>
-        this.buildPartnerContexts(profile.coPlayPartners),
+    const resolvedIds = resolved.map((p) => p.userId);
+    const [partnerLists, users] = await Promise.all([
+      Promise.all(
+        resolved.map((profile) =>
+          this.buildPartnerContexts(profile.coPlayPartners),
+        ),
       ),
-    );
+      this.users.findByIds(resolvedIds),
+    ]);
+    const usernameById = new Map(users.map((u) => [u.id, u.username]));
 
     const contexts: TasteProfileContextDto[] = resolved.map((profile, i) => ({
       userId: profile.userId,
-      username: lookupUsernameFromPartners(profile),
+      username: resolveUsername(profile.userId, usernameById),
       archetype: profile.archetype,
       intensityMetrics: profile.intensityMetrics,
       topAxes: pickTopAxes(profile.dimensions, MAX_TOP_AXES),
@@ -126,11 +135,13 @@ function toAxisEntries(
 }
 
 /**
- * Username is not present on the raw TasteProfileResult today — callers
- * provide it via a parallel lookup. Until a username field is added we
- * fall back to a synthetic identifier; the LLM context just needs a
- * stable handle.
+ * Resolve a real username from the batch lookup; fall back to
+ * "Unknown player" when the user was hard-deleted after their profile
+ * was computed.
  */
-function lookupUsernameFromPartners(profile: TasteProfileResult): string {
-  return `user:${profile.userId}`;
+function resolveUsername(
+  userId: number,
+  usernames: Map<number, string>,
+): string {
+  return usernames.get(userId) ?? 'Unknown player';
 }

--- a/api/src/lineups/common-ground-taste.integration.spec.ts
+++ b/api/src/lineups/common-ground-taste.integration.spec.ts
@@ -108,6 +108,24 @@ function describeCommonGroundTaste() {
   }
 
   /**
+   * Insert a real vote row so the user qualifies as an actual lineup voter
+   * under the ROK-1086 narrowed `findLineupVoterIds`. The vote target
+   * (`gameId`) is not meaningful for taste-scoring math — only membership
+   * in the voter set matters.
+   */
+  async function insertVote(
+    lineupId: number,
+    userId: number,
+    gameId: number,
+  ): Promise<void> {
+    await testApp.db.insert(schema.communityLineupVotes).values({
+      lineupId,
+      userId,
+      gameId,
+    });
+  }
+
+  /**
    * Insert a player taste vector directly. The first 7 values of `vector`
    * are the pgvector(7) column; `dimensions` stores the full axis pool.
    * We only fill the axes we care about for each test — others default 0.
@@ -185,7 +203,7 @@ function describeCommonGroundTaste() {
 
   describe('AC 4: taste-based sort', () => {
     it("sorts games so voters' shared taste axis wins over an off-axis game", async () => {
-      await createBuildingLineup();
+      const lineupId = await createBuildingLineup();
 
       // Two voters with opposing tastes. Both own both games equally so
       // ownership alone cannot decide the sort — taste must break the tie.
@@ -215,6 +233,11 @@ function describeCommonGroundTaste() {
         await addGameInterest(u, coopGame.id, 'steam_library');
         await addGameInterest(u, pvpGame.id, 'steam_library');
       }
+
+      // Admin is already `created_by`; wire the two synthetic voters as
+      // real vote casters so the narrowed voter-id query picks them up.
+      await insertVote(lineupId, coopVoter.id, coopGame.id);
+      await insertVote(lineupId, pvpVoter.id, pvpGame.id);
 
       const res = await testApp.request
         .get('/lineups/common-ground')
@@ -246,7 +269,7 @@ function describeCommonGroundTaste() {
 
   describe('AC: intensity scoring discriminates', () => {
     it("scores a high-player-count game above a low-player-count game when voters' intensity is high", async () => {
-      await createBuildingLineup();
+      const lineupId = await createBuildingLineup();
 
       // Two voters whose average intensity metric lands them in the
       // 'high' bucket (≥67). Keep taste vectors empty so taste score
@@ -286,6 +309,10 @@ function describeCommonGroundTaste() {
         await addGameInterest(u, highGame.id, 'steam_library');
       }
 
+      // Admin is creator; add real votes for the synthetic voters.
+      await insertVote(lineupId, voterA.id, highGame.id);
+      await insertVote(lineupId, voterB.id, highGame.id);
+
       const res = await testApp.request
         .get('/lineups/common-ground')
         .set('Authorization', `Bearer ${adminToken}`)
@@ -314,7 +341,7 @@ function describeCommonGroundTaste() {
       // The test module boots without `LlmService` configured to resolve a
       // provider. If the code path touches the provider registry, this
       // request would throw — we require the endpoint still respond 200.
-      await createBuildingLineup();
+      const lineupId = await createBuildingLineup();
       const voter = await createMember('nollm');
       await insertTasteVector(voter.id, { axisScores: { rpg: 80 } });
 
@@ -329,6 +356,7 @@ function describeCommonGroundTaste() {
         game.id,
         'steam_library',
       );
+      await insertVote(lineupId, voter.id, game.id);
 
       const res = await testApp.request
         .get('/lineups/common-ground')
@@ -356,7 +384,7 @@ function describeCommonGroundTaste() {
 
   describe('AC 6: weights configurable via SettingsService', () => {
     it('honors overridden tasteWeight — reflected in meta.appliedWeights and in taste score', async () => {
-      await createBuildingLineup();
+      const lineupId = await createBuildingLineup();
 
       const voter = await createMember('ac6');
       await insertTasteVector(voter.id, { axisScores: { strategy: 90 } });
@@ -372,6 +400,7 @@ function describeCommonGroundTaste() {
         game.id,
         'steam_library',
       );
+      await insertVote(lineupId, voter.id, game.id);
 
       // Baseline request with default weights
       const baseline = await testApp.request
@@ -489,7 +518,7 @@ function describeCommonGroundTaste() {
     });
 
     it('ignores a voter missing a taste vector without crashing; other voters still contribute', async () => {
-      await createBuildingLineup();
+      const lineupId = await createBuildingLineup();
 
       const voterWithVec = await createMember('withvec');
       const voterNoVec = await createMember('novec');
@@ -508,6 +537,12 @@ function describeCommonGroundTaste() {
         game.id,
         'steam_library',
       );
+
+      // Both users must cast real votes so they land in the voter set
+      // post-ROK-1086. voterNoVec must be a real voter for the
+      // "missing vector → silently skipped" scenario to be exercised.
+      await insertVote(lineupId, voterWithVec.id, game.id);
+      await insertVote(lineupId, voterNoVec.id, game.id);
 
       const res = await testApp.request
         .get('/lineups/common-ground')

--- a/api/src/lineups/lineups-query.helpers.ts
+++ b/api/src/lineups/lineups-query.helpers.ts
@@ -246,16 +246,17 @@ export function findBuildingLineup(db: PostgresJsDatabase<typeof schema>) {
 
 /**
  * Distinct union of users whose taste should inform Common Ground scoring
- * for a lineup (ROK-950). Combines:
- *   - vote casters on the lineup
- *   - nominators of games in the lineup
- *   - the lineup creator
- *   - any community member who has a stored taste vector (so nascent
- *     lineups with zero votes still benefit from known taste signals)
+ * for a lineup (ROK-950, narrowed in ROK-1086). The voter set is strictly
+ * the actual participants in the lineup:
+ *   - vote casters on the lineup (`community_lineup_votes.user_id`)
+ *   - nominators of games in the lineup (`community_lineup_entries.nominated_by`)
+ *   - the lineup creator (`community_lineups.created_by`)
  *
- * Returning a broader set is intentional: during the `building` phase the
- * scoring helper gets called before any votes exist, and the spec tests
- * require the taste factor to still reflect known community taste.
+ * Zero-voter contract: when this returns `[]`, `buildScoringContext`
+ * (`common-ground-context.helpers.ts`) yields `voterVector = null`,
+ * `voterIntensity = null`, and an empty `coPlayPartnerIds` set.
+ * `computeScoreBreakdown` then zeroes `tasteScore`, `socialScore`, and
+ * `intensityScore`. `baseScore` (ownership × owner-weight) is unaffected.
  */
 export async function findLineupVoterIds(
   db: PostgresJsDatabase<typeof schema>,
@@ -270,8 +271,6 @@ export async function findLineupVoterIds(
       UNION
       SELECT created_by AS user_id
         FROM community_lineups WHERE id = ${lineupId}
-      UNION
-      SELECT user_id FROM player_taste_vectors
     ) AS voters
   `);
   return rows.map((r) => r.user_id);

--- a/api/src/users/users.service.spec.ts
+++ b/api/src/users/users.service.spec.ts
@@ -296,6 +296,36 @@ function describeUsersService() {
   }
   describe('resetOnboarding (ROK-312)', () => describeResetOnboarding());
 
+  describe('findByIds (ROK-1088)', () => {
+    it('short-circuits on empty input without querying', async () => {
+      const result = await service.findByIds([]);
+      expect(result).toEqual([]);
+      expect(mockDb.query.users.findMany).not.toHaveBeenCalled();
+    });
+
+    it('returns the rows findMany resolves with', async () => {
+      const rows = [
+        { id: 1, username: 'Aragorn' },
+        { id: 7, username: 'Legolas' },
+      ];
+      (mockDb.query.users.findMany as jest.Mock).mockResolvedValue(rows);
+
+      const result = await service.findByIds([1, 7]);
+
+      expect(result).toEqual(rows);
+      expect(mockDb.query.users.findMany).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns an empty array when no users match', async () => {
+      (mockDb.query.users.findMany as jest.Mock).mockResolvedValue([]);
+
+      const result = await service.findByIds([999]);
+
+      expect(result).toEqual([]);
+      expect(mockDb.query.users.findMany).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('constants', () => {
     it('should export RECENT_MEMBER_DAYS as 30', () => {
       expect(RECENT_MEMBER_DAYS).toBe(30);

--- a/api/src/users/users.service.ts
+++ b/api/src/users/users.service.ts
@@ -2,7 +2,7 @@ import { Inject, Injectable, ConflictException, Logger } from '@nestjs/common';
 import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import * as schema from '../drizzle/schema';
-import { eq, sql, ilike, and, ne } from 'drizzle-orm';
+import { eq, sql, ilike, and, ne, inArray } from 'drizzle-orm';
 import type {
   UserRole,
   ActivityPeriod,
@@ -76,6 +76,13 @@ export class UsersService {
 
   async findById(id: number) {
     return this.db.query.users.findFirst({ where: eq(schema.users.id, id) });
+  }
+
+  async findByIds(ids: number[]) {
+    if (ids.length === 0) return [];
+    return this.db.query.users.findMany({
+      where: inArray(schema.users.id, ids),
+    });
   }
 
   async setRole(userId: number, role: UserRole) {

--- a/web/src/components/lineups/CommonGroundPanel.tsx
+++ b/web/src/components/lineups/CommonGroundPanel.tsx
@@ -1,108 +1,21 @@
 /**
  * Common Ground panel — shows games owned by multiple community members (ROK-934).
  * Renders filter controls, a horizontal-scroll game grid, and handles nomination.
+ *
+ * State + data plumbing lives in `useCommonGroundState`; pure blend
+ * helpers live in `common-ground-ai-merge.helpers.ts` (split out for
+ * ROK-1107 to keep this file below the 300-line soft limit).
  */
-import { type JSX, useRef, useState, useEffect, useMemo, useCallback } from 'react';
+import { type JSX, useRef, useState, useEffect, useCallback } from 'react';
 import type {
     AiSuggestionDto,
     CommonGroundGameDto,
     CommonGroundResponseDto,
 } from '@raid-ledger/contract';
 import type { CommonGroundParams } from '../../lib/api-client';
-import { useActiveLineups, useCommonGround, useNominateGame } from '../../hooks/use-lineups';
-import { useAiSuggestions } from '../../hooks/use-ai-suggestions';
-import { useDebouncedValue } from '../../hooks/use-debounced-value';
 import { CommonGroundFilters } from './CommonGroundFilters';
 import { CommonGroundGameCard } from './CommonGroundGameCard';
-
-/** Extract unique ITAD tags from the response for the genre filter dropdown. */
-function extractUniqueTags(data: { itadTags: string[] }[]): string[] {
-    const set = new Set<string>();
-    for (const g of data) {
-        for (const t of g.itadTags) set.add(t);
-    }
-    return [...set].sort();
-}
-
-/**
- * Promote an AI suggestion that Common Ground didn't return into the
- * same grid by mapping the AI DTO's enriched metadata into a
- * CommonGroundGameDto. `ownerCount` comes from the community-wide
- * count (matches Common Ground's badge), not voter-scoped ownership.
- * Synthetic `score` derives from LLM confidence so the merge sort
- * interleaves AI-only picks naturally with Common Ground picks rather
- * than front-loading them.
- */
-function aiOnlyStub(s: AiSuggestionDto): CommonGroundGameDto {
-    return {
-        gameId: s.gameId,
-        gameName: s.name,
-        slug: s.slug,
-        coverUrl: s.coverUrl,
-        ownerCount: s.communityOwnerCount,
-        wishlistCount: s.wishlistCount,
-        nonOwnerPrice: s.nonOwnerPrice,
-        itadCurrentCut: s.itadCurrentCut,
-        itadCurrentShop: s.itadCurrentShop,
-        itadCurrentUrl: s.itadCurrentUrl,
-        earlyAccess: s.earlyAccess,
-        itadTags: s.itadTags,
-        playerCount: s.playerCount,
-        score: s.confidence * 100,
-    };
-}
-
-/**
- * Mirror the Common Ground query's filter semantics on the frontend for
- * AI-only stubs. Keeps the grid consistent when the operator narrows
- * by owners / players / genre / search — AI cards that don't match the
- * filter vanish alongside the Common Ground rows that also fail.
- */
-function aiStubMatchesFilters(
-    stub: CommonGroundGameDto,
-    filters: CommonGroundParams,
-    search: string,
-): boolean {
-    if (filters.minOwners != null && stub.ownerCount < filters.minOwners) return false;
-    if (filters.maxPlayers != null && stub.playerCount) {
-        const { min, max } = stub.playerCount;
-        if (!(min <= filters.maxPlayers && max >= filters.maxPlayers)) return false;
-    }
-    if (filters.maxPlayers != null && !stub.playerCount) return false;
-    if (filters.genre && !stub.itadTags.includes(filters.genre)) return false;
-    const q = search.trim().toLowerCase();
-    if (q && !stub.gameName.toLowerCase().includes(q)) return false;
-    return true;
-}
-
-/**
- * Merge AI-suggested games into the Common Ground response. Games
- * already in the response get the badge via `aiSuggestionsByGameId` at
- * render time; games that the LLM suggested but Common Ground didn't
- * return get synthesised as stubs (with community-wide ownership +
- * confidence-derived score), filtered by the active Common Ground
- * filters, and then sorted alongside the CG rows by `score` so AI
- * picks land naturally in the mix rather than all at the front.
- */
-function mergeAiIntoCommonGround(
-    data: CommonGroundResponseDto | undefined,
-    aiMap: Map<number, AiSuggestionDto>,
-    filters: CommonGroundParams,
-    search: string,
-): CommonGroundResponseDto | undefined {
-    if (!data) return data;
-    if (aiMap.size === 0) return data;
-    const present = new Set(data.data.map((g) => g.gameId));
-    const aiOnly: CommonGroundGameDto[] = [];
-    for (const [gameId, ai] of aiMap) {
-        if (present.has(gameId)) continue;
-        const stub = aiOnlyStub(ai);
-        if (aiStubMatchesFilters(stub, filters, search)) aiOnly.push(stub);
-    }
-    if (aiOnly.length === 0) return data;
-    const merged = [...data.data, ...aiOnly].sort((a, b) => b.score - a.score);
-    return { ...data, data: merged };
-}
+import { useCommonGroundState } from './use-common-ground-state';
 
 /** Loading skeleton cards. */
 function LoadingSkeleton(): JSX.Element {
@@ -229,29 +142,9 @@ function GameGrid({
     );
 }
 
-/** Hook for nomination state management. */
-function useNomination(lineupId: number | undefined) {
-    const [nominatingId, setNominatingId] = useState<number | null>(null);
-    const nominate = useNominateGame();
-
-    const handleNominate = useCallback(
-        (gameId: number) => {
-            if (!lineupId) return;
-            setNominatingId(gameId);
-            nominate.mutate(
-                { lineupId, body: { gameId } },
-                { onSettled: () => setNominatingId(null) },
-            );
-        },
-        [lineupId, nominate],
-    );
-
-    return { nominatingId, handleNominate };
-}
-
 /** Content area — renders filters, loading/error states, and game grid. */
 function PanelContent({
-    data,
+    mergedData,
     filters,
     setFilters,
     availableTags,
@@ -262,10 +155,10 @@ function PanelContent({
     nominatingId,
     atCap,
     search,
-    onSearchChange,
+    setSearch,
     aiSuggestionsByGameId,
 }: {
-    data: CommonGroundResponseDto | undefined;
+    mergedData: CommonGroundResponseDto | undefined;
     filters: CommonGroundParams;
     setFilters: (f: CommonGroundParams) => void;
     availableTags: string[];
@@ -276,18 +169,18 @@ function PanelContent({
     nominatingId: number | null;
     atCap: boolean;
     search: string;
-    onSearchChange: (v: string) => void;
+    setSearch: (v: string) => void;
     aiSuggestionsByGameId: Map<number, AiSuggestionDto>;
 }): JSX.Element {
     return (
         <>
-            <CommonGroundFilters filters={filters} onChange={setFilters} availableTags={availableTags} search={search} onSearchChange={onSearchChange} />
+            <CommonGroundFilters filters={filters} onChange={setFilters} availableTags={availableTags} search={search} onSearchChange={setSearch} />
             {isLoading && <LoadingSkeleton />}
             {isError && <ErrorState onRetry={refetch} />}
-            {data && data.data.length === 0 && <EmptyState />}
-            {data && data.data.length > 0 && (
+            {mergedData && mergedData.data.length === 0 && <EmptyState />}
+            {mergedData && mergedData.data.length > 0 && (
                 <GameGrid
-                    games={data.data}
+                    games={mergedData.data}
                     onNominate={onNominate}
                     nominatingId={nominatingId}
                     atCap={atCap}
@@ -312,57 +205,12 @@ export function CommonGroundPanel({
     lineupId?: number;
     canParticipate?: boolean;
 } = {}): JSX.Element | null {
-    const { data: activeLineups } = useActiveLineups();
-    const newestBuilding = activeLineups?.find((l) => l.status === 'building') ?? null;
-    const resolvedId = propLineupId ?? newestBuilding?.id;
-    const [filters, setFilters] = useState<CommonGroundParams>({ minOwners: 0 });
-    const [search, setSearch] = useState('');
-    const hasBuilding = propLineupId != null || !!newestBuilding;
-    const apiParams = useMemo(
-        () => ({
-            ...filters,
-            search: search.trim() || undefined,
-            lineupId: resolvedId,
-        }),
-        [filters, search, resolvedId],
-    );
-    const debouncedParams = useDebouncedValue(apiParams, 300);
-    const { data, isLoading, isError, refetch } = useCommonGround(debouncedParams, hasBuilding);
-    const availableTags = useMemo(() => (data?.data ? extractUniqueTags(data.data) : []), [data]);
-    const rawAtCap = (data?.meta.nominatedCount ?? 0) >= (data?.meta.maxNominations ?? 20);
-    const atCap = rawAtCap || !canParticipate;
-    const { nominatingId, handleNominate } = useNomination(resolvedId);
-
-    // ROK-931: fetch AI suggestions alongside Common Ground and blend them
-    // into the same grid. `aiSuggestionsByGameId` drives the ✨ AI badge +
-    // tooltip reasoning on matching cards; AI-only games (not owned by
-    // anyone yet) are synthesised as stub CommonGroundGameDto entries.
-    const aiQuery = useAiSuggestions(resolvedId, { enabled: hasBuilding });
-    const aiSuggestionsByGameId = useMemo(() => {
-        const map = new Map<number, AiSuggestionDto>();
-        if (aiQuery.data?.kind === 'ok') {
-            for (const s of aiQuery.data.data.suggestions) map.set(s.gameId, s);
-        }
-        return map;
-    }, [aiQuery.data]);
-
-    const mergedData = useMemo(
-        () => mergeAiIntoCommonGround(data, aiSuggestionsByGameId, filters, search),
-        [data, aiSuggestionsByGameId, filters, search],
-    );
-
-    if (!hasBuilding) return null;
-
+    const state = useCommonGroundState(propLineupId, canParticipate);
+    if (!state.hasBuilding) return null;
     return (
         <section className="space-y-3">
-            <PanelHeader nominated={data?.meta.nominatedCount ?? 0} max={data?.meta.maxNominations ?? 20} />
-            <PanelContent
-                data={mergedData} filters={filters} setFilters={setFilters} availableTags={availableTags}
-                isLoading={isLoading} isError={isError} refetch={() => void refetch()}
-                onNominate={handleNominate} nominatingId={nominatingId} atCap={atCap}
-                search={search} onSearchChange={setSearch}
-                aiSuggestionsByGameId={aiSuggestionsByGameId}
-            />
+            <PanelHeader nominated={state.rawMeta.nominatedCount} max={state.rawMeta.maxNominations} />
+            <PanelContent {...state} />
         </section>
     );
 }

--- a/web/src/components/lineups/common-ground-ai-merge.helpers.test.ts
+++ b/web/src/components/lineups/common-ground-ai-merge.helpers.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for the Common Ground / AI-suggestions merge helpers
+ * (ROK-1107, extracted from CommonGroundPanel for ROK-931).
+ */
+import { describe, it, expect } from 'vitest';
+import type {
+    AiSuggestionDto,
+    CommonGroundGameDto,
+    CommonGroundResponseDto,
+} from '@raid-ledger/contract';
+import type { CommonGroundParams } from '../../lib/api-client';
+import {
+    aiOnlyStub,
+    aiStubMatchesFilters,
+    mergeAiIntoCommonGround,
+} from './common-ground-ai-merge.helpers';
+
+function makeAi(overrides: Partial<AiSuggestionDto> = {}): AiSuggestionDto {
+    return {
+        gameId: 100,
+        name: 'AI Game',
+        slug: 'ai-game',
+        coverUrl: null,
+        confidence: 0.5,
+        reasoning: 'because',
+        ownershipCount: 0,
+        voterTotal: 0,
+        communityOwnerCount: 2,
+        wishlistCount: 0,
+        nonOwnerPrice: null,
+        itadCurrentCut: null,
+        itadCurrentShop: null,
+        itadCurrentUrl: null,
+        earlyAccess: false,
+        itadTags: ['RPG'],
+        playerCount: { min: 1, max: 4 },
+        ...overrides,
+    };
+}
+
+function makeCg(overrides: Partial<CommonGroundGameDto> = {}): CommonGroundGameDto {
+    return {
+        gameId: 1,
+        gameName: 'CG Game',
+        slug: 'cg-game',
+        coverUrl: null,
+        ownerCount: 5,
+        wishlistCount: 0,
+        nonOwnerPrice: null,
+        itadCurrentCut: null,
+        itadCurrentShop: null,
+        itadCurrentUrl: null,
+        earlyAccess: false,
+        itadTags: [],
+        playerCount: null,
+        score: 50,
+        ...overrides,
+    };
+}
+
+function makeResponse(data: CommonGroundGameDto[]): CommonGroundResponseDto {
+    return {
+        data,
+        meta: {
+            total: data.length,
+            appliedWeights: {
+                ownerWeight: 1,
+                saleBonus: 1,
+                fullPricePenalty: 1,
+                tasteWeight: 1,
+                socialWeight: 1,
+                intensityWeight: 1,
+            },
+            activeLineupId: 1,
+            nominatedCount: 0,
+            maxNominations: 20,
+        },
+    };
+}
+
+describe('aiStubMatchesFilters', () => {
+    it('filters out AI stub when ownerCount is below minOwners', () => {
+        const stub = aiOnlyStub(makeAi({ communityOwnerCount: 1 }));
+        const filters: CommonGroundParams = { minOwners: 3 };
+        expect(aiStubMatchesFilters(stub, filters, '')).toBe(false);
+    });
+
+    it('keeps AI stub when ownerCount meets minOwners', () => {
+        const stub = aiOnlyStub(makeAi({ communityOwnerCount: 5 }));
+        const filters: CommonGroundParams = { minOwners: 3 };
+        expect(aiStubMatchesFilters(stub, filters, '')).toBe(true);
+    });
+
+    it('filters out AI stub when genre does not match itadTags', () => {
+        const stub = aiOnlyStub(makeAi({ itadTags: ['RPG'] }));
+        const filters: CommonGroundParams = { genre: 'Survival' };
+        expect(aiStubMatchesFilters(stub, filters, '')).toBe(false);
+    });
+
+    it('filters out AI stub when playerCount range does not cover maxPlayers', () => {
+        const stub = aiOnlyStub(makeAi({ playerCount: { min: 1, max: 2 } }));
+        const filters: CommonGroundParams = { maxPlayers: 4 };
+        expect(aiStubMatchesFilters(stub, filters, '')).toBe(false);
+    });
+
+    it('filters out AI stub with null playerCount when maxPlayers is set', () => {
+        const stub = aiOnlyStub(makeAi({ playerCount: null }));
+        const filters: CommonGroundParams = { maxPlayers: 4 };
+        expect(aiStubMatchesFilters(stub, filters, '')).toBe(false);
+    });
+
+    it('matches against search (case-insensitive, trimmed)', () => {
+        const stub = aiOnlyStub(makeAi({ name: 'Baldur’s Gate 3' }));
+        expect(aiStubMatchesFilters(stub, {}, '  baldur ')).toBe(true);
+        expect(aiStubMatchesFilters(stub, {}, 'halo')).toBe(false);
+    });
+});
+
+describe('mergeAiIntoCommonGround', () => {
+    it('returns undefined when data is undefined', () => {
+        expect(
+            mergeAiIntoCommonGround(undefined, new Map([[1, makeAi()]]), {}, ''),
+        ).toBeUndefined();
+    });
+
+    it('returns the same response unchanged when aiMap is empty', () => {
+        const resp = makeResponse([makeCg({ gameId: 1, score: 80 })]);
+        const merged = mergeAiIntoCommonGround(resp, new Map(), {}, '');
+        expect(merged).toBe(resp);
+    });
+
+    it('preserves the original CG entry when gameId appears in both data and aiMap', () => {
+        // AI-flagged CG card: the merge helper must leave the original CG
+        // entry in place — the ✨ AI badge/reasoning is wired at render
+        // time via `aiSuggestionsByGameId` (GameGrid), not by replacing
+        // the row here.
+        const original = makeCg({ gameId: 42, ownerCount: 7, score: 75 });
+        const resp = makeResponse([original]);
+        const aiMap = new Map<number, AiSuggestionDto>([
+            [42, makeAi({ gameId: 42, communityOwnerCount: 99, confidence: 0.9 })],
+        ]);
+        const merged = mergeAiIntoCommonGround(resp, aiMap, {}, '');
+        expect(merged).toBeDefined();
+        expect(merged!.data).toHaveLength(1);
+        expect(merged!.data[0]).toEqual(original);
+        expect(merged!.data[0]!.ownerCount).toBe(7);
+    });
+
+    it('appends AI-only stub entries and sorts stably on score ties', () => {
+        // Array.prototype.sort is stable in V8/ES2019+. Insertion order
+        // `[...data.data, ...aiOnly]` preserves CG entries ahead of
+        // AI-only stubs with equal scores.
+        const cg1 = makeCg({ gameId: 1, score: 50 });
+        const cg2 = makeCg({ gameId: 2, score: 50, gameName: 'CG Two' });
+        const resp = makeResponse([cg1, cg2]);
+        // confidence 0.5 -> synthetic score 50, matching the CG ties.
+        const aiMap = new Map<number, AiSuggestionDto>([
+            [3, makeAi({ gameId: 3, confidence: 0.5 })],
+        ]);
+
+        const merged = mergeAiIntoCommonGround(resp, aiMap, {}, '');
+        expect(merged).toBeDefined();
+        expect(merged!.data.map((g) => g.gameId)).toEqual([1, 2, 3]);
+    });
+
+    it('drops AI-only stubs that fail the active filters', () => {
+        const resp = makeResponse([makeCg({ gameId: 1, score: 80 })]);
+        const aiMap = new Map<number, AiSuggestionDto>([
+            [5, makeAi({ gameId: 5, communityOwnerCount: 1 })],
+        ]);
+        const merged = mergeAiIntoCommonGround(
+            resp,
+            aiMap,
+            { minOwners: 3 },
+            '',
+        );
+        // AI-only stub filtered out; merge returns the original response
+        // (no merged array allocated when aiOnly is empty).
+        expect(merged).toBe(resp);
+    });
+});

--- a/web/src/components/lineups/common-ground-ai-merge.helpers.ts
+++ b/web/src/components/lineups/common-ground-ai-merge.helpers.ts
@@ -1,0 +1,97 @@
+/**
+ * Pure helpers for blending AI suggestions into the Common Ground
+ * response (ROK-931). Extracted from CommonGroundPanel to keep the
+ * panel file below the 300-line soft limit (ROK-1107).
+ */
+import type {
+    AiSuggestionDto,
+    CommonGroundGameDto,
+    CommonGroundResponseDto,
+} from '@raid-ledger/contract';
+import type { CommonGroundParams } from '../../lib/api-client';
+
+/**
+ * Promote an AI suggestion that Common Ground didn't return into the
+ * same grid by mapping the AI DTO's enriched metadata into a
+ * CommonGroundGameDto. `ownerCount` comes from the community-wide
+ * count (matches Common Ground's badge), not voter-scoped ownership.
+ * Synthetic `score` derives from LLM confidence so the merge sort
+ * interleaves AI-only picks naturally with Common Ground picks rather
+ * than front-loading them.
+ */
+export function aiOnlyStub(s: AiSuggestionDto): CommonGroundGameDto {
+    return {
+        gameId: s.gameId,
+        gameName: s.name,
+        slug: s.slug,
+        coverUrl: s.coverUrl,
+        ownerCount: s.communityOwnerCount,
+        wishlistCount: s.wishlistCount,
+        nonOwnerPrice: s.nonOwnerPrice,
+        itadCurrentCut: s.itadCurrentCut,
+        itadCurrentShop: s.itadCurrentShop,
+        itadCurrentUrl: s.itadCurrentUrl,
+        earlyAccess: s.earlyAccess,
+        itadTags: s.itadTags,
+        playerCount: s.playerCount,
+        score: s.confidence * 100,
+    };
+}
+
+/**
+ * Mirror the Common Ground query's filter semantics on the frontend for
+ * AI-only stubs. Keeps the grid consistent when the operator narrows
+ * by owners / players / genre / search — AI cards that don't match the
+ * filter vanish alongside the Common Ground rows that also fail.
+ */
+export function aiStubMatchesFilters(
+    stub: CommonGroundGameDto,
+    filters: CommonGroundParams,
+    search: string,
+): boolean {
+    if (filters.minOwners != null && stub.ownerCount < filters.minOwners) return false;
+    if (filters.maxPlayers != null && stub.playerCount) {
+        const { min, max } = stub.playerCount;
+        if (!(min <= filters.maxPlayers && max >= filters.maxPlayers)) return false;
+    }
+    if (filters.maxPlayers != null && !stub.playerCount) return false;
+    if (filters.genre && !stub.itadTags.includes(filters.genre)) return false;
+    const q = search.trim().toLowerCase();
+    if (q && !stub.gameName.toLowerCase().includes(q)) return false;
+    return true;
+}
+
+/**
+ * Merge AI-suggested games into the Common Ground response. Games
+ * already in the response keep the original CG entry (the ✨ AI badge
+ * is wired at render time via the `aiSuggestionsByGameId` map passed
+ * separately to GameGrid); games that the LLM suggested but Common
+ * Ground didn't return get synthesised as stubs (with community-wide
+ * ownership + confidence-derived score), filtered by the active
+ * Common Ground filters, then sorted alongside the CG rows by `score`
+ * so AI picks land naturally in the mix rather than all at the front.
+ *
+ * Sort stability note: `Array.prototype.sort` is stable in V8/ES2019+.
+ * Insertion order (`[...data.data, ...aiOnly]`) is preserved on score
+ * ties, which means CG entries sort ahead of AI-only stubs with equal
+ * scores — desired behaviour.
+ */
+export function mergeAiIntoCommonGround(
+    data: CommonGroundResponseDto | undefined,
+    aiMap: Map<number, AiSuggestionDto>,
+    filters: CommonGroundParams,
+    search: string,
+): CommonGroundResponseDto | undefined {
+    if (!data) return data;
+    if (aiMap.size === 0) return data;
+    const present = new Set(data.data.map((g) => g.gameId));
+    const aiOnly: CommonGroundGameDto[] = [];
+    for (const [gameId, ai] of aiMap) {
+        if (present.has(gameId)) continue;
+        const stub = aiOnlyStub(ai);
+        if (aiStubMatchesFilters(stub, filters, search)) aiOnly.push(stub);
+    }
+    if (aiOnly.length === 0) return data;
+    const merged = [...data.data, ...aiOnly].sort((a, b) => b.score - a.score);
+    return { ...data, data: merged };
+}

--- a/web/src/components/lineups/use-common-ground-state.ts
+++ b/web/src/components/lineups/use-common-ground-state.ts
@@ -1,0 +1,154 @@
+/**
+ * State + data plumbing for the Common Ground panel (ROK-1107).
+ *
+ * Owns:
+ * - Resolving the active building lineup when no prop `lineupId`.
+ * - Filters, search, and debounced API params.
+ * - Common Ground + AI-suggestions queries.
+ * - The `aiSuggestionsByGameId` map that drives the ✨ AI badge.
+ * - Blending AI-only picks into the Common Ground grid.
+ * - Nomination mutation state (`nominatingId`, `onNominate`).
+ *
+ * Extracted from `CommonGroundPanel.tsx` to keep the panel file below
+ * the 300-line soft limit.
+ */
+import { useCallback, useMemo, useState } from 'react';
+import type {
+    AiSuggestionDto,
+    CommonGroundResponseDto,
+} from '@raid-ledger/contract';
+import type { CommonGroundParams } from '../../lib/api-client';
+import {
+    useActiveLineups,
+    useCommonGround,
+    useNominateGame,
+} from '../../hooks/use-lineups';
+import { useAiSuggestions } from '../../hooks/use-ai-suggestions';
+import { useDebouncedValue } from '../../hooks/use-debounced-value';
+import { mergeAiIntoCommonGround } from './common-ground-ai-merge.helpers';
+
+/** Extract unique ITAD tags from the response for the genre filter dropdown. */
+function extractUniqueTags(data: { itadTags: string[] }[]): string[] {
+    const set = new Set<string>();
+    for (const g of data) {
+        for (const t of g.itadTags) set.add(t);
+    }
+    return [...set].sort();
+}
+
+export interface UseCommonGroundStateResult {
+    hasBuilding: boolean;
+    mergedData: CommonGroundResponseDto | undefined;
+    rawMeta: {
+        nominatedCount: number;
+        maxNominations: number;
+    };
+    filters: CommonGroundParams;
+    setFilters: (f: CommonGroundParams) => void;
+    search: string;
+    setSearch: (v: string) => void;
+    availableTags: string[];
+    isLoading: boolean;
+    isError: boolean;
+    refetch: () => void;
+    onNominate: (gameId: number) => void;
+    nominatingId: number | null;
+    atCap: boolean;
+    aiSuggestionsByGameId: Map<number, AiSuggestionDto>;
+}
+
+export function useCommonGroundState(
+    propLineupId: number | undefined,
+    canParticipate: boolean,
+): UseCommonGroundStateResult {
+    const { data: activeLineups } = useActiveLineups();
+    const newestBuilding =
+        activeLineups?.find((l) => l.status === 'building') ?? null;
+    const resolvedId = propLineupId ?? newestBuilding?.id;
+    const hasBuilding = propLineupId != null || !!newestBuilding;
+
+    const [filters, setFilters] = useState<CommonGroundParams>({ minOwners: 0 });
+    const [search, setSearch] = useState('');
+
+    const apiParams = useMemo(
+        () => ({
+            ...filters,
+            search: search.trim() || undefined,
+            lineupId: resolvedId,
+        }),
+        [filters, search, resolvedId],
+    );
+    const debouncedParams = useDebouncedValue(apiParams, 300);
+    const { data, isLoading, isError, refetch } = useCommonGround(
+        debouncedParams,
+        hasBuilding,
+    );
+    const availableTags = useMemo(
+        () => (data?.data ? extractUniqueTags(data.data) : []),
+        [data],
+    );
+
+    // ROK-931: fetch AI suggestions alongside Common Ground and blend
+    // them into the same grid. The map drives the ✨ AI badge + tooltip
+    // reasoning on matching cards; AI-only games (not owned yet) are
+    // synthesised as stub CommonGroundGameDto entries.
+    const aiQuery = useAiSuggestions(resolvedId, { enabled: hasBuilding });
+    const aiSuggestionsByGameId = useMemo(() => {
+        const map = new Map<number, AiSuggestionDto>();
+        if (aiQuery.data?.kind === 'ok') {
+            for (const s of aiQuery.data.data.suggestions) map.set(s.gameId, s);
+        }
+        return map;
+    }, [aiQuery.data]);
+
+    const mergedData = useMemo(
+        () => mergeAiIntoCommonGround(data, aiSuggestionsByGameId, filters, search),
+        [data, aiSuggestionsByGameId, filters, search],
+    );
+
+    const rawAtCap =
+        (data?.meta.nominatedCount ?? 0) >= (data?.meta.maxNominations ?? 20);
+    const atCap = rawAtCap || !canParticipate;
+
+    const rawMeta = useMemo(
+        () => ({
+            nominatedCount: data?.meta.nominatedCount ?? 0,
+            maxNominations: data?.meta.maxNominations ?? 20,
+        }),
+        [data],
+    );
+
+    const [nominatingId, setNominatingId] = useState<number | null>(null);
+    const nominate = useNominateGame();
+    const onNominate = useCallback(
+        (gameId: number) => {
+            if (!resolvedId) return;
+            setNominatingId(gameId);
+            nominate.mutate(
+                { lineupId: resolvedId, body: { gameId } },
+                { onSettled: () => setNominatingId(null) },
+            );
+        },
+        [resolvedId, nominate],
+    );
+
+    const stableRefetch = useCallback(() => void refetch(), [refetch]);
+
+    return {
+        hasBuilding,
+        mergedData,
+        rawMeta,
+        filters,
+        setFilters,
+        search,
+        setSearch,
+        availableTags,
+        isLoading,
+        isError,
+        refetch: stableRefetch,
+        onNominate,
+        nominatingId,
+        atCap,
+        aiSuggestionsByGameId,
+    };
+}


### PR DESCRIPTION
## Summary

Batch of 3 tech-debt stories:
- **ROK-1086** (Tech Debt / Game Library): narrow `findLineupVoterIds` to actual participants — removes unconditional `player_taste_vectors` UNION that diluted Common Ground voter scoring; 5 integration tests rewired with real vote rows via new `insertVote` helper.
- **ROK-1088** (Tech Debt / Game Library): replace synthetic `user:${id}` username fallback in `TasteProfileContextBuilder` with real batched lookup via new `UsersService.findByIds`; "Unknown player" fallback for hard-deleted users.
- **ROK-1107** (Tech Debt / UI/UX): trim `CommonGroundPanel.tsx` from 297 to ~100 effective lines — extract `common-ground-ai-merge.helpers.ts` (pure merge/filter logic) and `use-common-ground-state.ts` (hook); adds 181 lines of direct Vitest coverage for the merge helpers (sort stability, min-owners filter, CG entry preservation).

Also includes one batch-level test-gap fix:
- `test: cover UsersService.findByIds (ROK-1088 gap)` — 3 unit tests (empty short-circuit, returns rows, no-match).

## Validation

- Per-story code review: **APPROVED** (all three)
- Test gap analysis: **PASS** (filled `findByIds` unit coverage)
- Build / TypeScript / Lint (all workspaces): **PASS**
- Unit tests + coverage: **PASS**
- Integration tests (api, 57 suites / 728 tests): **PASS**
- Playwright smoke (desktop + mobile, 431 passed / 0 failed): **PASS**
- Migration validation: SKIPPED (no migration files changed)
- Container startup: SKIPPED (no container files changed)

## Stories

| Story | Label | Area | Reviewer |
|-------|-------|------|----------|
| ROK-1086 | Tech Debt | Game Library | APPROVED |
| ROK-1088 | Tech Debt | Game Library | APPROVED |
| ROK-1107 | Tech Debt | UI/UX | APPROVED |

## Test plan

- [x] `./scripts/validate-ci.sh --full` passes locally
- [x] `npx playwright test` (both projects) passes locally
- [ ] CI green on PR
- [ ] Auto-merge (squash) enabled post-creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)