### PR TITLE
ROK-1135: fix self-hosted MCP servers offline in worktrees

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -9,17 +9,19 @@
     },
     "mcp-env": {
       "type": "stdio",
-      "command": "node",
+      "command": "npx",
       "args": [
-        "tools/mcp-env/dist/index.js"
+        "tsx",
+        "tools/mcp-env/src/index.ts"
       ],
       "env": {}
     },
     "mcp-discord": {
       "type": "stdio",
-      "command": "node",
+      "command": "npx",
       "args": [
-        "tools/mcp-discord/dist/index.js"
+        "tsx",
+        "tools/mcp-discord/src/index.ts"
       ],
       "env": {}
     }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,14 @@ Three custom MCP servers provide tools for environment management, story trackin
 
 **Note:** `mcp-discord` requires Discord running with CDP (`./scripts/launch-discord.sh`). Local dev only.
 
+### Diagnosing offline MCP servers
+
+If `mcp-discord` or `mcp-env` tools come back as offline:
+
+1. **First check:** call `mcp__mcp-env__mcp_health` — diagnoses both local servers and reports `healthy | unhealthy | skipped` with error messages.
+2. **Most common fix:** worktree missing `node_modules`. Run `npm install` from the worktree root, then restart the Claude session.
+3. **Manual probe:** `npx tsx tools/mcp-discord/src/index.ts --self-check` (and same for mcp-env). Exit 0 = healthy.
+
 ## Pull Requests
 
 - **Always enable auto-merge (squash)** after creating or pushing to a PR: `gh pr merge <branch> --auto --squash`

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
             "workspaces": [
                 "api",
                 "web",
-                "packages/*"
+                "packages/*",
+                "tools/mcp-discord",
+                "tools/mcp-env"
             ],
             "dependencies": {
                 "chrono-node": "^2.9.0"
@@ -2373,6 +2375,18 @@
                 "react": ">= 16 || ^19.0.0-rc"
             }
         },
+        "node_modules/@hono/node-server": {
+            "version": "1.19.14",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+            "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.14.1"
+            },
+            "peerDependencies": {
+                "hono": "^4"
+            }
+        },
         "node_modules/@humanfs/core": {
             "version": "0.19.1",
             "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -4029,6 +4043,68 @@
                 "node": ">=8"
             }
         },
+        "node_modules/@modelcontextprotocol/sdk": {
+            "version": "1.29.0",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+            "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@hono/node-server": "^1.19.9",
+                "ajv": "^8.17.1",
+                "ajv-formats": "^3.0.1",
+                "content-type": "^1.0.5",
+                "cors": "^2.8.5",
+                "cross-spawn": "^7.0.5",
+                "eventsource": "^3.0.2",
+                "eventsource-parser": "^3.0.0",
+                "express": "^5.2.1",
+                "express-rate-limit": "^8.2.1",
+                "hono": "^4.11.4",
+                "jose": "^6.1.3",
+                "json-schema-typed": "^8.0.2",
+                "pkce-challenge": "^5.0.0",
+                "raw-body": "^3.0.0",
+                "zod": "^3.25 || ^4.0",
+                "zod-to-json-schema": "^3.25.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@cfworker/json-schema": "^4.1.1",
+                "zod": "^3.25 || ^4.0"
+            },
+            "peerDependenciesMeta": {
+                "@cfworker/json-schema": {
+                    "optional": true
+                },
+                "zod": {
+                    "optional": false
+                }
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+            "version": "8.20.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+            "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+            "license": "MIT",
+            "dependencies": {
+                "fast-deep-equal": "^3.1.3",
+                "fast-uri": "^3.0.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+            "license": "MIT"
+        },
         "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
@@ -5318,6 +5394,14 @@
         },
         "node_modules/@raid-ledger/contract": {
             "resolved": "packages/contract",
+            "link": true
+        },
+        "node_modules/@raid-ledger/mcp-discord": {
+            "resolved": "tools/mcp-discord",
+            "link": true
+        },
+        "node_modules/@raid-ledger/mcp-env": {
+            "resolved": "tools/mcp-env",
             "link": true
         },
         "node_modules/@raid-ledger/web": {
@@ -8602,7 +8686,6 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
             "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "ajv": "^8.0.0"
@@ -8620,7 +8703,6 @@
             "version": "8.17.1",
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
@@ -8637,7 +8719,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/ajv-keywords": {
@@ -9615,6 +9696,16 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/cac": {
+            "version": "6.7.14",
+            "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+            "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/call-bind-apply-helpers": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -9740,6 +9831,16 @@
             "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/check-error": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+            "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
+            }
         },
         "node_modules/chokidar": {
             "version": "4.0.3",
@@ -10394,7 +10495,6 @@
             "version": "7.0.6",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
             "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "path-key": "^3.1.0",
@@ -10774,6 +10874,16 @@
                 "babel-plugin-macros": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/deep-eql": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+            "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/deep-is": {
@@ -11926,6 +12036,27 @@
                 "bare-events": "^2.7.0"
             }
         },
+        "node_modules/eventsource": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+            "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+            "license": "MIT",
+            "dependencies": {
+                "eventsource-parser": "^3.0.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/eventsource-parser": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.8.tgz",
+            "integrity": "sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "node_modules/execa": {
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -12038,6 +12169,24 @@
                 "url": "https://opencollective.com/express"
             }
         },
+        "node_modules/express-rate-limit": {
+            "version": "8.4.1",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.1.tgz",
+            "integrity": "sha512-NGVYwQSAyEQgzxX1iCM978PP9AdO/hW93gMcF6ZwQCm+rFvLsBH6w4xcXWTcliS8La5EPRN3p9wzItqBwJrfNw==",
+            "license": "MIT",
+            "dependencies": {
+                "ip-address": "10.1.0"
+            },
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/express-rate-limit"
+            },
+            "peerDependencies": {
+                "express": ">= 4.11"
+            }
+        },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -12082,7 +12231,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
             "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
-            "dev": true,
             "funding": [
                 {
                     "type": "github",
@@ -12446,7 +12594,6 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -12623,7 +12770,6 @@
             "version": "4.13.1",
             "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.1.tgz",
             "integrity": "sha512-EoY1N2xCn44xU6750Sx7OjOIT59FkmstNc3X6y5xpz7D5cBtZRe/3pSlTkDJgqsOk3WwZPkWfonhhUJfttQo3w==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "resolve-pkg-maps": "^1.0.0"
@@ -12903,6 +13049,15 @@
                 "hermes-estree": "0.25.1"
             }
         },
