### PR TITLE
ROK-1051: fix conflict warning banner unreadable in light mode

### DIFF
--- a/web/src/pages/event-detail-page.tsx
+++ b/web/src/pages/event-detail-page.tsx
@@ -183,8 +183,8 @@ function EventDetailBodySections({ page, voice, derived, handlers }: {
             <PostEventSections event={page.event} eventId={page.eventId} isCancelled={derived.isCancelled} isAdHoc={voice.isAdHoc} canManageRoster={derived.canManageRoster} />
             <MobileQuickInfo event={page.event} roster={page.roster} isSignedUp={derived.isSignedUp} alphabetical={alphabetical} />
             {page.event.myConflicts && page.event.myConflicts.length > 0 && (
-                <div className="bg-amber-500/10 border border-amber-500/30 rounded-lg p-3 mb-4">
-                    <p className="text-sm text-amber-300">
+                <div className="bg-amber-100 dark:bg-amber-500/10 border border-amber-300 dark:border-amber-500/30 rounded-lg p-3 mb-4">
+                    <p className="text-sm text-amber-600 dark:text-amber-300">
                         {page.event.myConflicts.map(c => `You're already signed up for ${c.title} at this time`).join('. ')}
                     </p>
                 </div>


### PR DESCRIPTION
## Summary
- Conflict warning banner ("You're already signed up for X at this time") on event detail page used dark-mode-only amber classes, leaving it nearly invisible in light mode.
- Swap to theme-aware Tailwind variants: `text-amber-600 dark:text-amber-300`, `bg-amber-100 dark:bg-amber-500/10`, `border-amber-300 dark:border-amber-500/30`.
- Single file: `web/src/pages/event-detail-page.tsx:186-187`.

## Test plan
- [ ] Light mode: visit an event you're signed up for that conflicts with another → banner text is clearly readable on amber background.
- [ ] Dark mode: same scenario → unchanged from before (amber-300 on amber-500/10).

Linear: https://linear.app/roknua-projects/issue/ROK-1051

🤖 Generated with [Claude Code](https://claude.com/claude-code)