### PR TITLE
ROK-1143: fix: filter intentional no_snapshot_yet 503s from Sentry

### DIFF
--- a/api/src/sentry/instrument.spec.ts
+++ b/api/src/sentry/instrument.spec.ts
@@ -107,6 +107,77 @@ function describeSentryInstrumentTs() {
       const regex = ignoreSpans[0];
       expect(regex.test('pg_catalog.pg_type')).toBe(true);
     });
+
+    describe('beforeSend filter', () => {
+      type SentryEvent = {
+        exception?: { values?: { type?: string; value?: string }[] };
+      };
+      type BeforeSend = (event: SentryEvent) => SentryEvent | null;
+
+      function getBeforeSend(): BeforeSend {
+        const config = sentryInitMock.mock.calls[0][0] as Record<
+          string,
+          unknown
+        >;
+        return config['beforeSend'] as BeforeSend;
+      }
+
+      it('drops ThrottlerException events', () => {
+        const result = getBeforeSend()({
+          exception: { values: [{ type: 'ThrottlerException' }] },
+        });
+        expect(result).toBeNull();
+      });
+
+      it('drops InternalOAuthError events (ROK-668)', () => {
+        const result = getBeforeSend()({
+          exception: { values: [{ type: 'InternalOAuthError' }] },
+        });
+        expect(result).toBeNull();
+      });
+
+      it('drops intentional no_snapshot_yet 503s (ROK-1143)', () => {
+        const result = getBeforeSend()({
+          exception: {
+            values: [
+              {
+                type: 'HttpException',
+                value: "{ error: 'no_snapshot_yet' }",
+              },
+            ],
+          },
+        });
+        expect(result).toBeNull();
+      });
+
+      it('still reports real 5xx HttpExceptions', () => {
+        const event: SentryEvent = {
+          exception: {
+            values: [{ type: 'HttpException', value: 'Internal Server Error' }],
+          },
+        };
+        expect(getBeforeSend()(event)).toBe(event);
+      });
+
+      it('still reports unrelated exceptions', () => {
+        const event: SentryEvent = {
+          exception: {
+            values: [
+              {
+                type: 'TypeError',
+                value: "Cannot read property 'x' of undefined",
+              },
+            ],
+          },
+        };
+        expect(getBeforeSend()(event)).toBe(event);
+      });
+
+      it('passes through events without an exception payload', () => {
+        const event: SentryEvent = {};
+        expect(getBeforeSend()(event)).toBe(event);
+      });
+    });
   });
 
   describe('when DISABLE_TELEMETRY=true', () => {

--- a/api/src/sentry/instrument.ts
+++ b/api/src/sentry/instrument.ts
@@ -19,12 +19,24 @@ if (!telemetryDisabled && isProduction) {
     tracesSampleRate: isProduction ? 0.1 : 1.0,
     beforeSend(event) {
       const exceptionType = event.exception?.values?.[0]?.type;
+      const exceptionValue = event.exception?.values?.[0]?.value;
       // Don't report rate-limit (ThrottlerException) events to Sentry
       if (exceptionType === 'ThrottlerException') {
         return null;
       }
       // Don't report transient Discord OAuth failures (ROK-668)
       if (exceptionType === 'InternalOAuthError') {
+        return null;
+      }
+      // Don't report intentional 503s emitted by community-insights panels
+      // before the daily snapshot cron has run (ROK-1143). The endpoints are
+      // doing the right thing operationally — the dashboard renders an empty
+      // state — but the 503 status used to spam Sentry → GitHub on every
+      // pre-cron page-view.
+      if (
+        typeof exceptionValue === 'string' &&
+        exceptionValue.includes('no_snapshot_yet')
+      ) {
         return null;
       }
       return event;


### PR DESCRIPTION
## Summary
- Stop community-insights `no_snapshot_yet` 503s from flooding Sentry (and the Sentry → GitHub issue pipeline) before the daily snapshot cron has run.
- Endpoint behaviour is intentionally unchanged: 503 is correct REST when the snapshot doesn't exist yet, the dashboard already renders an empty state.
- Filter sits alongside the existing `ThrottlerException` and `InternalOAuthError` `beforeSend` filters in `api/src/sentry/instrument.ts` — same precedent, same shape.

## Linear
ROK-1143

## Why this approach (Option B over Option A)
The Linear story listed two options: A) reshape 6 contract DTOs into a `status: 'pending' | 'ready'` discriminator and rework the frontend (~12 files), or B) extend the existing Sentry `beforeSend` filter (~2 files). The 503 itself is REST-accurate and the frontend already handles the empty state — only the alert classification was wrong, so Option B fixes the actual problem with minimal blast radius.

## Test plan
- [x] `validate-ci.sh --full` passes (build, typecheck, lint, unit+coverage, integration)
- [x] New `beforeSend` unit cases in `api/src/sentry/instrument.spec.ts`:
  - drops `ThrottlerException` (regression)
  - drops `InternalOAuthError` (regression)
  - drops `no_snapshot_yet` HttpException (this fix)
  - still reports real 5xx HttpExceptions
  - still reports unrelated exceptions (TypeError)
  - passes through events without an exception payload
- [ ] Post-deploy: confirm no further \`HttpException: no_snapshot_yet\` issues land in Sentry / GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)