### PR TITLE
ci: bump Postgres max_connections to 300 in test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -259,6 +259,24 @@ jobs:
       - name: Build contract
         run: npm run build -w packages/contract
 
+      - name: Bump Postgres max_connections
+        # GHA service containers don't accept `command:`, so we ALTER SYSTEM
+        # and restart the postgres container in place. Default 100 is too
+        # low for the shard's combined NestJS boot + parallel-query load.
+        run: |
+          PG_CONTAINER=$(docker ps --filter "ancestor=pgvector/pgvector:pg16" --format "{{.ID}}" | head -1)
+          if [ -z "$PG_CONTAINER" ]; then echo "Postgres container not found"; exit 1; fi
+          docker exec "$PG_CONTAINER" psql -U user -d raid_ledger_test -c "ALTER SYSTEM SET max_connections = 300;"
+          docker restart "$PG_CONTAINER"
+          for i in $(seq 1 30); do
+            if docker exec "$PG_CONTAINER" pg_isready -U user -d raid_ledger_test >/dev/null 2>&1; then
+              echo "Postgres ready"
+              break
+            fi
+            sleep 1
+          done
+          docker exec "$PG_CONTAINER" psql -U user -d raid_ledger_test -tAc "SHOW max_connections;"
+
       - name: Run integration tests (shard ${{ matrix.shard }})
         run: npm run test:integration -w api -- --shard=${{ matrix.shard }}
 
@@ -359,6 +377,24 @@ jobs:
 
       - name: Build web
         run: npm run build -w web
+
+      - name: Bump Postgres max_connections
+        # GHA service containers don't accept `command:`, so we ALTER SYSTEM
+        # and restart the postgres container in place. Default 100 is too
+        # low for the boot connection burst + parallel-query test load.
+        run: |
+          PG_CONTAINER=$(docker ps --filter "ancestor=pgvector/pgvector:pg16" --format "{{.ID}}" | head -1)
+          if [ -z "$PG_CONTAINER" ]; then echo "Postgres container not found"; exit 1; fi
+          docker exec "$PG_CONTAINER" psql -U user -d raid_ledger -c "ALTER SYSTEM SET max_connections = 300;"
+          docker restart "$PG_CONTAINER"
+          for i in $(seq 1 30); do
+            if docker exec "$PG_CONTAINER" pg_isready -U user -d raid_ledger >/dev/null 2>&1; then
+              echo "Postgres ready"
+              break
+            fi
+            sleep 1
+          done
+          docker exec "$PG_CONTAINER" psql -U user -d raid_ledger -tAc "SHOW max_connections;"
 
       - name: Run database migrations
         run: npm run db:migrate -w api


### PR DESCRIPTION
## Summary

CI's Postgres service ships with the default `max_connections = 100`. As the NestJS provider graph grows and integration shards accumulate tests with parallel-query patterns, shard 3/3 started hitting `PostgresError: sorry, too many clients already` on `igdb-discover-dynamic.integration.spec.ts`. Failure is reproducible (2 retries, same shard, same spec) on branches that pile a few extra modules on top of main.

## Why a workaround instead of `command: postgres -c max_connections=300`

GitHub Actions service containers do NOT accept a `command:` field. Only `image`, `env`, `ports`, `volumes`, `options` are valid. The cleanest workaround that doesn't require building+publishing a custom image: `ALTER SYSTEM` + `docker restart` in place (max_connections requires restart). Adds ~5 s per affected job.

## What

Added a "Bump Postgres max_connections" step to:
- `integration-test-shard` (line ~262)
- `smoke-test-shard` (line ~381)

Both run BEFORE the test step. Each step finds the running pgvector container, bumps `max_connections` to 300, restarts, waits for ready, and verifies the new value.

## Test plan

- [x] Diff is +36 lines, single file (`.github/workflows/ci.yml`)
- [x] CI itself will be the proof — both jobs continue to pass with the new step
- [x] No code changes; no functional impact on the app

## Linear

No story — this is operator-tier CI infra. Surfaced while shipping ROK-1115; that PR is currently blocked on this exact failure mode and will pass once this merges.