### PR TITLE
ROK-1138: fix AI Features card 'Offline' when active provider is working

### DIFF
--- a/api/src/ai/ai-admin.controller.spec.ts
+++ b/api/src/ai/ai-admin.controller.spec.ts
@@ -27,7 +27,10 @@ describe('AiAdminController', () => {
   let controller: AiAdminController;
   let mockLlmService: { isAvailable: jest.Mock; listModels: jest.Mock };
   let mockRegistry: { resolveActive: jest.Mock };
-  let mockLogService: { getUsageStats: jest.Mock };
+  let mockLogService: {
+    getUsageStats: jest.Mock;
+    getLastSuccessfulChatAt: jest.Mock;
+  };
   let mockSettings: { get: jest.Mock };
 
   beforeEach(async () => {
@@ -49,6 +52,7 @@ describe('AiAdminController', () => {
         errorRate: 0.02,
         byFeature: [],
       }),
+      getLastSuccessfulChatAt: jest.fn().mockResolvedValue(null),
     };
     mockSettings = { get: jest.fn().mockResolvedValue(null) };
 
@@ -113,6 +117,35 @@ describe('AiAdminController', () => {
       });
     });
   });
+
+  describe('heartbeat-derived availability (ROK-1138)', () => {
+    it('getStatus marks available when log heartbeat is recent and skips probe', async () => {
+      mockLogService.getLastSuccessfulChatAt.mockResolvedValue(new Date());
+      mockLlmService.isAvailable.mockResolvedValue(false);
+      const result = await controller.getStatus();
+      expect(result.available).toBe(true);
+      expect(mockLogService.getLastSuccessfulChatAt).toHaveBeenCalledWith(
+        'ollama',
+      );
+      expect(mockLlmService.isAvailable).not.toHaveBeenCalled();
+    });
+
+    it('getStatus falls through to probe when no heartbeat exists', async () => {
+      mockLogService.getLastSuccessfulChatAt.mockResolvedValue(null);
+      mockLlmService.isAvailable.mockResolvedValue(true);
+      const result = await controller.getStatus();
+      expect(result.available).toBe(true);
+      expect(mockLlmService.isAvailable).toHaveBeenCalled();
+    });
+
+    it('testConnection uses the same heartbeat path so it matches getStatus', async () => {
+      mockLogService.getLastSuccessfulChatAt.mockResolvedValue(new Date());
+      mockLlmService.isAvailable.mockResolvedValue(false);
+      const result = await controller.testConnection();
+      expect(result.success).toBe(true);
+      expect(mockLlmService.isAvailable).not.toHaveBeenCalled();
+    });
+  });
 });
 
 // — Adversarial tests —
