### PR TITLE
ROK-1116: fix: displayName "Unknown" leak + demo data activity_log gen

### DIFF
--- a/api/src/activity-log/activity-log.integration.spec.ts
+++ b/api/src/activity-log/activity-log.integration.spec.ts
@@ -5,6 +5,7 @@
  * Tests cover: direct DB logging, GET endpoints for lineups and events,
  * and that mutations (create lineup, signup) produce activity entries.
  */
+import { sql } from 'drizzle-orm';
 import { getTestApp, type TestApp } from '../common/testing/test-app';
 import {
   truncateAllTables,
@@ -235,5 +236,105 @@ function describeActivityLog() {
     });
   }
   describe('Direct DB logging', describeDirectLogging);
+
+  // ── displayName fallback (ROK-1116) ───────────────────────────
+
+  function describeUsernameFallback() {
+    const ENTITY_TYPE = 'event' as const;
+
+    it('returns username when actor displayName is null', async () => {
+      const [user] = await testApp.db
+        .insert(schema.users)
+        .values({
+          discordId: 'rok-1116:null-display',
+          username: 'alice',
+          displayName: null,
+        })
+        .returning();
+
+      const entityId = 90001;
+      await testApp.db.insert(schema.activityLog).values({
+        entityType: ENTITY_TYPE,
+        entityId,
+        action: 'event_created',
+        actorId: user.id,
+        metadata: null,
+      });
+
+      const res = await testApp.request
+        .get(`/events/${entityId}/activity`)
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(res.status).toBe(200);
+      const body = timeline(res);
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0].actor).not.toBeNull();
+      expect(body.data[0].actor!.displayName).toBe('alice');
+      expect(body.data[0].actor!.displayName).not.toBe('Unknown');
+    });
+
+    it('returns displayName when set', async () => {
+      const [user] = await testApp.db
+        .insert(schema.users)
+        .values({
+          discordId: 'rok-1116:has-display',
+          username: 'alice',
+          displayName: 'AliceCustom',
+        })
+        .returning();
+
+      const entityId = 90002;
+      await testApp.db.insert(schema.activityLog).values({
+        entityType: ENTITY_TYPE,
+        entityId,
+        action: 'event_created',
+        actorId: user.id,
+        metadata: null,
+      });
+
+      const res = await testApp.request
+        .get(`/events/${entityId}/activity`)
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(res.status).toBe(200);
+      const body = timeline(res);
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0].actor!.displayName).toBe('AliceCustom');
+    });
+
+    it('returns "Unknown" only when actor row is missing entirely', async () => {
+      // Simulate the legitimate orphan case: an activity_log row whose
+      // actor_id no longer resolves to a users row. The schema FK
+      // (`onDelete: 'set null'`) makes this unreachable via normal user
+      // deletion, so we bypass FK enforcement to insert a stale id —
+      // mirroring DBs that were restored from a backup taken before the
+      // FK existed, or migrated from another system.
+      const entityId = 90003;
+      const orphanActorId = 9_999_999;
+      await testApp.db.transaction(async (tx) => {
+        await tx.execute(
+          sql`SET LOCAL session_replication_role = 'replica'`,
+        );
+        await tx.insert(schema.activityLog).values({
+          entityType: ENTITY_TYPE,
+          entityId,
+          action: 'event_created',
+          actorId: orphanActorId,
+          metadata: null,
+        });
+      });
+
+      const res = await testApp.request
+        .get(`/events/${entityId}/activity`)
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(res.status).toBe(200);
+      const body = timeline(res);
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0].actor).not.toBeNull();
+      expect(body.data[0].actor!.displayName).toBe('Unknown');
+    });
+  }
+  describe('displayName fallback (ROK-1116)', describeUsernameFallback);
 }
 describe('Activity Log (integration)', describeActivityLog);

