### PR TITLE
ROK-1085: fix: cache admin auth token in Playwright globalSetup

### DIFF
--- a/scripts/playwright-global-setup.ts
+++ b/scripts/playwright-global-setup.ts
@@ -23,6 +23,10 @@ const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'password';
 
 const AUTH_DIR = path.resolve(__dirname, '.auth');
 const STORAGE_STATE_PATH = path.join(AUTH_DIR, 'admin.json');
+// ROK-1085: workers in scripts/smoke read this file via getAdminToken() to
+// avoid each one POSTing /auth/local in parallel (the rate limiter dropped
+// requests and caused did-not-run flakes under full-suite parallel run).
+const TOKEN_FILE_PATH = path.join(AUTH_DIR, 'admin-token.json');
 
 export default async function globalSetup(_config: FullConfig) {
     // Ensure .auth directory exists
@@ -43,6 +47,11 @@ export default async function globalSetup(_config: FullConfig) {
     }
 
     const { access_token } = (await loginRes.json()) as { access_token: string };
+
+    fs.writeFileSync(
+        TOKEN_FILE_PATH,
+        JSON.stringify({ access_token, issued_at: new Date().toISOString() }),
+    );
 
     // 2. Seed demo data (idempotent — safe to call if already seeded)
     const seedRes = await fetch(`${API_BASE}/admin/settings/demo/install`, {

--- a/scripts/smoke/api-helpers.spec.ts
+++ b/scripts/smoke/api-helpers.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for getAdminToken() — ROK-1085.
+ *
+ * Verifies the planned token-on-disk behavior:
+ *   1. When scripts/.auth/admin-token.json exists, getAdminToken() reads it
+ *      synchronously and does NOT call POST /auth/local.
+ *   2. When the file is missing, it falls back to the existing /auth/local
+ *      retry path.
+ *   3. The module-level cache prevents repeat reads / fetches on subsequent
+ *      calls within the same worker process.
+ *
+ * These tests intentionally fail against the current implementation in
+ * scripts/smoke/api-helpers.ts (which always calls fetch), and will pass once
+ * the dev wires the file-read path described in planning-artifacts/specs/ROK-1085.md.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// fs/promises mocks — declared at module-eval time (vi.mock is hoisted).
+const mockReadFile = vi.fn();
+vi.mock('node:fs/promises', () => ({
+    readFile: (...args: unknown[]) => mockReadFile(...args),
+    default: {
+        readFile: (...args: unknown[]) => mockReadFile(...args),
+    },
+}));
+// Also mock the un-prefixed form in case the dev imports from 'fs/promises'.
+vi.mock('fs/promises', () => ({
+    readFile: (...args: unknown[]) => mockReadFile(...args),
+    default: {
+        readFile: (...args: unknown[]) => mockReadFile(...args),
+    },
+}));
+
+const TOKEN_VALUE = 'jwt-from-disk-aaa.bbb.ccc';
+const FALLBACK_TOKEN = 'jwt-from-fallback-xxx.yyy.zzz';
+
+function makeEnoent(): NodeJS.ErrnoException {
+    const err = new Error(
+        "ENOENT: no such file or directory, open 'admin-token.json'",
+    ) as NodeJS.ErrnoException;
+    err.code = 'ENOENT';
+    return err;
+}
+
+describe('getAdminToken (ROK-1085)', () => {
+    let fetchSpy: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        vi.resetModules();
+        mockReadFile.mockReset();
+        fetchSpy = vi.fn(async () =>
+            new Response(JSON.stringify({ access_token: FALLBACK_TOKEN }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            }),
+        );
+        vi.stubGlobal('fetch', fetchSpy);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('reads admin-token.json and returns access_token without calling fetch', async () => {
+        mockReadFile.mockResolvedValueOnce(
+            JSON.stringify({
+                access_token: TOKEN_VALUE,
+                issued_at: '2026-04-27T00:00:00.000Z',
+            }),
+        );
+
+        const { getAdminToken } = await import('./api-helpers');
+        const token = await getAdminToken();
+
+        expect(token).toBe(TOKEN_VALUE);
+        expect(mockReadFile).toHaveBeenCalledTimes(1);
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('falls back to POST /auth/local when admin-token.json is missing', async () => {
+        mockReadFile.mockRejectedValueOnce(makeEnoent());
+
+        const { getAdminToken } = await import('./api-helpers');
+        const token = await getAdminToken();
+
+        // The implementation MUST attempt a file read first — otherwise the
+        // happy-path optimization (test 1) cannot exist. With the planned
+        // implementation, mockReadFile is called once and rejects with ENOENT,
+        // then fetch is called as the fallback.
+        expect(mockReadFile).toHaveBeenCalledTimes(1);
+        expect(token).toBe(FALLBACK_TOKEN);
+        expect(fetchSpy).toHaveBeenCalledTimes(1);
+        const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+        expect(String(url)).toContain('/auth/local');
+        expect(init?.method).toBe('POST');
+    });
+
+    it('caches the token in-process — second call hits neither fs nor fetch', async () => {
+        mockReadFile.mockResolvedValueOnce(
+            JSON.stringify({
+                access_token: TOKEN_VALUE,
+                issued_at: '2026-04-27T00:00:00.000Z',
+            }),
+        );
+
+        const { getAdminToken } = await import('./api-helpers');
+        const first = await getAdminToken();
+        const second = await getAdminToken();
+
+        expect(first).toBe(TOKEN_VALUE);
+        expect(second).toBe(TOKEN_VALUE);
+        expect(mockReadFile).toHaveBeenCalledTimes(1);
+        expect(fetchSpy).not.toHaveBeenCalled();
+    });
+});

--- a/scripts/smoke/api-helpers.ts
+++ b/scripts/smoke/api-helpers.ts
@@ -6,42 +6,70 @@
  * smoke spec files don't duplicate this boilerplate.
  */
 
+import { readFile } from 'node:fs/promises';
+import { resolve as resolvePath } from 'node:path';
+
 export const API_BASE = process.env.API_URL || 'http://localhost:3000';
 
 // ---------------------------------------------------------------------------
 // Admin token — cached at module level, with 429 back-off retry
 // ---------------------------------------------------------------------------
 
+// ROK-1085: globalSetup writes the JWT to scripts/.auth/admin-token.json so
+// each Playwright worker can read the cached token instead of hammering
+// /auth/local in parallel (the rate limiter rejected the fan-out and caused
+// flaky smoke runs). Falls back to the live login if the file is absent.
+const TOKEN_FILE_PATH = resolvePath(__dirname, '..', '.auth', 'admin-token.json');
+
 let _cachedToken: string | null = null;
 let _tokenPromise: Promise<string> | null = null;
+
+async function readTokenFromDisk(): Promise<string | null> {
+    try {
+        const raw = await readFile(TOKEN_FILE_PATH, 'utf8');
+        const parsed = JSON.parse(raw) as { access_token?: unknown };
+        if (typeof parsed.access_token === 'string' && parsed.access_token) {
+            return parsed.access_token;
+        }
+        return null;
+    } catch {
+        return null;
+    }
+}
+
+async function loginViaApi(): Promise<string> {
+    for (let attempt = 0; attempt < 3; attempt++) {
+        const res = await fetch(`${API_BASE}/auth/local`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                username: 'admin@local',
+                password: process.env.ADMIN_PASSWORD || 'password',
+            }),
+        });
+        if (res.ok) {
+            const { access_token } = (await res.json()) as {
+                access_token: string;
+            };
+            return access_token;
+        }
+        if (res.status === 429) {
+            const wait = attempt === 0 ? 5_000 : 15_000;
+            await new Promise((r) => setTimeout(r, wait));
+            continue;
+        }
+        throw new Error(`Auth failed: ${res.status}`);
+    }
+    throw new Error('Auth failed after 3 attempts (rate limited)');
+}
 
 export async function getAdminToken(): Promise<string> {
     if (_cachedToken) return _cachedToken;
     if (_tokenPromise) return _tokenPromise;
     _tokenPromise = (async () => {
-        for (let attempt = 0; attempt < 3; attempt++) {
-            const res = await fetch(`${API_BASE}/auth/local`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    username: 'admin@local',
-                    password: process.env.ADMIN_PASSWORD || 'password',
-                }),
-            });
-            if (res.ok) {
-                const { access_token } = (await res.json()) as {
-                    access_token: string;
-                };
-                return access_token;
-            }
-            if (res.status === 429) {
-                const wait = attempt === 0 ? 5_000 : 15_000;
-                await new Promise((r) => setTimeout(r, wait));
-                continue;
-            }
-            throw new Error(`Auth failed: ${res.status}`);
-        }
-        throw new Error('Auth failed after 3 attempts (rate limited)');
+        const fromDisk = await readTokenFromDisk();
+        if (fromDisk) return fromDisk;
+        return loginViaApi();
     })();
     _cachedToken = await _tokenPromise;
     _tokenPromise = null;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,7 +13,12 @@ export default defineConfig({
         environment: 'jsdom',
         globals: true,
         setupFiles: ['./web/src/test/setup.ts'],
-        include: ['web/src/**/*.test.{ts,tsx}'],
+        include: [
+            'web/src/**/*.test.{ts,tsx}',
+            // ROK-1085: unit tests for scripts/smoke helpers (excludes Playwright .smoke.spec.ts files).
+            'scripts/smoke/**/*.spec.ts',
+        ],
+        exclude: ['**/node_modules/**', 'scripts/smoke/**/*.smoke.spec.ts'],
     },
     resolve: {
         alias: {


### PR DESCRIPTION
## Summary
- `globalSetup` now writes the admin JWT to `scripts/.auth/admin-token.json` after its single auth call.
- `getAdminToken()` in `scripts/smoke/api-helpers.ts` reads from disk first; falls back to the existing `/auth/local` retry only when the file is missing.
- Eliminates the worker-process auth fan-out that tripped the `auth` rate-limit tier (10/min) under full-suite parallel runs.

## Why
Each Playwright worker has its own module-level `_cachedToken`. With ~8 workers × 2 projects (desktop + mobile), every worker called `POST /auth/local` independently on first use, generating 16+ simultaneous auth requests that hit the rate limiter. Workers that got 429 backed off for 5s/15s, then their tests reported as "did not run" or failed in setup. The story's pre-fix runs showed 76–162 did-not-run with passes drifting 333–422.

After this change: **3 `/auth/local` hits per `playwright test` invocation** (1 globalSetup + 2 from `auth.smoke.spec.ts` which intentionally tests the login endpoint as a feature). did-not-run: 0–4 across runs. Total test enumeration is stable at 732/732.

## Linear
[ROK-1085](https://linear.app/roknua-projects/issue/ROK-1085)

## Verification

| Run | Passed | Failed | Skipped | Did-not-run | Duration |
|-----|--------|--------|---------|-------------|----------|
| #1  | 490 | 55 | 183 | 4 | 11.4 min |
| #2  | 480 | 68 | 183 | 0 | ~12 min |

Pass count drift between runs is from a separate, pre-existing root cause (mobile-viewport selector flakes) — tracked in [ROK-1147](https://linear.app/roknua-projects/issue/ROK-1147). The auth-storm AC closed by this PR.

## Test plan
- [x] 3 unit tests (vitest) added at `scripts/smoke/api-helpers.spec.ts` covering disk-read fast path, ENOENT fallback, and module cache invariants
- [x] Full local CI green: api 5630 tests, web 3002 tests, integration 787 tests, lint 0 errors, builds + ts pass
- [x] 2 full Playwright smoke runs locally — auth fan-out confirmed eliminated via API log
- [x] Code review APPROVED (no auto-fixes, no blockers)

## Security
Zero net change. Same JWT, additional file location. `scripts/*` gitignore rule (line 31) covers `admin-token.json`. DEMO_MODE-only credential. Tiny upside: worker `api-helpers.ts` no longer needs `ADMIN_PASSWORD` env access in the happy path.