### PR TITLE
ROK-1114: fix AI Suggested-for-you (provider auto-pick + visible failure + admin gate)

### DIFF
--- a/api/src/ai/ai-admin.controller.spec.ts
+++ b/api/src/ai/ai-admin.controller.spec.ts
@@ -36,7 +36,10 @@ describe('AiAdminController', () => {
       listModels: jest.fn().mockResolvedValue([]),
     };
     mockRegistry = {
-      resolveActive: jest.fn().mockResolvedValue(createMockProvider()),
+      resolveActive: jest.fn().mockResolvedValue({
+        provider: createMockProvider(),
+        source: 'setting',
+      }),
     };
     mockLogService = {
       getUsageStats: jest.fn().mockResolvedValue({
@@ -179,15 +182,18 @@ describe('AiAdminController (adversarial)', () => {
     it('includes currentModel from settings', async () => {
       mockSettings.get.mockResolvedValue('phi3:mini');
       mockRegistry.resolveActive.mockResolvedValue({
-        key: 'ollama',
-        displayName: 'Ollama (Local)',
-        selfHosted: true,
-        defaultModel: 'mock-model',
-        requiresApiKey: false,
-        isAvailable: jest.fn(),
-        listModels: jest.fn(),
-        chat: jest.fn(),
-        generate: jest.fn(),
+        provider: {
+          key: 'ollama',
+          displayName: 'Ollama (Local)',
+          selfHosted: true,
+          defaultModel: 'mock-model',
+          requiresApiKey: false,
+          isAvailable: jest.fn(),
+          listModels: jest.fn(),
+          chat: jest.fn(),
+          generate: jest.fn(),
+        },
+        source: 'setting',
       });
       const result = await controller.getStatus();
       expect(result.currentModel).toBe('phi3:mini');
@@ -281,15 +287,18 @@ describe('ROK-1000: testChat timeout and diagnostics', () => {
     };
     mockRegistry = {
       resolveActive: jest.fn().mockResolvedValue({
-        key: 'ollama',
-        displayName: 'Ollama (Local)',
-        requiresApiKey: false,
-        selfHosted: true,
-        defaultModel: 'mock-model',
-        isAvailable: jest.fn().mockResolvedValue(true),
-        listModels: jest.fn().mockResolvedValue([]),
-        chat: jest.fn(),
-        generate: jest.fn(),
+        provider: {
+          key: 'ollama',
+          displayName: 'Ollama (Local)',
+          requiresApiKey: false,
+          selfHosted: true,
+          defaultModel: 'mock-model',
+          isAvailable: jest.fn().mockResolvedValue(true),
+          listModels: jest.fn().mockResolvedValue([]),
+          chat: jest.fn(),
+          generate: jest.fn(),
+        },
+        source: 'setting',
       }),
     };
     mockLogService = {
@@ -425,9 +434,10 @@ describe('ROK-1019: model resolution per provider', () => {
       }),
     };
     mockRegistry = {
-      resolveActive: jest
-        .fn()
-        .mockResolvedValue(createCloudProvider('google', 'Google (Gemini)')),
+      resolveActive: jest.fn().mockResolvedValue({
+        provider: createCloudProvider('google', 'Google (Gemini)'),
+        source: 'setting',
+      }),
     };
     mockLogService = {
       getUsageStats: jest.fn().mockResolvedValue({
@@ -468,9 +478,10 @@ describe('ROK-1019: model resolution per provider', () => {
     });
 
     it('AC4: error includes openai cloud default when provider is openai', async () => {
-      mockRegistry.resolveActive.mockResolvedValue(
-        createCloudProvider('openai', 'OpenAI'),
-      );
+      mockRegistry.resolveActive.mockResolvedValue({
+        provider: createCloudProvider('openai', 'OpenAI'),
+        source: 'setting',
+      });
       mockLlmService.chat.mockRejectedValue(new Error('HTTP 401'));
 
       const result = await controller.testChat();
@@ -481,9 +492,10 @@ describe('ROK-1019: model resolution per provider', () => {
     });
 
     it('AC4: error includes claude cloud default when provider is claude', async () => {
-      mockRegistry.resolveActive.mockResolvedValue(
-        createCloudProvider('claude', 'Claude'),
-      );
+      mockRegistry.resolveActive.mockResolvedValue({
+        provider: createCloudProvider('claude', 'Claude'),
+        source: 'setting',
+      });
       mockLlmService.chat.mockRejectedValue(new Error('HTTP 401'));
 
       const result = await controller.testChat();
@@ -497,15 +509,18 @@ describe('ROK-1019: model resolution per provider', () => {
   describe('testChat error — ollama keeps using ai_model setting', () => {
     it('AC4: ollama provider still uses the global ai_model setting', async () => {
       mockRegistry.resolveActive.mockResolvedValue({
-        key: 'ollama',
-        displayName: 'Ollama (Local)',
-        requiresApiKey: false,
-        selfHosted: true,
-        defaultModel: 'mock-model',
-        isAvailable: jest.fn().mockResolvedValue(true),
-        listModels: jest.fn().mockResolvedValue([]),
-        chat: jest.fn(),
-        generate: jest.fn(),
+        provider: {
+          key: 'ollama',
+          displayName: 'Ollama (Local)',
+          requiresApiKey: false,
+          selfHosted: true,
+          defaultModel: 'mock-model',
+          isAvailable: jest.fn().mockResolvedValue(true),
+          listModels: jest.fn().mockResolvedValue([]),
+          chat: jest.fn(),
+          generate: jest.fn(),
+        },
+        source: 'setting',
       });
       mockLlmService.chat.mockRejectedValue(new Error('Connection refused'));
 
@@ -526,15 +541,18 @@ describe('ROK-1019: model resolution per provider', () => {
 
     it('AC4: getStatus shows ai_model setting for ollama provider', async () => {
       mockRegistry.resolveActive.mockResolvedValue({
-        key: 'ollama',
-        displayName: 'Ollama (Local)',
-        requiresApiKey: false,
-        selfHosted: true,
-        defaultModel: 'mock-model',
-        isAvailable: jest.fn().mockResolvedValue(true),
-        listModels: jest.fn().mockResolvedValue([]),
-        chat: jest.fn(),
-        generate: jest.fn(),
+        provider: {
+          key: 'ollama',
+          displayName: 'Ollama (Local)',
+          requiresApiKey: false,
+          selfHosted: true,
+          defaultModel: 'mock-model',
+          isAvailable: jest.fn().mockResolvedValue(true),
+          listModels: jest.fn().mockResolvedValue([]),
+          chat: jest.fn(),
+          generate: jest.fn(),
+        },
+        source: 'setting',
       });
 
       const result = await controller.getStatus();

--- a/api/src/ai/ai-admin.controller.ts
+++ b/api/src/ai/ai-admin.controller.ts
@@ -151,7 +151,8 @@ export class AiAdminController {
   @Put('features')
   @HttpCode(HttpStatus.OK)
   async updateFeatures(
-    @Body() body: {
+    @Body()
+    body: {
       chatEnabled?: boolean;
       dynamicCategoriesEnabled?: boolean;
       aiSuggestionsEnabled?: boolean;

--- a/api/src/ai/ai-admin.controller.ts
+++ b/api/src/ai/ai-admin.controller.ts
@@ -127,6 +127,7 @@ export class AiAdminController {
   async getFeatures(): Promise<{
     chatEnabled: boolean;
     dynamicCategoriesEnabled: boolean;
+    aiSuggestionsEnabled: boolean;
   }> {
     const chat = await this.settings.get(
       AI_SETTING_KEYS.CHAT_ENABLED as SettingKey,
@@ -134,9 +135,15 @@ export class AiAdminController {
     const dynCat = await this.settings.get(
       AI_SETTING_KEYS.DYNAMIC_CATEGORIES_ENABLED as SettingKey,
     );
+    const sugg = await this.settings.get(
+      AI_SETTING_KEYS.SUGGESTIONS_ENABLED as SettingKey,
+    );
     return {
       chatEnabled: chat === 'true',
       dynamicCategoriesEnabled: dynCat === 'true',
+      // ROK-1114: defaults to true so an unconfigured install gets the
+      // feature; admin must explicitly set 'false' to disable.
+      aiSuggestionsEnabled: sugg !== 'false',
     };
   }
 
@@ -144,7 +151,11 @@ export class AiAdminController {
   @Put('features')
   @HttpCode(HttpStatus.OK)
   async updateFeatures(
-    @Body() body: { chatEnabled?: boolean; dynamicCategoriesEnabled?: boolean },
+    @Body() body: {
+      chatEnabled?: boolean;
+      dynamicCategoriesEnabled?: boolean;
+      aiSuggestionsEnabled?: boolean;
+    },
   ): Promise<{ success: boolean }> {
     if (body.chatEnabled !== undefined) {
       await this.settings.set(
@@ -156,6 +167,12 @@ export class AiAdminController {
       await this.settings.set(
         AI_SETTING_KEYS.DYNAMIC_CATEGORIES_ENABLED as SettingKey,
         String(body.dynamicCategoriesEnabled),
+      );
+    }
+    if (body.aiSuggestionsEnabled !== undefined) {
+      await this.settings.set(
+        AI_SETTING_KEYS.SUGGESTIONS_ENABLED as SettingKey,
+        String(body.aiSuggestionsEnabled),
       );
     }
     return { success: true };

--- a/api/src/ai/ai-admin.controller.ts
+++ b/api/src/ai/ai-admin.controller.ts
@@ -48,7 +48,8 @@ export class AiAdminController {
   /** GET /admin/ai/status — provider connectivity and current model. */
   @Get('status')
   async getStatus(): Promise<AiStatusDto> {
-    const provider = await this.registry.resolveActive();
+    const resolution = await this.registry.resolveActive();
+    const provider = resolution?.provider;
     const isAvailable = await this.withTimeout(
       this.llmService.isAvailable(),
       false,
@@ -169,7 +170,8 @@ export class AiAdminController {
   }> {
     const isUp = await this.withTimeout(this.llmService.isAvailable(), false);
     if (!isUp) return this.notAvailableResult();
-    const provider = await this.registry.resolveActive();
+    const resolution = await this.registry.resolveActive();
+    const provider = resolution?.provider;
     const modelSetting = await this.settings.get(
       AI_SETTING_KEYS.MODEL as SettingKey,
     );

--- a/api/src/ai/ai-providers.controller.ts
+++ b/api/src/ai/ai-providers.controller.ts
@@ -19,7 +19,7 @@ import { SettingsService } from '../settings/settings.service';
 import { OllamaDockerService } from './providers/ollama-docker.service';
 import { OllamaNativeService } from './providers/ollama-native.service';
 import { OllamaSetupService } from './providers/ollama-setup.service';
-import { AI_DEFAULTS, AI_SETTING_KEYS } from './llm.constants';
+import { AI_SETTING_KEYS } from './llm.constants';
 import type {
   AiProviderInfoDto,
   AiOllamaSetupDto,
@@ -96,12 +96,19 @@ export class AiProvidersController {
     return { success: true };
   }
 
-  /** Resolve active provider key from settings. */
+  /**
+   * Resolve active provider key. Honours an explicit `ai_provider` setting,
+   * else falls back to the registry's auto-pick (first cloud provider with
+   * a key configured). Returns empty string when nothing is configured so
+   * the per-provider "active" badge stays unset.
+   */
   private async getActiveProviderKey(): Promise<string> {
-    return (
-      (await this.settings.get(AI_SETTING_KEYS.PROVIDER as SettingKey)) ??
-      AI_DEFAULTS.provider
+    const explicit = await this.settings.get(
+      AI_SETTING_KEYS.PROVIDER as SettingKey,
     );
+    if (explicit) return explicit;
+    const resolution = await this.registry.resolveActive();
+    return resolution?.provider.key ?? '';
   }
 
   /** Build provider info including configuration and availability. */

--- a/api/src/ai/llm-provider-registry.spec.ts
+++ b/api/src/ai/llm-provider-registry.spec.ts
@@ -147,3 +147,55 @@ describe('LlmProviderRegistry (adversarial)', () => {
     });
   });
 });
+
+// ── ROK-1114: resolveActive must report resolution source ──────────
+//
+// To diagnose the prod outage where AI suggestions never loaded, the
+// LLM service needs to know whether the active provider came from a
+// real `app_settings` row (operator-configured) or from the hard-coded
+// `AI_DEFAULTS.provider` fallback. The current shape returns just the
+// provider, which loses that signal — we change the return type to
+// `{ provider, source: 'setting' | 'default' }` so logChatEntry can
+// emit `source=setting|default` and we can tell at-a-glance from logs
+// whether the operator missed the configuration step.
+
+describe('LlmProviderRegistry.resolveActive — source reporting (ROK-1114)', () => {
+  let registry: LlmProviderRegistry;
+  let mockSettings: { get: jest.Mock };
+
+  beforeEach(async () => {
+    mockSettings = { get: jest.fn() };
+    const module = await Test.createTestingModule({
+      providers: [
+        LlmProviderRegistry,
+        { provide: SettingsService, useValue: mockSettings },
+      ],
+    }).compile();
+    registry = module.get(LlmProviderRegistry);
+  });
+
+  it("returns source: 'setting' when ai_provider is set in app_settings", async () => {
+    const provider = createMockProvider('openai');
+    registry.register(provider);
+    mockSettings.get.mockResolvedValue('openai');
+
+    const result = await registry.resolveActive();
+
+    expect(result).toEqual({ provider, source: 'setting' });
+  });
+
+  it("returns source: 'default' when settings is empty (falls back to AI_DEFAULTS.provider)", async () => {
+    // The default key after ROK-1114 is 'google' — but this test should
+    // hold for whatever AI_DEFAULTS.provider is, so register that key
+    // dynamically rather than hard-coding 'ollama' or 'google'.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { AI_DEFAULTS } = require('./llm.constants');
+    const provider = createMockProvider(AI_DEFAULTS.provider);
+    registry.register(provider);
+    mockSettings.get.mockResolvedValue(null);
+
+    const result = await registry.resolveActive();
+
+    expect(result).toEqual({ provider, source: 'default' });
+  });
+});

--- a/api/src/ai/llm-provider-registry.spec.ts
+++ b/api/src/ai/llm-provider-registry.spec.ts
@@ -75,7 +75,7 @@ describe('LlmProviderRegistry', () => {
       // picks the first one whose ai_<key>_api_key is configured.
       const claude = createCloudProvider('claude');
       registry.register(claude);
-      mockSettings.get.mockImplementation(async (key: string) => {
+      mockSettings.get.mockImplementation((key: string) => {
         if (key === 'ai_provider') return null;
         if (key === 'ai_claude_api_key') return 'sk-test-claude';
         return null;
@@ -211,7 +211,7 @@ describe('LlmProviderRegistry.resolveActive — source reporting (ROK-1114)', ()
     const google = createCloudProvider('google');
     registry.register(claude);
     registry.register(google);
-    mockSettings.get.mockImplementation(async (key: string) => {
+    mockSettings.get.mockImplementation((key: string) => {
       if (key === 'ai_provider') return null;
       if (key === 'ai_claude_api_key') return 'sk-ant-test';
       return null;
@@ -227,7 +227,7 @@ describe('LlmProviderRegistry.resolveActive — source reporting (ROK-1114)', ()
     const google = createCloudProvider('google');
     registry.register(claude);
     registry.register(google);
-    mockSettings.get.mockImplementation(async (key: string) => {
+    mockSettings.get.mockImplementation((key: string) => {
       if (key === 'ai_provider') return null;
       if (key === 'ai_google_api_key') return 'AIza-test';
       return null;
@@ -277,7 +277,7 @@ describe('LlmProviderRegistry.resolveActive — source reporting (ROK-1114)', ()
     const google = createCloudProvider('google');
     registry.register(claude);
     registry.register(google);
-    mockSettings.get.mockImplementation(async (key: string) => {
+    mockSettings.get.mockImplementation((key: string) => {
       if (key === 'ai_provider') return 'google';
       if (key === 'ai_claude_api_key') return 'sk-ant-test';
       if (key === 'ai_google_api_key') return 'AIza-test';

--- a/api/src/ai/llm-provider-registry.spec.ts
+++ b/api/src/ai/llm-provider-registry.spec.ts
@@ -52,15 +52,19 @@ describe('LlmProviderRegistry', () => {
       registry.register(provider);
       mockSettings.get.mockResolvedValue('ollama');
       const result = await registry.resolveActive();
-      expect(result).toBe(provider);
+      expect(result).toEqual({ provider, source: 'setting' });
     });
 
     it('falls back to default provider when setting is null', async () => {
-      const provider = createMockProvider('ollama');
+      // AI_DEFAULTS.provider drives the fallback key — register a provider
+      // with that key so the lookup resolves regardless of the constant value.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { AI_DEFAULTS } = require('./llm.constants');
+      const provider = createMockProvider(AI_DEFAULTS.provider);
       registry.register(provider);
       mockSettings.get.mockResolvedValue(null);
       const result = await registry.resolveActive();
-      expect(result).toBe(provider);
+      expect(result).toEqual({ provider, source: 'default' });
     });
 
     it('returns undefined when no provider matches', async () => {
@@ -143,7 +147,8 @@ describe('LlmProviderRegistry (adversarial)', () => {
       registry.register(createMockProvider('openai'));
       mockSettings.get.mockResolvedValue('openai');
       const result = await registry.resolveActive();
-      expect(result?.key).toBe('openai');
+      expect(result?.provider.key).toBe('openai');
+      expect(result?.source).toBe('setting');
     });
   });
 });

--- a/api/src/ai/llm-provider-registry.spec.ts
+++ b/api/src/ai/llm-provider-registry.spec.ts
@@ -3,18 +3,32 @@ import { LlmProviderRegistry } from './llm-provider-registry';
 import { SettingsService } from '../settings/settings.service';
 import type { LlmProvider } from './llm-provider.interface';
 
-function createMockProvider(key: string): LlmProvider {
+interface MockProviderShape {
+  selfHosted?: boolean;
+  requiresApiKey?: boolean;
+}
+
+function createMockProvider(
+  key: string,
+  shape: MockProviderShape = {},
+): LlmProvider {
+  // Default shape mirrors the legacy ollama provider (self-hosted, keyless)
+  // so existing tests keep passing without explicitly opting in.
   return {
     key,
     displayName: `${key} Provider`,
-    requiresApiKey: false,
-    selfHosted: true,
+    requiresApiKey: shape.requiresApiKey ?? false,
+    selfHosted: shape.selfHosted ?? true,
     defaultModel: 'mock-model',
     isAvailable: jest.fn().mockResolvedValue(true),
     listModels: jest.fn().mockResolvedValue([]),
     chat: jest.fn().mockResolvedValue({ content: '', latencyMs: 0 }),
     generate: jest.fn().mockResolvedValue({ content: '', latencyMs: 0 }),
   };
+}
+
+function createCloudProvider(key: string): LlmProvider {
+  return createMockProvider(key, { selfHosted: false, requiresApiKey: true });
 }
 
 describe('LlmProviderRegistry', () => {
@@ -55,19 +69,22 @@ describe('LlmProviderRegistry', () => {
       expect(result).toEqual({ provider, source: 'setting' });
     });
 
-    it('falls back to default provider when setting is null', async () => {
-      // AI_DEFAULTS.provider drives the fallback key — register a provider
-      // with that key so the lookup resolves regardless of the constant value.
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const { AI_DEFAULTS } = require('./llm.constants');
-      const provider = createMockProvider(AI_DEFAULTS.provider);
-      registry.register(provider);
-      mockSettings.get.mockResolvedValue(null);
+    it('auto-picks the first cloud provider with an API key when setting is null', async () => {
+      // ROK-1114: removed AI_DEFAULTS.provider hardcoded fallback. With
+      // setting unset, the registry walks registered cloud providers and
+      // picks the first one whose ai_<key>_api_key is configured.
+      const claude = createCloudProvider('claude');
+      registry.register(claude);
+      mockSettings.get.mockImplementation(async (key: string) => {
+        if (key === 'ai_provider') return null;
+        if (key === 'ai_claude_api_key') return 'sk-test-claude';
+        return null;
+      });
       const result = await registry.resolveActive();
-      expect(result).toEqual({ provider, source: 'default' });
+      expect(result).toEqual({ provider: claude, source: 'auto' });
     });
 
-    it('returns undefined when no provider matches', async () => {
+    it('returns undefined when settings names a non-existent provider AND no auto-pick is available', async () => {
       mockSettings.get.mockResolvedValue('nonexistent');
       const result = await registry.resolveActive();
       expect(result).toBeUndefined();
@@ -124,22 +141,24 @@ describe('LlmProviderRegistry (adversarial)', () => {
   });
 
   describe('resolveActive — edge cases', () => {
-    it('returns undefined when settings returns unknown provider key', async () => {
+    it('falls through to auto-pick when settings names an unknown provider key', async () => {
+      // ROK-1114: an unknown explicit provider key no longer short-circuits
+      // — we still try auto-pick. With no cloud providers registered, the
+      // result is undefined.
       registry.register(createMockProvider('ollama'));
       mockSettings.get.mockResolvedValue('unknown-provider');
       const result = await registry.resolveActive();
       expect(result).toBeUndefined();
     });
 
-    it('returns the default provider (ollama) when settings returns empty string', async () => {
+    it('returns undefined when settings returns empty string and no API key is configured', async () => {
+      // Empty string is falsy → auto-pick path. With only a self-hosted
+      // provider registered (no requiresApiKey), auto-pick skips it.
       const provider = createMockProvider('ollama');
       registry.register(provider);
       mockSettings.get.mockResolvedValue('');
-      // empty string is falsy — should fall back to AI_DEFAULTS.provider ('ollama')
-      // but empty string is not null, so it depends on `??` operator (nullish coalescing)
-      // '' ?? 'ollama' = '' — so it looks up '' which won't exist
       const result = await registry.resolveActive();
-      expect(result).toBeUndefined(); // '' is not 'ollama', no match
+      expect(result).toBeUndefined();
     });
 
     it('resolves correctly after multiple providers are registered', async () => {
@@ -153,16 +172,14 @@ describe('LlmProviderRegistry (adversarial)', () => {
   });
 });
 
-// ── ROK-1114: resolveActive must report resolution source ──────────
+// ── ROK-1114: resolveActive auto-picks when ai_provider is unset ───
 //
-// To diagnose the prod outage where AI suggestions never loaded, the
-// LLM service needs to know whether the active provider came from a
-// real `app_settings` row (operator-configured) or from the hard-coded
-// `AI_DEFAULTS.provider` fallback. The current shape returns just the
-// provider, which loses that signal — we change the return type to
-// `{ provider, source: 'setting' | 'default' }` so logChatEntry can
-// emit `source=setting|default` and we can tell at-a-glance from logs
-// whether the operator missed the configuration step.
+// Original prod outage: AI suggestions never loaded because the registry
+// fell back to a hard-coded provider (`AI_DEFAULTS.provider`) that was not
+// actually configured with credentials. Rework drops the hardcoded default
+// and instead walks registered cloud providers, picking the first one
+// whose API key is set. `source: 'auto'` surfaces that path in logs so
+// operators can tell at-a-glance whether the explicit setting was honoured.
 
 describe('LlmProviderRegistry.resolveActive — source reporting (ROK-1114)', () => {
   let registry: LlmProviderRegistry;
@@ -180,7 +197,7 @@ describe('LlmProviderRegistry.resolveActive — source reporting (ROK-1114)', ()
   });
 
   it("returns source: 'setting' when ai_provider is set in app_settings", async () => {
-    const provider = createMockProvider('openai');
+    const provider = createCloudProvider('openai');
     registry.register(provider);
     mockSettings.get.mockResolvedValue('openai');
 
@@ -189,18 +206,88 @@ describe('LlmProviderRegistry.resolveActive — source reporting (ROK-1114)', ()
     expect(result).toEqual({ provider, source: 'setting' });
   });
 
-  it("returns source: 'default' when settings is empty (falls back to AI_DEFAULTS.provider)", async () => {
-    // The default key after ROK-1114 is 'google' — but this test should
-    // hold for whatever AI_DEFAULTS.provider is, so register that key
-    // dynamically rather than hard-coding 'ollama' or 'google'.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports
-    const { AI_DEFAULTS } = require('./llm.constants');
-    const provider = createMockProvider(AI_DEFAULTS.provider);
-    registry.register(provider);
+  it("auto-picks Claude with source: 'auto' when only Claude has an API key", async () => {
+    const claude = createCloudProvider('claude');
+    const google = createCloudProvider('google');
+    registry.register(claude);
+    registry.register(google);
+    mockSettings.get.mockImplementation(async (key: string) => {
+      if (key === 'ai_provider') return null;
+      if (key === 'ai_claude_api_key') return 'sk-ant-test';
+      return null;
+    });
+
+    const result = await registry.resolveActive();
+
+    expect(result).toEqual({ provider: claude, source: 'auto' });
+  });
+
+  it("auto-picks Google with source: 'auto' when only Google has an API key", async () => {
+    const claude = createCloudProvider('claude');
+    const google = createCloudProvider('google');
+    registry.register(claude);
+    registry.register(google);
+    mockSettings.get.mockImplementation(async (key: string) => {
+      if (key === 'ai_provider') return null;
+      if (key === 'ai_google_api_key') return 'AIza-test';
+      return null;
+    });
+
+    const result = await registry.resolveActive();
+
+    expect(result).toEqual({ provider: google, source: 'auto' });
+  });
+
+  it('returns undefined when ai_provider is unset AND no cloud API keys are configured', async () => {
+    registry.register(createCloudProvider('openai'));
+    registry.register(createCloudProvider('claude'));
+    registry.register(createCloudProvider('google'));
     mockSettings.get.mockResolvedValue(null);
 
     const result = await registry.resolveActive();
 
-    expect(result).toEqual({ provider, source: 'default' });
+    expect(result).toBeUndefined();
+  });
+
+  it('skips self-hosted providers in auto-pick', async () => {
+    // Ollama is self-hosted and keyless — even with no other providers
+    // registered, auto-pick must NOT select it. The only legitimate way
+    // to use Ollama is an explicit `ai_provider=ollama` setting.
+    const ollama = createMockProvider('ollama'); // selfHosted: true (default)
+    registry.register(ollama);
+    mockSettings.get.mockResolvedValue(null);
+
+    const result = await registry.resolveActive();
+
+    expect(result).toBeUndefined();
+  });
+
+  it('honours explicit ai_provider=ollama even though auto-pick would skip it', async () => {
+    const ollama = createMockProvider('ollama');
+    registry.register(ollama);
+    mockSettings.get.mockResolvedValue('ollama');
+
+    const result = await registry.resolveActive();
+
+    expect(result).toEqual({ provider: ollama, source: 'setting' });
+  });
+
+  it('prefers explicit setting over auto-pick when both are available', async () => {
+    const claude = createCloudProvider('claude');
+    const google = createCloudProvider('google');
+    registry.register(claude);
+    registry.register(google);
+    mockSettings.get.mockImplementation(async (key: string) => {
+      if (key === 'ai_provider') return 'google';
+      if (key === 'ai_claude_api_key') return 'sk-ant-test';
+      if (key === 'ai_google_api_key') return 'AIza-test';
+      return null;
+    });
+
+    const result = await registry.resolveActive();
+
+    // Should be google (the explicit setting) with source 'setting',
+    // even though claude has a key and is registered first.
+    expect(result).toEqual({ provider: google, source: 'setting' });
   });
 });

--- a/api/src/ai/llm-provider-registry.ts
+++ b/api/src/ai/llm-provider-registry.ts
@@ -5,6 +5,18 @@ import { AI_DEFAULTS, AI_SETTING_KEYS } from './llm.constants';
 import type { SettingKey } from '../drizzle/schema';
 
 /**
+ * Resolution outcome for the active LLM provider.
+ *
+ * `source` distinguishes operator configuration (`'setting'`) from the
+ * hard-coded `AI_DEFAULTS.provider` fallback (`'default'`) so the LLM
+ * service can surface that signal in logs (ROK-1114).
+ */
+export interface ActiveProviderResolution {
+  provider: LlmProvider;
+  source: 'setting' | 'default';
+}
+
+/**
  * Registry of available LLM providers.
  * Manages provider registration and active-provider resolution via settings.
  */
@@ -25,11 +37,16 @@ export class LlmProviderRegistry {
   }
 
   /** Resolve the currently active provider from settings. */
-  async resolveActive(): Promise<LlmProvider | undefined> {
-    const key =
-      (await this.settings.get(AI_SETTING_KEYS.PROVIDER as SettingKey)) ??
-      AI_DEFAULTS.provider;
-    return this.providers.get(key);
+  async resolveActive(): Promise<ActiveProviderResolution | undefined> {
+    const configured = await this.settings.get(
+      AI_SETTING_KEYS.PROVIDER as SettingKey,
+    );
+    const source: 'setting' | 'default' =
+      configured == null ? 'default' : 'setting';
+    const key = configured ?? AI_DEFAULTS.provider;
+    const provider = this.providers.get(key);
+    if (!provider) return undefined;
+    return { provider, source };
   }
 
   /** List all registered providers. */

--- a/api/src/ai/llm-provider-registry.ts
+++ b/api/src/ai/llm-provider-registry.ts
@@ -1,19 +1,20 @@
 import { Injectable } from '@nestjs/common';
 import { SettingsService } from '../settings/settings.service';
 import type { LlmProvider } from './llm-provider.interface';
-import { AI_DEFAULTS, AI_SETTING_KEYS } from './llm.constants';
+import { AI_SETTING_KEYS } from './llm.constants';
 import type { SettingKey } from '../drizzle/schema';
 
 /**
  * Resolution outcome for the active LLM provider.
  *
  * `source` distinguishes operator configuration (`'setting'`) from the
- * hard-coded `AI_DEFAULTS.provider` fallback (`'default'`) so the LLM
- * service can surface that signal in logs (ROK-1114).
+ * auto-pick fallback (`'auto'`, picked when `ai_provider` is unset but
+ * a cloud provider has an API key configured) so the LLM service can
+ * surface that signal in logs (ROK-1114).
  */
 export interface ActiveProviderResolution {
   provider: LlmProvider;
-  source: 'setting' | 'default';
+  source: 'setting' | 'auto';
 }
 
 /**
@@ -36,17 +37,40 @@ export class LlmProviderRegistry {
     return this.providers.get(key);
   }
 
-  /** Resolve the currently active provider from settings. */
+  /**
+   * Resolve the currently active provider.
+   *
+   * 1. If `ai_provider` is set in `app_settings` and matches a registered
+   *    provider, return it with `source: 'setting'`.
+   * 2. Otherwise auto-pick the first registered cloud provider whose API
+   *    key is configured (`ai_<key>_api_key`), returning `source: 'auto'`.
+   *    Self-hosted/keyless providers are skipped in auto-pick — they need
+   *    explicit operator selection via `ai_provider`.
+   * 3. If neither path yields a provider, return `undefined`.
+   */
   async resolveActive(): Promise<ActiveProviderResolution | undefined> {
     const configured = await this.settings.get(
       AI_SETTING_KEYS.PROVIDER as SettingKey,
     );
-    const source: 'setting' | 'default' =
-      configured == null ? 'default' : 'setting';
-    const key = configured ?? AI_DEFAULTS.provider;
-    const provider = this.providers.get(key);
-    if (!provider) return undefined;
-    return { provider, source };
+    if (configured) {
+      const provider = this.providers.get(configured);
+      if (provider) return { provider, source: 'setting' };
+    }
+    return this.autoPickProvider();
+  }
+
+  /** Auto-pick the first cloud provider whose API key is configured. */
+  private async autoPickProvider(): Promise<
+    ActiveProviderResolution | undefined
+  > {
+    for (const provider of this.providers.values()) {
+      if (provider.selfHosted) continue;
+      if (!provider.requiresApiKey) continue;
+      const settingKey = `ai_${provider.key}_api_key` as SettingKey;
+      const apiKey = await this.settings.get(settingKey);
+      if (apiKey) return { provider, source: 'auto' };
+    }
+    return undefined;
   }
 
   /** List all registered providers. */

--- a/api/src/ai/llm.constants.ts
+++ b/api/src/ai/llm.constants.ts
@@ -37,6 +37,8 @@ export const AI_SETTING_KEYS = {
   OLLAMA_URL: 'ai_ollama_url',
   CHAT_ENABLED: 'ai_chat_enabled',
   DYNAMIC_CATEGORIES_ENABLED: 'ai_dynamic_categories_enabled',
+  /** ROK-1114: master switch for per-user AI nomination suggestions. */
+  SUGGESTIONS_ENABLED: 'ai_suggestions_enabled',
   OPENAI_API_KEY: 'ai_openai_api_key',
   CLAUDE_API_KEY: 'ai_claude_api_key',
   GOOGLE_API_KEY: 'ai_google_api_key',

--- a/api/src/ai/llm.constants.ts
+++ b/api/src/ai/llm.constants.ts
@@ -1,6 +1,6 @@
 /** Default configuration values for the AI subsystem. */
 export const AI_DEFAULTS = {
-  provider: 'ollama',
+  provider: 'google',
   model: 'llama3.2:3b',
   ollamaUrl: 'http://localhost:11434',
   maxTokens: 1024,

--- a/api/src/ai/llm.constants.ts
+++ b/api/src/ai/llm.constants.ts
@@ -1,6 +1,12 @@
-/** Default configuration values for the AI subsystem. */
+/**
+ * Default configuration values for the AI subsystem.
+ *
+ * Provider selection is no longer hard-coded here (ROK-1114) — the registry
+ * either honours `app_settings.ai_provider` or auto-picks the first cloud
+ * provider whose API key is configured. Self-hosted Ollama remains
+ * keyless and must be selected explicitly via the setting.
+ */
 export const AI_DEFAULTS = {
-  provider: 'google',
   model: 'llama3.2:3b',
   ollamaUrl: 'http://localhost:11434',
   maxTokens: 1024,

--- a/api/src/ai/llm.service.spec.ts
+++ b/api/src/ai/llm.service.spec.ts
@@ -43,7 +43,9 @@ describe('LlmService', () => {
   beforeEach(async () => {
     mockProvider = createMockProvider();
     mockRegistry = {
-      resolveActive: jest.fn().mockResolvedValue(mockProvider),
+      resolveActive: jest
+        .fn()
+        .mockResolvedValue({ provider: mockProvider, source: 'setting' }),
       list: jest.fn().mockReturnValue([mockProvider]),
     };
     mockLogService = { log: jest.fn().mockResolvedValue(undefined) };
@@ -172,7 +174,9 @@ describe('LlmService (adversarial)', () => {
   beforeEach(async () => {
     mockProvider = createMockProvider();
     mockRegistry = {
-      resolveActive: jest.fn().mockResolvedValue(mockProvider),
+      resolveActive: jest
+        .fn()
+        .mockResolvedValue({ provider: mockProvider, source: 'setting' }),
       list: jest.fn().mockReturnValue([mockProvider]),
     };
     mockLogService = { log: jest.fn().mockResolvedValue(undefined) };
@@ -402,7 +406,9 @@ describe('ROK-1000: LlmService diagnostic logging', () => {
   beforeEach(async () => {
     mockProvider = createLoggingMockProvider();
     mockRegistry = {
-      resolveActive: jest.fn().mockResolvedValue(mockProvider),
+      resolveActive: jest
+        .fn()
+        .mockResolvedValue({ provider: mockProvider, source: 'setting' }),
       list: jest.fn().mockReturnValue([mockProvider]),
     };
     mockLogService = { log: jest.fn().mockResolvedValue(undefined) };

--- a/api/src/ai/llm.service.ts
+++ b/api/src/ai/llm.service.ts
@@ -143,7 +143,7 @@ export class LlmService {
   /** Log diagnostic info on chat entry. */
   private logChatEntry(
     providerKey: string,
-    source: 'setting' | 'default',
+    source: 'setting' | 'auto',
     model: string,
     feature: string,
     timeoutMs: number,

--- a/api/src/ai/llm.service.ts
+++ b/api/src/ai/llm.service.ts
@@ -50,12 +50,12 @@ export class LlmService {
     options: LlmChatOptions,
     context: LlmRequestContext,
   ): Promise<LlmChatResponse> {
-    const provider = await this.resolveOrThrow();
+    const { provider, source } = await this.resolveOrThrow();
     this.applyPreChecks(context);
     const prepared = this.prepareChatOptions(options);
     const model = options.model ?? provider.defaultModel;
     const timeoutMs = context.timeoutMs ?? AI_DEFAULTS.timeoutMs;
-    this.logChatEntry(provider.key, model, context.feature, timeoutMs);
+    this.logChatEntry(provider.key, source, model, context.feature, timeoutMs);
     const start = Date.now();
 
     return this.concurrencyLimiter.withLimit(async () => {
@@ -82,7 +82,7 @@ export class LlmService {
     options: LlmGenerateOptions,
     context: LlmRequestContext,
   ): Promise<LlmGenerateResponse> {
-    const provider = await this.resolveOrThrow();
+    const { provider } = await this.resolveOrThrow();
     this.applyPreChecks(context);
     const sanitizedPrompt = sanitizeInput(options.prompt);
     const model = options.model ?? provider.defaultModel;
@@ -110,9 +110,9 @@ export class LlmService {
 
   /** Check if the active provider is reachable. */
   async isAvailable(): Promise<boolean> {
-    const provider = await this.registry.resolveActive();
-    if (!provider) return false;
-    return provider.isAvailable();
+    const resolution = await this.registry.resolveActive();
+    if (!resolution) return false;
+    return resolution.provider.isAvailable();
   }
 
   /**
@@ -122,33 +122,34 @@ export class LlmService {
    * Haiku when the interactive chat is on Sonnet).
    */
   async getActiveProviderKey(): Promise<string | null> {
-    const provider = await this.registry.resolveActive();
-    return provider?.key ?? null;
+    const resolution = await this.registry.resolveActive();
+    return resolution?.provider.key ?? null;
   }
 
   /** List models from the active provider. */
   async listModels(): Promise<LlmModelInfo[]> {
-    const provider = await this.resolveOrThrow();
+    const { provider } = await this.resolveOrThrow();
     return provider.listModels();
   }
 
   private async resolveOrThrow() {
-    const provider = await this.registry.resolveActive();
-    if (!provider) {
+    const resolution = await this.registry.resolveActive();
+    if (!resolution) {
       throw new NotFoundException('No AI provider configured');
     }
-    return provider;
+    return resolution;
   }
 
   /** Log diagnostic info on chat entry. */
   private logChatEntry(
     providerKey: string,
+    source: 'setting' | 'default',
     model: string,
     feature: string,
     timeoutMs: number,
   ): void {
     this.logger.log(
-      `LLM chat | provider=${providerKey} model=${model} feature=${feature} timeout=${timeoutMs}ms`,
+      `LLM chat | provider=${providerKey} source=${source} model=${model} feature=${feature} timeout=${timeoutMs}ms`,
     );
   }
 

--- a/api/src/drizzle/schema/app-settings.ts
+++ b/api/src/drizzle/schema/app-settings.ts
@@ -92,6 +92,8 @@ export const SETTING_KEYS = {
   AI_CHAT_ENABLED: 'ai_chat_enabled',
   /** ROK-542: Whether AI dynamic categories feature is enabled */
   AI_DYNAMIC_CATEGORIES_ENABLED: 'ai_dynamic_categories_enabled',
+  /** ROK-1114: Whether per-user AI nomination suggestions are enabled. */
+  AI_SUGGESTIONS_ENABLED: 'ai_suggestions_enabled',
   /** ROK-542: OpenAI API key */
   AI_OPENAI_API_KEY: 'ai_openai_api_key',
   /** ROK-542: Claude (Anthropic) API key */

--- a/api/src/lineups/ai-suggestions/ai-suggestions.integration.spec.ts
+++ b/api/src/lineups/ai-suggestions/ai-suggestions.integration.spec.ts
@@ -14,6 +14,9 @@ import {
   truncateAllTables,
   loginAsAdmin,
 } from '../../common/testing/integration-helpers';
+import { SettingsService } from '../../settings/settings.service';
+import { LlmService } from '../../ai/llm.service';
+import { SETTING_KEYS } from '../../drizzle/schema';
 
 function describeAiSuggestions() {
   let testApp: TestApp;
@@ -66,6 +69,35 @@ function describeAiSuggestions() {
       const lineupId = await createLineup();
       const res = await testApp.request.get(`/lineups/${lineupId}/suggestions`);
       expect(res.status).toBe(401);
+    });
+
+    /**
+     * ROK-1114 round 3: when admin disables the feature, the endpoint
+     * MUST return 200 with empty suggestions and MUST NOT call the LLM.
+     * 503 would be wrong — it maps to "temporarily unavailable" UX,
+     * which is misleading for an intentional admin disable.
+     */
+    it('returns 200 with empty suggestions and does NOT call LlmService.chat when ai_suggestions_enabled is false', async () => {
+      const lineupId = await createLineup();
+      const settings = testApp.app.get(SettingsService);
+      const llm = testApp.app.get(LlmService);
+      const chatSpy = jest.spyOn(llm, 'chat');
+      await settings.set(SETTING_KEYS.AI_SUGGESTIONS_ENABLED, 'false');
+      try {
+        const res = await testApp.request
+          .get(`/lineups/${lineupId}/suggestions`)
+          .set('Authorization', `Bearer ${adminToken}`);
+        expect(res.status).toBe(200);
+        expect(res.body).toMatchObject({
+          suggestions: [],
+          voterCount: 0,
+          cached: false,
+        });
+        expect(chatSpy).not.toHaveBeenCalled();
+      } finally {
+        chatSpy.mockRestore();
+        await settings.set(SETTING_KEYS.AI_SUGGESTIONS_ENABLED, 'true');
+      }
     });
   });
 }

--- a/api/src/lineups/ai-suggestions/ai-suggestions.service.ts
+++ b/api/src/lineups/ai-suggestions/ai-suggestions.service.ts
@@ -14,6 +14,7 @@ import { LlmService } from '../../ai/llm.service';
 import { AI_DEFAULTS, AI_SETTING_KEYS } from '../../ai/llm.constants';
 import { GameTasteService } from '../../game-taste/game-taste.service';
 import * as schema from '../../drizzle/schema';
+import type { SettingKey } from '../../drizzle/schema';
 import {
   resolveVoterScope,
   type ResolvedVoterScope,
@@ -63,12 +64,20 @@ export class AiSuggestionsService {
   /**
    * Public entry point called from the controller. Delegates to
    * `getOrGenerate` with stampede dedupe keyed on lineupId + hash.
+   *
+   * Returns an empty payload (without calling the LLM) when admins have
+   * disabled the feature via `ai_suggestions_enabled = 'false'`. The UI
+   * collapses on empty success, hiding the section entirely (ROK-1114
+   * round 3).
    */
   async getSuggestions(
     lineupId: number,
     opts: GetSuggestionsOpts = {},
   ): Promise<AiSuggestionsResponseDto> {
     const lineup = await this.loadLineup(lineupId);
+    if (await this.isFeatureDisabled()) {
+      return this.emptyResponse();
+    }
     const scope = await resolveVoterScope(this.db, lineup, {
       personalizeUserId: opts.personalizeUserId,
     });
@@ -80,6 +89,23 @@ export class AiSuggestionsService {
     });
     this.inFlight.set(key, promise);
     return promise;
+  }
+
+  private async isFeatureDisabled(): Promise<boolean> {
+    const value = await this.settings.get(
+      AI_SETTING_KEYS.SUGGESTIONS_ENABLED as SettingKey,
+    );
+    return value === 'false';
+  }
+
+  private emptyResponse(): AiSuggestionsResponseDto {
+    return {
+      suggestions: [],
+      generatedAt: new Date().toISOString(),
+      voterCount: 0,
+      voterScopeStrategy: 'community',
+      cached: false,
+    } satisfies AiSuggestionsResponseDto;
   }
 
   private async loadLineup(lineupId: number): Promise<

--- a/api/src/lineups/ai-suggestions/ai-suggestions.service.ts
+++ b/api/src/lineups/ai-suggestions/ai-suggestions.service.ts
@@ -211,7 +211,8 @@ export class AiSuggestionsService {
   }> {
     const provider =
       (await this.settings.get(AI_SETTING_KEYS.PROVIDER as never)) ??
-      AI_DEFAULTS.provider;
+      (await this.llmService.getActiveProviderKey()) ??
+      'unknown';
     const model =
       (await this.settings.get(AI_SETTING_KEYS.MODEL as never)) ??
       AI_DEFAULTS.model;

--- a/scripts/smoke/community-lineup.smoke.spec.ts
+++ b/scripts/smoke/community-lineup.smoke.spec.ts
@@ -178,7 +178,7 @@ test.describe('Nomination modal', () => {
         await expect(modal.getByRole('heading', { name: 'Nominate a Game' })).toBeVisible({ timeout: 5_000 });
 
         // Search input inside the modal should be present
-        await expect(modal.getByPlaceholder('Search games...')).toBeVisible({ timeout: 3_000 });
+        await expect(modal.getByPlaceholder('Search by name or paste a Steam store URL')).toBeVisible({ timeout: 3_000 });
     });
 
     test('search input accepts text and shows results or empty state', async ({ page }) => {
@@ -189,7 +189,7 @@ test.describe('Nomination modal', () => {
         const modal = page.locator('[role="dialog"]');
         await expect(modal.getByRole('heading', { name: 'Nominate a Game' })).toBeVisible({ timeout: 5_000 });
 
-        const searchInput = modal.getByPlaceholder('Search games...');
+        const searchInput = modal.getByPlaceholder('Search by name or paste a Steam store URL');
         await searchInput.fill('xyznonexistent999');
 
         // Should show "No games found" or "Searching..." then "No games found"
@@ -207,7 +207,7 @@ test.describe('Nomination modal', () => {
         await expect(modal.getByRole('heading', { name: 'Nominate a Game' })).toBeVisible({ timeout: 5_000 });
 
         // Search for a game known to exist in most demo/IGDB-seeded databases
-        const searchInput = modal.getByPlaceholder('Search games...');
+        const searchInput = modal.getByPlaceholder('Search by name or paste a Steam store URL');
         await searchInput.fill('Lethal');
 
         // Wait for debounced search (300ms) + API response

--- a/scripts/smoke/paste-nominate.smoke.spec.ts
+++ b/scripts/smoke/paste-nominate.smoke.spec.ts
@@ -209,7 +209,7 @@ test.describe('Input focus suppresses detection (AC4)', () => {
         await expect(modal).toBeVisible({ timeout: 5_000 });
 
         // Focus the search input
-        const searchInput = modal.getByPlaceholder('Search games...');
+        const searchInput = modal.getByPlaceholder('Search by name or paste a Steam store URL');
         await searchInput.focus();
 
         // Dispatch paste on the focused input element

--- a/web/src/components/lineups/AiStatusBanner.tsx
+++ b/web/src/components/lineups/AiStatusBanner.tsx
@@ -1,0 +1,37 @@
+/**
+ * Inline AI status indicator (ROK-1114).
+ *
+ * Surfaces the AI suggestions query state for any consumer that would
+ * otherwise silently render nothing when the provider is mis-configured
+ * or returns 503. Used by both `CommonGroundPanel` and the per-user
+ * "Suggested for you" row inside `NominateModal`.
+ *
+ * Returns `null` for the success/idle case so it can sit unconditionally
+ * inside a section without polluting the layout.
+ */
+import { type JSX } from 'react';
+
+export interface AiStatusBannerProps {
+    isLoading: boolean;
+    isUnavailable: boolean;
+    isError: boolean;
+}
+
+export function AiStatusBanner({
+    isLoading,
+    isUnavailable,
+    isError,
+}: AiStatusBannerProps): JSX.Element | null {
+    if (isUnavailable) {
+        return (
+            <p className="text-xs text-muted">Suggestions temporarily unavailable</p>
+        );
+    }
+    if (isError) {
+        return <p className="text-xs text-muted">AI suggestions unavailable</p>;
+    }
+    if (isLoading) {
+        return <p className="text-xs text-muted">AI suggestions loading…</p>;
+    }
+    return null;
+}

--- a/web/src/components/lineups/AiSuggestionCard.test.tsx
+++ b/web/src/components/lineups/AiSuggestionCard.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Tests for AiSuggestionCard (ROK-931).
+ * Tests for AiSuggestionCard (ROK-931, ROK-1114).
  *
  * Verifies:
  *   - `mode='nominate'` renders a Nominate button that becomes "At cap"
@@ -7,6 +7,8 @@
  *   - `mode='pick'` renders a Pick button that fires `onPick` with the
  *     suggestion DTO.
  *   - Ownership pill only renders when voterTotal > 0.
+ *   - Reasoning is exposed via the AI badge `title` tooltip rather than
+ *     inline body text (ROK-1114 round-3 cleanup).
  */
 import { describe, it, expect, vi } from 'vitest';
 import { screen } from '@testing-library/react';
@@ -29,7 +31,7 @@ function buildSuggestion(overrides: Partial<AiSuggestionDto> = {}): AiSuggestion
 }
 
 describe('AiSuggestionCard (ROK-931)', () => {
-    it('renders the game name, reasoning, and ownership pill', () => {
+    it('renders the game name, ownership pill, and exposes reasoning via the AI badge tooltip', () => {
         renderWithProviders(
             <AiSuggestionCard
                 suggestion={buildSuggestion()}
@@ -37,8 +39,24 @@ describe('AiSuggestionCard (ROK-931)', () => {
             />,
         );
         expect(screen.getByText('Valheim')).toBeInTheDocument();
-        expect(screen.getByText('Fits co-op taste')).toBeInTheDocument();
         expect(screen.getByText('3/5 own')).toBeInTheDocument();
+        // Reasoning is no longer inline body text — it's the badge tooltip.
+        expect(screen.queryByText('Fits co-op taste')).not.toBeInTheDocument();
+        const badge = screen.getByText(/AI Pick/i);
+        expect(badge).toHaveAttribute('title', 'Fits co-op taste');
+    });
+
+    it('falls back to the default badge tooltip when reasoning is missing', () => {
+        renderWithProviders(
+            <AiSuggestionCard
+                // @ts-expect-error — reasoning is required on the schema; we
+                // intentionally drop it to exercise the badge fallback.
+                suggestion={{ ...buildSuggestion(), reasoning: undefined }}
+                lineupId={7}
+            />,
+        );
+        const badge = screen.getByText(/AI Pick/i);
+        expect(badge).toHaveAttribute('title', 'Suggested by AI');
     });
 
     it('hides the ownership pill when voterTotal is 0', () => {

--- a/web/src/components/lineups/AiSuggestionCard.tsx
+++ b/web/src/components/lineups/AiSuggestionCard.tsx
@@ -23,19 +23,20 @@ export interface AiSuggestionCardProps {
     onPick?: (suggestion: AiSuggestionDto) => void;
 }
 
-/** ✨ AI Pick chip rendered in the top-left of every suggestion cover. */
-function AiBadge(): JSX.Element {
+/** ✨ AI Pick chip rendered in the top-left of every suggestion cover.
+ * `reasoning` surfaces in the native title tooltip so the modal stays clean. */
+function AiBadge({ reasoning }: { reasoning?: string }): JSX.Element {
     return (
         <span
             className="absolute top-2 left-2 text-[10px] font-semibold tracking-wide uppercase bg-violet-500/90 text-white rounded-full px-2 py-0.5 shadow-sm"
-            title="Suggested by AI"
+            title={reasoning ?? 'Suggested by AI'}
         >
             ✨ AI Pick
         </span>
     );
 }
 
-function Cover({ src, alt }: { src: string | null; alt: string }): JSX.Element {
+function Cover({ src, alt, reasoning }: { src: string | null; alt: string; reasoning?: string }): JSX.Element {
     if (src) {
         return (
             <div className="relative">
@@ -44,14 +45,14 @@ function Cover({ src, alt }: { src: string | null; alt: string }): JSX.Element {
                     alt={alt}
                     className="w-full aspect-[3/4] object-cover rounded-t-xl"
                 />
-                <AiBadge />
+                <AiBadge reasoning={reasoning} />
             </div>
         );
     }
     return (
         <div className="relative w-full aspect-[3/4] bg-panel rounded-t-xl flex items-center justify-center text-dim">
             No art
-            <AiBadge />
+            <AiBadge reasoning={reasoning} />
         </div>
     );
 }
@@ -85,11 +86,10 @@ export function AiSuggestionCard({
     };
 
     return (
-        <div className="w-[180px] flex-shrink-0 rounded-xl bg-panel border border-edge/50 overflow-hidden flex flex-col">
-            <Cover src={suggestion.coverUrl} alt={suggestion.name} />
+        <div className="min-w-0 rounded-xl bg-panel border border-edge/50 overflow-hidden flex flex-col">
+            <Cover src={suggestion.coverUrl} alt={suggestion.name} reasoning={suggestion.reasoning} />
             <div className="p-3 flex flex-col gap-2 flex-1">
                 <h3 className="text-sm font-medium text-foreground line-clamp-1">{suggestion.name}</h3>
-                <p className="text-xs text-muted line-clamp-2 min-h-[2rem]">{suggestion.reasoning}</p>
                 <OwnershipPill count={suggestion.ownershipCount} total={suggestion.voterTotal} />
                 {mode === 'nominate' ? (
                     <button

--- a/web/src/components/lineups/CommonGroundPanel.test.tsx
+++ b/web/src/components/lineups/CommonGroundPanel.test.tsx
@@ -13,12 +13,25 @@
  * `aiIsUnavailable`, and `aiIsError` and that `CommonGroundPanel` reads
  * them — both pieces are part of the ROK-1114 dev work.
  */
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
 import { http, HttpResponse, delay } from 'msw';
 import { CommonGroundPanel } from './CommonGroundPanel';
 import { renderWithProviders } from '../../test/render-helpers';
 import { server } from '../../test/mocks/server';
+import { usePluginStore } from '../../stores/plugin-store';
+
+// ROK-1114 round 3: the AI suggestions overlay (banner + ✨ AI badge
+// blend) is now gated on the `ai` plugin being active. Seed it active
+// for the existing AI-state assertions; the dedicated "feature off"
+// suite below clears it.
+beforeEach(() => {
+    usePluginStore.getState().setActiveSlugs(['ai']);
+});
+
+afterEach(() => {
+    usePluginStore.setState({ activeSlugs: new Set(), initialized: false });
+});
 
 const API_BASE = 'http://localhost:3000';
 
@@ -148,5 +161,46 @@ describe('CommonGroundPanel — AI suggestion state surfacing (ROK-1114)', () =>
         await waitFor(() => {
             expect(screen.getByText('Valheim')).toBeInTheDocument();
         });
+    });
+});
+
+describe('CommonGroundPanel — AI feature gate (ROK-1114 round 3)', () => {
+    it('keeps the grid but hides the AI status banner when the AI plugin is inactive', async () => {
+        // Wipe the active-plugins set seeded by the suite-level beforeEach.
+        usePluginStore.setState({ activeSlugs: new Set(), initialized: true });
+        let suggestionsCalls = 0;
+        server.use(
+            http.get(`${API_BASE}/lineups/active`, () =>
+                HttpResponse.json(buildActiveLineups()),
+            ),
+            http.get(`${API_BASE}/lineups/common-ground`, () =>
+                HttpResponse.json(buildCommonGroundResponse()),
+            ),
+            http.get(`${API_BASE}/lineups/:id/suggestions`, () => {
+                suggestionsCalls += 1;
+                return HttpResponse.json(
+                    { error: 'AI_PROVIDER_UNAVAILABLE' },
+                    { status: 503 },
+                );
+            }),
+        );
+
+        renderWithProviders(<CommonGroundPanel />);
+
+        await waitFor(() => {
+            expect(screen.getByText('Valheim')).toBeInTheDocument();
+        });
+        // No AI status text in any form (loading/unavailable/error).
+        expect(
+            screen.queryByText(/Suggestions temporarily unavailable/i),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByText(/AI suggestions loading/i),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByText(/AI suggestions unavailable/i),
+        ).not.toBeInTheDocument();
+        // No fetch fired against the suggestions endpoint.
+        expect(suggestionsCalls).toBe(0);
     });
 });

--- a/web/src/components/lineups/CommonGroundPanel.test.tsx
+++ b/web/src/components/lineups/CommonGroundPanel.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * Tests for CommonGroundPanel AI surface states (ROK-1114).
+ *
+ * Validates the inline indicators that replace the silently-missing AI
+ * row that triggered the prod outage:
+ *   - "AI suggestions loading…" while the suggestions query is pending.
+ *   - "Suggestions temporarily unavailable" when the endpoint returns 503
+ *     (no provider configured).
+ *   - The Common Ground grid still renders alongside the unavailable
+ *     message — AI failure must NOT block the rest of the panel.
+ *
+ * These tests assume `useCommonGroundState` exposes `aiIsLoading`,
+ * `aiIsUnavailable`, and `aiIsError` and that `CommonGroundPanel` reads
+ * them — both pieces are part of the ROK-1114 dev work.
+ */
+import { describe, it, expect } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import { http, HttpResponse, delay } from 'msw';
+import { CommonGroundPanel } from './CommonGroundPanel';
+import { renderWithProviders } from '../../test/render-helpers';
+import { server } from '../../test/mocks/server';
+
+const API_BASE = 'http://localhost:3000';
+
+/** Active-lineups response with one building lineup so the panel mounts. */
+function buildActiveLineups() {
+    return [
+        {
+            id: 7,
+            title: 'Test Lineup',
+            status: 'building' as const,
+            targetDate: null,
+            entryCount: 0,
+            totalVoters: 0,
+            createdAt: '2026-04-25T00:00:00.000Z',
+            visibility: 'public' as const,
+        },
+    ];
+}
+
+/** Common Ground response with one game so the grid renders. */
+function buildCommonGroundResponse() {
+    return {
+        data: [
+            {
+                gameId: 42,
+                gameName: 'Valheim',
+                slug: 'valheim',
+                coverUrl: null,
+                ownerCount: 5,
+                wishlistCount: 2,
+                nonOwnerPrice: null,
+                itadCurrentCut: null,
+                itadCurrentShop: null,
+                itadCurrentUrl: null,
+                earlyAccess: false,
+                itadTags: [],
+                playerCount: { min: 1, max: 10 },
+                score: 80,
+            },
+        ],
+        meta: {
+            total: 1,
+            appliedWeights: {
+                ownerWeight: 1,
+                saleBonus: 0,
+                fullPricePenalty: 0,
+                tasteWeight: 0,
+                socialWeight: 0,
+                intensityWeight: 0,
+            },
+            activeLineupId: 7,
+            nominatedCount: 0,
+            maxNominations: 20,
+        },
+    };
+}
+
+describe('CommonGroundPanel — AI suggestion state surfacing (ROK-1114)', () => {
+    it('renders the loading indicator while AI suggestions are pending', async () => {
+        // Active lineup + Common Ground succeed; AI hangs so the loading
+        // indicator stays visible long enough to assert.
+        server.use(
+            http.get(`${API_BASE}/lineups/active`, () =>
+                HttpResponse.json(buildActiveLineups()),
+            ),
+            http.get(`${API_BASE}/lineups/common-ground`, () =>
+                HttpResponse.json(buildCommonGroundResponse()),
+            ),
+            http.get(`${API_BASE}/lineups/:id/suggestions`, async () => {
+                await delay('infinite');
+                return HttpResponse.json({});
+            }),
+        );
+
+        renderWithProviders(<CommonGroundPanel />);
+
+        const indicator = await screen.findByText(/AI suggestions loading/i);
+        expect(indicator).toBeInTheDocument();
+    });
+
+    it('renders "Suggestions temporarily unavailable" when AI returns 503', async () => {
+        server.use(
+            http.get(`${API_BASE}/lineups/active`, () =>
+                HttpResponse.json(buildActiveLineups()),
+            ),
+            http.get(`${API_BASE}/lineups/common-ground`, () =>
+                HttpResponse.json(buildCommonGroundResponse()),
+            ),
+            http.get(`${API_BASE}/lineups/:id/suggestions`, () =>
+                HttpResponse.json(
+                    { error: 'AI_PROVIDER_UNAVAILABLE' },
+                    { status: 503 },
+                ),
+            ),
+        );
+
+        renderWithProviders(<CommonGroundPanel />);
+
+        const message = await screen.findByText(
+            /Suggestions temporarily unavailable/i,
+        );
+        expect(message).toBeInTheDocument();
+    });
+
+    it('keeps rendering the Common Ground grid when AI returns 503 (regression guard)', async () => {
+        server.use(
+            http.get(`${API_BASE}/lineups/active`, () =>
+                HttpResponse.json(buildActiveLineups()),
+            ),
+            http.get(`${API_BASE}/lineups/common-ground`, () =>
+                HttpResponse.json(buildCommonGroundResponse()),
+            ),
+            http.get(`${API_BASE}/lineups/:id/suggestions`, () =>
+                HttpResponse.json(
+                    { error: 'AI_PROVIDER_UNAVAILABLE' },
+                    { status: 503 },
+                ),
+            ),
+        );
+
+        renderWithProviders(<CommonGroundPanel />);
+
+        // The unavailable message must appear…
+        await screen.findByText(/Suggestions temporarily unavailable/i);
+        // …and the Common Ground game card must STILL be visible. AI
+        // failure must not blank the grid.
+        await waitFor(() => {
+            expect(screen.getByText('Valheim')).toBeInTheDocument();
+        });
+    });
+});

--- a/web/src/components/lineups/CommonGroundPanel.tsx
+++ b/web/src/components/lineups/CommonGroundPanel.tsx
@@ -16,6 +16,7 @@ import type { CommonGroundParams } from '../../lib/api-client';
 import { CommonGroundFilters } from './CommonGroundFilters';
 import { CommonGroundGameCard } from './CommonGroundGameCard';
 import { useCommonGroundState } from './use-common-ground-state';
+import { AiStatusBanner } from './AiStatusBanner';
 
 /** Loading skeleton cards. */
 function LoadingSkeleton(): JSX.Element {
@@ -64,37 +65,6 @@ function PanelHeader({ nominated, max }: { nominated: number; max: number }): JS
             </span>
         </div>
     );
-}
-
-/**
- * Inline AI status indicator (ROK-1114).
- *
- * Surfaces the AI suggestions query state above the grid so a missing
- * provider configuration is visible to operators instead of silently
- * dropping the ✨ AI badges. MUST NOT block the Common Ground grid —
- * the indicator is purely additive.
- */
-function AiStatusBanner({
-    isLoading,
-    isUnavailable,
-    isError,
-}: {
-    isLoading: boolean;
-    isUnavailable: boolean;
-    isError: boolean;
-}): JSX.Element | null {
-    if (isUnavailable) {
-        return (
-            <p className="text-xs text-muted">Suggestions temporarily unavailable</p>
-        );
-    }
-    if (isError) {
-        return <p className="text-xs text-muted">AI suggestions unavailable</p>;
-    }
-    if (isLoading) {
-        return <p className="text-xs text-muted">AI suggestions loading…</p>;
-    }
-    return null;
 }
 
 const ARROW_CLS = 'absolute top-1/2 -translate-y-1/2 z-10 w-10 h-10 bg-surface/90 border border-edge rounded-full flex items-center justify-center text-foreground shadow-lg opacity-0 group-hover/carousel:opacity-100 transition-opacity hover:bg-panel';

--- a/web/src/components/lineups/CommonGroundPanel.tsx
+++ b/web/src/components/lineups/CommonGroundPanel.tsx
@@ -66,6 +66,37 @@ function PanelHeader({ nominated, max }: { nominated: number; max: number }): JS
     );
 }
 
+/**
+ * Inline AI status indicator (ROK-1114).
+ *
+ * Surfaces the AI suggestions query state above the grid so a missing
+ * provider configuration is visible to operators instead of silently
+ * dropping the ✨ AI badges. MUST NOT block the Common Ground grid —
+ * the indicator is purely additive.
+ */
+function AiStatusBanner({
+    isLoading,
+    isUnavailable,
+    isError,
+}: {
+    isLoading: boolean;
+    isUnavailable: boolean;
+    isError: boolean;
+}): JSX.Element | null {
+    if (isUnavailable) {
+        return (
+            <p className="text-xs text-muted">Suggestions temporarily unavailable</p>
+        );
+    }
+    if (isError) {
+        return <p className="text-xs text-muted">AI suggestions unavailable</p>;
+    }
+    if (isLoading) {
+        return <p className="text-xs text-muted">AI suggestions loading…</p>;
+    }
+    return null;
+}
+
 const ARROW_CLS = 'absolute top-1/2 -translate-y-1/2 z-10 w-10 h-10 bg-surface/90 border border-edge rounded-full flex items-center justify-center text-foreground shadow-lg opacity-0 group-hover/carousel:opacity-100 transition-opacity hover:bg-panel';
 
 function ScrollArrow({ direction, onClick }: { direction: 'left' | 'right'; onClick: () => void }) {
@@ -210,6 +241,11 @@ export function CommonGroundPanel({
     return (
         <section className="space-y-3">
             <PanelHeader nominated={state.rawMeta.nominatedCount} max={state.rawMeta.maxNominations} />
+            <AiStatusBanner
+                isLoading={state.aiIsLoading}
+                isUnavailable={state.aiIsUnavailable}
+                isError={state.aiIsError}
+            />
             <PanelContent {...state} />
         </section>
     );

--- a/web/src/components/lineups/NominateModal.test.tsx
+++ b/web/src/components/lineups/NominateModal.test.tsx
@@ -56,7 +56,7 @@ describe('NominateModal — search state', () => {
         renderWithProviders(
             <NominateModal isOpen={true} onClose={vi.fn()} lineupId={1} />,
         );
-        expect(screen.getByPlaceholderText(/search games/i)).toBeInTheDocument();
+        expect(screen.getByPlaceholderText(/Search by name or paste a Steam store URL/i)).toBeInTheDocument();
     });
 
     it('shows search results when available', () => {

--- a/web/src/components/lineups/NominateModal.tsx
+++ b/web/src/components/lineups/NominateModal.tsx
@@ -29,8 +29,9 @@ function SearchInput({ value, onChange }: { value: string; onChange: (v: string)
             type="text"
             value={value}
             onChange={(e) => onChange(e.target.value)}
-            placeholder="Search games..."
+            placeholder="Search by name or paste a Steam store URL"
             className="w-full px-4 py-2.5 bg-surface/50 border border-edge rounded-lg text-foreground placeholder:text-dim focus:outline-none focus:ring-2 focus:ring-emerald-500 mb-3"
+            autoFocus
         />
     );
 }
@@ -171,17 +172,16 @@ export function NominateModal({ isOpen, onClose, lineupId, preSelectedGame }: No
                 />
             ) : (
                 <>
-                    <p className="text-xs text-dim mb-3">Search by name or paste a Steam store URL</p>
-                    <PersonalSuggestionsRow
-                        lineupId={lineupId}
-                        onPickSuggestion={(s) => handleSelect({ id: s.gameId, name: s.name, coverUrl: s.coverUrl })}
-                    />
                     <SearchInput value={query} onChange={setQuery} />
                     {searchLoading && <p className="text-sm text-muted py-4 text-center">Searching...</p>}
                     {results.length > 0 && <SearchResults results={results} onSelect={handleSelect} />}
                     {query.length >= 2 && !searchLoading && results.length === 0 && (
                         <p className="text-sm text-muted py-4 text-center">No games found</p>
                     )}
+                    <PersonalSuggestionsRow
+                        lineupId={lineupId}
+                        onPickSuggestion={(s) => handleSelect({ id: s.gameId, name: s.name, coverUrl: s.coverUrl })}
+                    />
                 </>
             )}
         </Modal>

--- a/web/src/components/lineups/NominateModal.tsx
+++ b/web/src/components/lineups/NominateModal.tsx
@@ -159,7 +159,7 @@ export function NominateModal({ isOpen, onClose, lineupId, preSelectedGame }: No
     const results = searchData?.data ?? [];
 
     return (
-        <Modal isOpen={isOpen} onClose={handleClose} title="Nominate a Game" maxWidth="max-w-lg">
+        <Modal isOpen={isOpen} onClose={handleClose} title="Nominate a Game" maxWidth="max-w-4xl">
             {selected ? (
                 <PreviewCard
                     game={selected}

--- a/web/src/components/lineups/NominateModal.tsx
+++ b/web/src/components/lineups/NominateModal.tsx
@@ -2,10 +2,13 @@
  * Game nomination modal for Community Lineup (ROK-935).
  * Provides game search, preview with art, and optional note input.
  */
-import { type JSX, useState, useCallback } from 'react';
+import { type JSX, useState, useCallback, useEffect, useRef } from 'react';
 import { Modal } from '../ui/modal';
 import { useGameSearch } from '../../hooks/use-game-search';
 import { useNominateGame } from '../../hooks/use-lineups';
+import { extractSteamAppId } from '../../hooks/use-steam-paste';
+import { getGameBySteamAppId } from '../../lib/api-client';
+import { toast } from '../../lib/toast';
 import { PersonalSuggestionsRow } from './PersonalSuggestionsRow';
 
 export interface SelectedGame {
@@ -116,13 +119,68 @@ function PreviewCard({ game, note, onNoteChange, onSubmit, onBack, isPending }: 
     );
 }
 
+/**
+ * Watch the search query for a Steam store URL and resolve it via the
+ * library API. Mirrors the page-level paste flow (`useSteamPasteDetection`)
+ * which bails when an input is focused — so the modal owns its own copy.
+ *
+ * Each appId is resolved at most once even if the user re-pastes; loading
+ * is tracked in a ref so the effect doesn't re-fire on the toast/state churn.
+ */
+function useSteamUrlAutoResolve(
+    query: string,
+    isOpen: boolean,
+    onResolved: (game: SelectedGame) => void,
+): void {
+    const lastTriedRef = useRef<number | null>(null);
+    const inFlightRef = useRef(false);
+    useEffect(() => {
+        if (!isOpen) {
+            lastTriedRef.current = null;
+            return;
+        }
+        const appId = extractSteamAppId(query);
+        if (appId == null || appId === lastTriedRef.current) return;
+        if (inFlightRef.current) return;
+        lastTriedRef.current = appId;
+        inFlightRef.current = true;
+        (async () => {
+            try {
+                const game = await getGameBySteamAppId(appId);
+                onResolved({
+                    id: game.id,
+                    name: game.name,
+                    coverUrl: game.coverUrl ?? null,
+                });
+            } catch {
+                toast.error('Game not found in library');
+            } finally {
+                inFlightRef.current = false;
+            }
+        })();
+    }, [query, isOpen, onResolved]);
+}
+
 /** Game nomination modal with search and preview. */
 export function NominateModal({ isOpen, onClose, lineupId, preSelectedGame }: NominateModalProps): JSX.Element {
     const [query, setQuery] = useState('');
     const [selected, setSelected] = useState<SelectedGame | null>(null);
     const [note, setNote] = useState('');
-    const { data: searchData, isLoading: searchLoading } = useGameSearch(query, isOpen);
+    const isSteamUrl = extractSteamAppId(query) !== null;
+    // When a Steam URL is in the input we don't want to run the name
+    // search — it just wastes a request and renders "No games found".
+    const { data: searchData, isLoading: searchLoading } = useGameSearch(
+        isSteamUrl ? '' : query,
+        isOpen,
+    );
     const nominate = useNominateGame();
+    // Resolve any Steam store URL pasted into the search input. The
+    // page-level paste detector skips the modal (its global listener
+    // bails when an input is focused), so the modal owns this flow.
+    useSteamUrlAutoResolve(query, isOpen, (game) => {
+        setSelected(game);
+        setQuery('');
+    });
 
     // Sync pre-selected game when modal opens with one (ROK-945)
     const [appliedPreSelect, setAppliedPreSelect] = useState<SelectedGame | null>(null);

--- a/web/src/components/lineups/PersonalSuggestionsRow.test.tsx
+++ b/web/src/components/lineups/PersonalSuggestionsRow.test.tsx
@@ -11,7 +11,7 @@
  *   - Renders cards with Pick buttons on success, and Pick fires
  *     `onPickSuggestion(dto)`.
  */
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { http, HttpResponse } from 'msw';
@@ -19,6 +19,18 @@ import type { AiSuggestionsResponseDto } from '@raid-ledger/contract';
 import { PersonalSuggestionsRow } from './PersonalSuggestionsRow';
 import { renderWithProviders } from '../../test/render-helpers';
 import { server } from '../../test/mocks/server';
+import { usePluginStore } from '../../stores/plugin-store';
+
+// ROK-1114 round 3: PersonalSuggestionsRow now short-circuits to null
+// when the AI plugin is inactive. Seed it active for the existing
+// scenarios; the "feature off" suite below clears it explicitly.
+beforeEach(() => {
+    usePluginStore.getState().setActiveSlugs(['ai']);
+});
+
+afterEach(() => {
+    usePluginStore.setState({ activeSlugs: new Set(), initialized: false });
+});
 
 const API_BASE = 'http://localhost:3000';
 
@@ -168,5 +180,29 @@ describe('PersonalSuggestionsRow — AI surface states (ROK-1114)', () => {
                 screen.queryByText(/AI suggestions loading/i),
             ).not.toBeInTheDocument();
         });
+    });
+});
+
+describe('PersonalSuggestionsRow — AI feature gate (ROK-1114 round 3)', () => {
+    it('renders nothing AND fires no fetch when the AI plugin is inactive', async () => {
+        // Wipe the active-plugins set seeded by the suite-level beforeEach.
+        usePluginStore.setState({ activeSlugs: new Set(), initialized: true });
+        let calls = 0;
+        server.use(
+            http.get(`${API_BASE}/lineups/:id/suggestions`, () => {
+                calls += 1;
+                return HttpResponse.json(buildResponse());
+            }),
+        );
+        const { container } = renderWithProviders(
+            <PersonalSuggestionsRow lineupId={7} onPickSuggestion={vi.fn()} />,
+        );
+        // Give React Query a beat — if it were going to fetch, it would
+        // queue inside this microtask cycle.
+        await waitFor(() => {
+            expect(container).toBeEmptyDOMElement();
+        });
+        expect(calls).toBe(0);
+        expect(screen.queryByText(/Suggested for you/i)).not.toBeInTheDocument();
     });
 });

--- a/web/src/components/lineups/PersonalSuggestionsRow.test.tsx
+++ b/web/src/components/lineups/PersonalSuggestionsRow.test.tsx
@@ -1,9 +1,13 @@
 /**
- * Tests for PersonalSuggestionsRow (ROK-931).
+ * Tests for PersonalSuggestionsRow (ROK-931, ROK-1114).
  *
  * Verifies that the per-user "Suggested for you" row:
  *   - Calls the backend with `?personalize=me` (not the group-scope URL).
- *   - Renders nothing (null) on 503 or empty suggestions.
+ *   - Renders nothing on empty success (don't pollute modal with empty section).
+ *   - Surfaces an inline "Suggestions temporarily unavailable" message
+ *     when the hook reports `kind === 'unavailable'` (503) — ROK-1114
+ *     replaces the silent-null behavior.
+ *   - Surfaces "AI suggestions unavailable" on a generic query error.
  *   - Renders cards with Pick buttons on success, and Pick fires
  *     `onPickSuggestion(dto)`.
  */
@@ -71,20 +75,6 @@ describe('PersonalSuggestionsRow (ROK-931)', () => {
         });
     });
 
-    it('renders nothing when the hook reports unavailable (503)', async () => {
-        server.use(
-            http.get(`${API_BASE}/lineups/:id/suggestions`, () =>
-                HttpResponse.json({ error: 'AI_PROVIDER_UNAVAILABLE' }, { status: 503 }),
-            ),
-        );
-        const { container } = renderWithProviders(
-            <PersonalSuggestionsRow lineupId={7} onPickSuggestion={vi.fn()} />,
-        );
-        await waitFor(() => {
-            expect(container.textContent).not.toContain('Suggested for you');
-        });
-    });
-
     it('fires onPickSuggestion with the DTO when the Pick button is clicked', async () => {
         server.use(
             http.get(`${API_BASE}/lineups/:id/suggestions`, () =>
@@ -102,5 +92,65 @@ describe('PersonalSuggestionsRow (ROK-931)', () => {
         expect(handlePick).toHaveBeenCalledWith(
             expect.objectContaining({ gameId: 99, name: 'It Takes Two' }),
         );
+    });
+});
+
+describe('PersonalSuggestionsRow — AI surface states (ROK-1114)', () => {
+    it('renders "Suggestions temporarily unavailable" when AI returns 503', async () => {
+        server.use(
+            http.get(`${API_BASE}/lineups/:id/suggestions`, () =>
+                HttpResponse.json(
+                    { error: 'AI_PROVIDER_UNAVAILABLE' },
+                    { status: 503 },
+                ),
+            ),
+        );
+        renderWithProviders(
+            <PersonalSuggestionsRow lineupId={7} onPickSuggestion={vi.fn()} />,
+        );
+        const message = await screen.findByText(
+            /Suggestions temporarily unavailable/i,
+        );
+        expect(message).toBeInTheDocument();
+        // Header still visible so the user knows what the section is for.
+        expect(screen.getByText(/Suggested for you/i)).toBeInTheDocument();
+    });
+
+    it('renders "AI suggestions unavailable" when the query errors out', async () => {
+        // Generic 500 — `getAiSuggestions` only special-cases 503, so a 500
+        // surfaces as a generic query error (`query.isError === true`).
+        server.use(
+            http.get(`${API_BASE}/lineups/:id/suggestions`, () =>
+                HttpResponse.json({ error: 'INTERNAL' }, { status: 500 }),
+            ),
+        );
+        renderWithProviders(
+            <PersonalSuggestionsRow lineupId={7} onPickSuggestion={vi.fn()} />,
+        );
+        const message = await screen.findByText(/AI suggestions unavailable/i);
+        expect(message).toBeInTheDocument();
+        expect(screen.getByText(/Suggested for you/i)).toBeInTheDocument();
+    });
+
+    it('renders the loading indicator while the suggestions query is pending', async () => {
+        let resolve: ((v: Response) => void) | undefined;
+        const pending = new Promise<Response>((r) => {
+            resolve = r;
+        });
+        server.use(
+            http.get(`${API_BASE}/lineups/:id/suggestions`, () => pending),
+        );
+        renderWithProviders(
+            <PersonalSuggestionsRow lineupId={7} onPickSuggestion={vi.fn()} />,
+        );
+        const loading = await screen.findByText(/AI suggestions loading/i);
+        expect(loading).toBeInTheDocument();
+        // Cleanup the dangling promise so the test runner exits.
+        resolve?.(HttpResponse.json(buildResponse({ suggestions: [] })));
+        await waitFor(() => {
+            expect(
+                screen.queryByText(/AI suggestions loading/i),
+            ).not.toBeInTheDocument();
+        });
     });
 });

--- a/web/src/components/lineups/PersonalSuggestionsRow.test.tsx
+++ b/web/src/components/lineups/PersonalSuggestionsRow.test.tsx
@@ -93,6 +93,22 @@ describe('PersonalSuggestionsRow (ROK-931)', () => {
             expect.objectContaining({ gameId: 99, name: 'It Takes Two' }),
         );
     });
+
+    it('lays out cards in a responsive grid (ROK-1114 round 3)', async () => {
+        server.use(
+            http.get(`${API_BASE}/lineups/:id/suggestions`, () =>
+                HttpResponse.json(buildResponse()),
+            ),
+        );
+        renderWithProviders(
+            <PersonalSuggestionsRow lineupId={7} onPickSuggestion={vi.fn()} />,
+        );
+        const grid = await screen.findByTestId('personal-suggestions-grid');
+        // Grid container — not flex/overflow-x — so mouse users can see all
+        // suggestions without horizontal scroll inside the wider modal.
+        expect(grid.className).toMatch(/\bgrid\b/);
+        expect(grid.className).toMatch(/grid-cols-/);
+    });
 });
 
 describe('PersonalSuggestionsRow — AI surface states (ROK-1114)', () => {

--- a/web/src/components/lineups/PersonalSuggestionsRow.tsx
+++ b/web/src/components/lineups/PersonalSuggestionsRow.tsx
@@ -8,18 +8,23 @@
  * `onPickSuggestion(dto)` — NominateModal sets its selected-game state
  * so PreviewCard takes over and the user can add a note before
  * confirming.
+ *
+ * Loading/unavailable/error states surface via the shared `AiStatusBanner`
+ * (ROK-1114) so a mis-configured AI provider is visible to operators
+ * instead of silently dropping the entire row.
  */
 import { type JSX } from 'react';
 import type { AiSuggestionDto } from '@raid-ledger/contract';
 import { useAiSuggestions } from '../../hooks/use-ai-suggestions';
 import { AiSuggestionCard } from './AiSuggestionCard';
+import { AiStatusBanner } from './AiStatusBanner';
 
 export interface PersonalSuggestionsRowProps {
     lineupId: number;
     onPickSuggestion: (suggestion: AiSuggestionDto) => void;
 }
 
-function LoadingSkeleton(): JSX.Element {
+function SuggestionSkeletons(): JSX.Element {
     return (
         <div className="flex gap-3 overflow-x-auto pb-2">
             {Array.from({ length: 3 }, (_, i) => (
@@ -34,42 +39,56 @@ function LoadingSkeleton(): JSX.Element {
     );
 }
 
+function SectionHeader(): JSX.Element {
+    return (
+        <h3 className="text-xs font-semibold text-muted uppercase tracking-wide">
+            Suggested for you
+        </h3>
+    );
+}
+
 export function PersonalSuggestionsRow({
     lineupId,
     onPickSuggestion,
 }: PersonalSuggestionsRowProps): JSX.Element | null {
     const query = useAiSuggestions(lineupId, { personalize: true });
-
-    if (query.isLoading) {
-        return (
-            <section className="space-y-2 mb-3" aria-label="Suggested for you">
-                <h3 className="text-xs font-semibold text-muted uppercase tracking-wide">
-                    Suggested for you
-                </h3>
-                <LoadingSkeleton />
-            </section>
-        );
-    }
     const result = query.data;
-    if (!result || result.kind === 'unavailable') return null;
-    const suggestions = result.data.suggestions;
-    if (suggestions.length === 0) return null;
+    const isUnavailable = result?.kind === 'unavailable';
+    const isError = query.isError;
+    const suggestions =
+        result && result.kind !== 'unavailable' ? result.data.suggestions : [];
+
+    // Suppress the section entirely on empty success — keeps the modal
+    // tidy when the LLM had no candidates to recommend.
+    if (!query.isLoading && !isUnavailable && !isError && suggestions.length === 0) {
+        return null;
+    }
+
     return (
         <section className="space-y-2 mb-3" aria-label="Suggested for you">
-            <h3 className="text-xs font-semibold text-muted uppercase tracking-wide">
-                Suggested for you
-            </h3>
-            <div className="flex gap-3 overflow-x-auto overflow-y-hidden pb-2" style={{ scrollbarWidth: 'none' }}>
-                {suggestions.map((s) => (
-                    <AiSuggestionCard
-                        key={s.gameId}
-                        suggestion={s}
-                        lineupId={lineupId}
-                        mode="pick"
-                        onPick={onPickSuggestion}
-                    />
-                ))}
-            </div>
+            <SectionHeader />
+            <AiStatusBanner
+                isLoading={query.isLoading}
+                isUnavailable={isUnavailable}
+                isError={isError}
+            />
+            {query.isLoading && <SuggestionSkeletons />}
+            {suggestions.length > 0 && (
+                <div
+                    className="flex gap-3 overflow-x-auto overflow-y-hidden pb-2"
+                    style={{ scrollbarWidth: 'none' }}
+                >
+                    {suggestions.map((s) => (
+                        <AiSuggestionCard
+                            key={s.gameId}
+                            suggestion={s}
+                            lineupId={lineupId}
+                            mode="pick"
+                            onPick={onPickSuggestion}
+                        />
+                    ))}
+                </div>
+            )}
         </section>
     );
 }

--- a/web/src/components/lineups/PersonalSuggestionsRow.tsx
+++ b/web/src/components/lineups/PersonalSuggestionsRow.tsx
@@ -16,6 +16,7 @@
 import { type JSX } from 'react';
 import type { AiSuggestionDto } from '@raid-ledger/contract';
 import { useAiSuggestions } from '../../hooks/use-ai-suggestions';
+import { useAiSuggestionsAvailable } from '../../hooks/use-ai-suggestions-available';
 import { AiSuggestionCard } from './AiSuggestionCard';
 import { AiStatusBanner } from './AiStatusBanner';
 
@@ -51,12 +52,22 @@ export function PersonalSuggestionsRow({
     lineupId,
     onPickSuggestion,
 }: PersonalSuggestionsRowProps): JSX.Element | null {
-    const query = useAiSuggestions(lineupId, { personalize: true });
+    // ROK-1114 round 3: when the AI plugin is uninstalled or admins
+    // disabled the suggestions feature, render nothing — no header, no
+    // skeleton, no banner. The query call below is also gated via the
+    // shared `enabled` flag inside useAiSuggestions, so it never fires.
+    const aiAvailable = useAiSuggestionsAvailable();
+    const query = useAiSuggestions(lineupId, {
+        personalize: true,
+        enabled: aiAvailable,
+    });
     const result = query.data;
     const isUnavailable = result?.kind === 'unavailable';
     const isError = query.isError;
     const suggestions =
         result && result.kind !== 'unavailable' ? result.data.suggestions : [];
+
+    if (!aiAvailable) return null;
 
     // Suppress the section entirely on empty success — keeps the modal
     // tidy when the LLM had no candidates to recommend.

--- a/web/src/components/lineups/PersonalSuggestionsRow.tsx
+++ b/web/src/components/lineups/PersonalSuggestionsRow.tsx
@@ -26,11 +26,11 @@ export interface PersonalSuggestionsRowProps {
 
 function SuggestionSkeletons(): JSX.Element {
     return (
-        <div className="flex gap-3 overflow-x-auto pb-2">
-            {Array.from({ length: 3 }, (_, i) => (
+        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 pb-2">
+            {Array.from({ length: 4 }, (_, i) => (
                 <div
                     key={i}
-                    className="w-[180px] flex-shrink-0 rounded-xl bg-panel border border-edge/50 animate-pulse"
+                    className="min-w-0 rounded-xl bg-panel border border-edge/50 animate-pulse"
                 >
                     <div className="aspect-[3/4] bg-zinc-800/50 rounded-t-xl" />
                 </div>
@@ -75,8 +75,8 @@ export function PersonalSuggestionsRow({
             {query.isLoading && <SuggestionSkeletons />}
             {suggestions.length > 0 && (
                 <div
-                    className="flex gap-3 overflow-x-auto overflow-y-hidden pb-2"
-                    style={{ scrollbarWidth: 'none' }}
+                    className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-3 pb-2"
+                    data-testid="personal-suggestions-grid"
                 >
                     {suggestions.map((s) => (
                         <AiSuggestionCard

--- a/web/src/components/lineups/use-common-ground-state.ts
+++ b/web/src/components/lineups/use-common-ground-state.ts
@@ -55,6 +55,12 @@ export interface UseCommonGroundStateResult {
     nominatingId: number | null;
     atCap: boolean;
     aiSuggestionsByGameId: Map<number, AiSuggestionDto>;
+    /** AI suggestions query is in flight (and the panel actually has a lineup). */
+    aiIsLoading: boolean;
+    /** AI endpoint returned 503 (no provider configured) — see ROK-1114. */
+    aiIsUnavailable: boolean;
+    /** AI suggestions query errored for any other reason. */
+    aiIsError: boolean;
 }
 
 export function useCommonGroundState(
@@ -134,6 +140,10 @@ export function useCommonGroundState(
 
     const stableRefetch = useCallback(() => void refetch(), [refetch]);
 
+    const aiIsUnavailable = aiQuery.data?.kind === 'unavailable';
+    const aiIsLoading = hasBuilding && aiQuery.isLoading;
+    const aiIsError = aiQuery.isError && !aiIsUnavailable;
+
     return {
         hasBuilding,
         mergedData,
@@ -150,5 +160,8 @@ export function useCommonGroundState(
         nominatingId,
         atCap,
         aiSuggestionsByGameId,
+        aiIsLoading,
+        aiIsUnavailable,
+        aiIsError,
     };
 }

--- a/web/src/components/lineups/use-common-ground-state.ts
+++ b/web/src/components/lineups/use-common-ground-state.ts
@@ -24,6 +24,7 @@ import {
     useNominateGame,
 } from '../../hooks/use-lineups';
 import { useAiSuggestions } from '../../hooks/use-ai-suggestions';
+import { useAiSuggestionsAvailable } from '../../hooks/use-ai-suggestions-available';
 import { useDebouncedValue } from '../../hooks/use-debounced-value';
 import { mergeAiIntoCommonGround } from './common-ground-ai-merge.helpers';
 
@@ -98,14 +99,23 @@ export function useCommonGroundState(
     // them into the same grid. The map drives the ✨ AI badge + tooltip
     // reasoning on matching cards; AI-only games (not owned yet) are
     // synthesised as stub CommonGroundGameDto entries.
-    const aiQuery = useAiSuggestions(resolvedId, { enabled: hasBuilding });
+    //
+    // ROK-1114 round 3: gate the entire AI side on the combined
+    // plugin+admin-toggle hook. When the AI surface is off, never fire
+    // the request and never seed the badge map — the grid keeps
+    // rendering, just without the ✨ AI overlay.
+    const aiAvailable = useAiSuggestionsAvailable();
+    const aiQuery = useAiSuggestions(resolvedId, {
+        enabled: hasBuilding && aiAvailable,
+    });
     const aiSuggestionsByGameId = useMemo(() => {
         const map = new Map<number, AiSuggestionDto>();
+        if (!aiAvailable) return map;
         if (aiQuery.data?.kind === 'ok') {
             for (const s of aiQuery.data.data.suggestions) map.set(s.gameId, s);
         }
         return map;
-    }, [aiQuery.data]);
+    }, [aiAvailable, aiQuery.data]);
 
     const mergedData = useMemo(
         () => mergeAiIntoCommonGround(data, aiSuggestionsByGameId, filters, search),
@@ -140,9 +150,12 @@ export function useCommonGroundState(
 
     const stableRefetch = useCallback(() => void refetch(), [refetch]);
 
-    const aiIsUnavailable = aiQuery.data?.kind === 'unavailable';
-    const aiIsLoading = hasBuilding && aiQuery.isLoading;
-    const aiIsError = aiQuery.isError && !aiIsUnavailable;
+    // When the AI feature is disabled (plugin off or admin toggle off),
+    // collapse all AI status flags so CommonGroundPanel never renders
+    // the AI status banner. The grid still renders normally.
+    const aiIsUnavailable = aiAvailable && aiQuery.data?.kind === 'unavailable';
+    const aiIsLoading = aiAvailable && hasBuilding && aiQuery.isLoading;
+    const aiIsError = aiAvailable && aiQuery.isError && !aiIsUnavailable;
 
     return {
         hasBuilding,

--- a/web/src/hooks/admin/use-ai-settings.ts
+++ b/web/src/hooks/admin/use-ai-settings.ts
@@ -111,9 +111,16 @@ export function useOllamaStop() {
     });
 }
 
+export interface AiFeaturesResponse {
+    chatEnabled: boolean;
+    dynamicCategoriesEnabled: boolean;
+    /** ROK-1114: master switch for per-user AI nomination suggestions. */
+    aiSuggestionsEnabled: boolean;
+}
+
 /** Query AI feature toggle states. */
 export function useAiFeatures() {
-    return useQuery<{ chatEnabled: boolean; dynamicCategoriesEnabled: boolean }>({
+    return useQuery<AiFeaturesResponse>({
         queryKey: [...AI_KEY, 'features'],
         queryFn: () => adminFetch('/admin/ai/features'),
         enabled: !!getAuthToken(),
@@ -127,7 +134,7 @@ export function useUpdateAiFeatures() {
     return useMutation<
         { success: boolean },
         Error,
-        { chatEnabled?: boolean; dynamicCategoriesEnabled?: boolean }
+        Partial<AiFeaturesResponse>
     >({
         mutationFn: (body) =>
             adminFetch('/admin/ai/features', {

--- a/web/src/hooks/use-ai-suggestions-available.ts
+++ b/web/src/hooks/use-ai-suggestions-available.ts
@@ -1,0 +1,30 @@
+/**
+ * Combined gate for the AI nomination suggestions surface (ROK-1114).
+ *
+ * Returns `true` only when BOTH:
+ *   1. The AI plugin is currently active (admin has installed it), AND
+ *   2. The `ai_suggestions_enabled` admin toggle is not explicitly false.
+ *
+ * Used by every AI surface — the modal row, the CommonGround banner,
+ * the ✨ AI Pick badges, the React Query `enabled` flag on
+ * `useAiSuggestions`, and the lineup-detail prefetch — so an
+ * uninstalled plugin or admin disable hides the entire feature with
+ * no banners, badges, headers, skeletons or fetches.
+ *
+ * The `aiSuggestionsEnabled` field defaults to `true` server-side, so
+ * `undefined` (loading) is treated as enabled to avoid first-render
+ * flicker. This is consistent with how the rest of the AI surfaces
+ * have always rendered before the toggle existed.
+ */
+import { useAiFeatures } from './admin/use-ai-settings';
+import { usePluginStore } from '../stores/plugin-store';
+
+export function useAiSuggestionsAvailable(): boolean {
+    const pluginActive = usePluginStore((s) => s.isPluginActive('ai'));
+    const { data } = useAiFeatures();
+    if (!pluginActive) return false;
+    // Treat undefined (loading / unauthenticated) as enabled so we don't
+    // hide AI on first render. The server defaults this to true and only
+    // an explicit `false` disables the feature.
+    return data?.aiSuggestionsEnabled !== false;
+}

--- a/web/src/hooks/use-ai-suggestions.ts
+++ b/web/src/hooks/use-ai-suggestions.ts
@@ -10,6 +10,7 @@ import {
   getAiSuggestions,
   type AiSuggestionsResult,
 } from '../lib/api/ai-suggestions-api';
+import { useAiSuggestionsAvailable } from './use-ai-suggestions-available';
 
 /** Query key prefix for AI suggestion queries. */
 const AI_SUGGESTIONS_KEY = ['ai-suggestions'] as const;
@@ -24,10 +25,13 @@ export function useAiSuggestions(
   options: UseAiSuggestionsOptions = {},
 ) {
   const { enabled = true, personalize = false } = options;
+  const aiAvailable = useAiSuggestionsAvailable();
   return useQuery<AiSuggestionsResult>({
     queryKey: [...AI_SUGGESTIONS_KEY, lineupId, { personalize }],
     queryFn: () => getAiSuggestions(lineupId as number, { personalize }),
-    enabled: enabled && lineupId != null,
+    // ROK-1114: gate on the combined plugin+feature flag so a disabled
+    // AI plugin (or admin toggle) never fires the request.
+    enabled: enabled && aiAvailable && lineupId != null,
     staleTime: 5 * 60 * 1000,
     gcTime: 30 * 60 * 1000,
     retry: false,

--- a/web/src/hooks/use-steam-paste.ts
+++ b/web/src/hooks/use-steam-paste.ts
@@ -38,8 +38,13 @@ export function extractSteamAppId(text: string): number | null {
 interface UseSteamPasteOptions {
   /** Only listen when true (e.g. lineup is in building status). */
   enabled: boolean;
-  /** Whether the nominate modal is currently open. */
-  modalOpen: boolean;
+  /**
+   * Modal-open flag. Retained for backward compatibility but no longer
+   * gates the listener — the modal's own input-focused check is enough
+   * to prevent double-handling, and detaching the page-level handler
+   * meant pasting outside the search input did nothing (ROK-1114).
+   */
+  modalOpen?: boolean;
   /** Called with the resolved game to open the modal. */
   onGameResolved: (game: IgdbGameDto) => void;
 }
@@ -47,10 +52,16 @@ interface UseSteamPasteOptions {
 /**
  * Registers a document-level paste listener that detects Steam
  * store URLs, resolves them via the API, and triggers the callback.
+ *
+ * The listener stays attached even while the nominate modal is open
+ * so a paste anywhere outside an input field still resolves and slots
+ * the game into the modal's preview card. Pastes that land inside an
+ * input (the modal's search box) are skipped here — the modal owns
+ * its own resolver for that path so the URL stays visible in the
+ * field while resolving.
  */
 export function useSteamPasteDetection({
   enabled,
-  modalOpen,
   onGameResolved,
 }: UseSteamPasteOptions): void {
   const loadingRef = useRef(false);
@@ -78,8 +89,8 @@ export function useSteamPasteDetection({
   );
 
   useEffect(() => {
-    if (!enabled || modalOpen) return;
+    if (!enabled) return;
     document.addEventListener('paste', handlePaste);
     return () => document.removeEventListener('paste', handlePaste);
-  }, [enabled, modalOpen, handlePaste]);
+  }, [enabled, handlePaste]);
 }

--- a/web/src/pages/lineup-detail-page.tsx
+++ b/web/src/pages/lineup-detail-page.tsx
@@ -21,6 +21,7 @@ import { TiebreakerView } from '../components/lineups/tiebreaker/TiebreakerView'
 import { TiebreakerPromptModal } from '../components/lineups/tiebreaker/TiebreakerPromptModal';
 import { useAuth, isOperatorOrAdmin } from '../hooks/use-auth';
 import { useAiSuggestions } from '../hooks/use-ai-suggestions';
+import { useAiSuggestionsAvailable } from '../hooks/use-ai-suggestions-available';
 import { useSteamPasteDetection } from '../hooks/use-steam-paste';
 import { canParticipateInLineup } from '../lib/lineup-eligibility';
 
@@ -83,14 +84,14 @@ export function LineupDetailPage(): JSX.Element {
   const canParticipate = canParticipateInLineup(lineup, user);
   const canNominate = isBuilding && canParticipate;
 
-  // ROK-1114: warm the per-user suggestions cache while the user is on
-  // the lineup page so opening the Nominate modal feels instant instead
-  // of waiting 5-20s for the LLM. Gating logic (plugin active + admin
-  // toggle on) lives inside `useAiSuggestions` so we don't fire when
-  // the AI plugin is uninstalled or admins disabled the feature.
+  // ROK-1114 round 3: warm the per-user suggestions cache while the
+  // user is on the lineup page so opening the Nominate modal feels
+  // instant instead of waiting 5-20s for the LLM. Gated on the combined
+  // plugin+admin toggle so we don't fire when AI is uninstalled or off.
+  const aiAvailable = useAiSuggestionsAvailable();
   useAiSuggestions(lineupId, {
     personalize: true,
-    enabled: !!canNominate,
+    enabled: !!canNominate && aiAvailable,
   });
 
   const handleGameResolved = useCallback((game: SelectedGame) => {

--- a/web/src/pages/lineup-detail-page.tsx
+++ b/web/src/pages/lineup-detail-page.tsx
@@ -20,6 +20,7 @@ import { SteamNudgeBanner } from '../components/lineups/SteamNudgeBanner';
 import { TiebreakerView } from '../components/lineups/tiebreaker/TiebreakerView';
 import { TiebreakerPromptModal } from '../components/lineups/tiebreaker/TiebreakerPromptModal';
 import { useAuth, isOperatorOrAdmin } from '../hooks/use-auth';
+import { useAiSuggestions } from '../hooks/use-ai-suggestions';
 import { useSteamPasteDetection } from '../hooks/use-steam-paste';
 import { canParticipateInLineup } from '../lib/lineup-eligibility';
 
@@ -81,6 +82,16 @@ export function LineupDetailPage(): JSX.Element {
   const isBuilding = !isLoading && !error && lineup?.status === 'building';
   const canParticipate = canParticipateInLineup(lineup, user);
   const canNominate = isBuilding && canParticipate;
+
+  // ROK-1114: warm the per-user suggestions cache while the user is on
+  // the lineup page so opening the Nominate modal feels instant instead
+  // of waiting 5-20s for the LLM. Gating logic (plugin active + admin
+  // toggle on) lives inside `useAiSuggestions` so we don't fire when
+  // the AI plugin is uninstalled or admins disabled the feature.
+  useAiSuggestions(lineupId, {
+    personalize: true,
+    enabled: !!canNominate,
+  });
 
   const handleGameResolved = useCallback((game: SelectedGame) => {
     setPreSelectedGame(game);

--- a/web/src/plugins/ai/slots/ai-feature-toggles.test.tsx
+++ b/web/src/plugins/ai/slots/ai-feature-toggles.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Tests for AiFeatureToggles (ROK-1114 round 3).
+ *
+ * Verifies the new "AI Nomination Suggestions" toggle:
+ *   - Reads its initial state from `data?.aiSuggestionsEnabled`,
+ *     defaulting to ON when the field is missing (mirrors the
+ *     server-side default).
+ *   - Sends `{ aiSuggestionsEnabled: false }` when toggled off so the
+ *     LLM cost cap takes effect immediately.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { http, HttpResponse } from 'msw';
+import { server } from '../../../test/mocks/server';
+import { renderWithProviders } from '../../../test/render-helpers';
+import { AiFeatureToggles } from './ai-feature-toggles';
+
+vi.mock('../../../hooks/use-auth', () => ({
+    getAuthToken: vi.fn(() => 'test-token'),
+}));
+
+const API = 'http://localhost:3000';
+
+/**
+ * The toggle button has no accessible name (label/description sit in
+ * sibling <p>'s) so we locate it by walking up from the label text to
+ * the row container, then querying the row's switch.
+ */
+async function findToggleFor(label: RegExp): Promise<HTMLElement> {
+    const labelEl = await screen.findByText(label);
+    const row = labelEl.closest('div.flex.items-center');
+    if (!row) throw new Error(`row for label ${label} not found`);
+    const switchEl = row.querySelector('[role="switch"]');
+    if (!switchEl) throw new Error(`switch for label ${label} not found`);
+    return switchEl as HTMLElement;
+}
+
+function mockFeatures(overrides: Partial<{
+    chatEnabled: boolean;
+    dynamicCategoriesEnabled: boolean;
+    aiSuggestionsEnabled: boolean;
+}> = {}) {
+    server.use(
+        http.get(`${API}/admin/ai/features`, () =>
+            HttpResponse.json({
+                chatEnabled: false,
+                dynamicCategoriesEnabled: false,
+                aiSuggestionsEnabled: true,
+                ...overrides,
+            }),
+        ),
+    );
+}
+
+describe('AiFeatureToggles — AI Nomination Suggestions toggle (ROK-1114 round 3)', () => {
+    it('renders the new toggle in the on state by default', async () => {
+        mockFeatures({ aiSuggestionsEnabled: true });
+        renderWithProviders(<AiFeatureToggles disabled={false} />);
+        const toggle = await findToggleFor(/AI Nomination Suggestions/i);
+        await waitFor(() => {
+            expect(toggle).toHaveAttribute('aria-checked', 'true');
+        });
+    });
+
+    it('reflects an off state when the server reports aiSuggestionsEnabled: false', async () => {
+        mockFeatures({ aiSuggestionsEnabled: false });
+        renderWithProviders(<AiFeatureToggles disabled={false} />);
+        const toggle = await findToggleFor(/AI Nomination Suggestions/i);
+        await waitFor(() => {
+            expect(toggle).toHaveAttribute('aria-checked', 'false');
+        });
+    });
+
+    it('sends { aiSuggestionsEnabled: false } when toggled off', async () => {
+        mockFeatures({ aiSuggestionsEnabled: true });
+        const seen: unknown[] = [];
+        server.use(
+            http.put(`${API}/admin/ai/features`, async ({ request }) => {
+                seen.push(await request.json());
+                return HttpResponse.json({ success: true });
+            }),
+        );
+        renderWithProviders(<AiFeatureToggles disabled={false} />);
+        const toggle = await findToggleFor(/AI Nomination Suggestions/i);
+        await waitFor(() => {
+            expect(toggle).toHaveAttribute('aria-checked', 'true');
+        });
+        const user = userEvent.setup();
+        await user.click(toggle);
+        await waitFor(() => {
+            expect(seen).toContainEqual({ aiSuggestionsEnabled: false });
+        });
+    });
+});

--- a/web/src/plugins/ai/slots/ai-feature-toggles.tsx
+++ b/web/src/plugins/ai/slots/ai-feature-toggles.tsx
@@ -42,6 +42,10 @@ export function AiFeatureToggles({ disabled }: AiFeatureTogglesProps) {
 
     const chatEnabled = data?.chatEnabled ?? false;
     const dynCatEnabled = data?.dynamicCategoriesEnabled ?? false;
+    // Default true so an unconfigured install gets the feature; admin
+    // must explicitly disable. Mirrors the backend default in
+    // ai-admin.controller.getFeatures.
+    const aiSuggestionsEnabled = data?.aiSuggestionsEnabled ?? true;
 
     return (
         <div className="space-y-1 divide-y divide-edge/50">
@@ -58,6 +62,13 @@ export function AiFeatureToggles({ disabled }: AiFeatureTogglesProps) {
                 enabled={dynCatEnabled}
                 disabled={disabled}
                 onChange={(v) => mutate({ dynamicCategoriesEnabled: v })}
+            />
+            <FeatureToggle
+                label="AI Nomination Suggestions"
+                description="Per-user 'Suggested for you' picks in the Nominate modal and ✨ AI badges on the Common Ground grid. Disable to cap LLM costs."
+                enabled={aiSuggestionsEnabled}
+                disabled={disabled}
+                onChange={(v) => mutate({ aiSuggestionsEnabled: v })}
             />
         </div>
     );

--- a/web/src/test/mocks/handlers.ts
+++ b/web/src/test/mocks/handlers.ts
@@ -171,6 +171,41 @@ export const handlers = [
     // Lineups — banner (ROK-1065: visibility surfaces in banner response).
     http.get(`${API_BASE}/lineups/banner`, () => HttpResponse.json(null)),
 
+    // Lineups — common ground (ROK-934). Default empty payload so panels
+    // mount without unhandled-request warnings; tests override per-case.
+    http.get(`${API_BASE}/lineups/common-ground`, () =>
+        HttpResponse.json({
+            data: [],
+            meta: {
+                total: 0,
+                appliedWeights: {
+                    ownerWeight: 1,
+                    saleBonus: 0,
+                    fullPricePenalty: 0,
+                    tasteWeight: 0,
+                    socialWeight: 0,
+                    intensityWeight: 0,
+                },
+                activeLineupId: 0,
+                nominatedCount: 0,
+                maxNominations: 20,
+            },
+        }),
+    ),
+
+    // Lineups — AI suggestions (ROK-931, ROK-1114). Default success payload
+    // so CommonGroundPanel mounts cleanly; tests override to assert
+    // loading/unavailable/error states.
+    http.get(`${API_BASE}/lineups/:id/suggestions`, () =>
+        HttpResponse.json({
+            suggestions: [],
+            generatedAt: '2026-04-25T00:00:00.000Z',
+            voterCount: 0,
+            voterScopeStrategy: 'community',
+            cached: false,
+        }),
+    ),
+
     // Lineups — invitees add (ROK-1065). Returns refreshed detail.
     http.post(
         `${API_BASE}/lineups/:id/invitees`,

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -3,6 +3,34 @@ import * as matchers from 'vitest-axe/matchers';
 import { expect, beforeAll, afterEach, afterAll } from 'vitest';
 import { server } from './mocks/server';
 
+// Node 24 ships a built-in `localStorage` whose prototype shadows the jsdom
+// polyfill — the result is an empty object with no `getItem`/`setItem`. Restore
+// a working in-memory storage on `globalThis` and `window` before any source
+// module reads `localStorage` at import time. See ROK-1114.
+if (typeof globalThis.localStorage?.getItem !== 'function') {
+    const store = new Map<string, string>();
+    const polyfill: Storage = {
+        get length() {
+            return store.size;
+        },
+        clear: () => store.clear(),
+        getItem: (key: string) => store.get(key) ?? null,
+        key: (i: number) => Array.from(store.keys())[i] ?? null,
+        removeItem: (key: string) => void store.delete(key),
+        setItem: (key: string, value: string) => void store.set(key, String(value)),
+    };
+    Object.defineProperty(globalThis, 'localStorage', {
+        configurable: true,
+        value: polyfill,
+    });
+    if (typeof window !== 'undefined') {
+        Object.defineProperty(window, 'localStorage', {
+            configurable: true,
+            value: polyfill,
+        });
+    }
+}
+
 // vitest-axe matchers (toHaveNoViolations)
 expect.extend(matchers);
 


### PR DESCRIPTION
## Summary

Fixes the ROK-931 AI nomination suggestions surface that never loaded in production. Two compounding bugs (backend default → unreachable Ollama; frontend silently swallowed errors) plus operator-driven UX rework on top.

### Backend
- `LlmProviderRegistry.resolveActive()` now returns `{ provider, source: 'setting' | 'auto' }` and auto-picks the first cloud provider with a configured API key when no `ai_provider` setting is set. Hardcoded `'google'`/`'ollama'` defaults removed.
- `LlmService.logChatEntry` log line includes `source=setting|auto` for prod observability.
- New `ai_suggestions_enabled` admin toggle (default ON). When OFF, `AiSuggestionsService` short-circuits to an empty payload — no LLM call, no DB writes.

### Frontend
- New shared `<AiStatusBanner>` surfaces loading / 503 / error states for both `CommonGroundPanel` and `PersonalSuggestionsRow`. Failures are now visible instead of silent.
- `AiSuggestionCard` reasoning moved into the AI Pick badge tooltip; inline `<p>` text removed.
- Nominate modal widened (`max-w-lg → max-w-4xl`) with responsive grid (`2 / md:3 / lg:4`); SearchInput floats to the top, autofocused.
- Steam URL paste now resolves both inside the modal's search input AND anywhere else with the modal open.
- New `useAiSuggestionsAvailable()` hook combines `usePluginStore.isPluginActive('ai')` AND the admin toggle. When AI plugin is uninstalled OR admin disables: NO AI UI renders anywhere (no banners, badges, headers, skeletons). Common Ground grid keeps rendering.
- Lineup detail page pre-fetches the per-user suggestions on mount so opening the Nominate modal feels instant.

### Linear
ROK-1114

## Test plan
- [x] Unit tests added/updated (85 backend AI tests + 20 frontend AI tests)
- [x] CI passes (build + lint + type + tests + integration)
- [x] Operator tested locally (3 rework rounds)
- [x] Code review APPROVED WITH FIXES (7 LOW findings, no blockers)
- [x] Steam URL paste verified (in-input + outside-input)
- [x] Admin toggle verified end-to-end (off → no UI; on → restored)

## Out of scope (separate stories will be filed)
- AI Features admin panel "Offline" header mismatch (`ai-plugin-content.tsx`)
- `AI_DEFAULTS.model = 'llama3.2:3b'` fallback used by 3 callers when active provider isn't Ollama
- Reviewer F-1: move `aiSuggestionsEnabled` flag to a non-admin endpoint to stop 401s for regular users

🤖 Generated with [Claude Code](https://claude.com/claude-code)