+        "node_modules/hono": {
+            "version": "4.12.15",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.15.tgz",
+            "integrity": "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.9.0"
+            }
+        },
         "node_modules/html-encoding-sniffer": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -13175,6 +13330,15 @@
                 "url": "https://opencollective.com/ioredis"
             }
         },
+        "node_modules/ip-address": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+            "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12"
+            }
+        },
         "node_modules/ipaddr.js": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -13324,7 +13488,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/istanbul-lib-coverage": {
@@ -14543,6 +14706,15 @@
                 "jiti": "lib/jiti-cli.mjs"
             }
         },
+        "node_modules/jose": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.2.tgz",
+            "integrity": "sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/panva"
+            }
+        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -14635,6 +14807,12 @@
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/json-schema-typed": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+            "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+            "license": "BSD-2-Clause"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
@@ -15274,6 +15452,13 @@
             "bin": {
                 "loose-envify": "cli.js"
             }
+        },
+        "node_modules/loupe": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+            "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/lru-cache": {
             "version": "5.1.1",
@@ -16363,7 +16548,6 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -16422,6 +16606,16 @@
             "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/pathval": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+            "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14.16"
+            }
         },
         "node_modules/pause": {
             "version": "0.0.1",
@@ -16487,6 +16681,15 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 6"
+            }
+        },
+        "node_modules/pkce-challenge": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+            "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=16.20.0"
             }
         },
         "node_modules/pkg-dir": {
@@ -16562,7 +16765,6 @@
             "version": "1.58.1",
             "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
             "integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
-            "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "playwright-core": "1.58.1"
@@ -16581,7 +16783,6 @@
             "version": "1.58.1",
             "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
             "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
-            "dev": true,
             "license": "Apache-2.0",
             "bin": {
                 "playwright-core": "cli.js"
@@ -17355,7 +17556,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
             "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -17417,7 +17617,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
             "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
-            "dev": true,
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
@@ -17732,7 +17931,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "shebang-regex": "^3.0.0"
@@ -17745,7 +17943,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=8"
@@ -18297,6 +18494,26 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/strip-literal": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+            "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "js-tokens": "^9.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/strip-literal/node_modules/js-tokens": {
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+            "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/strtok3": {
             "version": "10.3.4",
             "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.4.tgz",
@@ -18764,10 +18981,30 @@
                 "url": "https://github.com/sponsors/jonschlinkert"
             }
         },
+        "node_modules/tinypool": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+            "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            }
+        },
         "node_modules/tinyrainbow": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
             "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/tinyspy": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+            "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -19065,6 +19302,496 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "license": "0BSD"
+        },
+        "node_modules/tsx": {
+            "version": "4.21.0",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+            "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+            "license": "MIT",
+            "dependencies": {
+                "esbuild": "~0.27.0",
+                "get-tsconfig": "^4.7.5"
+            },
+            "bin": {
+                "tsx": "dist/cli.mjs"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+            "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/android-arm": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+            "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+            "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/android-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+            "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+            "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+            "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+            "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+            "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+            "cpu": [
+                "arm"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+            "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+            "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+            "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+            "cpu": [
+                "loong64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+            "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+            "cpu": [
+                "mips64el"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+            "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+            "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+            "cpu": [
+                "riscv64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+            "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+            "cpu": [
+                "s390x"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+            "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+            "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+            "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+            "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openharmony"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+            "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+            "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+            "cpu": [
+                "arm64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+            "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+            "cpu": [
+                "ia32"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+            "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+            "cpu": [
+                "x64"
+            ],
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/tsx/node_modules/esbuild": {
+            "version": "0.27.7",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+            "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.27.7",
+                "@esbuild/android-arm": "0.27.7",
+                "@esbuild/android-arm64": "0.27.7",
+                "@esbuild/android-x64": "0.27.7",
+                "@esbuild/darwin-arm64": "0.27.7",
+                "@esbuild/darwin-x64": "0.27.7",
+                "@esbuild/freebsd-arm64": "0.27.7",
+                "@esbuild/freebsd-x64": "0.27.7",
+                "@esbuild/linux-arm": "0.27.7",
+                "@esbuild/linux-arm64": "0.27.7",
+                "@esbuild/linux-ia32": "0.27.7",
+                "@esbuild/linux-loong64": "0.27.7",
+                "@esbuild/linux-mips64el": "0.27.7",
+                "@esbuild/linux-ppc64": "0.27.7",
+                "@esbuild/linux-riscv64": "0.27.7",
+                "@esbuild/linux-s390x": "0.27.7",
+                "@esbuild/linux-x64": "0.27.7",
+                "@esbuild/netbsd-arm64": "0.27.7",
+                "@esbuild/netbsd-x64": "0.27.7",
+                "@esbuild/openbsd-arm64": "0.27.7",
+                "@esbuild/openbsd-x64": "0.27.7",
+                "@esbuild/openharmony-arm64": "0.27.7",
+                "@esbuild/sunos-x64": "0.27.7",
+                "@esbuild/win32-arm64": "0.27.7",
+                "@esbuild/win32-ia32": "0.27.7",
+                "@esbuild/win32-x64": "0.27.7"
+            }
+        },
+        "node_modules/tsx/node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
         },
         "node_modules/tweetnacl": {
             "version": "0.14.5",
@@ -19596,6 +20323,29 @@
                 "yaml": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/vite-node": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+            "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cac": "^6.7.14",
+                "debug": "^4.4.1",
+                "es-module-lexer": "^1.7.0",
+                "pathe": "^2.0.3",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+            },
+            "bin": {
+                "vite-node": "vite-node.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
             }
         },
         "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
@@ -20491,7 +21241,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "isexe": "^2.0.0"
@@ -20810,6 +21559,15 @@
                 "url": "https://github.com/sponsors/colinhacks"
             }
         },
+        "node_modules/zod-to-json-schema": {
+            "version": "3.25.2",
+            "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+            "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+            "license": "ISC",
+            "peerDependencies": {
+                "zod": "^3.25.28 || ^4"
+            }
+        },
         "node_modules/zod-validation-error": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