@@ -121,7 +154,10 @@ describe('AiAdminController (adversarial)', () => {
   let controller: AiAdminController;
   let mockLlmService: { isAvailable: jest.Mock; listModels: jest.Mock };
   let mockRegistry: { resolveActive: jest.Mock };
-  let mockLogService: { getUsageStats: jest.Mock };
+  let mockLogService: {
+    getUsageStats: jest.Mock;
+    getLastSuccessfulChatAt: jest.Mock;
+  };
   let mockSettings: { get: jest.Mock };
 
   beforeEach(async () => {
@@ -138,6 +174,7 @@ describe('AiAdminController (adversarial)', () => {
         errorRate: 0,
         byFeature: [],
       }),
+      getLastSuccessfulChatAt: jest.fn().mockResolvedValue(null),
     };
     mockSettings = { get: jest.fn().mockResolvedValue(null) };
 
@@ -237,6 +274,20 @@ describe('AiAdminController (adversarial)', () => {
     });
 
     it('includes latency in the success message when available', async () => {
+      mockRegistry.resolveActive.mockResolvedValue({
+        provider: {
+          key: 'ollama',
+          displayName: 'Ollama (Local)',
+          requiresApiKey: false,
+          selfHosted: true,
+          defaultModel: 'mock-model',
+          isAvailable: jest.fn().mockResolvedValue(true),
+          listModels: jest.fn(),
+          chat: jest.fn(),
+          generate: jest.fn(),
+        },
+        source: 'setting',
+      });
       mockLlmService.isAvailable.mockResolvedValue(true);
       const result = await controller.testConnection();
       expect(result.message).toContain('ms');
@@ -273,7 +324,10 @@ describe('ROK-1000: testChat timeout and diagnostics', () => {
     chat: jest.Mock;
   };
   let mockRegistry: { resolveActive: jest.Mock };
-  let mockLogService: { getUsageStats: jest.Mock };
+  let mockLogService: {
+    getUsageStats: jest.Mock;
+    getLastSuccessfulChatAt: jest.Mock;
+  };
   let mockSettings: { get: jest.Mock };
 
   beforeEach(async () => {
@@ -309,6 +363,7 @@ describe('ROK-1000: testChat timeout and diagnostics', () => {
         errorRate: 0,
         byFeature: [],
       }),
+      getLastSuccessfulChatAt: jest.fn().mockResolvedValue(null),
     };
     mockSettings = { get: jest.fn().mockResolvedValue('llama3.2:3b') };
 
@@ -407,7 +462,10 @@ describe('ROK-1019: model resolution per provider', () => {
     chat: jest.Mock;
   };
   let mockRegistry: { resolveActive: jest.Mock };
-  let mockLogService: { getUsageStats: jest.Mock };
+  let mockLogService: {
+    getUsageStats: jest.Mock;
+    getLastSuccessfulChatAt: jest.Mock;
+  };
   let mockSettings: { get: jest.Mock };
 
   function createCloudProvider(key: string, name: string): LlmProvider {
@@ -447,6 +505,7 @@ describe('ROK-1019: model resolution per provider', () => {
         errorRate: 0,
         byFeature: [],
       }),
+      getLastSuccessfulChatAt: jest.fn().mockResolvedValue(null),
     };
     // Simulate a stale Ollama model in the global ai_model setting
     mockSettings = { get: jest.fn().mockResolvedValue('llama3.2:3b') };

--- a/api/src/ai/ai-admin.controller.ts
+++ b/api/src/ai/ai-admin.controller.ts
@@ -20,7 +20,11 @@ import { LlmProviderRegistry } from './llm-provider-registry';
 import { AiRequestLogService } from './ai-request-log.service';
 import { SettingsService } from '../settings/settings.service';
 import { AI_DEFAULTS, AI_SETTING_KEYS, CLOUD_DEFAULTS } from './llm.constants';
-import { buildStatusResponse, buildUsageResponse } from './ai-admin.helpers';
+import {
+  buildStatusResponse,
+  buildUsageResponse,
+  deriveAvailability,
+} from './ai-admin.helpers';
 import type {
   AiStatusDto,
   AiTestConnectionDto,
@@ -50,10 +54,7 @@ export class AiAdminController {
   async getStatus(): Promise<AiStatusDto> {
     const resolution = await this.registry.resolveActive();
     const provider = resolution?.provider;
-    const isAvailable = await this.withTimeout(
-      this.llmService.isAvailable(),
-      false,
-    );
+    const isAvailable = await this.resolveAvailability(provider?.key ?? null);
     const modelSetting = await this.settings.get(
       AI_SETTING_KEYS.MODEL as SettingKey,
     );
@@ -76,9 +77,9 @@ export class AiAdminController {
   @Post('test-connection')
   async testConnection(): Promise<AiTestConnectionDto> {
     const start = Date.now();
-    const available = await this.withTimeout(
-      this.llmService.isAvailable(),
-      false,
+    const resolution = await this.registry.resolveActive();
+    const available = await this.resolveAvailability(
+      resolution?.provider?.key ?? null,
     );
     const latencyMs = Date.now() - start;
     return {
@@ -108,6 +109,26 @@ export class AiAdminController {
       return CLOUD_DEFAULTS[providerKey as keyof typeof CLOUD_DEFAULTS];
     }
     return modelSetting ?? AI_DEFAULTS.model;
+  }
+
+  /**
+   * Heartbeat-first availability check (ROK-1138). If a successful chat ran
+   * within `AI_DEFAULTS.availabilityFreshnessMs` we skip the live probe;
+   * otherwise fall back to the existing timeout-wrapped probe.
+   */
+  private async resolveAvailability(
+    providerKey: string | null,
+  ): Promise<boolean> {
+    const lastSuccessAt = providerKey
+      ? await this.logService.getLastSuccessfulChatAt(providerKey)
+      : null;
+    return deriveAvailability({
+      providerKey,
+      lastSuccessAt,
+      probe: () => this.withTimeout(this.llmService.isAvailable(), false),
+      now: new Date(),
+      freshnessMs: AI_DEFAULTS.availabilityFreshnessMs,
+    });
   }
 
   /** Race a promise against a 3s timeout, returning fallback on timeout/error. */

--- a/api/src/ai/ai-admin.helpers.spec.ts
+++ b/api/src/ai/ai-admin.helpers.spec.ts
@@ -1,4 +1,8 @@
-import { buildStatusResponse, buildUsageResponse } from './ai-admin.helpers';
+import {
+  buildStatusResponse,
+  buildUsageResponse,
+  deriveAvailability,
+} from './ai-admin.helpers';
 import type { LlmProvider } from './llm-provider.interface';
 
 describe('ai-admin.helpers', () => {
@@ -168,5 +172,101 @@ describe('ai-admin.helpers (adversarial)', () => {
       // Math.round(0.123456789 * 10000) / 10000 = 0.1235
       expect(result.errorRate).toBe(0.1235);
     });
+  });
+});
+
+describe('deriveAvailability', () => {
+  const FRESHNESS_MS = 5 * 60 * 1000;
+  const NOW = new Date('2026-04-27T12:00:00.000Z');
+
+  it('returns false immediately when providerKey is null and does not call probe', async () => {
+    const probe = jest.fn<Promise<boolean>, []>().mockRejectedValue(new Error('probe should not run'));
+    const result = await deriveAvailability({
+      providerKey: null,
+      lastSuccessAt: new Date(NOW.getTime() - 1000),
+      probe,
+      now: NOW,
+      freshnessMs: FRESHNESS_MS,
+    });
+    expect(result).toBe(false);
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it('returns true without calling probe when lastSuccessAt is within freshness window', async () => {
+    const probe = jest.fn<Promise<boolean>, []>().mockRejectedValue(new Error('probe should not run'));
+    const result = await deriveAvailability({
+      providerKey: 'claude',
+      lastSuccessAt: new Date(NOW.getTime() - 30_000), // 30s ago
+      probe,
+      now: NOW,
+      freshnessMs: FRESHNESS_MS,
+    });
+    expect(result).toBe(true);
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it('treats lastSuccessAt exactly freshnessMs old as still fresh (boundary)', async () => {
+    const probe = jest.fn<Promise<boolean>, []>().mockRejectedValue(new Error('probe should not run'));
+    const result = await deriveAvailability({
+      providerKey: 'claude',
+      lastSuccessAt: new Date(NOW.getTime() - FRESHNESS_MS),
+      probe,
+      now: NOW,
+      freshnessMs: FRESHNESS_MS,
+    });
+    expect(result).toBe(true);
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it('falls through to probe and returns true when probe resolves true and lastSuccessAt is stale', async () => {
+    const probe = jest.fn<Promise<boolean>, []>().mockResolvedValue(true);
+    const result = await deriveAvailability({
+      providerKey: 'claude',
+      lastSuccessAt: new Date(NOW.getTime() - (FRESHNESS_MS + 1)), // just past window
+      probe,
+      now: NOW,
+      freshnessMs: FRESHNESS_MS,
+    });
+    expect(result).toBe(true);
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls through to probe and returns false when probe resolves false and lastSuccessAt is stale', async () => {
+    const probe = jest.fn<Promise<boolean>, []>().mockResolvedValue(false);
+    const result = await deriveAvailability({
+      providerKey: 'claude',
+      lastSuccessAt: new Date(NOW.getTime() - 10 * 60 * 1000), // 10 min ago
+      probe,
+      now: NOW,
+      freshnessMs: FRESHNESS_MS,
+    });
+    expect(result).toBe(false);
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls through to probe when lastSuccessAt is null', async () => {
+    const probe = jest.fn<Promise<boolean>, []>().mockResolvedValue(true);
+    const result = await deriveAvailability({
+      providerKey: 'claude',
+      lastSuccessAt: null,
+      probe,
+      now: NOW,
+      freshnessMs: FRESHNESS_MS,
+    });
+    expect(result).toBe(true);
+    expect(probe).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns false when probe throws (swallows rejection)', async () => {
+    const probe = jest.fn<Promise<boolean>, []>().mockRejectedValue(new Error('boom'));
+    const result = await deriveAvailability({
+      providerKey: 'claude',
+      lastSuccessAt: null,
+      probe,
+      now: NOW,
+      freshnessMs: FRESHNESS_MS,
+    });
+    expect(result).toBe(false);
+    expect(probe).toHaveBeenCalledTimes(1);
   });
 });

--- a/api/src/ai/ai-admin.helpers.spec.ts
+++ b/api/src/ai/ai-admin.helpers.spec.ts
@@ -180,7 +180,9 @@ describe('deriveAvailability', () => {
   const NOW = new Date('2026-04-27T12:00:00.000Z');
 
   it('returns false immediately when providerKey is null and does not call probe', async () => {
-    const probe = jest.fn<Promise<boolean>, []>().mockRejectedValue(new Error('probe should not run'));
+    const probe = jest
+      .fn<Promise<boolean>, []>()
+      .mockRejectedValue(new Error('probe should not run'));
     const result = await deriveAvailability({
       providerKey: null,
       lastSuccessAt: new Date(NOW.getTime() - 1000),
@@ -193,7 +195,9 @@ describe('deriveAvailability', () => {
   });
 
   it('returns true without calling probe when lastSuccessAt is within freshness window', async () => {
-    const probe = jest.fn<Promise<boolean>, []>().mockRejectedValue(new Error('probe should not run'));
+    const probe = jest
+      .fn<Promise<boolean>, []>()
+      .mockRejectedValue(new Error('probe should not run'));
     const result = await deriveAvailability({
       providerKey: 'claude',
       lastSuccessAt: new Date(NOW.getTime() - 30_000), // 30s ago
@@ -206,7 +210,9 @@ describe('deriveAvailability', () => {
   });
 
   it('treats lastSuccessAt exactly freshnessMs old as still fresh (boundary)', async () => {
-    const probe = jest.fn<Promise<boolean>, []>().mockRejectedValue(new Error('probe should not run'));
+    const probe = jest
+      .fn<Promise<boolean>, []>()
+      .mockRejectedValue(new Error('probe should not run'));
     const result = await deriveAvailability({
       providerKey: 'claude',
       lastSuccessAt: new Date(NOW.getTime() - FRESHNESS_MS),
@@ -258,7 +264,9 @@ describe('deriveAvailability', () => {
   });
 
   it('returns false when probe throws (swallows rejection)', async () => {
-    const probe = jest.fn<Promise<boolean>, []>().mockRejectedValue(new Error('boom'));
+    const probe = jest
+      .fn<Promise<boolean>, []>()
+      .mockRejectedValue(new Error('boom'));
     const result = await deriveAvailability({
       providerKey: 'claude',
       lastSuccessAt: null,

--- a/api/src/ai/ai-admin.helpers.ts
+++ b/api/src/ai/ai-admin.helpers.ts
@@ -20,6 +20,34 @@ export function buildStatusResponse(
   };
 }
 
+/**
+ * Derive whether an AI provider is available.
+ *
+ * Heartbeat-first: if a successful chat ran within the freshness window we
+ * skip the live probe (cheaper, and avoids probe/chat divergence — see
+ * ROK-1138). Otherwise fall through to the caller-supplied probe.
+ */
+export async function deriveAvailability(opts: {
+  providerKey: string | null;
+  lastSuccessAt: Date | null;
+  probe: () => Promise<boolean>;
+  now: Date;
+  freshnessMs: number;
+}): Promise<boolean> {
+  if (opts.providerKey === null) return false;
+  if (
+    opts.lastSuccessAt !== null &&
+    opts.now.getTime() - opts.lastSuccessAt.getTime() <= opts.freshnessMs
+  ) {
+    return true;
+  }
+  try {
+    return await opts.probe();
+  } catch {
+    return false;
+  }
+}
+
 /** Build the AI usage response DTO from raw stats. */
 export function buildUsageResponse(stats: AiUsageStats): AiUsageDto {
   return {

--- a/api/src/ai/ai-providers.controller.spec.ts
+++ b/api/src/ai/ai-providers.controller.spec.ts
@@ -9,6 +9,7 @@ import { OllamaDockerService } from './providers/ollama-docker.service';
 import { OllamaModelService } from './providers/ollama-model.service';
 import { OllamaSetupService } from './providers/ollama-setup.service';
 import { OllamaNativeService } from './providers/ollama-native.service';
+import { AiRequestLogService } from './ai-request-log.service';
 import type { LlmProvider } from './llm-provider.interface';
 
 function createMockProvider(overrides: Partial<LlmProvider> = {}): LlmProvider {
@@ -49,6 +50,7 @@ describe('AiProvidersController', () => {
     getSetupState: jest.Mock;
     startSetup: jest.Mock;
   };
+  let mockLogService: { getLastSuccessfulChatAt: jest.Mock };
 
   beforeEach(async () => {
     mockRegistry = {
@@ -83,6 +85,9 @@ describe('AiProvidersController', () => {
         success: true,
       }),
     };
+    mockLogService = {
+      getLastSuccessfulChatAt: jest.fn().mockResolvedValue(null),
+    };
 
     const module = await Test.createTestingModule({
       controllers: [AiProvidersController],
@@ -93,6 +98,7 @@ describe('AiProvidersController', () => {
         { provide: OllamaNativeService, useValue: mockNative },
         { provide: OllamaModelService, useValue: {} },
         { provide: OllamaSetupService, useValue: mockSetupService },
+        { provide: AiRequestLogService, useValue: mockLogService },
         { provide: PluginRegistryService, useValue: { isActive: jest.fn() } },
         { provide: Reflector, useValue: new Reflector() },
       ],
@@ -340,6 +346,92 @@ describe('AiProvidersController', () => {
       const result = await controller.stopOllama();
 
       expect(result).toEqual({ success: true });
+    });
+  });
+
+  describe('ROK-1138: heartbeat-derived availability for active provider', () => {
+    it('marks active provider available when heartbeat is recent and skips probe', async () => {
+      const probe = jest.fn().mockResolvedValue(false);
+      const provider = createMockProvider({
+        key: 'claude',
+        displayName: 'Claude',
+        requiresApiKey: true,
+        selfHosted: false,
+        isAvailable: probe,
+      });
+      mockRegistry.list.mockReturnValue([provider]);
+      mockSettings.get.mockImplementation((key: string) => {
+        if (key === 'ai_provider') return Promise.resolve('claude');
+        if (key === 'ai_claude_api_key') return Promise.resolve('sk-test');
+        return Promise.resolve(null);
+      });
+      mockLogService.getLastSuccessfulChatAt.mockResolvedValue(new Date());
+
+      const result = await controller.listProviders();
+      const claude = result.find((p) => p.key === 'claude');
+
+      expect(claude!.available).toBe(true);
+      expect(claude!.active).toBe(true);
+      expect(probe).not.toHaveBeenCalled();
+    });
+
+    it('falls through to probe when active provider has no recent heartbeat', async () => {
+      const probe = jest.fn().mockResolvedValue(true);
+      const provider = createMockProvider({
+        key: 'claude',
+        displayName: 'Claude',
+        requiresApiKey: true,
+        selfHosted: false,
+        isAvailable: probe,
+      });
+      mockRegistry.list.mockReturnValue([provider]);
+      mockSettings.get.mockImplementation((key: string) => {
+        if (key === 'ai_provider') return Promise.resolve('claude');
+        if (key === 'ai_claude_api_key') return Promise.resolve('sk-test');
+        return Promise.resolve(null);
+      });
+      mockLogService.getLastSuccessfulChatAt.mockResolvedValue(null);
+
+      const result = await controller.listProviders();
+      const claude = result.find((p) => p.key === 'claude');
+
+      expect(claude!.available).toBe(true);
+      expect(probe).toHaveBeenCalled();
+    });
+
+    it('non-active provider keeps probe-only path (no heartbeat lookup)', async () => {
+      const activeProbe = jest.fn().mockResolvedValue(true);
+      const inactiveProbe = jest.fn().mockResolvedValue(true);
+      const active = createMockProvider({
+        key: 'claude',
+        displayName: 'Claude',
+        requiresApiKey: true,
+        selfHosted: false,
+        isAvailable: activeProbe,
+      });
+      const inactive = createMockProvider({
+        key: 'openai',
+        displayName: 'OpenAI',
+        requiresApiKey: true,
+        selfHosted: false,
+        isAvailable: inactiveProbe,
+      });
+      mockRegistry.list.mockReturnValue([active, inactive]);
+      mockSettings.get.mockImplementation((key: string) => {
+        if (key === 'ai_provider') return Promise.resolve('claude');
+        if (key === 'ai_claude_api_key') return Promise.resolve('sk-test');
+        if (key === 'ai_openai_api_key') return Promise.resolve('sk-other');
+        return Promise.resolve(null);
+      });
+      mockLogService.getLastSuccessfulChatAt.mockResolvedValue(null);
+
+      await controller.listProviders();
+
+      expect(mockLogService.getLastSuccessfulChatAt).toHaveBeenCalledTimes(1);
+      expect(mockLogService.getLastSuccessfulChatAt).toHaveBeenCalledWith(
+        'claude',
+      );
+      expect(inactiveProbe).toHaveBeenCalled();
     });
   });
 });

--- a/api/src/ai/ai-providers.controller.ts
+++ b/api/src/ai/ai-providers.controller.ts
@@ -156,7 +156,9 @@ export class AiProvidersController {
     let probeResult: { available: boolean; error?: string } | null = null;
     const available = await deriveAvailability({
       providerKey: provider.key,
-      lastSuccessAt: await this.logService.getLastSuccessfulChatAt(provider.key),
+      lastSuccessAt: await this.logService.getLastSuccessfulChatAt(
+        provider.key,
+      ),
       probe: async () => {
         probeResult = await this.checkAvailableWithError(provider);
         return probeResult.available;

--- a/api/src/ai/ai-providers.controller.ts
+++ b/api/src/ai/ai-providers.controller.ts
@@ -19,13 +19,15 @@ import { SettingsService } from '../settings/settings.service';
 import { OllamaDockerService } from './providers/ollama-docker.service';
 import { OllamaNativeService } from './providers/ollama-native.service';
 import { OllamaSetupService } from './providers/ollama-setup.service';
-import { AI_SETTING_KEYS } from './llm.constants';
+import { AiRequestLogService } from './ai-request-log.service';
+import { AI_DEFAULTS, AI_SETTING_KEYS } from './llm.constants';
 import type {
   AiProviderInfoDto,
   AiOllamaSetupDto,
   AiProviderConfigDto,
 } from '@raid-ledger/contract';
 import { getApiKeySettingKey, buildProviderInfo } from './ai-providers.helpers';
+import { deriveAvailability } from './ai-admin.helpers';
 import type { SettingKey } from '../drizzle/schema';
 
 /**
@@ -43,6 +45,7 @@ export class AiProvidersController {
     private readonly docker: OllamaDockerService,
     private readonly native: OllamaNativeService,
     private readonly ollamaSetup: OllamaSetupService,
+    private readonly logService: AiRequestLogService,
   ) {}
 
   /** GET /admin/ai/providers — List all providers with status. */
@@ -124,7 +127,7 @@ export class AiProvidersController {
   ): Promise<AiProviderInfoDto> {
     const configured = await this.isConfigured(provider);
     const { available, error } = configured
-      ? await this.checkAvailableWithError(provider)
+      ? await this.resolveAvailability(provider, provider.key === activeKey)
       : { available: false, error: undefined };
     const info = buildProviderInfo(
       provider as never,
@@ -137,6 +140,32 @@ export class AiProvidersController {
       await this.enrichOllamaInfo(info);
     }
     return info;
+  }
+
+  /**
+   * Active provider: heartbeat-first availability (ROK-1138). If a recent
+   * successful chat is logged we skip the live probe (and there is no error
+   * to surface). Otherwise — and for non-active providers — fall back to the
+   * existing probe path so error messaging stays intact.
+   */
+  private async resolveAvailability(
+    provider: { key: string; isAvailable: () => Promise<boolean> },
+    isActive: boolean,
+  ): Promise<{ available: boolean; error?: string }> {
+    if (!isActive) return this.checkAvailableWithError(provider);
+    let probeResult: { available: boolean; error?: string } | null = null;
+    const available = await deriveAvailability({
+      providerKey: provider.key,
+      lastSuccessAt: await this.logService.getLastSuccessfulChatAt(provider.key),
+      probe: async () => {
+        probeResult = await this.checkAvailableWithError(provider);
+        return probeResult.available;
+      },
+      now: new Date(),
+      freshnessMs: AI_DEFAULTS.availabilityFreshnessMs,
+    });
+    if (probeResult) return probeResult;
+    return { available };
   }
 
   /** Add Ollama-specific setup state from DB to provider info. */

--- a/api/src/ai/ai-request-log.service.spec.ts
+++ b/api/src/ai/ai-request-log.service.spec.ts
@@ -185,4 +185,25 @@ describe('AiRequestLogService (adversarial)', () => {
       expect(stats.errorRate).toBe(0);
     });
   });
+
+  describe('getLastSuccessfulChatAt', () => {
+    it('returns null when no rows exist for the provider', async () => {
+      mockDb.where.mockResolvedValueOnce([{ lastAt: null }]);
+      const result = await service.getLastSuccessfulChatAt('claude');
+      expect(result).toBeNull();
+    });
+
+    it('returns null when no row is returned at all', async () => {
+      mockDb.where.mockResolvedValueOnce([]);
+      const result = await service.getLastSuccessfulChatAt('claude');
+      expect(result).toBeNull();
+    });
+
+    it('returns the latest createdAt when successful entries exist', async () => {
+      const latest = new Date('2026-04-27T11:55:00.000Z');
+      mockDb.where.mockResolvedValueOnce([{ lastAt: latest }]);
+      const result = await service.getLastSuccessfulChatAt('claude');
+      expect(result).toEqual(latest);
+    });
+  });
 });

--- a/api/src/ai/ai-request-log.service.ts
+++ b/api/src/ai/ai-request-log.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Inject } from '@nestjs/common';
-import { sql, gte } from 'drizzle-orm';
+import { sql, gte, and, eq } from 'drizzle-orm';
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import * as schema from '../drizzle/schema';
 import { aiRequestLogs } from '../drizzle/schema';
@@ -50,6 +50,24 @@ export class AiRequestLogService {
       success: entry.success,
       errorMessage: entry.errorMessage ?? null,
     });
+  }
+
+  /**
+   * Returns the timestamp of the most recent successful chat for a given
+   * provider, or `null` if no successful entry exists. Used to derive
+   * availability from a recent heartbeat (ROK-1138).
+   */
+  async getLastSuccessfulChatAt(providerKey: string): Promise<Date | null> {
+    const [row] = await this.db
+      .select({ lastAt: sql<Date | null>`max(${aiRequestLogs.createdAt})` })
+      .from(aiRequestLogs)
+      .where(
+        and(
+          eq(aiRequestLogs.provider, providerKey),
+          eq(aiRequestLogs.success, true),
+        ),
+      );
+    return row?.lastAt ?? null;
   }
 
   /** Get aggregated usage stats since a given date. */

--- a/api/src/ai/llm.constants.ts
+++ b/api/src/ai/llm.constants.ts
@@ -16,6 +16,7 @@ export const AI_DEFAULTS = {
   rateLimitPerMinute: 20,
   circuitBreakerThreshold: 5,
   circuitBreakerCooldownMs: 60_000,
+  availabilityFreshnessMs: 5 * 60 * 1000,
 } as const;
 
 /** System prompt prepended to all LLM requests as a guardrail. */


### PR DESCRIPTION
## Summary
- Replace live HTTP probe with **heartbeat from `aiRequestLogs`** (5-min window) for the AI Features card header and per-provider Active indicator. Probe stays as a fallback when no recent successful chat exists.
- Pure `deriveAvailability` helper unit-tested with 7 cases (boundary, null providerKey, fresh/stale heartbeat, probe-throws). Added `getLastSuccessfulChatAt(providerKey)` to `AiRequestLogService`.
- Both `getStatus()` and `buildInfo()` (active branch) now share the same derivation, so the card header always matches the per-provider indicator.

## Why
The probe (`provider.isAvailable()` → `fetchClaude(.../v1/messages, max_tokens: 1)`) wraps in a 2–3 s `Promise.race` timeout and exercises a different code path than real chat (1-token shape, no retries, different rate-limit treatment). Operator hit this on Apr 26 2026 during ROK-1114 testing — Claude was actively serving chat traffic but the card header rendered "Offline" because the probe timed out. Heartbeat from the request log reflects what the user actually perceives: "the provider is serving chat right now."

## Linear
ROK-1138

## Files
- `api/src/ai/ai-admin.helpers.ts` — `deriveAvailability` pure helper
- `api/src/ai/ai-admin.controller.ts` — `getStatus` + `testConnection` use heartbeat
- `api/src/ai/ai-providers.controller.ts` — active provider uses heartbeat; non-active keeps probe-with-error path
- `api/src/ai/ai-request-log.service.ts` — `getLastSuccessfulChatAt`
- `api/src/ai/llm.constants.ts` — `availabilityFreshnessMs: 5 * 60 * 1000`
- spec files updated for new injections + heartbeat branches

## Test plan
- [x] 7 unit tests for `deriveAvailability` (TDD-first, pinned `<=` boundary)
- [x] 3 unit tests for `getLastSuccessfulChatAt` (empty rows, null aggregate, latest timestamp)
- [x] 6 controller tests covering heartbeat hit/miss + non-active providers
- [x] api unit tests: 415 suites / 5646 tests
- [x] api integration tests: 67 suites / 796 tests (clean run on Lead's box)
- [x] web build + tests: 248 suites / 3002 tests
- [x] Operator tested locally — confirmed header + per-provider indicator agree
- [x] Code review: APPROVED, 0 auto-fixes, 3 low-severity tech debt items tracked separately

## Out of scope
- No contract change, no migration, no UI logic change (only the boolean flowing in).
- Per-provider probe internals unchanged (probe stays as a fallback).
- \`IntegrationCard.isConfigured\` prop name (cosmetic, used widely — separate cleanup).