--- a/api/src/activity-log/activity-log.integration.spec.ts
+++ b/api/src/activity-log/activity-log.integration.spec.ts
@@ -312,9 +312,7 @@ function describeActivityLog() {
       const entityId = 90003;
       const orphanActorId = 9_999_999;
       await testApp.db.transaction(async (tx) => {
-        await tx.execute(
-          sql`SET LOCAL session_replication_role = 'replica'`,
-        );
+        await tx.execute(sql`SET LOCAL session_replication_role = 'replica'`);
         await tx.insert(schema.activityLog).values({
           entityType: ENTITY_TYPE,
           entityId,

--- a/api/src/activity-log/activity-log.service.ts
+++ b/api/src/activity-log/activity-log.service.ts
@@ -9,6 +9,7 @@ import type {
 } from '@raid-ledger/contract';
 import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
 import * as schema from '../drizzle/schema';
+import { displayNameSql } from '../users/display-name.helpers';
 
 interface ActivityRow {
   id: number;
@@ -65,7 +66,7 @@ export class ActivityLogService {
         id: schema.activityLog.id,
         action: schema.activityLog.action,
         actorId: schema.activityLog.actorId,
-        actorName: schema.users.displayName,
+        actorName: displayNameSql(schema.users),
         metadata: schema.activityLog.metadata,
         createdAt: schema.activityLog.createdAt,
       })

--- a/api/src/activity-log/activity-log.service.ts
+++ b/api/src/activity-log/activity-log.service.ts
@@ -25,7 +25,8 @@ function mapRow(r: ActivityRow): ActivityEntryDto {
     id: r.id,
     action: r.action as ActivityActionDto,
     actor: r.actorId
-      ? { id: r.actorId, displayName: r.actorName ?? 'Unknown' }
+      ? // 'Unknown' fallback fires only for orphan rows whose actorId points at a user the LEFT JOIN couldn't resolve (residue from before the activity_log.actor_id FK was enforced).
+        { id: r.actorId, displayName: r.actorName ?? 'Unknown' }
       : null,
     metadata: (r.metadata as Record<string, unknown>) ?? null,
     createdAt: r.createdAt.toISOString(),

--- a/api/src/admin/demo-data-clear.helpers.ts
+++ b/api/src/admin/demo-data-clear.helpers.ts
@@ -172,5 +172,21 @@ async function deleteDemoUserDependents(
       .delete(schema.events)
       .where(inArray(schema.events.id, demoEventIds));
   }
+  // ROK-1116: also delete/null-out rows referencing demo users via NO ACTION
+  // FKs (community_lineups.created_by, event_templates.user_id, pug_slots.*).
+  // Without this the user delete below fails with a 23503 FK violation.
+  await db
+    .delete(schema.communityLineups)
+    .where(inArray(schema.communityLineups.createdBy, demoUserIds));
+  await db
+    .delete(schema.eventTemplates)
+    .where(inArray(schema.eventTemplates.userId, demoUserIds));
+  await db
+    .delete(schema.pugSlots)
+    .where(inArray(schema.pugSlots.createdBy, demoUserIds));
+  await db
+    .update(schema.pugSlots)
+    .set({ claimedByUserId: null })
+    .where(inArray(schema.pugSlots.claimedByUserId, demoUserIds));
   await db.delete(schema.users).where(inArray(schema.users.id, demoUserIds));
 }

--- a/api/src/admin/demo-data-install-activity.helpers.ts
+++ b/api/src/admin/demo-data-install-activity.helpers.ts
@@ -5,7 +5,16 @@
  * normally call ActivityLogService.log(...). These pure builders produce the
  * activity_log inserts so demo events render proper timelines.
  */
+import { inArray } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import * as schema from '../drizzle/schema';
+
+type Db = PostgresJsDatabase<typeof schema>;
+type BatchInsert = (
+  table: Parameters<Db['insert']>[0],
+  rows: Record<string, unknown>[],
+  onConflict?: 'doNothing',
+) => Promise<unknown>;
 
 type EventRow = Pick<
   typeof schema.events.$inferSelect,
@@ -44,4 +53,28 @@ export function buildSignupAddedActivityRows(
         metadata: { role: roles?.[0] ?? null },
       };
     });
+}
+
+/** Re-fetches creator_id post-reassignment, then bulk-inserts activity rows. */
+export async function installActivityLog(
+  db: Db,
+  batchInsert: BatchInsert,
+  createdEvents: (typeof schema.events.$inferSelect)[],
+  createdSignups: (typeof schema.eventSignups.$inferSelect)[],
+): Promise<void> {
+  if (createdEvents.length === 0) return;
+  const eventIds = createdEvents.map((e) => e.id);
+  const finalEvents = await db
+    .select({
+      id: schema.events.id,
+      creatorId: schema.events.creatorId,
+      title: schema.events.title,
+    })
+    .from(schema.events)
+    .where(inArray(schema.events.id, eventIds));
+  const rows = [
+    ...buildEventCreatedActivityRows(finalEvents),
+    ...buildSignupAddedActivityRows(createdSignups),
+  ];
+  if (rows.length > 0) await batchInsert(schema.activityLog, rows);
 }

--- a/api/src/admin/demo-data-install-activity.helpers.ts
+++ b/api/src/admin/demo-data-install-activity.helpers.ts
@@ -1,0 +1,47 @@
+/**
+ * Demo data activity_log row builders (ROK-1116).
+ *
+ * Demo data install bypasses the SignupsService / EventsService paths that
+ * normally call ActivityLogService.log(...). These pure builders produce the
+ * activity_log inserts so demo events render proper timelines.
+ */
+import * as schema from '../drizzle/schema';
+
+type EventRow = Pick<
+  typeof schema.events.$inferSelect,
+  'id' | 'creatorId' | 'title'
+>;
+
+type SignupRow = Pick<
+  typeof schema.eventSignups.$inferSelect,
+  'eventId' | 'userId' | 'preferredRoles'
+>;
+
+export function buildEventCreatedActivityRows(
+  events: EventRow[],
+): Record<string, unknown>[] {
+  return events.map((e) => ({
+    entityType: 'event' as const,
+    entityId: e.id,
+    action: 'event_created' as const,
+    actorId: e.creatorId,
+    metadata: { title: e.title },
+  }));
+}
+
+export function buildSignupAddedActivityRows(
+  signups: SignupRow[],
+): Record<string, unknown>[] {
+  return signups
+    .filter((s): s is SignupRow & { userId: number } => s.userId != null)
+    .map((s) => {
+      const roles = s.preferredRoles as string[] | null;
+      return {
+        entityType: 'event' as const,
+        entityId: s.eventId,
+        action: 'signup_added' as const,
+        actorId: s.userId,
+        metadata: { role: roles?.[0] ?? null },
+      };
+    });
+}

--- a/api/src/admin/demo-data-install-activity.helpers.ts
+++ b/api/src/admin/demo-data-install-activity.helpers.ts
@@ -35,7 +35,7 @@ export function buildSignupAddedActivityRows(
   return signups
     .filter((s): s is SignupRow & { userId: number } => s.userId != null)
     .map((s) => {
-      const roles = s.preferredRoles as string[] | null;
+      const roles = s.preferredRoles;
       return {
         entityType: 'event' as const,
         entityId: s.eventId,

--- a/api/src/admin/demo-data.integration.spec.ts
+++ b/api/src/admin/demo-data.integration.spec.ts
@@ -150,9 +150,7 @@ function describeDemoData() {
         .set('Authorization', `Bearer ${adminToken}`);
 
       const demoEventIds = (
-        await testApp.db
-          .select({ id: schema.events.id })
-          .from(schema.events)
+        await testApp.db.select({ id: schema.events.id }).from(schema.events)
       ).map((r) => r.id);
       expect(demoEventIds.length).toBeGreaterThan(0);
 
@@ -170,8 +168,11 @@ function describeDemoData() {
           ),
         );
 
-      const eventsWithActivity = new Set(eventCreatedRows.map((r) => r.entityId));
-      for (const id of demoEventIds) expect(eventsWithActivity.has(id)).toBe(true);
+      const eventsWithActivity = new Set(
+        eventCreatedRows.map((r) => r.entityId),
+      );
+      for (const id of demoEventIds)
+        expect(eventsWithActivity.has(id)).toBe(true);
       for (const r of eventCreatedRows) expect(r.actorId).not.toBeNull();
     });
 
@@ -219,10 +220,7 @@ function describeDemoData() {
       const orphanActors = await testApp.db
         .select({ id: schema.activityLog.id })
         .from(schema.activityLog)
-        .leftJoin(
-          schema.users,
-          eq(schema.users.id, schema.activityLog.actorId),
-        )
+        .leftJoin(schema.users, eq(schema.users.id, schema.activityLog.actorId))
         .where(isNull(schema.users.id));
 
       expect(orphanActors).toHaveLength(0);

--- a/api/src/admin/demo-data.integration.spec.ts
+++ b/api/src/admin/demo-data.integration.spec.ts
@@ -230,6 +230,42 @@ function describeDemoData() {
     describeActivityLogOnInstall());
 
   // ===================================================================
+  // Clear with FK blockers (ROK-1116)
+  // ===================================================================
+
+  function describeClearWithBlockers() {
+    it('should clear demo data even when demo users own community_lineups', async () => {
+      await testApp.request
+        .post('/admin/settings/demo/install')
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      const [seedAdmin] = await testApp.db
+        .select({ id: schema.users.id })
+        .from(schema.users)
+        .where(eq(schema.users.username, 'SeedAdmin'));
+      await testApp.db.insert(schema.communityLineups).values({
+        createdBy: seedAdmin.id,
+        title: 'Demo blocker lineup',
+      });
+
+      const clearRes = await testApp.request
+        .post('/admin/settings/demo/clear')
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      expect(clearRes.status).toBe(200);
+      expect(clearRes.body.success).toBe(true);
+
+      const remainingUsers = await testApp.db
+        .select({ id: schema.users.id })
+        .from(schema.users)
+        .where(eq(schema.users.username, 'SeedAdmin'));
+      expect(remainingUsers).toHaveLength(0);
+    });
+  }
+  describe('clear with FK blockers (ROK-1116)', () =>
+    describeClearWithBlockers());
+
+  // ===================================================================
   // Auth Guards
   // ===================================================================
 

--- a/api/src/admin/demo-data.integration.spec.ts
+++ b/api/src/admin/demo-data.integration.spec.ts
@@ -8,11 +8,13 @@
  * Note: installDemoData depends on having games in the DB (seeded baseline
  * has one game). The full ~100-user install is tested end-to-end.
  */
+import { and, eq, inArray, isNull } from 'drizzle-orm';
 import { getTestApp, type TestApp } from '../common/testing/test-app';
 import {
   truncateAllTables,
   loginAsAdmin,
 } from '../common/testing/integration-helpers';
+import * as schema from '../drizzle/schema';
 
 function describeDemoData() {
   let testApp: TestApp;
@@ -136,6 +138,98 @@ function describeDemoData() {
   }
   describe('install and clear lifecycle', () =>
     describeInstallAndClearLifecycle());
+
+  // ===================================================================
+  // Activity log entries (ROK-1116)
+  // ===================================================================
+
+  function describeActivityLogOnInstall() {
+    it('should log event_created for every demo event with a live actor', async () => {
+      await testApp.request
+        .post('/admin/settings/demo/install')
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      const demoEventIds = (
+        await testApp.db
+          .select({ id: schema.events.id })
+          .from(schema.events)
+      ).map((r) => r.id);
+      expect(demoEventIds.length).toBeGreaterThan(0);
+
+      const eventCreatedRows = await testApp.db
+        .select({
+          entityId: schema.activityLog.entityId,
+          actorId: schema.activityLog.actorId,
+        })
+        .from(schema.activityLog)
+        .where(
+          and(
+            eq(schema.activityLog.entityType, 'event'),
+            eq(schema.activityLog.action, 'event_created'),
+            inArray(schema.activityLog.entityId, demoEventIds),
+          ),
+        );
+
+      const eventsWithActivity = new Set(eventCreatedRows.map((r) => r.entityId));
+      for (const id of demoEventIds) expect(eventsWithActivity.has(id)).toBe(true);
+      for (const r of eventCreatedRows) expect(r.actorId).not.toBeNull();
+    });
+
+    it('should log signup_added for every demo signup with a live actor', async () => {
+      await testApp.request
+        .post('/admin/settings/demo/install')
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      const demoSignups = await testApp.db
+        .select({
+          eventId: schema.eventSignups.eventId,
+          userId: schema.eventSignups.userId,
+        })
+        .from(schema.eventSignups);
+      const linkedSignups = demoSignups.filter((s) => s.userId !== null);
+      expect(linkedSignups.length).toBeGreaterThan(0);
+
+      const signupRows = await testApp.db
+        .select({
+          entityId: schema.activityLog.entityId,
+          actorId: schema.activityLog.actorId,
+        })
+        .from(schema.activityLog)
+        .where(
+          and(
+            eq(schema.activityLog.entityType, 'event'),
+            eq(schema.activityLog.action, 'signup_added'),
+          ),
+        );
+
+      const present = new Set(
+        signupRows.map((r) => `${r.entityId}:${r.actorId}`),
+      );
+      for (const s of linkedSignups) {
+        expect(present.has(`${s.eventId}:${s.userId}`)).toBe(true);
+      }
+      for (const r of signupRows) expect(r.actorId).not.toBeNull();
+    });
+
+    it('should not produce orphan activity actor refs after install', async () => {
+      await testApp.request
+        .post('/admin/settings/demo/install')
+        .set('Authorization', `Bearer ${adminToken}`);
+
+      const orphanActors = await testApp.db
+        .select({ id: schema.activityLog.id })
+        .from(schema.activityLog)
+        .leftJoin(
+          schema.users,
+          eq(schema.users.id, schema.activityLog.actorId),
+        )
+        .where(isNull(schema.users.id));
+
+      expect(orphanActors).toHaveLength(0);
+    });
+  }
+  describe('activity_log on install (ROK-1116)', () =>
+    describeActivityLogOnInstall());
 
   // ===================================================================
   // Auth Guards

--- a/api/src/admin/demo-data.integration.spec.ts
+++ b/api/src/admin/demo-data.integration.spec.ts
@@ -243,10 +243,15 @@ function describeDemoData() {
         .select({ id: schema.users.id })
         .from(schema.users)
         .where(eq(schema.users.username, 'SeedAdmin'));
-      await testApp.db.insert(schema.communityLineups).values({
-        createdBy: seedAdmin.id,
-        title: 'Demo blocker lineup',
-      });
+      const adminUserId = testApp.seed.adminUser.id;
+      const [demoLineup] = await testApp.db
+        .insert(schema.communityLineups)
+        .values({ createdBy: seedAdmin.id, title: 'Demo blocker lineup' })
+        .returning({ id: schema.communityLineups.id });
+      const [adminLineup] = await testApp.db
+        .insert(schema.communityLineups)
+        .values({ createdBy: adminUserId, title: 'Real admin lineup' })
+        .returning({ id: schema.communityLineups.id });
 
       const clearRes = await testApp.request
         .post('/admin/settings/demo/clear')
@@ -260,6 +265,15 @@ function describeDemoData() {
         .from(schema.users)
         .where(eq(schema.users.username, 'SeedAdmin'));
       expect(remainingUsers).toHaveLength(0);
+
+      // Demo-owned lineup gone, non-demo lineup preserved.
+      const survivors = await testApp.db
+        .select({ id: schema.communityLineups.id })
+        .from(schema.communityLineups)
+        .where(
+          inArray(schema.communityLineups.id, [demoLineup.id, adminLineup.id]),
+        );
+      expect(survivors.map((r) => r.id)).toEqual([adminLineup.id]);
     });
   }
   describe('clear with FK blockers (ROK-1116)', () =>

--- a/api/src/admin/demo-data.service.ts
+++ b/api/src/admin/demo-data.service.ts
@@ -185,7 +185,10 @@ export class DemoDataService {
       evResult.origEvents,
       evResult.genEvents,
     );
-    await this.installActivityLog(evResult.createdEvents, suResult.createdSignups);
+    await this.installActivityLog(
+      evResult.createdEvents,
+      suResult.createdSignups,
+    );
     return {
       events: evResult.createdEvents.length,
       characters: chResult.createdChars.length,

--- a/api/src/admin/demo-data.service.ts
+++ b/api/src/admin/demo-data.service.ts
@@ -185,7 +185,9 @@ export class DemoDataService {
       evResult.origEvents,
       evResult.genEvents,
     );
-    await this.installActivityLog(
+    await activityH.installActivityLog(
+      this.db,
+      bi,
       evResult.createdEvents,
       suResult.createdSignups,
     );
@@ -194,28 +196,6 @@ export class DemoDataService {
       characters: chResult.createdChars.length,
       signups: suResult.uniqueSignups.length,
     };
-  }
-
-  /** Insert activity_log rows for demo events + signups (ROK-1116). */
-  private async installActivityLog(
-    createdEvents: (typeof schema.events.$inferSelect)[],
-    createdSignups: (typeof schema.eventSignups.$inferSelect)[],
-  ): Promise<void> {
-    if (createdEvents.length === 0) return;
-    const eventIds = createdEvents.map((e) => e.id);
-    const finalEvents = await this.db
-      .select({
-        id: schema.events.id,
-        creatorId: schema.events.creatorId,
-        title: schema.events.title,
-      })
-      .from(schema.events)
-      .where(inArray(schema.events.id, eventIds));
-    const rows = [
-      ...activityH.buildEventCreatedActivityRows(finalEvents),
-      ...activityH.buildSignupAddedActivityRows(createdSignups),
-    ];
-    if (rows.length > 0) await this.batchInsert(schema.activityLog, rows);
   }
 
   private async installSecondaryEntities(

--- a/api/src/admin/demo-data.service.ts
+++ b/api/src/admin/demo-data.service.ts
@@ -14,6 +14,7 @@ import { getEventsDefinitions } from './demo-data.constants';
 import * as coreH from './demo-data-install-core.helpers';
 import * as signupsH from './demo-data-install-signups.helpers';
 import * as secondaryH from './demo-data-install-secondary.helpers';
+import * as activityH from './demo-data-install-activity.helpers';
 import * as tasteH from './demo-data-install-taste.helpers';
 import * as clearH from './demo-data-clear.helpers';
 import { TasteProfileService } from '../taste-profile/taste-profile.service';
@@ -184,11 +185,34 @@ export class DemoDataService {
       evResult.origEvents,
       evResult.genEvents,
     );
+    await this.installActivityLog(evResult.createdEvents, suResult.createdSignups);
     return {
       events: evResult.createdEvents.length,
       characters: chResult.createdChars.length,
       signups: suResult.uniqueSignups.length,
     };
+  }
+
+  /** Insert activity_log rows for demo events + signups (ROK-1116). */
+  private async installActivityLog(
+    createdEvents: (typeof schema.events.$inferSelect)[],
+    createdSignups: (typeof schema.eventSignups.$inferSelect)[],
+  ): Promise<void> {
+    if (createdEvents.length === 0) return;
+    const eventIds = createdEvents.map((e) => e.id);
+    const finalEvents = await this.db
+      .select({
+        id: schema.events.id,
+        creatorId: schema.events.creatorId,
+        title: schema.events.title,
+      })
+      .from(schema.events)
+      .where(inArray(schema.events.id, eventIds));
+    const rows = [
+      ...activityH.buildEventCreatedActivityRows(finalEvents),
+      ...activityH.buildSignupAddedActivityRows(createdSignups),
+    ];
+    if (rows.length > 0) await this.batchInsert(schema.activityLog, rows);
   }
 
   private async installSecondaryEntities(

--- a/api/src/notifications/live-noshow.helpers.ts
+++ b/api/src/notifications/live-noshow.helpers.ts
@@ -6,6 +6,7 @@ import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { eq, and, sql, inArray, notInArray } from 'drizzle-orm';
 import * as schema from '../drizzle/schema';
 import { resolveEventCapacity } from '../events/signups-signup.helpers';
+import { resolveDisplayName } from '../users/display-name.helpers';
 
 /** Minimum voice presence (seconds) to count as "showed up". */
 export const PRESENCE_THRESHOLD_SEC = 120;
@@ -274,7 +275,7 @@ export async function batchFetchPlayerDisplayInfo(
   for (const uid of userIds) {
     const user = userMap.get(uid);
     result.set(uid, {
-      displayName: user?.displayName ?? user?.username ?? 'Unknown',
+      displayName: user ? resolveDisplayName(user) : 'Unknown',
       role: roleMap.get(uid) ?? null,
     });
   }

--- a/api/src/users/display-name.helpers.spec.ts
+++ b/api/src/users/display-name.helpers.spec.ts
@@ -1,0 +1,55 @@
+/**
+ * Unit tests for display-name helpers (ROK-1116).
+ *
+ * The helpers centralize the `displayName ?? username` fallback so that the
+ * literal string "Unknown" only appears at edges where the user row is
+ * genuinely missing (orphan / hard-deleted references). See spec
+ * `planning-artifacts/specs/ROK-1116.md`.
+ */
+import { resolveDisplayName, displayNameSql } from './display-name.helpers';
+import * as schema from '../drizzle/schema';
+
+describe('resolveDisplayName', () => {
+  it('returns displayName when present', () => {
+    expect(
+      resolveDisplayName({ displayName: 'Alice', username: 'alice123' }),
+    ).toBe('Alice');
+  });
+
+  it('falls back to username when displayName is null', () => {
+    expect(
+      resolveDisplayName({ displayName: null, username: 'alice123' }),
+    ).toBe('alice123');
+  });
+
+  it('falls back to username when displayName is undefined', () => {
+    expect(
+      resolveDisplayName({ displayName: undefined, username: 'alice123' }),
+    ).toBe('alice123');
+  });
+
+  it('falls back to username when displayName is empty string', () => {
+    // Mirrors the existing identity-panel.tsx pattern (`||` not `??`) so empty
+    // strings are treated as "no displayName chosen".
+    expect(
+      resolveDisplayName({ displayName: '', username: 'alice123' }),
+    ).toBe('alice123');
+  });
+
+  it('returns username unchanged for live user record', () => {
+    expect(
+      resolveDisplayName({ displayName: null, username: 'bob' }),
+    ).toBe('bob');
+  });
+});
+
+describe('displayNameSql', () => {
+  it('returns a non-null Drizzle SQL chunk for the users table', () => {
+    const chunk = displayNameSql(schema.users);
+    expect(chunk).toBeDefined();
+    expect(chunk).not.toBeNull();
+    // Drizzle SQL objects expose `.queryChunks` — smoke check that we got one
+    // back rather than a primitive.
+    expect(typeof chunk).toBe('object');
+  });
+});

--- a/api/src/users/display-name.helpers.spec.ts
+++ b/api/src/users/display-name.helpers.spec.ts
@@ -31,15 +31,15 @@ describe('resolveDisplayName', () => {
   it('falls back to username when displayName is empty string', () => {
     // Mirrors the existing identity-panel.tsx pattern (`||` not `??`) so empty
     // strings are treated as "no displayName chosen".
-    expect(
-      resolveDisplayName({ displayName: '', username: 'alice123' }),
-    ).toBe('alice123');
+    expect(resolveDisplayName({ displayName: '', username: 'alice123' })).toBe(
+      'alice123',
+    );
   });
 
   it('returns username unchanged for live user record', () => {
-    expect(
-      resolveDisplayName({ displayName: null, username: 'bob' }),
-    ).toBe('bob');
+    expect(resolveDisplayName({ displayName: null, username: 'bob' })).toBe(
+      'bob',
+    );
   });
 });
 

--- a/api/src/users/display-name.helpers.ts
+++ b/api/src/users/display-name.helpers.ts
@@ -1,0 +1,18 @@
+import { sql, type SQL } from 'drizzle-orm';
+import type { PgColumn } from 'drizzle-orm/pg-core';
+
+export function resolveDisplayName({
+  displayName,
+  username,
+}: {
+  displayName?: string | null;
+  username: string;
+}): string {
+  return displayName || username;
+}
+
+export function displayNameSql<
+  T extends { displayName: PgColumn; username: PgColumn },
+>(table: T): SQL<string> {
+  return sql<string>`COALESCE(${table.displayName}, ${table.username})`;
+}

--- a/packages/contract/src/activity-log.schema.ts
+++ b/packages/contract/src/activity-log.schema.ts
@@ -38,6 +38,7 @@ export type ActivityEntityTypeDto = z.infer<typeof ActivityEntityTypeSchema>;
 /** Actor identity embedded in activity entries. */
 const ActivityActorSchema = z.object({
     id: z.number(),
+    // Non-null at the API boundary — backend uses displayNameSql(users).
     displayName: z.string(),
 });
 

--- a/web/src/components/onboarding/welcome-step.test.tsx
+++ b/web/src/components/onboarding/welcome-step.test.tsx
@@ -3,52 +3,11 @@
  *
  * The displayName input has been removed from the FTE welcome step. The step
  * now renders a static welcome message plus Continue/Skip buttons. Continue
- * advances to the next step without invoking any profile-update mutation, and
- * the displayName-availability hook is no longer referenced.
+ * advances to the next step without invoking any profile-update mutation.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { WelcomeStep } from './welcome-step';
-
-const updateProfileMutate = vi.fn();
-const checkDisplayNameSpy = vi.fn(() => ({ data: undefined, isLoading: false }));
-
-vi.mock('../../hooks/use-auth', () => ({
-    useAuth: vi.fn(() => ({
-        user: {
-            id: 1,
-            username: 'testuser',
-            displayName: null,
-            role: 'member',
-            onboardingCompletedAt: null,
-        },
-    })),
-}));
-
-vi.mock('../../hooks/use-onboarding-fte', () => ({
-    useCheckDisplayName: (...args: unknown[]) => checkDisplayNameSpy(...args),
-    useUpdateUserProfile: vi.fn(() => ({
-        mutate: updateProfileMutate,
-        isPending: false,
-    })),
-}));
-
-function createQueryClient() {
-    return new QueryClient({
-        defaultOptions: {
-            queries: { retry: false },
-        },
-    });
-}
-
-function renderWithProviders(ui: React.ReactElement) {
-    return render(
-        <QueryClientProvider client={createQueryClient()}>
-            {ui}
-        </QueryClientProvider>,
-    );
-}
 
 const mockOnNext = vi.fn();
 const mockOnSkip = vi.fn();
@@ -59,49 +18,32 @@ describe('WelcomeStep (ROK-1116 — displayName input hidden)', () => {
     });
 
     it('does NOT render a display name input', () => {
-        renderWithProviders(
-            <WelcomeStep onNext={mockOnNext} onSkip={mockOnSkip} />,
-        );
+        render(<WelcomeStep onNext={mockOnNext} onSkip={mockOnSkip} />);
 
         expect(screen.queryByLabelText(/display name/i)).toBeNull();
     });
 
     it('renders welcome heading "Welcome to Raid Ledger"', () => {
-        renderWithProviders(
-            <WelcomeStep onNext={mockOnNext} onSkip={mockOnSkip} />,
-        );
+        render(<WelcomeStep onNext={mockOnNext} onSkip={mockOnSkip} />);
 
         expect(
             screen.getByText(/welcome to raid ledger/i),
         ).toBeInTheDocument();
     });
 
-    it('Continue button calls onNext when clicked and does NOT invoke the profile-update mutation', () => {
-        renderWithProviders(
-            <WelcomeStep onNext={mockOnNext} onSkip={mockOnSkip} />,
-        );
+    it('Continue button calls onNext when clicked', () => {
+        render(<WelcomeStep onNext={mockOnNext} onSkip={mockOnSkip} />);
 
         fireEvent.click(screen.getByRole('button', { name: /continue/i }));
 
         expect(mockOnNext).toHaveBeenCalledOnce();
-        expect(updateProfileMutate).not.toHaveBeenCalled();
     });
 
     it('Skip button calls onSkip when clicked', () => {
-        renderWithProviders(
-            <WelcomeStep onNext={mockOnNext} onSkip={mockOnSkip} />,
-        );
+        render(<WelcomeStep onNext={mockOnNext} onSkip={mockOnSkip} />);
 
         fireEvent.click(screen.getByRole('button', { name: /skip/i }));
 
         expect(mockOnSkip).toHaveBeenCalledOnce();
-    });
-
-    it('does not invoke the displayName availability hook', () => {
-        renderWithProviders(
-            <WelcomeStep onNext={mockOnNext} onSkip={mockOnSkip} />,
-        );
-
-        expect(checkDisplayNameSpy).not.toHaveBeenCalled();
     });
 });

--- a/web/src/components/onboarding/welcome-step.test.tsx
+++ b/web/src/components/onboarding/welcome-step.test.tsx
@@ -1,9 +1,19 @@
+/**
+ * WelcomeStep tests (ROK-1116).
+ *
+ * The displayName input has been removed from the FTE welcome step. The step
+ * now renders a static welcome message plus Continue/Skip buttons. Continue
+ * advances to the next step without invoking any profile-update mutation, and
+ * the displayName-availability hook is no longer referenced.
+ */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { WelcomeStep } from './welcome-step';
 
-// Mock the hooks
+const updateProfileMutate = vi.fn();
+const checkDisplayNameSpy = vi.fn(() => ({ data: undefined, isLoading: false }));
+
 vi.mock('../../hooks/use-auth', () => ({
     useAuth: vi.fn(() => ({
         user: {
@@ -17,14 +27,9 @@ vi.mock('../../hooks/use-auth', () => ({
 }));
 
 vi.mock('../../hooks/use-onboarding-fte', () => ({
-    useCheckDisplayName: vi.fn((name: string) => ({
-        data: name === 'TakenName' ? { available: false } : { available: true },
-        isLoading: false,
-    })),
+    useCheckDisplayName: (...args: unknown[]) => checkDisplayNameSpy(...args),
     useUpdateUserProfile: vi.fn(() => ({
-        mutate: vi.fn((_displayName, options) => {
-            options?.onSuccess?.();
-        }),
+        mutate: updateProfileMutate,
         isPending: false,
     })),
 }));
@@ -41,93 +46,50 @@ function renderWithProviders(ui: React.ReactElement) {
     return render(
         <QueryClientProvider client={createQueryClient()}>
             {ui}
-        </QueryClientProvider>
+        </QueryClientProvider>,
     );
 }
 
 const mockOnNext = vi.fn();
 const mockOnSkip = vi.fn();
-function welcomestepGroup1() {
-it('renders welcome message and display name input', () => {
-        renderWithProviders(
-            <WelcomeStep onNext={mockOnNext} onSkip={mockOnSkip} />
-        );
 
-        expect(screen.getByText(/welcome to raid ledger!/i)).toBeInTheDocument();
-        expect(screen.getByLabelText(/display name/i)).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: /next/i })).toBeInTheDocument();
-        expect(screen.getByRole('button', { name: /skip/i })).toBeInTheDocument();
+describe('WelcomeStep (ROK-1116 — displayName input hidden)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
     });
 
-it('pre-fills display name from user username', () => {
+    it('does NOT render a display name input', () => {
         renderWithProviders(
-            <WelcomeStep onNext={mockOnNext} onSkip={mockOnSkip} />
+            <WelcomeStep onNext={mockOnNext} onSkip={mockOnSkip} />,
         );
 
-        const input = screen.getByLabelText(/display name/i) as HTMLInputElement;
-        expect(input.value).toBe('testuser');
+        expect(screen.queryByLabelText(/display name/i)).toBeNull();
     });
 
-}
-
-function welcomestepGroup2() {
-it('validates display name length (min 2 chars)', () => {
+    it('renders welcome heading "Welcome to Raid Ledger"', () => {
         renderWithProviders(
-            <WelcomeStep onNext={mockOnNext} onSkip={mockOnSkip} />
+            <WelcomeStep onNext={mockOnNext} onSkip={mockOnSkip} />,
         );
 
-        const input = screen.getByLabelText(/display name/i);
-        fireEvent.change(input, { target: { value: 'a' } });
-
-        expect(screen.getByText(/1\/30 characters \(min 2\)/i)).toBeInTheDocument();
+        expect(
+            screen.getByText(/welcome to raid ledger/i),
+        ).toBeInTheDocument();
     });
 
-it('validates display name length (max 30 chars)', () => {
+    it('Continue button calls onNext when clicked and does NOT invoke the profile-update mutation', () => {
         renderWithProviders(
-            <WelcomeStep onNext={mockOnNext} onSkip={mockOnSkip} />
+            <WelcomeStep onNext={mockOnNext} onSkip={mockOnSkip} />,
         );
 
-        const input = screen.getByLabelText(/display name/i);
-        fireEvent.change(input, { target: { value: 'a'.repeat(30) } });
+        fireEvent.click(screen.getByRole('button', { name: /continue/i }));
 
-        expect(screen.getByText(/30\/30 characters/i)).toBeInTheDocument();
+        expect(mockOnNext).toHaveBeenCalledOnce();
+        expect(updateProfileMutate).not.toHaveBeenCalled();
     });
 
-}
-
-function welcomestepGroup3() {
-it('shows availability indicator when name is available', async () => {
+    it('Skip button calls onSkip when clicked', () => {
         renderWithProviders(
-            <WelcomeStep onNext={mockOnNext} onSkip={mockOnSkip} />
-        );
-
-        const input = screen.getByLabelText(/display name/i);
-        fireEvent.change(input, { target: { value: 'AvailableName' } });
-
-        await waitFor(() => {
-            expect(screen.getByText(/available/i)).toBeInTheDocument();
-        });
-    });
-
-it('shows taken indicator when name is unavailable', async () => {
-        renderWithProviders(
-            <WelcomeStep onNext={mockOnNext} onSkip={mockOnSkip} />
-        );
-
-        const input = screen.getByLabelText(/display name/i);
-        fireEvent.change(input, { target: { value: 'TakenName' } });
-
-        await waitFor(() => {
-            expect(screen.getByText(/taken/i)).toBeInTheDocument();
-        });
-    });
-
-}
-
-function welcomestepGroup4() {
-it('calls onSkip when Skip button is clicked', () => {
-        renderWithProviders(
-            <WelcomeStep onNext={mockOnNext} onSkip={mockOnSkip} />
+            <WelcomeStep onNext={mockOnNext} onSkip={mockOnSkip} />,
         );
 
         fireEvent.click(screen.getByRole('button', { name: /skip/i }));
@@ -135,87 +97,11 @@ it('calls onSkip when Skip button is clicked', () => {
         expect(mockOnSkip).toHaveBeenCalledOnce();
     });
 
-it('calls onNext after successful update', async () => {
+    it('does not invoke the displayName availability hook', () => {
         renderWithProviders(
-            <WelcomeStep onNext={mockOnNext} onSkip={mockOnSkip} />
+            <WelcomeStep onNext={mockOnNext} onSkip={mockOnSkip} />,
         );
 
-        const input = screen.getByLabelText(/display name/i);
-        fireEvent.change(input, { target: { value: 'ValidName' } });
-
-        await waitFor(() => {
-            expect(screen.getByText(/available/i)).toBeInTheDocument();
-        });
-
-        fireEvent.click(screen.getByRole('button', { name: /next/i }));
-
-        await waitFor(() => {
-            expect(mockOnNext).toHaveBeenCalledOnce();
-        });
+        expect(checkDisplayNameSpy).not.toHaveBeenCalled();
     });
-
-}
-
-function welcomestepGroup5() {
-it('supports Enter key to submit', async () => {
-        renderWithProviders(
-            <WelcomeStep onNext={mockOnNext} onSkip={mockOnSkip} />
-        );
-
-        const input = screen.getByLabelText(/display name/i);
-        fireEvent.change(input, { target: { value: 'ValidName' } });
-
-        await waitFor(() => {
-            expect(screen.getByText(/available/i)).toBeInTheDocument();
-        });
-
-        fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
-
-        await waitFor(() => {
-            expect(mockOnNext).toHaveBeenCalledOnce();
-        });
-    });
-
-}
-
-function welcomestepGroup6() {
-it('disables Next button when name is too short', () => {
-        renderWithProviders(
-            <WelcomeStep onNext={mockOnNext} onSkip={mockOnSkip} />
-        );
-
-        const input = screen.getByLabelText(/display name/i);
-        fireEvent.change(input, { target: { value: 'a' } });
-
-        const nextButton = screen.getByRole('button', { name: /next/i });
-        expect(nextButton).toBeDisabled();
-    });
-
-it('disables Next button when name is taken', async () => {
-        renderWithProviders(
-            <WelcomeStep onNext={mockOnNext} onSkip={mockOnSkip} />
-        );
-
-        const input = screen.getByLabelText(/display name/i);
-        fireEvent.change(input, { target: { value: 'TakenName' } });
-
-        await waitFor(() => {
-            const nextButton = screen.getByRole('button', { name: /next/i });
-            expect(nextButton).toBeDisabled();
-        });
-    });
-
-}
-
-describe('WelcomeStep', () => {
-beforeEach(() => {
-        vi.clearAllMocks();
-    });
-
-    welcomestepGroup1();
-    welcomestepGroup2();
-    welcomestepGroup3();
-    welcomestepGroup4();
-    welcomestepGroup5();
-    welcomestepGroup6();
 });

--- a/web/src/components/onboarding/welcome-step.tsx
+++ b/web/src/components/onboarding/welcome-step.tsx
@@ -1,16 +1,8 @@
-import { useState } from 'react';
-import { useAuth } from '../../hooks/use-auth';
-import { useCheckDisplayName, useUpdateUserProfile } from '../../hooks/use-onboarding-fte';
-
 interface WelcomeStepProps {
     onNext: () => void;
     onSkip: () => void;
 }
 
-/**
- * Step 1: Welcome & Display Name (ROK-219).
- * Pre-fills from Discord username, validates 2-30 chars with uniqueness check.
- */
 function WelcomeHeader() {
     return (
         <div>
@@ -20,57 +12,18 @@ function WelcomeHeader() {
                 </svg>
             </div>
             <h2 className="text-2xl font-bold text-foreground">Welcome to Raid Ledger!</h2>
-            <p className="text-muted mt-2">Let's set up your profile. Choose a display name that other players will see.</p>
-        </div>
-    );
-}
-
-function NameAvailabilityHint({ touched, length, checkingName, isAvailable }: {
-    touched: boolean; length: number; checkingName: boolean; isAvailable: boolean;
-}) {
-    if (!touched || length < 2) return null;
-    return <span className={checkingName ? 'text-dim' : isAvailable ? 'text-emerald-400' : 'text-red-400'}>{checkingName ? 'Checking...' : isAvailable ? 'Available' : 'Taken'}</span>;
-}
-
-function DisplayNameInput({ displayName, setDisplayName, touched, setTouched, checkingName, isAvailable, isValidLength, canSubmit, handleSubmit }: {
-    displayName: string; setDisplayName: (v: string) => void; touched: boolean; setTouched: (v: boolean) => void;
-    checkingName: boolean; isAvailable: boolean; isValidLength: boolean; canSubmit: boolean; handleSubmit: () => void;
-}) {
-    return (
-        <div className="max-w-sm mx-auto space-y-2">
-            <label htmlFor="display-name" className="block text-sm font-medium text-foreground text-left">Display Name</label>
-            <input id="display-name" type="text" value={displayName}
-                onChange={(e) => { setDisplayName(e.target.value); if (!touched) setTouched(true); }}
-                onKeyDown={(e) => { if (e.key === 'Enter' && canSubmit) handleSubmit(); }}
-                placeholder="Your display name" maxLength={30}
-                className="w-full px-4 py-3 bg-panel border border-edge rounded-lg text-foreground placeholder-dim focus:outline-none focus:ring-2 focus:ring-emerald-500 text-base" autoFocus />
-            <div className="flex items-center justify-between text-xs">
-                <span className={displayName.length > 0 && !isValidLength ? 'text-red-400' : 'text-dim'}>{displayName.length}/30 characters (min 2)</span>
-                <NameAvailabilityHint touched={touched} length={displayName.length} checkingName={checkingName} isAvailable={isAvailable} />
-            </div>
+            <p className="text-muted mt-2">We'll get you set up so you can start joining events.</p>
         </div>
     );
 }
 
 export function WelcomeStep({ onNext, onSkip }: WelcomeStepProps) {
-    const { user } = useAuth();
-    const [displayName, setDisplayName] = useState(() => user?.displayName ?? user?.username ?? '');
-    const [touched, setTouched] = useState(false);
-    const { data: availability, isLoading: checkingName } = useCheckDisplayName(touched ? displayName : '');
-    const updateProfile = useUpdateUserProfile();
-    const isValidLength = displayName.length >= 2 && displayName.length <= 30;
-    const isAvailable = availability?.available ?? true;
-    const canSubmit = isValidLength && isAvailable && !checkingName;
-    const handleSubmit = () => { if (!canSubmit) return; updateProfile.mutate(displayName, { onSuccess: () => onNext() }); };
-
     return (
         <div className="text-center space-y-6">
             <WelcomeHeader />
-            <DisplayNameInput displayName={displayName} setDisplayName={setDisplayName} touched={touched} setTouched={setTouched}
-                checkingName={checkingName} isAvailable={isAvailable} isValidLength={isValidLength} canSubmit={canSubmit} handleSubmit={handleSubmit} />
             <div className="flex gap-3 justify-center max-w-sm mx-auto">
                 <button type="button" onClick={onSkip} className="flex-1 px-4 py-2.5 bg-panel hover:bg-overlay text-muted rounded-lg transition-colors text-sm">Skip</button>
-                <button type="button" onClick={handleSubmit} disabled={!canSubmit || updateProfile.isPending} className="flex-1 px-4 py-2.5 bg-emerald-600 hover:bg-emerald-500 disabled:bg-overlay disabled:text-dim text-white font-medium rounded-lg transition-colors text-sm">{updateProfile.isPending ? 'Saving...' : 'Next'}</button>
+                <button type="button" onClick={onNext} className="flex-1 px-4 py-2.5 bg-emerald-600 hover:bg-emerald-500 text-white font-medium rounded-lg transition-colors text-sm">Continue</button>
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary

- Fix root cause of "Unknown" rendering in event activity panels — `activity_log.service` query now selects `COALESCE(display_name, username)` so users with NULL `displayName` (most production users) render their Discord username, not the literal `"Unknown"`.
- Make demo data a real test surface for activity-log: `installDemoData` now also bulk-inserts `event_created` + `signup_added` activity rows so demo events render proper timelines (was bypassing the service layer that normally logs activity).
- Fix the `clearDemoData` 23503 FK violation: 3 NO-ACTION FKs to `users` (`community_lineups.created_by`, `event_templates.user_id`, `pug_slots.created_by` + `claimed_by_user_id`) were blocking demo user delete.
- Hide the displayName input from the FTE welcome step; centralize the `displayName ?? username` ladder in `resolveDisplayName()` + `displayNameSql()` helpers.

## Linear

ROK-1116 — original story
ROK-1141, ROK-1142 — follow-up tech debt filed during review

## Why

Original diagnosis was partial: `users.username` is `NOT NULL` and always set; `displayName` is user-chosen via the FTE wizard (ROK-219) but most users skip it. The `"Unknown"` leak was concentrated in the activity-log query which only selected `displayName`. Demo data also bypassed the service layer that emits activity rows, so demo events had empty timelines — making it impossible to visually verify the fix without a fresh manual signup.

## Acceptance criteria

- [x] FTE welcome step renders no display-name input.
- [x] GET /events/:id/activity returns actor.displayName === username for users with NULL displayName.
- [x] 'Unknown' only fires for orphan rows whose actorId points at a hard-deleted user (preserved by integration test).
- [x] installDemoData produces event_created + signup_added activity rows for every demo event/signup.
- [x] clearDemoData succeeds when demo users own community_lineups (regression test added).
- [x] No DB migration. No Discord OAuth scope change. No backfill.

## Test plan

- [x] validate-ci.sh --full — build, typecheck, lint, unit + coverage, integration tests, all green
- [x] 13 new tests added (3 unit for resolveDisplayName, 1 smoke for displayNameSql, 3 integration for activity-log fallback, 4 integration for demo-data activity_log + clear-FK, 4 vitest for welcome-step)
- [x] Manual verification: operator confirmed activity panel + roster slots render real demo usernames after Install Demo Data

🤖 Generated with [Claude Code](https://claude.com/claude-code)