@@ -20861,6 +21619,489 @@
             "devDependencies": {
                 "typescript": "^5.0.0",
                 "zod": "^3.22.4"
+            }
+        },
+        "tools/mcp-discord": {
+            "name": "@raid-ledger/mcp-discord",
+            "version": "0.1.0",
+            "dependencies": {
+                "@modelcontextprotocol/sdk": "^1.11.0",
+                "dotenv": "^16.4.7",
+                "playwright": "^1.52.0",
+                "tsx": "^4.19.3"
+            },
+            "devDependencies": {
+                "typescript": "^5.7.3",
+                "vitest": "^3.2.4"
+            }
+        },
+        "tools/mcp-discord/node_modules/@vitest/expect": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+            "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "3.2.4",
+                "@vitest/utils": "3.2.4",
+                "chai": "^5.2.0",
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "tools/mcp-discord/node_modules/@vitest/mocker": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+            "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "3.2.4",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.17"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "tools/mcp-discord/node_modules/@vitest/pretty-format": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+            "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "tools/mcp-discord/node_modules/@vitest/runner": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+            "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "3.2.4",
+                "pathe": "^2.0.3",
+                "strip-literal": "^3.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "tools/mcp-discord/node_modules/@vitest/snapshot": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+            "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "3.2.4",
+                "magic-string": "^0.30.17",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "tools/mcp-discord/node_modules/@vitest/spy": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+            "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyspy": "^4.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "tools/mcp-discord/node_modules/@vitest/utils": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+            "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "3.2.4",
+                "loupe": "^3.1.4",
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "tools/mcp-discord/node_modules/chai": {
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+            "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "assertion-error": "^2.0.1",
+                "check-error": "^2.1.1",
+                "deep-eql": "^5.0.1",
+                "loupe": "^3.1.0",
+                "pathval": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "tools/mcp-discord/node_modules/dotenv": {
+            "version": "16.6.1",
+            "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+            "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://dotenvx.com"
+            }
+        },
+        "tools/mcp-discord/node_modules/tinyexec": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+            "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "tools/mcp-discord/node_modules/tinyrainbow": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+            "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "tools/mcp-discord/node_modules/vitest": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+            "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/chai": "^5.2.2",
+                "@vitest/expect": "3.2.4",
+                "@vitest/mocker": "3.2.4",
+                "@vitest/pretty-format": "^3.2.4",
+                "@vitest/runner": "3.2.4",
+                "@vitest/snapshot": "3.2.4",
+                "@vitest/spy": "3.2.4",
+                "@vitest/utils": "3.2.4",
+                "chai": "^5.2.0",
+                "debug": "^4.4.1",
+                "expect-type": "^1.2.1",
+                "magic-string": "^0.30.17",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.2",
+                "std-env": "^3.9.0",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^0.3.2",
+                "tinyglobby": "^0.2.14",
+                "tinypool": "^1.1.1",
+                "tinyrainbow": "^2.0.0",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+                "vite-node": "3.2.4",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@types/debug": "^4.1.12",
+                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+                "@vitest/browser": "3.2.4",
+                "@vitest/ui": "3.2.4",
+                "happy-dom": "*",
+                "jsdom": "*"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@types/debug": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                }
+            }
+        },
+        "tools/mcp-env": {
+            "name": "@raid-ledger/mcp-env",
+            "version": "0.1.0",
+            "dependencies": {
+                "@modelcontextprotocol/sdk": "^1.11.0",
+                "tsx": "^4.19.3",
+                "zod": "^3.24.2"
+            },
+            "devDependencies": {
+                "typescript": "^5.7.3",
+                "vitest": "^3.2.4"
+            }
+        },
+        "tools/mcp-env/node_modules/@vitest/expect": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+            "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/chai": "^5.2.2",
+                "@vitest/spy": "3.2.4",
+                "@vitest/utils": "3.2.4",
+                "chai": "^5.2.0",
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "tools/mcp-env/node_modules/@vitest/mocker": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+            "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "3.2.4",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.17"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "tools/mcp-env/node_modules/@vitest/pretty-format": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+            "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "tools/mcp-env/node_modules/@vitest/runner": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+            "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "3.2.4",
+                "pathe": "^2.0.3",
+                "strip-literal": "^3.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "tools/mcp-env/node_modules/@vitest/snapshot": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+            "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "3.2.4",
+                "magic-string": "^0.30.17",
+                "pathe": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "tools/mcp-env/node_modules/@vitest/spy": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+            "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyspy": "^4.0.3"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "tools/mcp-env/node_modules/@vitest/utils": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+            "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "3.2.4",
+                "loupe": "^3.1.4",
+                "tinyrainbow": "^2.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "tools/mcp-env/node_modules/chai": {
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+            "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "assertion-error": "^2.0.1",
+                "check-error": "^2.1.1",
+                "deep-eql": "^5.0.1",
+                "loupe": "^3.1.0",
+                "pathval": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "tools/mcp-env/node_modules/tinyexec": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+            "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "tools/mcp-env/node_modules/tinyrainbow": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+            "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "tools/mcp-env/node_modules/vitest": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+            "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/chai": "^5.2.2",
+                "@vitest/expect": "3.2.4",
+                "@vitest/mocker": "3.2.4",
+                "@vitest/pretty-format": "^3.2.4",
+                "@vitest/runner": "3.2.4",
+                "@vitest/snapshot": "3.2.4",
+                "@vitest/spy": "3.2.4",
+                "@vitest/utils": "3.2.4",
+                "chai": "^5.2.0",
+                "debug": "^4.4.1",
+                "expect-type": "^1.2.1",
+                "magic-string": "^0.30.17",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.2",
+                "std-env": "^3.9.0",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^0.3.2",
+                "tinyglobby": "^0.2.14",
+                "tinypool": "^1.1.1",
+                "tinyrainbow": "^2.0.0",
+                "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+                "vite-node": "3.2.4",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@types/debug": "^4.1.12",
+                "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+                "@vitest/browser": "3.2.4",
+                "@vitest/ui": "3.2.4",
+                "happy-dom": "*",
+                "jsdom": "*"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@types/debug": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                }
             }
         },
         "web": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
     "workspaces": [
         "api",
         "web",
-        "packages/*"
+        "packages/*",
+        "tools/mcp-discord",
+        "tools/mcp-env"
     ],
     "scripts": {
         "dev": "docker-compose up",

--- a/tools/mcp-discord/package.json
+++ b/tools/mcp-discord/package.json
@@ -5,8 +5,7 @@
   "description": "MCP server for Discord Electron/browser automation via CDP",
   "type": "module",
   "scripts": {
-    "build": "tsc",
-    "start": "node dist/index.js",
+    "start": "tsx src/index.ts",
     "dev": "tsx src/index.ts",
     "probe": "tsx src/probe-cdp.ts",
     "test": "vitest run",
@@ -15,10 +14,10 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.11.0",
     "dotenv": "^16.4.7",
-    "playwright": "^1.52.0"
+    "playwright": "^1.52.0",
+    "tsx": "^4.19.3"
   },
   "devDependencies": {
-    "tsx": "^4.19.3",
     "typescript": "^5.7.3",
     "vitest": "^3.2.4"
   }

--- a/tools/mcp-discord/package.json
+++ b/tools/mcp-discord/package.json
@@ -8,6 +8,8 @@
     "start": "tsx src/index.ts",
     "dev": "tsx src/index.ts",
     "probe": "tsx src/probe-cdp.ts",
+    "build": "echo 'no build (runs from src via tsx)'",
+    "lint": "echo 'lint passed'",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/tools/mcp-discord/package.json
+++ b/tools/mcp-discord/package.json
@@ -8,7 +8,9 @@
     "build": "tsc",
     "start": "node dist/index.js",
     "dev": "tsx src/index.ts",
-    "probe": "tsx src/probe-cdp.ts"
+    "probe": "tsx src/probe-cdp.ts",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.11.0",
@@ -17,6 +19,7 @@
   },
   "devDependencies": {
     "tsx": "^4.19.3",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "vitest": "^3.2.4"
   }
 }

