### PR TITLE
chore: batch 2026-04-26 (ROK-1134, ROK-1137, ROK-1133)

### DIFF
--- a/.claude/skills/linear/SKILL.md
+++ b/.claude/skills/linear/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: linear
+description: Sync Linear with the work the agent has done or is about to do — update the active story, capture surfaced tech debt as new stories, link dependencies (blocks / blocked-by / related-to), and reconcile spec drift. Operator-invoked, multi-step.
+disable-model-invocation: true
+allowed-tools: "Bash(git*), Read, Grep, Glob"
+---
+
+# /linear — Keep Linear in Sync
+
+Operator-invoked. When the operator types `/linear`, run the full Linear-sync pipeline below so the active story (and anything it depends on) reflects reality.
+
+The goal: Linear should never be more than one prompt out of date. The operator should be able to walk away and come back, read the active story, and know exactly where things stand without asking.
+
+## Inputs (auto-detect, do not ask)
+
+1. **Active story ID** — derive from, in order:
+   - `task.md` at repo root (if present, parse the `ROK-XXX` from the header)
+   - Current branch name (`sjdodge/rok-XXXX-...` → `ROK-XXXX`)
+   - Most recent commits on the branch (`git log --oneline origin/main..HEAD` for `ROK-XXXX` references)
+   - If still ambiguous, ask the operator which story.
+
+2. **Work-in-flight signal** — gather:
+   - `git diff origin/main...HEAD` (committed changes on this branch)
+   - `git status` (uncommitted changes)
+   - Any `planning-artifacts/specs/ROK-XXX.md` or `planning-artifacts/review-ROK-XXX.md` updates
+   - Recent conversation context — what was just finished or is imminent
+
+3. **Surfaced tech debt** — anything in the conversation flagged as "we should clean this up later", "TODO", "this is a workaround", reviewer findings not in scope, etc.
+
+4. **New dependencies surfaced** — anything in the conversation indicating "this is blocked by X", "we need Y first", "this depends on Z being merged".
+
+## Steps
+
+### Step 1 — Locate and read the active story
+
+```
+mcp__linear__get_issue { id: "ROK-XXXX" }
+```
+
+Read its current description, AC, status, labels, blockedBy / blocks / relatedTo.
+
+### Step 2 — Reconcile description with reality
+
+Compare the current Linear description against what was actually built (or what's about to be built). Common drifts to fix:
+
+- **Deferrals** — items in the original AC that were deferred to a follow-up. Strike them through and add a "Deferred to ROK-YYY" line, OR move them to a new story.
+- **Replaced components** — if the implementation chose a different component / library / pattern than the original spec, update the description so reviewers measure against current reality.
+- **Added scope** — anything found necessary mid-implementation that wasn't in the original AC. Add to the AC list.
+- **Changed semantics** — if a contract field, endpoint, or behavior diverged from the original spec, update the relevant section.
+
+If the changes are non-trivial, use `mcp__linear__save_issue { id, description }` to update.
+
+### Step 3 — Capture surfaced tech debt as new stories
+
+For each piece of tech debt surfaced in the conversation that is NOT in scope of the current story:
+
+1. Verify it isn't already tracked: `mcp__linear__list_issues { query: "<short keywords>", project: "Raid Ledger" }`.
+2. If not tracked, create a new story:
+
+```
+mcp__linear__save_issue {
+  team: "Roknua's projects",
+  project: "Raid Ledger",
+  title: "tech-debt: <concise>",          // or fix:, chore:, perf:
+  labels: ["Tech Debt", "<Area>"],         // pick the correct area label
+  priority: 3,                              // medium by default
+  description: "<what / why / pointers to file:line / any AC>",
+  relatedTo: ["ROK-XXXX"],                  // link back to the story that surfaced it
+}
+```
+
+3. Apply Linear story conventions from MEMORY.md:
+   - Title prefix: `feat:` / `fix:` / `tech-debt:` / `chore:` / `perf:` / `spike:`
+   - One area label (no `Area:` prefix — labels are bare names)
+   - Always project = "Raid Ledger", team = "Roknua's projects"
+4. Investigate before creating — verify the file paths and behavior referenced are real (`feedback_investigate_before_stories`).
+
+### Step 4 — Map dependencies
+
+For each dependency relationship surfaced:
+
+- **This story is blocked by another** → `mcp__linear__save_issue { id: "ROK-XXXX", blockedBy: ["ROK-YYYY"] }`
+- **This story blocks another** → `mcp__linear__save_issue { id: "ROK-XXXX", blocks: ["ROK-ZZZZ"] }`
+- **Related (informational only)** → `mcp__linear__save_issue { id: "ROK-XXXX", relatedTo: ["ROK-WWWW"] }`
+
+Note: blockedBy / blocks / relatedTo on `save_issue` are **append-only**. To remove, use `removeBlockedBy` / `removeBlocks` / `removeRelatedTo`.
+
+If the operator mentions a new dependency that isn't yet a Linear story, create it first via Step 3, then link.
+
+### Step 5 — Comment with a progress summary
+
+Add a comment to the active story summarizing what was just done and what's next:
+
+```
+mcp__linear__save_comment {
+  issue: "ROK-XXXX",
+  body: "<short markdown summary>"
+}
+```
+
+Template:
+
+```markdown
+**Progress (YYYY-MM-DD)**
+
+Done:
+- <bullet> (<file:line> if relevant)
+- <bullet>
+
+In flight:
+- <bullet>
+
+Next:
+- <bullet>
+
+Surfaced:
+- ROK-NNNN — <new tech-debt / dependency / follow-up>
+```
+
+Skip the comment if nothing material happened since the last sync.
+
+### Step 6 — Status transition (if appropriate)
+
+Only transition status when there's clear evidence:
+
+- Backlog → In Progress: at least one commit on the branch referencing the story
+- In Progress → In Review: PR is open and not draft
+- In Review → Done: PR is merged
+
+Do NOT auto-promote to Done speculatively. If unsure, ask the operator.
+
+```
+mcp__linear__save_issue { id: "ROK-XXXX", state: "In Progress" }
+```
+
+### Step 7 — Report back
+
+Return a concise summary to the operator:
+
+- Active story: ROK-XXXX (status, title)
+- Description updates: <what changed, or "no change needed">
+- New stories created: ROK-YYYY (tech-debt: ...), ROK-ZZZZ (...)
+- Dependencies linked: blocks / blockedBy / relatedTo
+- Comment added: yes/no
+- Status transition: <from → to, or "no change">
+
+## Rules
+
+- **Always investigate before creating new stories** (`feedback_investigate_before_stories`) — verify the file paths and code referenced before writing speculative AC.
+- **Never close stories**. Only the operator (or a merged PR) closes work.
+- **Never delete stories** the operator created. If something is genuinely a dupe, mark `duplicateOf` instead.
+- **Append-only relations**: don't try to "set" the blocked-by list — use `blockedBy` to add and `removeBlockedBy` to remove.
+- **One story per concern**: if the conversation surfaced 3 unrelated cleanups, file 3 stories, not one mega-story.
+- **Stay terse in descriptions** — link to commits / file paths rather than re-explaining what the code does.
+- This skill is **operator-invoked only**. Do not auto-run it inside `/build`, `/dispatch`, or `/bulk` pipelines — those have their own Linear sync steps.
+
+## Edge cases
+
+- **Branch isn't tied to a story** (e.g. `batch/2026-04-22`): find every `ROK-XXX` mentioned in the commits since `origin/main`, then ask the operator which one to sync.
+- **Story is already Done in Linear** but operator wants more work logged: add a comment, propose creating a follow-up story instead of reopening.
+- **No active story at all** (exploratory work): offer to create one (`feat:` / `spike:`) so the work has a home.
+- **Multiple stories touched in one branch**: sync each one in turn, with shared dependency links between them.

--- a/.claude/skills/operator-testing/SKILL.md
+++ b/.claude/skills/operator-testing/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: operator-testing
+description: Deploy the current branch to the local dev environment for hands-on testing. Operator-invoked — overrides whatever is currently deployed.
+disable-model-invocation: true
+allowed-tools: "Bash(./scripts/deploy_dev.sh*), Bash(git*)"
+---
+
+# Operator Testing
+
+Deploy the current branch via `./scripts/deploy_dev.sh` so the operator can test the work in a browser / Discord / API surface.
+
+Aliases: `/opt` (same skill).
+
+## Authority
+
+This skill is **operator-invoked and always overrides** whatever branch is currently deployed. The operator knows what they want to test — when they type `/opt`, take the env. The "don't steal a deployed branch" rule applies to *autonomous agent deploys*, not to this skill.
+
+## Steps
+
+1. Confirm current branch: `git branch --show-current`.
+2. (Optional, informational) Run `./scripts/deploy_dev.sh --status` so the report tells the operator what's being replaced. Don't gate on it — just inform.
+3. Deploy:
+   - With contract/schema changes since the last deploy: `./scripts/deploy_dev.sh --ci --rebuild`
+   - Otherwise: `./scripts/deploy_dev.sh --ci`
+4. Report the API and Web URLs from the script output (default `:3000` and `:5173`/`:5174`) plus the branch now deployed.
+5. If the operator wants a fresh DB: pass `--fresh` (warn that it wipes data).
+6. If the operator wants a different branch: switch with `--branch <name>` first.
+
+## Notes
+
+- Worktree-safe — the deploy script auto-detects worktrees and copies `.env` from the main repo.
+- For a hard reset with new admin creds, point the operator at `/deploy-fresh` instead.
+- This skill does NOT run as part of `/build`, `/dispatch`, or `/bulk` pipelines — those are local-only until Step 5 / Push, per memory rules.

--- a/.claude/skills/opt/SKILL.md
+++ b/.claude/skills/opt/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: opt
+description: Alias for /operator-testing — deploy the current branch to local dev for hands-on testing. Operator-invoked, always overrides whatever is currently deployed.
+disable-model-invocation: true
+allowed-tools: "Bash(./scripts/deploy_dev.sh*), Bash(git*)"
+---
+
+# /opt — alias for /operator-testing
+
+This is an alias for the `/operator-testing` skill. Read and follow the instructions at `.claude/skills/operator-testing/SKILL.md`.
+
+Key point: `/opt` is **operator-invoked and always overrides** the current deploy. The "don't steal a deployed branch" rule applies to *autonomous agent deploys*, not to this skill.

--- a/.claude/skills/push/SKILL.md
+++ b/.claude/skills/push/SKILL.md
@@ -39,7 +39,7 @@ Evaluate the changed files and classify the changeset:
 
 | Files Changed | Checks Needed |
 |---------------|---------------|
-| **Only** `.claude/skills/`, `.md` files, `docs/` | **None** — skip to Step 9 (push) |
+| **Only** `.claude/`, `CLAUDE.md`, `.mcp.json`, `.md` files, `docs/` | **None** — skip to Step 9 (push). Still run Step 2a to make sure operator config is staged. |
 | **Only** `web/src/` (no api, no contract) | Web only: build contract + web, typecheck web, lint web, test web, Playwright |
 | **Only** `api/src/` (no web, no contract) | API only: build contract + api, typecheck api, lint api, test api |
 | **Only** `packages/contract/` | Contract + both: build all, typecheck all, lint all, test all |
@@ -79,6 +79,22 @@ git status --short
 - If there are unstaged changes that should be included → stage and commit them
 - If there are untracked files that should be included → add and commit them
 - If changes are intentionally uncommitted → proceed (they won't be pushed)
+
+### Step 2a: Operator config files MUST ride along (STRICT)
+
+Before continuing, explicitly check for **operator-authored config** that must never be left behind:
+
+```bash
+git status --short -- .claude/skills .claude/agents .claude/settings.json .claude/settings.local.json CLAUDE.md .mcp.json 2>/dev/null
+```
+
+If anything appears (modified, staged, or untracked):
+
+1. Stage all of it: `git add .claude/skills .claude/agents .claude/settings.json .claude/settings.local.json CLAUDE.md .mcp.json` (only paths that exist)
+2. Commit with a `chore(config): ...` prefix — do NOT tag the active story ID, these are independent operator config updates riding along.
+3. Example: `git commit -m "chore(config): update /opt skill, deploy etiquette memory, MCP fix story refs"`
+
+This rule is in CLAUDE.md ("Operator Config Files"). The reason: parallel agents would otherwise assume these aren't theirs, cherry-pick around them, and leave them behind.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,26 @@ Three custom MCP servers provide tools for environment management, story trackin
 - **Always enable auto-merge (squash)** after creating or pushing to a PR: `gh pr merge <branch> --auto --squash`
 - This is safe to run whether the PR was just created or already existed — it's a no-op if already enabled.
 
+## Operator Config Files (STRICT — applies to ALL agents)
+
+The following paths are **operator-authored configuration**. They are intentionally bundled into whatever PR is open at the time, regardless of which story the PR is for:
+
+- `.claude/skills/**` — slash commands and agent skills
+- `.claude/agents/**` — agent definitions
+- `.claude/settings.json`, `.claude/settings.local.json` — Claude Code harness config
+- `CLAUDE.md` (this file) — project instructions
+- `.mcp.json` — MCP server registrations
+
+**Rules:**
+
+1. **Never cherry-pick around them.** If you encounter commits or staged changes touching these paths on a branch you're working on, treat them as in-scope and let them ride along.
+2. **Never revert them** because "they look unrelated to my story." They are intentionally unrelated — the operator updates them opportunistically and they ship with the next PR that goes out.
+3. **Never exclude them** from `git add` / `git commit` / `git push` / `git rebase` / cherry-pick / squash flows.
+4. **When committing them**, use a `chore(config): ...` prefix in the commit message so they're easy to spot in PR diffs. Do NOT mention the active story ID — they're independent.
+5. **`/push` (and any agent that pushes)** must check for unstaged or untracked changes under these paths and stage + commit them before pushing. Do not leave them in the working tree.
+
+This rule exists because parallel agents kept seeing these commits, assuming "not my work," and cherry-picking around them — leaving operator config changes orphaned across batches.
+
 ## Local Dev Environment
 
 - **Start everything:** `./scripts/deploy_dev.sh` — ensures Docker is up, runs migrations, seeds data, starts API + web in watch mode

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,11 @@ Run `./scripts/validate-ci.sh --full` before pushing any branch. This replaces m
 
 Migration and container checks run conditionally based on `git diff` against `origin/main`. Playwright remains a separate step because it requires a running dev environment.
 
+**Backup integration tests** (`api/src/backup/backup.integration.spec.ts`) shell out to `pg_dump` / `pg_restore`. They are gated by `SKIP_BACKUP_INTEGRATION`:
+
+- Locally: `validate-ci.sh` checks for `pg_dump` on PATH. If missing, it prints a yellow warning, sets `SKIP_BACKUP_INTEGRATION=1`, and the suite skips. Install `postgresql-client` (e.g. `brew install libpq` on macOS) to run them.
+- In CI: pass `--ci` to `validate-ci.sh`. Missing `pg_dump` then hard-fails instead of skipping, so CI never silently misses these tests.
+
 ### Smoke Test Verification (STRICT — learned from ROK-935 incident)
 
 **CI runs BOTH desktop AND mobile Playwright projects.** Local verification MUST match CI:

--- a/api/src/backup/backup.integration.spec.ts
+++ b/api/src/backup/backup.integration.spec.ts
@@ -24,15 +24,25 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 
+// Allow opting out locally when pg_dump/pg_restore are not on PATH.
+// validate-ci.sh sets this when it detects a missing pg_dump binary in
+// non-CI mode. In CI the env var is never set, so the suite always runs.
+const SKIP_BACKUP_INTEGRATION = process.env.SKIP_BACKUP_INTEGRATION === '1';
+const describeBackup = SKIP_BACKUP_INTEGRATION ? describe.skip : describe;
+
 // Force direct pg_dump/pg_restore execution (no Docker routing)
 // so it works with the Testcontainers DB.
 process.env.DB_CONTAINER_NAME = '';
 
 // Isolate test backups in a temp directory so we never touch real backup files.
-const TEST_BACKUP_DIR = fs.mkdtempSync(
-  path.join(os.tmpdir(), 'raid-ledger-backup-test-'),
-);
-process.env.BACKUP_DIR = TEST_BACKUP_DIR;
+// Skip directory creation when the suite is gated off — it would leak temp dirs
+// every run on machines without pg_dump.
+const TEST_BACKUP_DIR = SKIP_BACKUP_INTEGRATION
+  ? ''
+  : fs.mkdtempSync(path.join(os.tmpdir(), 'raid-ledger-backup-test-'));
+if (!SKIP_BACKUP_INTEGRATION) {
+  process.env.BACKUP_DIR = TEST_BACKUP_DIR;
+}
 
 function describeBackupCRUD() {
   let testApp: TestApp;
@@ -242,9 +252,9 @@ function describeBackupCRUD() {
   describe('POST /admin/backups/:type/:filename/restore', () =>
     describePOSTAdminBackupsTypeFilenameRestore());
 }
-describe('Backup CRUD (integration)', () => describeBackupCRUD());
+describeBackup('Backup CRUD (integration)', () => describeBackupCRUD());
 
-describe('Backup auth enforcement (integration)', () => {
+describeBackup('Backup auth enforcement (integration)', () => {
   let testApp: TestApp;
 
   beforeAll(async () => {

--- a/api/src/lineups/lineup-notification-routing.helpers.ts
+++ b/api/src/lineups/lineup-notification-routing.helpers.ts
@@ -27,18 +27,28 @@ type Db = PostgresJsDatabase<typeof schema>;
 /**
  * Resolve lineup visibility: prefer the caller-provided value, fall back
  * to a DB lookup so older callers aren't broken (ROK-1065).
+ *
+ * Fail-closed (ROK-1134): if no caller-provided visibility AND the lineup
+ * row is missing (race against hard delete or broken FK), return `null`.
+ * Callers must treat `null` as "skip the channel embed" so we never leak
+ * to the public channel for a non-existent lineup.
  */
 export async function resolveLineupVisibility(
   db: Db,
   lineup: LineupInfo,
-): Promise<'public' | 'private'> {
+): Promise<'public' | 'private' | null> {
   if (lineup.visibility) return lineup.visibility;
   const [row] = await db
     .select({ visibility: schema.communityLineups.visibility })
     .from(schema.communityLineups)
     .where(eq(schema.communityLineups.id, lineup.id))
     .limit(1);
-  return row?.visibility ?? 'public';
+  // Fail-closed: no row means the lineup vanished (race against hard delete
+  // or broken FK). Return null so callers suppress the channel embed.
+  // The column is NOT NULL with default 'public', so an existing row always
+  // resolves to a real visibility value.
+  if (!row) return null;
+  return row.visibility ?? 'public';
 }
 
 /**
@@ -52,6 +62,7 @@ export async function routeLineupCreatedIfPrivate(
   lineup: LineupInfo,
 ): Promise<boolean> {
   const visibility = await resolveLineupVisibility(db, lineup);
+  if (visibility === null) return true;
   if (visibility !== 'private') return false;
   await fanOutLineupCreatedDMsToInvitees(
     db,
@@ -76,6 +87,7 @@ export async function routeVotingOpenIfPrivate(
   baseUrl: string | undefined,
 ): Promise<boolean> {
   const visibility = await resolveLineupVisibility(db, lineup);
+  if (visibility === null) return true;
   if (visibility !== 'private') return false;
   await fanOutVotingDMsToInvitees(
     db,
@@ -101,6 +113,7 @@ export async function routeNominationMilestoneIfPrivate(
   entryCount: number,
 ): Promise<boolean> {
   const visibility = await resolveLineupVisibility(db, lineup);
+  if (visibility === null) return true;
   if (visibility !== 'private') return false;
   await fanOutMilestoneDMsToInvitees(
     db,
@@ -126,6 +139,7 @@ export async function routeMatchesFoundIfPrivate(
   matchCount: number,
 ): Promise<boolean> {
   const visibility = await resolveLineupVisibility(db, lineup);
+  if (visibility === null) return true;
   if (visibility !== 'private') return false;
   await fanOutMatchesFoundDMsToInvitees(
     db,
@@ -149,6 +163,7 @@ export async function routeSchedulingOpenIfPrivate(
   match: MatchInfo,
 ): Promise<boolean> {
   const visibility = await resolveLineupVisibility(db, lineup);
+  if (visibility === null) return true;
   if (visibility !== 'private') return false;
   await fanOutSchedulingDMsToInvitees(
     db,
@@ -173,6 +188,7 @@ export async function routeEventCreatedIfPrivate(
   eventId: number | undefined,
 ): Promise<boolean> {
   const visibility = await resolveLineupVisibility(db, lineup);
+  if (visibility === null) return true;
   if (visibility !== 'private') return false;
   await fanOutEventCreatedDMsToInvitees(
     db,

--- a/api/src/lineups/lineup-notification.service.private-visibility.spec.ts
+++ b/api/src/lineups/lineup-notification.service.private-visibility.spec.ts
@@ -429,4 +429,73 @@ describe('LineupNotificationService — private-visibility gating (ROK-1115)', (
       expect(mockBotClient.sendEmbed).toHaveBeenCalledTimes(1);
     });
   });
+
+  // ── ROK-1134: fail-closed when underlying lineup row is missing ──────────
+  //
+  // When the orchestrator is called without a caller-provided visibility AND
+  // the DB lookup returns no row (race against a hard delete or broken FK),
+  // `resolveLineupVisibility` must NOT default to 'public'. It must return
+  // null, and every `route*IfPrivate` must treat that null as "private path
+  // taken" so the channel embed (and DM fan-out) is suppressed.
+
+  describe('fail-closed when lineup row is missing (ROK-1134)', () => {
+    /** Override the visibility-probe chain to simulate a missing row. */
+    function mockMissingLineupRow(
+      db: ReturnType<typeof makeMockDb>,
+    ): void {
+      db.select.mockReturnValue({
+        from: jest.fn().mockReturnValue({
+          where: jest.fn().mockReturnValue({
+            limit: jest.fn().mockResolvedValue([]),
+          }),
+        }),
+      });
+    }
+
+    it('notifyNominationMilestone — does not post channel embed when lineup row is missing', async () => {
+      mockMissingLineupRow(mockDb);
+
+      // No `visibility` passed → resolveLineupVisibility falls through to DB,
+      // which now returns [] (no row).
+      await callMilestone(service, LINEUP_ID, 50, [milestoneEntry('Game A')]);
+
+      expect(mockBotClient.sendEmbed).not.toHaveBeenCalled();
+      expect(mockNotificationService.create).not.toHaveBeenCalled();
+    });
+
+    it('notifyMatchesFound — does not post channel embed when lineup row is missing', async () => {
+      mockMissingLineupRow(mockDb);
+
+      await callMatchesFound(service, LINEUP_ID, [
+        makeMatch({ thresholdMet: true }),
+      ]);
+
+      expect(mockBotClient.sendEmbed).not.toHaveBeenCalled();
+      expect(mockNotificationService.create).not.toHaveBeenCalled();
+    });
+
+    it('notifySchedulingOpen — does not post channel embed when lineup row is missing', async () => {
+      mockMissingLineupRow(mockDb);
+
+      await callSchedulingOpen(service, makeMatch({ status: 'scheduling' }));
+
+      expect(mockBotClient.sendEmbed).not.toHaveBeenCalled();
+      expect(mockNotificationService.create).not.toHaveBeenCalled();
+    });
+
+    it('notifyEventCreated — does not post channel embed when lineup row is missing', async () => {
+      mockMissingLineupRow(mockDb);
+      const eventDate = new Date('2026-04-20T18:00:00Z');
+
+      await callEventCreated(
+        service,
+        makeMatch({ status: 'scheduled', linkedEventId: 200 }),
+        eventDate,
+        200,
+      );
+
+      expect(mockBotClient.sendEmbed).not.toHaveBeenCalled();
+      expect(mockNotificationService.create).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/api/src/lineups/lineup-notification.service.private-visibility.spec.ts
+++ b/api/src/lineups/lineup-notification.service.private-visibility.spec.ts
@@ -440,9 +440,7 @@ describe('LineupNotificationService — private-visibility gating (ROK-1115)', (
 
   describe('fail-closed when lineup row is missing (ROK-1134)', () => {
     /** Override the visibility-probe chain to simulate a missing row. */
-    function mockMissingLineupRow(
-      db: ReturnType<typeof makeMockDb>,
-    ): void {
+    function mockMissingLineupRow(db: ReturnType<typeof makeMockDb>): void {
       db.select.mockReturnValue({
         from: jest.fn().mockReturnValue({
           where: jest.fn().mockReturnValue({

--- a/scripts/validate-ci.sh
+++ b/scripts/validate-ci.sh
@@ -146,7 +146,10 @@ check_backup_prereqs() {
 }
 
 run_integration_tests() {
-  check_backup_prereqs
+  # Explicit `|| return` — `set -e` is disabled inside `||`/`&&` lists, and
+  # run_step calls us with `"$@" || rc=$?`, so a bare check_backup_prereqs
+  # would not halt this function on failure.
+  check_backup_prereqs || return $?
   npm run test:integration -w api
 }
 

--- a/scripts/validate-ci.sh
+++ b/scripts/validate-ci.sh
@@ -9,6 +9,10 @@
 # Usage:
 #   ./scripts/validate-ci.sh          # Run all checks
 #   ./scripts/validate-ci.sh --full   # Same (accepted for explicitness)
+#   ./scripts/validate-ci.sh --ci     # Hard-fail on missing local prereqs
+#                                     # (e.g. pg_dump). Use in CI to ensure
+#                                     # backup integration tests never silently
+#                                     # skip.
 # =============================================================================
 
 set -euo pipefail
@@ -30,6 +34,9 @@ FAILURES=0
 # Scope flags
 migrations_changed=false
 container_changed=false
+
+# Mode flags
+ci_mode=false
 
 # ---------------------------------------------------------------------------
 # Result tracking helpers
@@ -116,7 +123,30 @@ run_unit_tests() {
   (cd "$REPO_ROOT/web" && npx vitest run --coverage)
 }
 
+check_backup_prereqs() {
+  # Backup integration tests shell out to pg_dump/pg_restore. On dev machines
+  # without postgresql-client installed they hard-fail with 500 → 200 mismatch
+  # and obscure real failures. CI runners install postgresql-client, so the
+  # binary is always present there.
+  if command -v pg_dump >/dev/null 2>&1; then
+    export SKIP_BACKUP_INTEGRATION=0
+    return 0
+  fi
+
+  if $ci_mode; then
+    echo -e "${RED}pg_dump not found on PATH.${NC}"
+    echo -e "${RED}CI mode requires postgresql-client installed for backup integration tests.${NC}"
+    return 1
+  fi
+
+  echo -e "${YELLOW}pg_dump not found on PATH — skipping backup integration tests.${NC}"
+  echo -e "${YELLOW}Install postgresql-client (e.g. \`brew install libpq\` on macOS) to run them locally.${NC}"
+  export SKIP_BACKUP_INTEGRATION=1
+  return 0
+}
+
 run_integration_tests() {
+  check_backup_prereqs
   npm run test:integration -w api
 }
 
@@ -222,10 +252,13 @@ print_summary() {
 # ---------------------------------------------------------------------------
 
 main() {
-  # Accept --full for explicitness (default behavior)
+  # Accept --full for explicitness (default behavior).
+  # --ci hard-fails on missing local prereqs (pg_dump) instead of skipping
+  # so CI never silently skips backup integration tests.
   while [ $# -gt 0 ]; do
     case "$1" in
       --full) shift ;;
+      --ci) ci_mode=true; shift ;;
       *) echo -e "${RED}Unknown argument: $1${NC}"; exit 1 ;;
     esac
   done

--- a/web/src/components/features/game-time/GameTimeWidget.test.tsx
+++ b/web/src/components/features/game-time/GameTimeWidget.test.tsx
@@ -171,6 +171,36 @@ describe('GameTimeWidget — part 1', () => {
         expect(titleMatches.length).toBeGreaterThanOrEqual(2);
     });
 
+    it('preview block resolves character avatars when gameId is threaded through (ROK-1133)', () => {
+        mockEditorData({
+            slots: [{ dayOfWeek: 0, hour: 19, status: 'available' }],
+        });
+
+        renderWidget({
+            eventStart: '2026-02-09T19:00:00',
+            eventEnd: '2026-02-09T22:00:00',
+            eventTitle: 'Raid Night',
+            gameName: 'World of Warcraft',
+            gameId: 5,
+            attendees: [
+                {
+                    id: 42,
+                    username: 'Astra',
+                    avatar: null,
+                    discordId: null,
+                    characters: [{ gameId: 5, avatarUrl: '/char.png' }],
+                },
+            ],
+            attendeeCount: 1,
+        });
+
+        fireEvent.click(screen.getByTestId('game-time-widget'));
+
+        const previewBlock = screen.getByTestId('preview-block-1-19');
+        const charAvatar = previewBlock.querySelector('img[src*="/char.png"]');
+        expect(charAvatar).not.toBeNull();
+    });
+
 });
 
 describe('GameTimeWidget — part 2', () => {

--- a/web/src/components/features/game-time/GameTimeWidget.tsx
+++ b/web/src/components/features/game-time/GameTimeWidget.tsx
@@ -107,6 +107,26 @@ function OverlapBadge({ hasOverlap }: { hasOverlap: boolean }) {
     );
 }
 
+function EventDetailHeader({ title, coverUrl, gameName, timeLabel, creatorUsername }: {
+    title: string; coverUrl?: string | null; gameName?: string; timeLabel: string; creatorUsername?: string | null;
+}) {
+    return (
+        <>
+            {coverUrl && <div className="w-14 h-14 rounded-lg bg-cover bg-center shrink-0 ring-1 ring-white/10" style={{ backgroundImage: `url(${coverUrl})` }} />}
+            <div className="flex-1 min-w-0">
+                <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-emerald-300/80">Highlighted Event</p>
+                <h4 className="text-sm font-semibold text-foreground truncate mt-1">{title}</h4>
+                <div className="flex items-center gap-2 mt-1 text-xs text-muted">
+                    {gameName && <span>{gameName}</span>}
+                    {gameName && timeLabel && <span className="text-faint">·</span>}
+                    {timeLabel && <span>{timeLabel}</span>}
+                </div>
+                {creatorUsername && <p className="text-[11px] text-dim mt-1">Hosted by {creatorUsername}</p>}
+            </div>
+        </>
+    );
+}
+
 function EventDetailCard({ title, coverUrl, gameName, gameId, timeLabel, creatorUsername, attendees }: {
     title: string; coverUrl?: string | null; gameName?: string; timeLabel: string; creatorUsername?: string | null;
     gameId?: number | null; attendees?: AttendeePreview[];
@@ -114,17 +134,7 @@ function EventDetailCard({ title, coverUrl, gameName, gameId, timeLabel, creator
     return (
         <div className="rounded-lg border border-edge bg-panel/50 overflow-hidden">
             <div className="flex items-start gap-3 p-3">
-                {coverUrl && <div className="w-14 h-14 rounded-lg bg-cover bg-center shrink-0 ring-1 ring-white/10" style={{ backgroundImage: `url(${coverUrl})` }} />}
-                <div className="flex-1 min-w-0">
-                    <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-emerald-300/80">Highlighted Event</p>
-                    <h4 className="text-sm font-semibold text-foreground truncate mt-1">{title}</h4>
-                    <div className="flex items-center gap-2 mt-1 text-xs text-muted">
-                        {gameName && <span>{gameName}</span>}
-                        {gameName && timeLabel && <span className="text-faint">·</span>}
-                        {timeLabel && <span>{timeLabel}</span>}
-                    </div>
-                    {creatorUsername && <p className="text-[11px] text-dim mt-1">Hosted by {creatorUsername}</p>}
-                </div>
+                <EventDetailHeader title={title} coverUrl={coverUrl} gameName={gameName} timeLabel={timeLabel} creatorUsername={creatorUsername} />
                 {attendees && attendees.length > 0 && (
                     <div className="shrink-0 self-center">
                         <MemberAvatarGroup
@@ -171,6 +181,24 @@ function useGameTimeWidgetData(props: GameTimeWidgetProps) {
     return { editor, hasOverlap, previewBlocks, eventTimeLabel };
 }
 
+function GameTimeWidgetModalHeader({ onClose }: { onClose: () => void }) {
+    return (
+        <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
+            <div>
+                <p className="text-muted text-xs">Read-only view — your weekly availability with this event highlighted.</p>
+                <p className="text-dim text-xs mt-1">Uses the same compact weekly layout as profile and scheduling.</p>
+            </div>
+            <Link
+                to="/profile/gaming"
+                onClick={onClose}
+                className="inline-flex items-center justify-center rounded-lg border border-edge bg-panel px-3 py-2 text-xs font-medium text-emerald-300 hover:bg-overlay transition-colors"
+            >
+                Edit my game time &rarr;
+            </Link>
+        </div>
+    );
+}
+
 function GameTimeWidgetModal({ editor, previewBlocks, eventTitle, coverUrl, gameName, gameId, eventTimeLabel, creatorUsername, attendees, onClose }: {
     editor: ReturnType<typeof useGameTimeEditor>; previewBlocks: GameTimePreviewBlock[];
     eventTitle?: string; coverUrl?: string | null; gameName?: string; gameId?: number | null; eventTimeLabel: string; creatorUsername?: string | null;
@@ -182,19 +210,7 @@ function GameTimeWidgetModal({ editor, previewBlocks, eventTitle, coverUrl, game
     return (
         <Modal isOpen onClose={onClose} title="My Game Time" maxWidth="max-w-3xl" bodyClassName="p-4 pb-6 overflow-y-auto max-h-[calc(90vh-8rem)]">
             <div className="space-y-4">
-                <div className="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
-                    <div>
-                        <p className="text-muted text-xs">Read-only view — your weekly availability with this event highlighted.</p>
-                        <p className="text-dim text-xs mt-1">Uses the same compact weekly layout as profile and scheduling.</p>
-                    </div>
-                    <Link
-                        to="/profile/gaming"
-                        onClick={onClose}
-                        className="inline-flex items-center justify-center rounded-lg border border-edge bg-panel px-3 py-2 text-xs font-medium text-emerald-300 hover:bg-overlay transition-colors"
-                    >
-                        Edit my game time &rarr;
-                    </Link>
-                </div>
+                <GameTimeWidgetModalHeader onClose={onClose} />
                 <div className="rounded-lg border border-edge overflow-hidden">
                     <GameTimeGrid
                         slots={editor.slots}

--- a/web/src/components/features/game-time/PreviewBlockOverlays.tsx
+++ b/web/src/components/features/game-time/PreviewBlockOverlays.tsx
@@ -85,6 +85,7 @@ function PreviewBlock({ block, pos, hasEventUnderneath }: {
                         coverUrl: block.coverUrl, startHour: block.startHour,
                         endHour: block.endHour, description: block.description,
                         creatorUsername: block.creatorUsername,
+                        gameId: block.gameId,
                         signupsPreview: block.attendees, signupCount: block.attendeeCount,
                     }}
                     spanHours={block.endHour - block.startHour}

--- a/web/src/components/features/game-time/RichEventBlock.tsx
+++ b/web/src/components/features/game-time/RichEventBlock.tsx
@@ -25,7 +25,7 @@ interface RichEventBlockProps {
             id: number;
             username: string;
             avatar: string | null;
-            characters?: Array<{ gameId: number; avatarUrl: string | null }>;
+            characters?: Array<{ gameId: number | string; avatarUrl: string | null }>;
         }>;
         signupCount?: number;
     };

--- a/web/src/components/features/game-time/game-time-grid.types.ts
+++ b/web/src/components/features/game-time/game-time-grid.types.ts
@@ -23,7 +23,16 @@ export interface GameTimePreviewBlock {
     coverUrl?: string | null;
     description?: string | null;
     creatorUsername?: string | null;
-    attendees?: Array<{ id: number; username: string; avatar: string | null }>;
+    /** Game ID threaded through so RichEventBlock can resolve character avatars (ROK-1133) */
+    gameId?: number | null;
+    attendees?: Array<{
+        id: number;
+        username: string;
+        avatar: string | null;
+        customAvatarUrl?: string | null;
+        discordId?: string | null;
+        characters?: Array<{ gameId: number | string; name?: string; avatarUrl: string | null }>;
+    }>;
     attendeeCount?: number;
 }
 


### PR DESCRIPTION
## Summary

Batch of 3 tech-debt stories, single PR via `/bulk` pipeline:

| Story | Label | Area | Reviewer |
|-------|-------|------|----------|
| ROK-1134 | Tech Debt | Discord Bot | APPROVED |
| ROK-1137 | Tech Debt | Testing Infra | APPROVED WITH FIXES |
| ROK-1133 | Tech Debt | UI/UX | APPROVED |

## What

- **ROK-1134** — `resolveLineupVisibility` now returns `'public' | 'private' | null`; all 6 `route*IfPrivate` callers treat `null` as "skip channel embed" so a missing `community_lineups` row no longer leaks an embed to the public channel. Fail-closed default. TDD: 4 new failing tests added first, then helper widened.
- **ROK-1137** — `scripts/validate-ci.sh` now precondition-checks for `pg_dump` and sets `SKIP_BACKUP_INTEGRATION=1` when missing locally; `api/src/backup/backup.integration.spec.ts` honors the flag. `--ci` mode hard-fails (not skips) so CI never silently passes. Reviewer caught a critical `set -e`-inside-`||`-chain propagation bug; fixed in-band.
- **ROK-1133** — GameTime preview-block follow-ups: `gameId` now threads from `PreviewBlockOverlays` into `RichEventBlock` (character avatars no longer fall back to Discord), `EventDetailCard` and `GameTimeWidgetModal` extracted into sub-components to clear the two `max-lines-per-function` warnings, `RichEventBlockProps` `gameId` widened to `number | string`. Item 3 (Modal `bodyClassName` dedupe) deferred per spec.

Operator-config commit (`chore(config):`) bundles new `/linear`, `/operator-testing`, `/opt` skills and the CLAUDE.md "Operator Config Files" rule — riding along per project convention.

## Linear

- ROK-1134 — fail-closed `resolveLineupVisibility`
- ROK-1137 — `validate-ci.sh` skip backup tests when `pg_dump` missing
- ROK-1133 — GameTime preview-block follow-ups
- ROK-1140 — **filed during this batch** (web vitest fails on Node 24+ with `localStorage.getItem is not a function`, 119 tests across 29 files; tracks the broader unit-test failure observed locally that does NOT reproduce in CI's Node-20 environment)

## Validation

| Check | Result | Notes |
|-------|--------|-------|
| Per-story code review | ✓ | 1134 APPROVED clean; 1137 APPROVED WITH FIXES (critical `--ci` propagation bug auto-fixed); 1133 APPROVED clean |
| Build / TypeScript / Lint | ✓ | `validate-ci.sh --full` PASS for all three steps |
| Unit tests (api) | ✓ | 5611 / 5611 in 11s |
| Unit tests (web — narrow) | ✓ | 188 / 188 across `game-time/*` + `AttendeeAvatars` (this batch's surface) |
| Unit tests (web — broad) | pre-existing on origin/main | 119 / 2789 fail locally with `localStorage.getItem is not a function`. Reproduced on clean `npm install` of `e9d25979` with Node 24.11.1+; CI passes (Node 20). Tracked in **ROK-1140**. |
| Integration tests (api) | ✓ | 788 / 788 in 265s |
| Playwright (desktop + mobile) | ✓ | 471 passed, 0 failed, 27 did-not-run (sharding) |

## Test plan

- [x] `validate-ci.sh --full` build/typecheck/lint PASS
- [x] api unit + integration suites green
- [x] web vitest narrow-scoped to touched files green
- [x] `npx playwright test` (both projects) green
- [x] Operator-config files staged + committed under `chore(config):`
- [x] Auto-merge enabled after PR creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)