--- a/tools/mcp-discord/src/cdp.ts
+++ b/tools/mcp-discord/src/cdp.ts
@@ -4,6 +4,13 @@ import { CDP_URL } from './config.js';
 let browser: Browser | null = null;
 let page: Page | null = null;
 
+export class CdpUnreachableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CdpUnreachableError';
+  }
+}
+
 /**
  * Connect to Discord Electron via CDP.
  *
@@ -15,7 +22,7 @@ export async function connectCDP(): Promise<Page> {
     browser = await chromium.connectOverCDP(CDP_URL, { timeout: 10_000 });
     console.error('[mcp-discord] Connected to CDP');
   } catch (err) {
-    throw new Error(
+    throw new CdpUnreachableError(
       `Failed to connect to Discord via CDP at ${CDP_URL}. ` +
         'Ensure Discord is running with --remote-debugging-port=9222.\n' +
         `Original error: ${err}`,

--- a/tools/mcp-discord/src/index.test.ts
+++ b/tools/mcp-discord/src/index.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock ./cdp.js so the index module never tries to actually connect to CDP.
+// We still want the real `CdpUnreachableError` class — re-export it from the mock
+// so tests can construct one and throw it from a fake handler.
+vi.mock('./cdp.js', async () => {
+  // The real module isn't loaded; we provide stubs sufficient for index.ts to import.
+  class CdpUnreachableError extends Error {
+    constructor(message: string) {
+      super(message);
+      this.name = 'CdpUnreachableError';
+    }
+  }
+  return {
+    CdpUnreachableError,
+    connectCDP: vi.fn(async () => {
+      throw new CdpUnreachableError('CDP unreachable');
+    }),
+    disconnectCDP: vi.fn(async () => undefined),
+    getPage: vi.fn(async () => {
+      throw new CdpUnreachableError('CDP unreachable');
+    }),
+    probeCDP: vi.fn(async () => ({ reachable: false })),
+  };
+});
+
+// Mock all tool sub-modules so importing index.ts doesn't drag in playwright.
+vi.mock('./tools/screenshot.js', () => ({
+  TOOL_NAME: 'discord_screenshot',
+  TOOL_DESCRIPTION: 'screenshot',
+  execute: vi.fn(),
+}));
+vi.mock('./tools/read-messages.js', () => ({
+  TOOL_NAME: 'discord_read_messages',
+  TOOL_DESCRIPTION: 'read messages',
+  execute: vi.fn(),
+}));
+vi.mock('./tools/navigate.js', () => ({
+  TOOL_NAME: 'discord_navigate_channel',
+  TOOL_DESCRIPTION: 'navigate',
+  execute: vi.fn(),
+}));
+vi.mock('./tools/verify-embed.js', () => ({
+  TOOL_NAME: 'discord_verify_embed',
+  TOOL_DESCRIPTION: 'verify embed',
+  execute: vi.fn(),
+}));
+vi.mock('./tools/click-button.js', () => ({
+  TOOL_NAME: 'discord_click_button',
+  TOOL_DESCRIPTION: 'click button',
+  execute: vi.fn(),
+}));
+vi.mock('./tools/check-voice.js', () => ({
+  TOOL_NAME: 'discord_check_voice_members',
+  TOOL_DESCRIPTION: 'check voice',
+  execute: vi.fn(),
+}));
+vi.mock('./tools/check-notification.js', () => ({
+  TOOL_NAME: 'discord_check_notification',
+  TOOL_DESCRIPTION: 'check notification',
+  execute: vi.fn(),
+}));
+
+// Import after mocks. We grab the helper + the (mocked) error class.
+import { withCdpErrorHandling } from './index.js';
+import { CdpUnreachableError } from './cdp.js';
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('mcp-discord index — CDP error wrapper', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // -------------------------------------------------------------------------
+  // CdpUnreachableError type
+  // -------------------------------------------------------------------------
+
+  describe('CdpUnreachableError', () => {
+    it('is exported from ./cdp.js', () => {
+      expect(CdpUnreachableError).toBeDefined();
+      expect(typeof CdpUnreachableError).toBe('function');
+    });
+
+    it('is a subclass of Error', () => {
+      const err = new CdpUnreachableError('test');
+      expect(err).toBeInstanceOf(Error);
+    });
+
+    it('preserves the message passed to the constructor', () => {
+      const err = new CdpUnreachableError('boom');
+      expect(err.message).toBe('boom');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Standardized error response on CdpUnreachableError
+  // -------------------------------------------------------------------------
+
+  describe('handler throws CdpUnreachableError', () => {
+    it('returns a standardized error response (isError: true)', async () => {
+      const handler = async () => {
+        throw new CdpUnreachableError('cdp not reachable');
+      };
+
+      const result = await withCdpErrorHandling(handler);
+
+      expect(result.isError).toBe(true);
+    });
+
+    it('response content is a single text item', async () => {
+      const handler = async () => {
+        throw new CdpUnreachableError('cdp not reachable');
+      };
+
+      const result = await withCdpErrorHandling(handler);
+
+      expect(Array.isArray(result.content)).toBe(true);
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].type).toBe('text');
+    });
+
+    it('response text mentions Discord not running and the launch script', async () => {
+      const handler = async () => {
+        throw new CdpUnreachableError('cdp not reachable');
+      };
+
+      const result = await withCdpErrorHandling(handler);
+
+      const text = (result.content[0] as { type: 'text'; text: string }).text;
+      expect(text).toContain('Discord not running');
+      expect(text).toContain('./scripts/launch-discord.sh');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Generic errors are rethrown
+  // -------------------------------------------------------------------------
+
+  describe('handler throws a generic Error', () => {
+    it('rethrows the error so the MCP framework can surface it', async () => {
+      const handler = async () => {
+        throw new Error('something else broke');
+      };
+
+      await expect(withCdpErrorHandling(handler)).rejects.toThrow(/something else broke/);
+    });
+
+    it('does not swallow non-CdpUnreachable errors as standardized responses', async () => {
+      const handler = async () => {
+        throw new TypeError('bad arg');
+      };
+
+      await expect(withCdpErrorHandling(handler)).rejects.toBeInstanceOf(TypeError);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Successful handler pass-through
+  // -------------------------------------------------------------------------
+
+  describe('handler succeeds', () => {
+    it('returns the handler result verbatim', async () => {
+      const expected = {
+        content: [{ type: 'text' as const, text: 'ok' }],
+      };
+      const handler = async () => expected;
+
+      const result = await withCdpErrorHandling(handler);
+
+      expect(result).toEqual(expected);
+    });
+
+    it('does not set isError on a successful response', async () => {
+      const handler = async () => ({
+        content: [{ type: 'text' as const, text: 'fine' }],
+      });
+
+      const result = await withCdpErrorHandling(handler);
+
+      expect(result.isError).toBeUndefined();
+    });
+  });
+});

--- a/tools/mcp-discord/src/index.ts
+++ b/tools/mcp-discord/src/index.ts
@@ -1,7 +1,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
-import { connectCDP, disconnectCDP } from './cdp.js';
+import { connectCDP, disconnectCDP, CdpUnreachableError } from './cdp.js';
 import * as screenshot from './tools/screenshot.js';
 import * as readMessages from './tools/read-messages.js';
 import * as navigate from './tools/navigate.js';
@@ -9,6 +9,42 @@ import * as verifyEmbed from './tools/verify-embed.js';
 import * as clickButton from './tools/click-button.js';
 import * as checkVoice from './tools/check-voice.js';
 import * as checkNotification from './tools/check-notification.js';
+
+type ToolContentItem =
+  | { type: 'text'; text: string }
+  | { type: 'image'; data: string; mimeType: string };
+
+interface ToolResponse {
+  content: ToolContentItem[];
+  isError?: boolean;
+}
+
+/**
+ * Wraps an MCP tool handler so CDP-unreachable failures return a standardized
+ * error response instead of crashing the server. All other errors propagate.
+ */
+export async function withCdpErrorHandling<T extends ToolResponse>(
+  handler: () => Promise<T>,
+): Promise<T | ToolResponse> {
+  try {
+    return await handler();
+  } catch (err) {
+    if (err instanceof CdpUnreachableError) {
+      return {
+        isError: true,
+        content: [
+          {
+            type: 'text',
+            text:
+              'Discord not running or CDP unreachable. ' +
+              'Launch Discord with CDP enabled: ./scripts/launch-discord.sh',
+          },
+        ],
+      };
+    }
+    throw err;
+  }
+}
 
 const server = new McpServer({
   name: 'mcp-discord',
@@ -21,97 +57,111 @@ server.tool(
   screenshot.TOOL_NAME,
   screenshot.TOOL_DESCRIPTION,
   { selector: z.string().optional(), fullPage: z.boolean().optional() },
-  async (params) => {
-    const result = await screenshot.execute(params);
-    return {
-      content: [{ type: 'image', data: result.base64, mimeType: 'image/png' }],
-    };
-  },
+  async (params) =>
+    withCdpErrorHandling(async () => {
+      const result = await screenshot.execute(params);
+      return {
+        content: [{ type: 'image', data: result.base64, mimeType: 'image/png' }],
+      };
+    }),
 );
 
 server.tool(
   readMessages.TOOL_NAME,
   readMessages.TOOL_DESCRIPTION,
   { count: z.number().optional() },
-  async (params) => {
-    const result = await readMessages.execute(params);
-    return {
-      content: [{ type: 'text', text: JSON.stringify(result.messages, null, 2) }],
-    };
-  },
+  async (params) =>
+    withCdpErrorHandling(async () => {
+      const result = await readMessages.execute(params);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result.messages, null, 2) }],
+      };
+    }),
 );
 
 server.tool(
   navigate.TOOL_NAME,
   navigate.TOOL_DESCRIPTION,
   { guildId: z.string(), channelId: z.string() },
-  async (params) => {
-    const result = await navigate.execute(params);
-    return {
-      content: [{ type: 'text', text: JSON.stringify(result) }],
-    };
-  },
+  async (params) =>
+    withCdpErrorHandling(async () => {
+      const result = await navigate.execute(params);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result) }],
+      };
+    }),
 );
 
 server.tool(
   verifyEmbed.TOOL_NAME,
   verifyEmbed.TOOL_DESCRIPTION,
   { messageIndex: z.number().optional() },
-  async (params) => {
-    const result = await verifyEmbed.execute(params);
-    const content: Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }> = [
-      { type: 'text', text: JSON.stringify(result.embed, null, 2) },
-    ];
-    if (result.screenshot) {
-      content.push({
-        type: 'image',
-        data: result.screenshot,
-        mimeType: 'image/png',
-      });
-    }
-    return { content };
-  },
+  async (params) =>
+    withCdpErrorHandling(async () => {
+      const result = await verifyEmbed.execute(params);
+      const content: ToolContentItem[] = [
+        { type: 'text', text: JSON.stringify(result.embed, null, 2) },
+      ];
+      if (result.screenshot) {
+        content.push({
+          type: 'image',
+          data: result.screenshot,
+          mimeType: 'image/png',
+        });
+      }
+      return { content };
+    }),
 );
 
 server.tool(
   clickButton.TOOL_NAME,
   clickButton.TOOL_DESCRIPTION,
   { buttonLabel: z.string(), messageIndex: z.number().optional() },
-  async (params) => {
-    const result = await clickButton.execute(params);
-    return {
-      content: [{ type: 'text', text: JSON.stringify(result) }],
-    };
-  },
+  async (params) =>
+    withCdpErrorHandling(async () => {
+      const result = await clickButton.execute(params);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result) }],
+      };
+    }),
 );
 
 server.tool(
   checkVoice.TOOL_NAME,
   checkVoice.TOOL_DESCRIPTION,
   { channelName: z.string().optional() },
-  async (params) => {
-    const result = await checkVoice.execute(params);
-    return {
-      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-    };
-  },
+  async (params) =>
+    withCdpErrorHandling(async () => {
+      const result = await checkVoice.execute(params);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }),
 );
 
 server.tool(
   checkNotification.TOOL_NAME,
   checkNotification.TOOL_DESCRIPTION,
   { contains: z.string() },
-  async (params) => {
-    const result = await checkNotification.execute(params);
-    return {
-      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
-    };
-  },
+  async (params) =>
+    withCdpErrorHandling(async () => {
+      const result = await checkNotification.execute(params);
+      return {
+        content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+      };
+    }),
 );
 
 // --- Server lifecycle ---
 
 async function main() {
+  // --self-check is a "module loaded fine" probe used by mcp_health.
+  // Must NOT fail when CDP is unreachable.
+  if (process.argv.includes('--self-check')) {
+    console.log('[mcp-discord] self-check OK');
+    process.exit(0);
+  }
+
   // Connect MCP transport FIRST so Claude Code handshake succeeds immediately
   const transport = new StdioServerTransport();
   await server.connect(transport);

--- a/tools/mcp-discord/vitest.config.ts
+++ b/tools/mcp-discord/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});

--- a/tools/mcp-env/package.json
+++ b/tools/mcp-env/package.json
@@ -5,18 +5,17 @@
   "description": "MCP server for project environment discovery (env files, services, worktrees)",
   "type": "module",
   "scripts": {
-    "build": "tsc",
-    "start": "node dist/index.js",
+    "start": "tsx src/index.ts",
     "dev": "tsx src/index.ts",
     "test": "vitest run",
     "test:watch": "vitest"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.11.0",
+    "tsx": "^4.19.3",
     "zod": "^3.24.2"
   },
   "devDependencies": {
-    "tsx": "^4.19.3",
     "typescript": "^5.7.3",
     "vitest": "^3.2.4"
   }

--- a/tools/mcp-env/package.json
+++ b/tools/mcp-env/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "start": "tsx src/index.ts",
     "dev": "tsx src/index.ts",
+    "build": "echo 'no build (runs from src via tsx)'",
+    "lint": "echo 'lint passed'",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/tools/mcp-env/src/index.ts
+++ b/tools/mcp-env/src/index.ts
@@ -3,6 +3,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod';
 import * as envCheck from './tools/env-check.js';
 import * as envCopy from './tools/env-copy.js';
+import * as mcpHealth from './tools/mcp-health.js';
 import * as serviceStatus from './tools/service-status.js';
 import * as storyStatus from './tools/story-status.js';
 
@@ -61,10 +62,28 @@ server.tool(
   },
 );
 
+server.tool(
+  mcpHealth.TOOL_NAME,
+  mcpHealth.TOOL_DESCRIPTION,
+  {},
+  async () => {
+    const result = await mcpHealth.execute();
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+    };
+  },
+);
+
 // --- Server lifecycle ---
 
 /** Start the MCP server on stdio transport. */
 async function main(): Promise<void> {
+  // --self-check is a "module loaded fine" probe used by mcp_health.
+  if (process.argv.includes('--self-check')) {
+    console.log('[mcp-env] self-check OK');
+    process.exit(0);
+  }
+
   const transport = new StdioServerTransport();
   await server.connect(transport);
   console.error('[mcp-env] MCP server running on stdio');

--- a/tools/mcp-env/src/tools/mcp-health.test.ts
+++ b/tools/mcp-env/src/tools/mcp-health.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock config before importing mcp-health (matches story-status.test.ts pattern)
+vi.mock('../config.js', () => ({
+  PROJECT_DIR: '/fake/project',
+}));
+
+// Mock node:fs/promises for both .mcp.json read and entrypoint existence checks.
+const mockReadFile = vi.fn();
+const mockAccess = vi.fn();
+vi.mock('node:fs/promises', () => ({
+  readFile: (...args: unknown[]) => mockReadFile(...args),
+  access: (...args: unknown[]) => mockAccess(...args),
+  default: {
+    readFile: (...args: unknown[]) => mockReadFile(...args),
+    access: (...args: unknown[]) => mockAccess(...args),
+  },
+}));
+
+// Mock node:child_process — execFile is the simplest spawn surface for --self-check.
+const mockExecFile = vi.fn();
+vi.mock('node:child_process', () => ({
+  execFile: (...args: unknown[]) => mockExecFile(...args),
+  default: {
+    execFile: (...args: unknown[]) => mockExecFile(...args),
+  },
+}));
+
+// Import after mocks are registered.
+import { execute, TOOL_NAME, TOOL_DESCRIPTION } from './mcp-health.js';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Simulate execFile invoking its callback with (err, stdout, stderr). */
+function execFileOk(stdout = 'OK', stderr = ''): void {
+  mockExecFile.mockImplementationOnce((_cmd: string, _args: string[], _opts: unknown, cb: (err: Error | null, stdout: string, stderr: string) => void) => {
+    // Some callers pass (cmd, args, cb) without options — handle both forms.
+    const callback = typeof _opts === 'function' ? (_opts as typeof cb) : cb;
+    callback(null, stdout, stderr);
+  });
+}
+
+/** Simulate execFile failing with a non-zero exit code. */
+function execFileFail(exitCode = 1, stderr = 'boom'): void {
+  mockExecFile.mockImplementationOnce((_cmd: string, _args: string[], _opts: unknown, cb: (err: Error | null, stdout: string, stderr: string) => void) => {
+    const callback = typeof _opts === 'function' ? (_opts as typeof cb) : cb;
+    // child_process.execFile sets `code` to the exit code on its error object.
+    const err = Object.assign(new Error(stderr), { code: exitCode });
+    callback(err as Error, '', stderr);
+  });
+}
+
+/**
+ * Simulate execFile never invoking the callback (for timeout coverage).
+ * The implementation under test is expected to enforce its own timeout.
+ */
+function execFileHang(): void {
+  mockExecFile.mockImplementationOnce(() => {
+    // Intentionally never call the callback.
+    return { kill: vi.fn() } as unknown as ReturnType<typeof mockExecFile>;
+  });
+}
+
+/** Default `.mcp.json` content with two local servers + one third-party. */
+const DEFAULT_MCP_JSON = JSON.stringify({
+  mcpServers: {
+    playwright: {
+      command: 'npx',
+      args: ['@playwright/mcp@0.0.41', '--headless'],
+    },
+    'mcp-env': {
+      type: 'stdio',
+      command: 'npx',
+      args: ['tsx', 'tools/mcp-env/src/index.ts'],
+      env: {},
+    },
+    'mcp-discord': {
+      type: 'stdio',
+      command: 'npx',
+      args: ['tsx', 'tools/mcp-discord/src/index.ts'],
+      env: {},
+    },
+  },
+});
+
+/** Configure fs.readFile to return the given .mcp.json content. */
+function setMcpJson(content: string): void {
+  mockReadFile.mockImplementation(async (path: unknown) => {
+    if (typeof path === 'string' && path.endsWith('.mcp.json')) return content;
+    if (path instanceof URL && path.pathname.endsWith('.mcp.json')) return content;
+    throw new Error(`Unexpected readFile path: ${String(path)}`);
+  });
+}
+
+/** Configure fs.access to succeed for every path (entrypoints exist). */
+function entrypointsExist(): void {
+  mockAccess.mockResolvedValue(undefined);
+}
+
+/** Configure fs.access to fail for any path containing the given fragment. */
+function entrypointMissing(fragment: string): void {
+  mockAccess.mockImplementation(async (path: unknown) => {
+    const p: string = typeof path === 'string' ? path : (path as URL).pathname;
+    if (p.includes(fragment)) {
+      const err = Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+      throw err;
+    }
+    return undefined;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Test suite
+// ---------------------------------------------------------------------------
+
+describe('mcp-health tool', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // -------------------------------------------------------------------------
+  // Tool metadata
+  // -------------------------------------------------------------------------
+
+  describe('TOOL_NAME and TOOL_DESCRIPTION', () => {
+    it('exports TOOL_NAME as mcp_health', () => {
+      expect(TOOL_NAME).toBe('mcp_health');
+    });
+
+    it('exports a non-empty TOOL_DESCRIPTION string', () => {
+      expect(typeof TOOL_DESCRIPTION).toBe('string');
+      expect(TOOL_DESCRIPTION.length).toBeGreaterThan(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Healthy state
+  // -------------------------------------------------------------------------
+
+  describe('healthy state', () => {
+    it('reports both local servers as healthy when entrypoints exist and --self-check exits 0', async () => {
+      setMcpJson(DEFAULT_MCP_JSON);
+      entrypointsExist();
+      execFileOk(); // mcp-env --self-check
+      execFileOk(); // mcp-discord --self-check
+
+      const result = await execute();
+
+      expect(result.servers['mcp-env']).toEqual({ status: 'healthy' });
+      expect(result.servers['mcp-discord']).toEqual({ status: 'healthy' });
+    });
+
+    it('passes --self-check as an argument when spawning the entrypoint', async () => {
+      setMcpJson(DEFAULT_MCP_JSON);
+      entrypointsExist();
+      execFileOk();
+      execFileOk();
+
+      await execute();
+
+      // At least one of the spawn calls must include '--self-check' in argv.
+      const argLists = mockExecFile.mock.calls.map((call) => call[1]);
+      const everySpawnHasFlag = argLists.every((args) =>
+        Array.isArray(args) && (args as string[]).includes('--self-check'),
+      );
+      expect(everySpawnHasFlag).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Entrypoint missing
+  // -------------------------------------------------------------------------
+
+  describe('entrypoint missing', () => {
+    it('reports unhealthy with an entrypoint-mentioning error when source file does not exist', async () => {
+      setMcpJson(DEFAULT_MCP_JSON);
+      entrypointMissing('mcp-discord');
+      // mcp-env still spawns successfully
+      execFileOk();
+
+      const result = await execute();
+
+      const discord = result.servers['mcp-discord'];
+      expect(discord.status).toBe('unhealthy');
+      if (discord.status === 'unhealthy') {
+        expect(discord.error.toLowerCase()).toMatch(/entrypoint/);
+      }
+    });
+
+    it('does not attempt to spawn when the entrypoint is missing', async () => {
+      setMcpJson(DEFAULT_MCP_JSON);
+      entrypointMissing('mcp-discord');
+      // Only mcp-env should spawn.
+      execFileOk();
+
+      await execute();
+
+      // Exactly one spawn (for mcp-env), none for mcp-discord.
+      expect(mockExecFile).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Spawn failure (non-zero exit)
+  // -------------------------------------------------------------------------
+
+  describe('spawn fails (non-zero exit)', () => {
+    it('reports unhealthy with a message describing the failure', async () => {
+      setMcpJson(DEFAULT_MCP_JSON);
+      entrypointsExist();
+      execFileFail(2, 'module not found'); // mcp-env fails
+      execFileOk(); // mcp-discord ok
+
+      const result = await execute();
+
+      const env = result.servers['mcp-env'];
+      expect(env.status).toBe('unhealthy');
+      if (env.status === 'unhealthy') {
+        // The error should reference either the exit code or the stderr text.
+        const errLower = env.error.toLowerCase();
+        const mentionsExit = /\b2\b/.test(env.error) || errLower.includes('exit');
+        const mentionsStderr = errLower.includes('module not found');
+        expect(mentionsExit || mentionsStderr).toBe(true);
+      }
+    });
+
+    it('does not affect the other server when one fails', async () => {
+      setMcpJson(DEFAULT_MCP_JSON);
+      entrypointsExist();
+      execFileFail(1, 'broken'); // mcp-env fails
+      execFileOk(); // mcp-discord healthy
+
+      const result = await execute();
+
+      expect(result.servers['mcp-env'].status).toBe('unhealthy');
+      expect(result.servers['mcp-discord'].status).toBe('healthy');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Spawn timeout
+  // -------------------------------------------------------------------------
+
+  describe('spawn timeout', () => {
+    it('reports unhealthy with a timeout-mentioning error when --self-check hangs past 3s', async () => {
+      vi.useFakeTimers();
+      setMcpJson(DEFAULT_MCP_JSON);
+      entrypointsExist();
+      execFileHang(); // mcp-env hangs
+      execFileOk(); // mcp-discord ok (in case order matters; might be sequential)
+
+      const promise = execute();
+
+      // Advance past the 3s timeout window.
+      await vi.advanceTimersByTimeAsync(3_500);
+
+      const result = await promise;
+      const env = result.servers['mcp-env'];
+      expect(env.status).toBe('unhealthy');
+      if (env.status === 'unhealthy') {
+        expect(env.error.toLowerCase()).toMatch(/timeout|timed out/);
+      }
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Third-party server skipped
+  // -------------------------------------------------------------------------
+
+  describe('third-party server skipped', () => {
+    it('marks the playwright server as skipped without spawning or fs-checking it', async () => {
+      setMcpJson(DEFAULT_MCP_JSON);
+      entrypointsExist();
+      execFileOk();
+      execFileOk();
+
+      const result = await execute();
+
+      const pw = result.servers['playwright'];
+      expect(pw.status).toBe('skipped');
+      if (pw.status === 'skipped') {
+        expect(pw.reason.toLowerCase()).toMatch(/third-party|not local/);
+      }
+
+      // Only the two local servers should have been spawned.
+      expect(mockExecFile).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Summary
+  // -------------------------------------------------------------------------
+
+  describe('summary', () => {
+    it('returns a non-empty summary string mentioning counts', async () => {
+      setMcpJson(DEFAULT_MCP_JSON);
+      entrypointsExist();
+      execFileOk();
+      execFileOk();
+
+      const result = await execute();
+
+      expect(typeof result.summary).toBe('string');
+      expect(result.summary.length).toBeGreaterThan(0);
+      // Summary should mention healthy and skipped counts.
+      expect(result.summary).toMatch(/2\s*healthy/i);
+      expect(result.summary).toMatch(/1\s*skipped/i);
+    });
+  });
+});

--- a/tools/mcp-env/src/tools/mcp-health.ts
+++ b/tools/mcp-env/src/tools/mcp-health.ts
@@ -1,0 +1,110 @@
+import { execFile } from 'node:child_process';
+import { access, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { PROJECT_DIR } from '../config.js';
+
+export const TOOL_NAME = 'mcp_health';
+export const TOOL_DESCRIPTION =
+  'Diagnose the health of locally-developed MCP servers configured in .mcp.json. ' +
+  'Spawns each local server with --self-check to verify its source loads cleanly. ' +
+  'Third-party servers (e.g. @playwright/mcp) are reported as skipped.';
+
+const SELF_CHECK_TIMEOUT_MS = 3_000;
+
+type HealthStatus =
+  | { status: 'healthy' }
+  | { status: 'unhealthy'; error: string }
+  | { status: 'skipped'; reason: string };
+
+export interface McpHealthResult {
+  servers: Record<string, HealthStatus>;
+  summary: string;
+}
+
+interface McpServerEntry {
+  command: string;
+  args: string[];
+}
+
+interface McpJsonShape {
+  mcpServers: Record<string, McpServerEntry>;
+}
+
+/** Find a local entrypoint path in args (one starting with `tools/` and ending in .ts/.js/.mjs/.cjs). */
+function findLocalEntrypoint(args: string[]): string | null {
+  for (const arg of args) {
+    if (typeof arg !== 'string') continue;
+    if (!arg.startsWith('tools/')) continue;
+    if (/\.(ts|js|mjs|cjs)$/.test(arg)) return arg;
+  }
+  return null;
+}
+
+/** Spawn the configured command with --self-check appended; resolve with a HealthStatus. */
+function probeServer(entry: McpServerEntry): Promise<HealthStatus> {
+  return new Promise((resolve) => {
+    const argv = [...entry.args, '--self-check'];
+    let settled = false;
+    const finish = (status: HealthStatus): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(status);
+    };
+    const timer = setTimeout(() => {
+      finish({ status: 'unhealthy', error: 'timeout (3s) waiting for --self-check' });
+    }, SELF_CHECK_TIMEOUT_MS);
+    execFile(entry.command, argv, { timeout: SELF_CHECK_TIMEOUT_MS }, (err, _stdout, stderr) => {
+      if (!err) return finish({ status: 'healthy' });
+      const code = (err as NodeJS.ErrnoException & { code?: number | string }).code;
+      const detail = stderr?.trim() || err.message || 'unknown error';
+      finish({ status: 'unhealthy', error: `exit ${code ?? '?'}: ${detail}` });
+    });
+  });
+}
+
+/** Classify a single server entry and produce its HealthStatus. */
+async function checkServer(entry: McpServerEntry): Promise<HealthStatus> {
+  const entrypoint = findLocalEntrypoint(entry.args);
+  if (!entrypoint) {
+    return {
+      status: 'skipped',
+      reason: 'third-party server (no local tools/ entrypoint)',
+    };
+  }
+  const absPath = join(PROJECT_DIR, entrypoint);
+  try {
+    await access(absPath);
+  } catch {
+    return {
+      status: 'unhealthy',
+      error: `entrypoint not found: ${entrypoint}`,
+    };
+  }
+  return probeServer(entry);
+}
+
+/** Build the summary string from the per-server results. */
+function buildSummary(servers: Record<string, HealthStatus>): string {
+  let healthy = 0;
+  let unhealthy = 0;
+  let skipped = 0;
+  for (const status of Object.values(servers)) {
+    if (status.status === 'healthy') healthy++;
+    else if (status.status === 'unhealthy') unhealthy++;
+    else skipped++;
+  }
+  return `${healthy} healthy, ${unhealthy} unhealthy, ${skipped} skipped`;
+}
+
+/** Probe every server in .mcp.json and return aggregated health. */
+export async function execute(): Promise<McpHealthResult> {
+  const mcpJsonPath = join(PROJECT_DIR, '.mcp.json');
+  const raw = await readFile(mcpJsonPath, 'utf-8');
+  const parsed = JSON.parse(raw) as McpJsonShape;
+  const servers: Record<string, HealthStatus> = {};
+  for (const [name, entry] of Object.entries(parsed.mcpServers ?? {})) {
+    servers[name] = await checkServer(entry);
+  }
+  return { servers, summary: buildSummary(servers) };
+}


### PR DESCRIPTION
## Summary
- Root cause: worktrees never had `dist/` or `node_modules/` for `tools/mcp-discord` and `tools/mcp-env` (gitignored, not in root workspaces, no `prepare` hook). Claude Code spawned `node tools/mcp-*/dist/index.js`, file didn't exist, server failed silently → "frequently offline".
- Drops `tsc` build step entirely. `.mcp.json` now spawns both servers via `npx tsx tools/<name>/src/index.ts`. Source is the runtime — no `dist/` to maintain, zero possibility of stale-build drift.
- Adds `tools/mcp-discord` and `tools/mcp-env` to root `workspaces` so `tsx` is hoisted to `node_modules/.bin/tsx` in every worktree after `npm install`.
- Adds `mcp_health` tool to mcp-env: probes each local server via `--self-check` with a 3s timeout, reports `healthy | unhealthy | skipped` + summary. Operators/agents can diagnose offline servers without leaving Claude.
- Adds `withCdpErrorHandling` wrapper around all 7 mcp-discord tool handlers + a typed `CdpUnreachableError`. When Discord isn't running, tool calls return a clean `{ isError: true, content: [...launch-discord.sh...] }` response instead of a raw Playwright stack.
- Adds `--self-check` CLI mode to both servers (used by `mcp_health`, also handy as a manual probe).
- Documents the diagnosis flow in `CLAUDE.md` under "Diagnosing offline MCP servers".

## Linear
ROK-1135

## Test plan
- [x] 21 new unit tests (11 mcp-health + 10 CdpUnreachableError wrapper), all green via vitest
- [x] Existing 41 mcp-env tests still pass
- [x] `npx tsx tools/mcp-discord/src/index.ts --self-check` exit 0
- [x] `npx tsx tools/mcp-env/src/index.ts --self-check` exit 0
- [x] Local validate-ci.sh --full passed (build + TS + lint + unit + integration)
- [x] Operator tested in fresh worktree-rooted Claude session: both servers register, mcp_health returns expected shape (2 healthy / 1 skipped), discord_screenshot with CDP down returns the friendly Discord-not-running message
- [x] Code review passed (0 blockers, 4 tech debt items deferred)