### PR TITLE
ROK-1118: fix: lineup auto-advance + live UI refresh

### DIFF
--- a/api/src/drizzle/schema/app-settings.ts
+++ b/api/src/drizzle/schema/app-settings.ts
@@ -106,6 +106,8 @@ export const SETTING_KEYS = {
   AI_OLLAMA_SETUP_ERROR: 'ai_ollama_setup_error',
   /** ROK-932: Dedicated Discord channel for Community Lineup embeds */
   DISCORD_BOT_LINEUP_CHANNEL: 'discord_bot_lineup_channel',
+  /** ROK-1118: Minimum distinct nominations required for building→voting auto-advance. */
+  LINEUP_AUTO_ADVANCE_MIN_NOMINATIONS: 'lineup_auto_advance_min_nominations',
   /** ROK-946: Default hours for lineup building phase */
   LINEUP_DEFAULT_BUILDING_HOURS: 'lineup_default_building_hours',
   /** ROK-946: Default hours for lineup voting phase */

--- a/api/src/drizzle/schema/app-settings.ts
+++ b/api/src/drizzle/schema/app-settings.ts
@@ -108,6 +108,9 @@ export const SETTING_KEYS = {
   DISCORD_BOT_LINEUP_CHANNEL: 'discord_bot_lineup_channel',
   /** ROK-1118: Minimum distinct nominations required for building→voting auto-advance. */
   LINEUP_AUTO_ADVANCE_MIN_NOMINATIONS: 'lineup_auto_advance_min_nominations',
+  /** ROK-1118: Minimum nominations per voter required for building→voting auto-advance. */
+  LINEUP_AUTO_ADVANCE_MIN_NOMINATIONS_PER_VOTER:
+    'lineup_auto_advance_min_nominations_per_voter',
   /** ROK-946: Default hours for lineup building phase */
   LINEUP_DEFAULT_BUILDING_HOURS: 'lineup_default_building_hours',
   /** ROK-946: Default hours for lineup voting phase */

--- a/api/src/lineups/lineups-actions.helpers.ts
+++ b/api/src/lineups/lineups-actions.helpers.ts
@@ -38,7 +38,14 @@ import { carryOverFromLastDecided } from './lineups-carryover.helpers';
 import {
   fireLineupCreated,
   fireNominationMilestone,
+  fireNominationRemoved,
 } from './lineups-notify-hooks.helpers';
+import {
+  findEntry,
+  validateRemoval,
+  deleteEntry,
+} from './lineups-removal.helpers';
+import type { CallerIdentity } from './lineups.service';
 
 type Db = PostgresJsDatabase<typeof schema>;
 type ResolveChannelName = (channelId: string) => string | null;
@@ -149,6 +156,48 @@ export interface NominateDeps {
   lineupNotifications: LineupNotificationService;
   logger: Logger;
   resolveChannelName: ResolveChannelName;
+}
+
+export interface RemoveNominationDeps {
+  db: Db;
+  activityLog: ActivityLogService;
+  lineupNotifications: LineupNotificationService;
+  logger: Logger;
+}
+
+/** Remove a nomination during the building phase. */
+export async function runRemoveNomination(
+  deps: RemoveNominationDeps,
+  lineupId: number,
+  gameId: number,
+  caller: CallerIdentity,
+): Promise<void> {
+  const [lineup] = await findLineupById(deps.db, lineupId);
+  if (!lineup) throw new NotFoundException('Lineup not found');
+  if (lineup.status !== 'building') {
+    throw new BadRequestException('Can only remove during building');
+  }
+
+  const entry = await findEntry(deps.db, lineupId, gameId);
+  validateRemoval(entry, caller);
+  await deleteEntry(deps.db, lineupId, gameId);
+  await deps.activityLog.log(
+    'lineup',
+    lineupId,
+    'nomination_removed',
+    caller.id,
+    { gameId },
+  );
+
+  fireNominationRemoved(
+    deps.lineupNotifications,
+    deps.logger,
+    deps.db,
+    lineupId,
+    gameId,
+    entry,
+    caller,
+  );
 }
 
 /** Nominate a game into a lineup. */

--- a/api/src/lineups/lineups-auto-advance.helpers.ts
+++ b/api/src/lineups/lineups-auto-advance.helpers.ts
@@ -1,0 +1,63 @@
+/**
+ * Auto-advance orchestration for lineup status (ROK-1118).
+ *
+ * Called fire-and-forget after every nominate / vote / unnominate. Loads
+ * the lineup, routes to the building or voting quorum check, and (when
+ * ready) calls `runStatusTransition` to flip the status. Errors are
+ * caught and logged — the caller's mutation must never fail because the
+ * advance attempt failed.
+ */
+import type { Logger } from '@nestjs/common';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from '../drizzle/schema';
+import type { LineupStatus } from '../drizzle/schema';
+import type { ActivityLogService } from '../activity-log/activity-log.service';
+import type { SettingsService } from '../settings/settings.service';
+import type { LineupPhaseQueueService } from './queue/lineup-phase.queue';
+import type { LineupNotificationService } from './lineup-notification.service';
+import { findLineupById } from './lineups-query.helpers';
+import { runStatusTransition } from './lineups-transition.helpers';
+import {
+  checkBuildingQuorum,
+  checkVotingQuorum,
+} from './quorum/quorum-check.helpers';
+
+type Db = PostgresJsDatabase<typeof schema>;
+
+export interface AutoAdvanceDeps {
+  db: Db;
+  activityLog: ActivityLogService;
+  settings: SettingsService;
+  phaseQueue: LineupPhaseQueueService;
+  lineupNotifications: LineupNotificationService;
+  logger: Logger;
+}
+
+const NEXT_STATUS: Partial<Record<LineupStatus, LineupStatus>> = {
+  building: 'voting',
+  voting: 'decided',
+};
+
+/** Try to auto-advance a lineup to its next phase if quorum is met. */
+export async function maybeAutoAdvance(
+  deps: AutoAdvanceDeps,
+  lineupId: number,
+): Promise<void> {
+  try {
+    const [lineup] = await findLineupById(deps.db, lineupId);
+    if (!lineup) return;
+    const nextStatus = NEXT_STATUS[lineup.status as LineupStatus];
+    if (!nextStatus) return;
+
+    const result =
+      lineup.status === 'building'
+        ? await checkBuildingQuorum(deps.db, deps.settings, lineup)
+        : await checkVotingQuorum(deps.db, lineup);
+    if (!result.ready) return;
+
+    await runStatusTransition(deps, lineupId, { status: nextStatus });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    deps.logger.warn(`maybeAutoAdvance(${lineupId}) skipped: ${msg}`);
+  }
+}

--- a/api/src/lineups/lineups-auto-advance.helpers.ts
+++ b/api/src/lineups/lineups-auto-advance.helpers.ts
@@ -21,6 +21,7 @@ import {
   checkBuildingQuorum,
   checkVotingQuorum,
 } from './quorum/quorum-check.helpers';
+import type { LineupsGateway } from './lineups.gateway';
 
 type Db = PostgresJsDatabase<typeof schema>;
 
@@ -30,6 +31,7 @@ export interface AutoAdvanceDeps {
   settings: SettingsService;
   phaseQueue: LineupPhaseQueueService;
   lineupNotifications: LineupNotificationService;
+  lineupsGateway: LineupsGateway;
   logger: Logger;
 }
 

--- a/api/src/lineups/lineups-auto-advance.integration.spec.ts
+++ b/api/src/lineups/lineups-auto-advance.integration.spec.ts
@@ -152,19 +152,20 @@ function describeAutoAdvance() {
     expect(adv.status).toBe(200);
     expect(await readStatus(lineupId)).toBe('voting');
 
-    // First vote — creator. Status should remain 'voting'.
+    // All three voters back the same game so the auto-advance landing
+    // state has a clear winner — `guardTiebreakerOnTransition` would
+    // otherwise block the transition (spec: ROK-1118, edge case "tie").
     const v1 = await vote(adminToken, lineupId, games[0].id);
     expect(v1.status).toBe(200);
     expect(await readStatus(lineupId)).toBe('voting');
 
-    // Second vote — invitee1. Still missing invitee2.
-    const v2 = await vote(invitee1.token, lineupId, games[1].id);
+    const v2 = await vote(invitee1.token, lineupId, games[0].id);
     expect(v2.status).toBe(200);
     expect(await readStatus(lineupId)).toBe('voting');
 
     // Third (final) vote — invitee2 closes the quorum.
     // After this call the auto-advance hook should fire.
-    const v3 = await vote(invitee2.token, lineupId, games[2].id);
+    const v3 = await vote(invitee2.token, lineupId, games[0].id);
     expect(v3.status).toBe(200);
 
     // Status should now be 'decided' WITHOUT any explicit PATCH /status call.

--- a/api/src/lineups/lineups-auto-advance.integration.spec.ts
+++ b/api/src/lineups/lineups-auto-advance.integration.spec.ts
@@ -129,8 +129,9 @@ function describeAutoAdvance() {
 
   // -- AC: voting → decided auto-advance for a private lineup ---------------
 
-  it('flips a private lineup from voting → decided when all invitees + creator vote', async () => {
+  it('flips a private lineup from voting → decided when all voters use their full vote allotment', async () => {
     // Two invitees + the admin creator = 3 expected voters.
+    // Default lineup.maxVotesPerPlayer = 3, so each must cast 3 votes.
     const invitee1 = await createMember('priv-voter-1');
     const invitee2 = await createMember('priv-voter-2');
 
@@ -141,40 +142,49 @@ function describeAutoAdvance() {
     expect(createRes.status).toBe(201);
     const lineupId = createRes.body.id as number;
 
-    // Each invitee nominates a game (so there's something to vote on).
-    const games = await createGames(3);
-    await nominate(invitee1.token, lineupId, games[0].id);
-    await nominate(invitee2.token, lineupId, games[1].id);
-    await nominate(adminToken, lineupId, games[2].id);
+    // Need enough games so each voter can cast 3 distinct votes plus a
+    // shared favorite that wins. Layout: g0 is the shared favorite (3 votes);
+    // each voter also picks 2 personal games. Total games: 1 + 2*3 = 7.
+    const games = await createGames(7);
+    await nominate(adminToken, lineupId, games[0].id);
+    await nominate(invitee1.token, lineupId, games[1].id);
+    await nominate(invitee2.token, lineupId, games[2].id);
+    await nominate(adminToken, lineupId, games[3].id);
+    await nominate(invitee1.token, lineupId, games[4].id);
+    await nominate(invitee2.token, lineupId, games[5].id);
+    await nominate(adminToken, lineupId, games[6].id);
 
-    // Operator advances to voting.
+    // Manually advance to voting (we're testing voting→decided, not
+    // building→voting; default per-voter min nominations = 3 isn't reached).
     const adv = await advanceToVoting(lineupId, adminToken);
     expect(adv.status).toBe(200);
     expect(await readStatus(lineupId)).toBe('voting');
 
-    // All three voters back the same game so the auto-advance landing
-    // state has a clear winner — `guardTiebreakerOnTransition` would
-    // otherwise block the transition (spec: ROK-1118, edge case "tie").
-    const v1 = await vote(adminToken, lineupId, games[0].id);
-    expect(v1.status).toBe(200);
+    // Each voter casts 1/3 votes — quorum NOT met (operator's bug report).
+    await vote(adminToken, lineupId, games[0].id);
+    await vote(invitee1.token, lineupId, games[0].id);
+    await vote(invitee2.token, lineupId, games[0].id);
     expect(await readStatus(lineupId)).toBe('voting');
 
-    const v2 = await vote(invitee1.token, lineupId, games[0].id);
-    expect(v2.status).toBe(200);
+    // Each voter casts 2/3 votes — still not full allotment.
+    await vote(adminToken, lineupId, games[1].id);
+    await vote(invitee1.token, lineupId, games[2].id);
+    await vote(invitee2.token, lineupId, games[3].id);
     expect(await readStatus(lineupId)).toBe('voting');
 
-    // Third (final) vote — invitee2 closes the quorum.
-    // After this call the auto-advance hook should fire.
-    const v3 = await vote(invitee2.token, lineupId, games[0].id);
-    expect(v3.status).toBe(200);
+    // Each voter casts their 3rd (final) vote — quorum closes. The shared
+    // favorite g0 has 3 votes; everything else has 1, so no tie at the top.
+    await vote(adminToken, lineupId, games[4].id);
+    await vote(invitee1.token, lineupId, games[5].id);
+    await vote(invitee2.token, lineupId, games[6].id);
 
-    // Status should now be 'decided' WITHOUT any explicit PATCH /status call.
+    // Status should flip without any explicit PATCH /status call.
     expect(await readStatus(lineupId)).toBe('decided');
   });
 
-  // -- AC: voting → decided does NOT advance with one invitee missing -------
+  // -- AC: voting → decided does NOT advance with partial participation -----
 
-  it('does not advance a private lineup when one invitee has not voted', async () => {
+  it('does not advance a private lineup when one invitee has not voted at all', async () => {
     const invitee1 = await createMember('partial-1');
     const invitee2 = await createMember('partial-2');
 
@@ -193,44 +203,70 @@ function describeAutoAdvance() {
     await advanceToVoting(lineupId, adminToken);
     expect(await readStatus(lineupId)).toBe('voting');
 
-    // Only 2 of the 3 expected voters cast a vote.
-    await vote(adminToken, lineupId, games[0].id);
-    await vote(invitee1.token, lineupId, games[0].id);
+    // Two of three voters use their full allotment of 3.
+    for (let i = 0; i < 3; i++) {
+      await vote(adminToken, lineupId, games[i].id);
+      await vote(invitee1.token, lineupId, games[i].id);
+    }
 
     // invitee2 stays silent → quorum not met → no auto-advance.
     expect(await readStatus(lineupId)).toBe('voting');
   });
 
+  it('does not advance a private lineup when voters have only used part of their allotment', async () => {
+    // Operator's bug report: cast 1 of 3 available votes, room advances.
+    const invitee = await createMember('partial-allotment');
+
+    const createRes = await createPrivateLineup(adminToken, [invitee.userId]);
+    expect(createRes.status).toBe(201);
+    const lineupId = createRes.body.id as number;
+
+    const games = await createGames(3);
+    await nominate(invitee.token, lineupId, games[0].id);
+    await nominate(adminToken, lineupId, games[1].id);
+
+    await advanceToVoting(lineupId, adminToken);
+    expect(await readStatus(lineupId)).toBe('voting');
+
+    // Each voter casts only 1 of their 3 available votes.
+    await vote(adminToken, lineupId, games[0].id);
+    await vote(invitee.token, lineupId, games[0].id);
+
+    // Quorum NOT met — voters still have 2 unused votes each.
+    expect(await readStatus(lineupId)).toBe('voting');
+  });
+
   // -- AC: building → voting auto-advance for a public lineup ---------------
 
-  it('auto-advances a public lineup from building → voting once the floor is met', async () => {
-    // Default floor is 4 distinct nominations. Use 4 distinct nominators so
-    // both AC conditions (every expected nominator has nominated AND total
-    // nominations ≥ floor) line up.
+  it('auto-advances a public lineup from building → voting once each voter hits their per-voter minimum', async () => {
+    // Default per-voter min nominations = 3, default total floor = 4.
+    // With 2 nominators × 3 noms = 6 noms total → both gates pass.
     const m1 = await createMember('pub-nom-1');
     const m2 = await createMember('pub-nom-2');
-    const m3 = await createMember('pub-nom-3');
-    const m4 = await createMember('pub-nom-4');
 
     const createRes = await createPublicLineup(adminToken);
     expect(createRes.status).toBe(201);
     const lineupId = createRes.body.id as number;
     expect(await readStatus(lineupId)).toBe('building');
 
-    const games = await createGames(4);
+    const games = await createGames(6);
 
-    // 3 distinct nominators — below the floor of 4. Status must NOT change.
-    const n1 = await nominate(m1.token, lineupId, games[0].id);
-    expect(n1.status).toBe(201);
-    const n2 = await nominate(m2.token, lineupId, games[1].id);
-    expect(n2.status).toBe(201);
-    const n3 = await nominate(m3.token, lineupId, games[2].id);
-    expect(n3.status).toBe(201);
+    // m1 nominates 2 of 3 → below per-voter min, no advance.
+    await nominate(m1.token, lineupId, games[0].id);
+    await nominate(m1.token, lineupId, games[1].id);
     expect(await readStatus(lineupId)).toBe('building');
 
-    // 4th distinct nominator hits the floor — auto-advance should fire.
-    const n4 = await nominate(m4.token, lineupId, games[3].id);
-    expect(n4.status).toBe(201);
+    // m1 hits 3, but m2 has 0 → still below.
+    await nominate(m1.token, lineupId, games[2].id);
+    expect(await readStatus(lineupId)).toBe('building');
+
+    // m2 hits 2 of 3 → still below per-voter min.
+    await nominate(m2.token, lineupId, games[3].id);
+    await nominate(m2.token, lineupId, games[4].id);
+    expect(await readStatus(lineupId)).toBe('building');
+
+    // m2's 3rd nomination closes the quorum — total = 6, both at min 3.
+    await nominate(m2.token, lineupId, games[5].id);
     expect(await readStatus(lineupId)).toBe('voting');
   });
 

--- a/api/src/lineups/lineups-auto-advance.integration.spec.ts
+++ b/api/src/lineups/lineups-auto-advance.integration.spec.ts
@@ -71,10 +71,7 @@ function describeAutoAdvance() {
       .send({ title: 'Auto Advance Public' });
   }
 
-  async function createPrivateLineup(
-    token: string,
-    inviteeUserIds: number[],
-  ) {
+  async function createPrivateLineup(token: string, inviteeUserIds: number[]) {
     return testApp.request
       .post('/lineups')
       .set('Authorization', `Bearer ${token}`)

--- a/api/src/lineups/lineups-auto-advance.integration.spec.ts
+++ b/api/src/lineups/lineups-auto-advance.integration.spec.ts
@@ -1,0 +1,267 @@
+/**
+ * Lineup auto-advance integration tests (ROK-1118).
+ *
+ * TDD gate: these tests define the behavior of the auto-advance feature.
+ * They MUST fail until the implementation in `maybeAutoAdvance` ships.
+ *
+ * Behaviors covered (one per AC):
+ *
+ *   1. Voting → decided auto-advances for a private lineup once every
+ *      expected voter (creator + invitees) has cast at least one vote.
+ *   2. Voting → decided does NOT advance when one invitee has not yet voted.
+ *   3. Building → voting auto-advances for a public lineup when every
+ *      distinct nominator has nominated and total nominations meet the floor.
+ *   4. Operator manual transition via PATCH /lineups/:id/status still works
+ *      (regression guard against the auto-advance feature breaking the
+ *      existing override path).
+ */
+import { getTestApp, type TestApp } from '../common/testing/test-app';
+import {
+  truncateAllTables,
+  loginAsAdmin,
+} from '../common/testing/integration-helpers';
+import * as schema from '../drizzle/schema';
+import { eq } from 'drizzle-orm';
+
+function describeAutoAdvance() {
+  let testApp: TestApp;
+  let adminToken: string;
+
+  beforeAll(async () => {
+    testApp = await getTestApp();
+    adminToken = await loginAsAdmin(testApp.request, testApp.seed);
+  });
+
+  afterEach(async () => {
+    testApp.seed = await truncateAllTables(testApp.db);
+    adminToken = await loginAsAdmin(testApp.request, testApp.seed);
+  });
+
+  // -- Helpers ---------------------------------------------------------------
+
+  async function createMember(
+    tag: string,
+  ): Promise<{ token: string; userId: number }> {
+    const bcrypt = await import('bcrypt');
+    const hash = await bcrypt.hash('AutoAdvance1!', 4);
+    const [user] = await testApp.db
+      .insert(schema.users)
+      .values({
+        discordId: `local:${tag}@auto.local`,
+        username: tag,
+        role: 'member',
+      })
+      .returning();
+    const email = `${tag}@auto.local`.toLowerCase();
+    await testApp.db.insert(schema.localCredentials).values({
+      email,
+      passwordHash: hash,
+      userId: user.id,
+    });
+    const res = await testApp.request
+      .post('/auth/local')
+      .send({ email, password: 'AutoAdvance1!' });
+    return { token: res.body.access_token as string, userId: user.id };
+  }
+
+  async function createPublicLineup(token: string) {
+    return testApp.request
+      .post('/lineups')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ title: 'Auto Advance Public' });
+  }
+
+  async function createPrivateLineup(
+    token: string,
+    inviteeUserIds: number[],
+  ) {
+    return testApp.request
+      .post('/lineups')
+      .set('Authorization', `Bearer ${token}`)
+      .send({
+        title: 'Auto Advance Private',
+        visibility: 'private',
+        inviteeUserIds,
+      });
+  }
+
+  async function createGames(count: number) {
+    const games: (typeof schema.games.$inferSelect)[] = [];
+    for (let i = 0; i < count; i++) {
+      const [game] = await testApp.db
+        .insert(schema.games)
+        .values({
+          name: `AutoAdvance Game ${i + 1}`,
+          slug: `auto-game-${i + 1}-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`,
+        })
+        .returning();
+      games.push(game);
+    }
+    return games;
+  }
+
+  async function nominate(token: string, lineupId: number, gameId: number) {
+    return testApp.request
+      .post(`/lineups/${lineupId}/nominate`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ gameId });
+  }
+
+  async function vote(token: string, lineupId: number, gameId: number) {
+    return testApp.request
+      .post(`/lineups/${lineupId}/vote`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ gameId });
+  }
+
+  async function advanceToVoting(lineupId: number, token: string) {
+    return testApp.request
+      .patch(`/lineups/${lineupId}/status`)
+      .set('Authorization', `Bearer ${token}`)
+      .send({ status: 'voting' });
+  }
+
+  /** Read the current persisted status from the DB (bypasses cache). */
+  async function readStatus(lineupId: number): Promise<string> {
+    const [row] = await testApp.db
+      .select({ status: schema.communityLineups.status })
+      .from(schema.communityLineups)
+      .where(eq(schema.communityLineups.id, lineupId));
+    return row?.status ?? 'missing';
+  }
+
+  // -- AC: voting → decided auto-advance for a private lineup ---------------
+
+  it('flips a private lineup from voting → decided when all invitees + creator vote', async () => {
+    // Two invitees + the admin creator = 3 expected voters.
+    const invitee1 = await createMember('priv-voter-1');
+    const invitee2 = await createMember('priv-voter-2');
+
+    const createRes = await createPrivateLineup(adminToken, [
+      invitee1.userId,
+      invitee2.userId,
+    ]);
+    expect(createRes.status).toBe(201);
+    const lineupId = createRes.body.id as number;
+
+    // Each invitee nominates a game (so there's something to vote on).
+    const games = await createGames(3);
+    await nominate(invitee1.token, lineupId, games[0].id);
+    await nominate(invitee2.token, lineupId, games[1].id);
+    await nominate(adminToken, lineupId, games[2].id);
+
+    // Operator advances to voting.
+    const adv = await advanceToVoting(lineupId, adminToken);
+    expect(adv.status).toBe(200);
+    expect(await readStatus(lineupId)).toBe('voting');
+
+    // First vote — creator. Status should remain 'voting'.
+    const v1 = await vote(adminToken, lineupId, games[0].id);
+    expect(v1.status).toBe(200);
+    expect(await readStatus(lineupId)).toBe('voting');
+
+    // Second vote — invitee1. Still missing invitee2.
+    const v2 = await vote(invitee1.token, lineupId, games[1].id);
+    expect(v2.status).toBe(200);
+    expect(await readStatus(lineupId)).toBe('voting');
+
+    // Third (final) vote — invitee2 closes the quorum.
+    // After this call the auto-advance hook should fire.
+    const v3 = await vote(invitee2.token, lineupId, games[2].id);
+    expect(v3.status).toBe(200);
+
+    // Status should now be 'decided' WITHOUT any explicit PATCH /status call.
+    expect(await readStatus(lineupId)).toBe('decided');
+  });
+
+  // -- AC: voting → decided does NOT advance with one invitee missing -------
+
+  it('does not advance a private lineup when one invitee has not voted', async () => {
+    const invitee1 = await createMember('partial-1');
+    const invitee2 = await createMember('partial-2');
+
+    const createRes = await createPrivateLineup(adminToken, [
+      invitee1.userId,
+      invitee2.userId,
+    ]);
+    expect(createRes.status).toBe(201);
+    const lineupId = createRes.body.id as number;
+
+    const games = await createGames(3);
+    await nominate(invitee1.token, lineupId, games[0].id);
+    await nominate(invitee2.token, lineupId, games[1].id);
+    await nominate(adminToken, lineupId, games[2].id);
+
+    await advanceToVoting(lineupId, adminToken);
+    expect(await readStatus(lineupId)).toBe('voting');
+
+    // Only 2 of the 3 expected voters cast a vote.
+    await vote(adminToken, lineupId, games[0].id);
+    await vote(invitee1.token, lineupId, games[0].id);
+
+    // invitee2 stays silent → quorum not met → no auto-advance.
+    expect(await readStatus(lineupId)).toBe('voting');
+  });
+
+  // -- AC: building → voting auto-advance for a public lineup ---------------
+
+  it('auto-advances a public lineup from building → voting once the floor is met', async () => {
+    // Default floor is 4 distinct nominations. Use 4 distinct nominators so
+    // both AC conditions (every expected nominator has nominated AND total
+    // nominations ≥ floor) line up.
+    const m1 = await createMember('pub-nom-1');
+    const m2 = await createMember('pub-nom-2');
+    const m3 = await createMember('pub-nom-3');
+    const m4 = await createMember('pub-nom-4');
+
+    const createRes = await createPublicLineup(adminToken);
+    expect(createRes.status).toBe(201);
+    const lineupId = createRes.body.id as number;
+    expect(await readStatus(lineupId)).toBe('building');
+
+    const games = await createGames(4);
+
+    // 3 distinct nominators — below the floor of 4. Status must NOT change.
+    const n1 = await nominate(m1.token, lineupId, games[0].id);
+    expect(n1.status).toBe(201);
+    const n2 = await nominate(m2.token, lineupId, games[1].id);
+    expect(n2.status).toBe(201);
+    const n3 = await nominate(m3.token, lineupId, games[2].id);
+    expect(n3.status).toBe(201);
+    expect(await readStatus(lineupId)).toBe('building');
+
+    // 4th distinct nominator hits the floor — auto-advance should fire.
+    const n4 = await nominate(m4.token, lineupId, games[3].id);
+    expect(n4.status).toBe(201);
+    expect(await readStatus(lineupId)).toBe('voting');
+  });
+
+  // -- AC: operator manual advance still works (regression guard) -----------
+
+  it('still honors a manual PATCH /lineups/:id/status from an operator', async () => {
+    const invitee = await createMember('manual-1');
+    const createRes = await createPrivateLineup(adminToken, [invitee.userId]);
+    expect(createRes.status).toBe(201);
+    const lineupId = createRes.body.id as number;
+
+    const games = await createGames(1);
+    await nominate(invitee.token, lineupId, games[0].id);
+
+    // Operator forces voting even though the auto-advance heuristic might not
+    // fire (single invitee, no floor). The manual override path must keep
+    // working unchanged.
+    const adv = await advanceToVoting(lineupId, adminToken);
+    expect(adv.status).toBe(200);
+    expect(await readStatus(lineupId)).toBe('voting');
+
+    // Operator can also force decided directly.
+    const dec = await testApp.request
+      .patch(`/lineups/${lineupId}/status`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ status: 'decided', decidedGameId: games[0].id });
+    expect(dec.status).toBe(200);
+    expect(await readStatus(lineupId)).toBe('decided');
+  });
+}
+
+describe('Lineup auto-advance (ROK-1118, integration)', describeAutoAdvance);

--- a/api/src/lineups/lineups-auto-advance.spec.ts
+++ b/api/src/lineups/lineups-auto-advance.spec.ts
@@ -1,0 +1,134 @@
+/**
+ * Unit tests for maybeAutoAdvance (ROK-1118).
+ */
+import type { Logger } from '@nestjs/common';
+import { ConflictException } from '@nestjs/common';
+
+jest.mock('./lineups-query.helpers', () => ({
+  findLineupById: jest.fn(),
+}));
+
+jest.mock('./lineups-transition.helpers', () => ({
+  runStatusTransition: jest.fn(),
+}));
+
+jest.mock('./quorum/quorum-check.helpers', () => ({
+  checkBuildingQuorum: jest.fn(),
+  checkVotingQuorum: jest.fn(),
+}));
+
+import { findLineupById } from './lineups-query.helpers';
+import { runStatusTransition } from './lineups-transition.helpers';
+import {
+  checkBuildingQuorum,
+  checkVotingQuorum,
+} from './quorum/quorum-check.helpers';
+import { maybeAutoAdvance } from './lineups-auto-advance.helpers';
+
+function makeLogger(): Logger {
+  return {
+    warn: jest.fn(),
+    log: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    verbose: jest.fn(),
+  } as unknown as Logger;
+}
+
+function makeDeps(logger: Logger = makeLogger()) {
+  return {
+    db: {} as never,
+    activityLog: {} as never,
+    settings: {} as never,
+    phaseQueue: {} as never,
+    lineupNotifications: {} as never,
+    logger,
+  };
+}
+
+function setLineup(status: string | null) {
+  if (status === null) {
+    (findLineupById as jest.Mock).mockResolvedValue([]);
+  } else {
+    (findLineupById as jest.Mock).mockResolvedValue([{ id: 7, status }]);
+  }
+}
+
+describe('maybeAutoAdvance', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('returns silently when the lineup does not exist', async () => {
+    setLineup(null);
+    await maybeAutoAdvance(makeDeps(), 7);
+    expect(runStatusTransition).not.toHaveBeenCalled();
+  });
+
+  it('no-ops on terminal status (decided)', async () => {
+    setLineup('decided');
+    await maybeAutoAdvance(makeDeps(), 7);
+    expect(checkBuildingQuorum).not.toHaveBeenCalled();
+    expect(checkVotingQuorum).not.toHaveBeenCalled();
+    expect(runStatusTransition).not.toHaveBeenCalled();
+  });
+
+  it('does not transition when building quorum is not ready', async () => {
+    setLineup('building');
+    (checkBuildingQuorum as jest.Mock).mockResolvedValue({
+      ready: false,
+      reason: 'floor',
+    });
+    await maybeAutoAdvance(makeDeps(), 7);
+    expect(runStatusTransition).not.toHaveBeenCalled();
+  });
+
+  it('transitions building → voting when quorum is ready', async () => {
+    setLineup('building');
+    (checkBuildingQuorum as jest.Mock).mockResolvedValue({ ready: true });
+    (runStatusTransition as jest.Mock).mockResolvedValue(undefined);
+
+    await maybeAutoAdvance(makeDeps(), 7);
+
+    expect(runStatusTransition).toHaveBeenCalledWith(expect.any(Object), 7, {
+      status: 'voting',
+    });
+  });
+
+  it('transitions voting → decided when quorum is ready', async () => {
+    setLineup('voting');
+    (checkVotingQuorum as jest.Mock).mockResolvedValue({ ready: true });
+    (runStatusTransition as jest.Mock).mockResolvedValue(undefined);
+
+    await maybeAutoAdvance(makeDeps(), 7);
+
+    expect(runStatusTransition).toHaveBeenCalledWith(expect.any(Object), 7, {
+      status: 'decided',
+    });
+  });
+
+  it('swallows ConflictException from a concurrent caller', async () => {
+    setLineup('voting');
+    (checkVotingQuorum as jest.Mock).mockResolvedValue({ ready: true });
+    (runStatusTransition as jest.Mock).mockRejectedValue(
+      new ConflictException('raced'),
+    );
+    const logger = makeLogger();
+
+    await expect(
+      maybeAutoAdvance(makeDeps(logger), 7),
+    ).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('maybeAutoAdvance(7)'),
+    );
+  });
+
+  it('swallows arbitrary errors from the quorum check', async () => {
+    setLineup('voting');
+    (checkVotingQuorum as jest.Mock).mockRejectedValue(new Error('boom'));
+    const logger = makeLogger();
+
+    await expect(
+      maybeAutoAdvance(makeDeps(logger), 7),
+    ).resolves.toBeUndefined();
+    expect(logger.warn).toHaveBeenCalled();
+  });
+});

--- a/api/src/lineups/lineups-auto-advance.spec.ts
+++ b/api/src/lineups/lineups-auto-advance.spec.ts
@@ -42,6 +42,7 @@ function makeDeps(logger: Logger = makeLogger()) {
     settings: {} as never,
     phaseQueue: {} as never,
     lineupNotifications: {} as never,
+    lineupsGateway: {} as never,
     logger,
   };
 }

--- a/api/src/lineups/lineups-lifecycle.helpers.ts
+++ b/api/src/lineups/lineups-lifecycle.helpers.ts
@@ -2,8 +2,12 @@
  * Lifecycle helpers extracted from LineupsService to stay
  * under the 300-line file limit (ROK-932).
  */
-import { BadRequestException, type Logger } from '@nestjs/common';
-import { eq } from 'drizzle-orm';
+import {
+  BadRequestException,
+  ConflictException,
+  type Logger,
+} from '@nestjs/common';
+import { and, eq } from 'drizzle-orm';
 import { clearLinkedEventsByLineup } from './standalone-poll/standalone-poll-query.helpers';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type {
@@ -66,7 +70,17 @@ export function insertLineup(
   });
 }
 
-/** Apply a status transition with phase scheduling. */
+/**
+ * Apply a status transition with phase scheduling.
+ *
+ * ROK-1118: the UPDATE is conditional on the lineup's current status to
+ * make concurrent auto-advance callers safe. If two voters race to close
+ * the quorum, both will compute `expectedPre = 'voting'` from their own
+ * snapshot, but only one UPDATE will match the row's actual status —
+ * the loser sees `rowCount === 0` and we throw `ConflictException`. The
+ * manual `PATCH /lineups/:id/status` path surfaces this as 409;
+ * `maybeAutoAdvance` swallows it.
+ */
 export async function applyStatusUpdate(
   db: Db,
   settings: SettingsService,
@@ -81,10 +95,22 @@ export async function applyStatusUpdate(
     settings,
   );
   const values = buildTransitionValues(dto, phaseDeadline);
-  await db
+  const expectedPre = lineup.status;
+  const updated = await db
     .update(schema.communityLineups)
     .set(values)
-    .where(eq(schema.communityLineups.id, id));
+    .where(
+      and(
+        eq(schema.communityLineups.id, id),
+        eq(schema.communityLineups.status, expectedPre),
+      ),
+    )
+    .returning({ id: schema.communityLineups.id });
+  if (updated.length === 0) {
+    throw new ConflictException(
+      `Lineup ${id} status changed concurrently; expected '${expectedPre}'`,
+    );
+  }
 
   const nextPhase = getNextPhase(dto.status);
   if (nextPhase && phaseDeadline) {

--- a/api/src/lineups/lineups-transition.helpers.ts
+++ b/api/src/lineups/lineups-transition.helpers.ts
@@ -27,6 +27,7 @@ import {
   fireVotingOpen,
   fireDecidedNotifications,
 } from './lineups-notify-hooks.helpers';
+import type { LineupsGateway } from './lineups.gateway';
 
 type Db = PostgresJsDatabase<typeof schema>;
 
@@ -36,6 +37,7 @@ export interface TransitionDeps {
   settings: SettingsService;
   phaseQueue: LineupPhaseQueueService;
   lineupNotifications: LineupNotificationService;
+  lineupsGateway: LineupsGateway;
   logger: Logger;
 }
 
@@ -62,6 +64,10 @@ export async function runStatusTransition(
     dto,
     lineup,
   );
+  // ROK-1118: emit immediately after the conditional UPDATE succeeds so
+  // subscribed clients see the phase flip without polling. The timestamp
+  // matches the row's `updatedAt` we just wrote (within milliseconds).
+  deps.lineupsGateway.emitStatusChange(id, dto.status, new Date());
   if (dto.status === 'decided') {
     await runMatchingAlgorithm(deps.db, id, deps.logger);
   }

--- a/api/src/lineups/lineups.gateway.spec.ts
+++ b/api/src/lineups/lineups.gateway.spec.ts
@@ -1,0 +1,149 @@
+import { LineupsGateway } from './lineups.gateway';
+import { JwtService } from '@nestjs/jwt';
+import type { Socket } from 'socket.io';
+
+let gateway: LineupsGateway;
+let mockServer: { to: jest.Mock };
+let mockEmit: jest.Mock;
+let mockJwtService: { verify: jest.Mock };
+
+function setupEach() {
+  mockEmit = jest.fn();
+  mockServer = {
+    to: jest.fn().mockReturnValue({ emit: mockEmit }),
+  };
+  mockJwtService = {
+    verify: jest.fn().mockReturnValue({ sub: 1, username: 'test' }),
+  };
+
+  gateway = new LineupsGateway(mockJwtService as unknown as JwtService);
+  (gateway as unknown as { server: typeof mockServer }).server = mockServer;
+}
+
+function makeClient(
+  id: string,
+  overrides: Record<string, unknown> = {},
+): Socket {
+  return {
+    id,
+    handshake: { auth: { token: 'valid-jwt-token' } },
+    disconnect: jest.fn(),
+    ...overrides,
+  } as unknown as Socket;
+}
+
+function testAcceptsValidToken() {
+  const client = makeClient('client-1');
+  gateway.handleConnection(client);
+  expect(mockJwtService.verify).toHaveBeenCalledWith('valid-jwt-token');
+  expect(client.disconnect).not.toHaveBeenCalled();
+}
+
+function testDisconnectsWithoutToken() {
+  const client = makeClient('client-2', { handshake: { auth: {} } });
+  gateway.handleConnection(client);
+  expect(client.disconnect).toHaveBeenCalledWith(true);
+}
+
+function testDisconnectsWithInvalidToken() {
+  mockJwtService.verify.mockImplementationOnce(() => {
+    throw new Error('invalid token');
+  });
+  const client = makeClient('client-3', {
+    handshake: { auth: { token: 'bad-token' } },
+  });
+  gateway.handleConnection(client);
+  expect(client.disconnect).toHaveBeenCalledWith(true);
+}
+
+function testDisconnectsWithMissingAuthObject() {
+  const client = makeClient('client-4', { handshake: {} });
+  gateway.handleConnection(client);
+  expect(client.disconnect).toHaveBeenCalledWith(true);
+}
+
+function testHandleDisconnect() {
+  const client = { id: 'client-x' } as unknown as Socket;
+  gateway.handleDisconnect(client);
+}
+
+function testHandleSubscribe() {
+  const mockJoin = jest.fn().mockResolvedValue(undefined);
+  const client = { id: 'client-5', join: mockJoin } as unknown as Socket;
+  gateway.handleSubscribe(client, { lineupId: 42 });
+  expect(mockJoin).toHaveBeenCalledWith('lineup:42');
+}
+
+function testHandleUnsubscribe() {
+  const mockLeave = jest.fn().mockResolvedValue(undefined);
+  const client = { id: 'client-6', leave: mockLeave } as unknown as Socket;
+  gateway.handleUnsubscribe(client, { lineupId: 42 });
+  expect(mockLeave).toHaveBeenCalledWith('lineup:42');
+}
+
+function testEmitStatusChangeBuilding() {
+  const ts = new Date('2026-04-27T12:00:00.000Z');
+  gateway.emitStatusChange(42, 'building', ts);
+  expect(mockServer.to).toHaveBeenCalledWith('lineup:42');
+  expect(mockEmit).toHaveBeenCalledWith('lineup:status', {
+    lineupId: 42,
+    status: 'building',
+    statusChangedAt: '2026-04-27T12:00:00.000Z',
+  });
+}
+
+function testEmitStatusChangeVoting() {
+  const ts = new Date('2026-04-27T13:00:00.000Z');
+  gateway.emitStatusChange(7, 'voting', ts);
+  expect(mockServer.to).toHaveBeenCalledWith('lineup:7');
+  expect(mockEmit).toHaveBeenCalledWith('lineup:status', {
+    lineupId: 7,
+    status: 'voting',
+    statusChangedAt: '2026-04-27T13:00:00.000Z',
+  });
+}
+
+function testEmitStatusChangeDecided() {
+  const ts = new Date('2026-04-27T14:00:00.000Z');
+  gateway.emitStatusChange(99, 'decided', ts);
+  expect(mockEmit).toHaveBeenCalledWith('lineup:status', {
+    lineupId: 99,
+    status: 'decided',
+    statusChangedAt: '2026-04-27T14:00:00.000Z',
+  });
+}
+
+function testEmitStatusChangeRejectsUnknownStatus() {
+  expect(() =>
+    gateway.emitStatusChange(
+      1,
+      'bogus' as unknown as 'building',
+      new Date('2026-04-27T15:00:00.000Z'),
+    ),
+  ).toThrow();
+  expect(mockEmit).not.toHaveBeenCalled();
+}
+
+beforeEach(() => setupEach());
+
+describe('LineupsGateway — connection', () => {
+  it('accepts connection with valid auth token', () => testAcceptsValidToken());
+  it('disconnects client without auth token', () =>
+    testDisconnectsWithoutToken());
+  it('disconnects client with invalid auth token', () =>
+    testDisconnectsWithInvalidToken());
+  it('disconnects client with missing auth object', () =>
+    testDisconnectsWithMissingAuthObject());
+  it('handles client disconnect', () => testHandleDisconnect());
+  it('joins the correct room for lineup', () => testHandleSubscribe());
+  it('leaves the correct room for lineup', () => testHandleUnsubscribe());
+});
+
+describe('LineupsGateway — emit', () => {
+  it('emits building status to the correct room', () =>
+    testEmitStatusChangeBuilding());
+  it('emits voting status', () => testEmitStatusChangeVoting());
+  it('emits decided status', () => testEmitStatusChangeDecided());
+  it('rejects unknown status before emit', () =>
+    testEmitStatusChangeRejectsUnknownStatus());
+});

--- a/api/src/lineups/lineups.gateway.ts
+++ b/api/src/lineups/lineups.gateway.ts
@@ -1,0 +1,119 @@
+import { Inject, Logger } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import {
+  WebSocketGateway,
+  WebSocketServer,
+  SubscribeMessage,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+  ConnectedSocket,
+  MessageBody,
+} from '@nestjs/websockets';
+import { Server, Socket } from 'socket.io';
+import {
+  LineupRealtimeEventNames,
+  LineupStatusEventSchema,
+} from '@raid-ledger/contract';
+import type { LineupStatus } from '../drizzle/schema';
+import { perfLog } from '../common/perf-logger';
+
+/**
+ * WebSocket gateway for real-time community lineup updates (ROK-1118).
+ *
+ * Namespace: /lineups
+ * Events:
+ * - lineup:status — lineup advanced phase (building → voting → decided / archived)
+ *
+ * Auth: JWT from socket.handshake.auth.token (validated on connection).
+ * Note: Single-instance only for v1. Redis adapter is optional and documented.
+ */
+@WebSocketGateway({
+  namespace: '/lineups',
+  cors: {
+    origin: process.env.CLIENT_URL || '*',
+    credentials: true,
+  },
+})
+export class LineupsGateway
+  implements OnGatewayConnection, OnGatewayDisconnect
+{
+  private readonly logger = new Logger(LineupsGateway.name);
+
+  constructor(@Inject(JwtService) private readonly jwtService: JwtService) {}
+
+  @WebSocketServer()
+  server!: Server;
+
+  handleConnection(client: Socket): void {
+    const token = (client.handshake.auth as Record<string, unknown> | undefined)
+      ?.token;
+
+    if (!token || typeof token !== 'string') {
+      this.logger.debug(`Client ${client.id} rejected: no auth token provided`);
+      client.disconnect(true);
+      return;
+    }
+
+    try {
+      this.jwtService.verify(token);
+      this.logger.debug(`Client ${client.id} connected with valid token`);
+    } catch {
+      this.logger.debug(`Client ${client.id} rejected: invalid auth token`);
+      client.disconnect(true);
+    }
+  }
+
+  handleDisconnect(client: Socket): void {
+    this.logger.debug(`Client ${client.id} disconnected`);
+  }
+
+  /** Client subscribes to updates for a specific lineup. */
+  @SubscribeMessage('subscribe')
+  handleSubscribe(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() data: { lineupId: number },
+  ): void {
+    const room = `lineup:${data.lineupId}`;
+    void client.join(room);
+    this.logger.debug(
+      `Client ${client.id} subscribed to lineup ${data.lineupId}`,
+    );
+  }
+
+  /** Client unsubscribes from lineup updates. */
+  @SubscribeMessage('unsubscribe')
+  handleUnsubscribe(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() data: { lineupId: number },
+  ): void {
+    const room = `lineup:${data.lineupId}`;
+    void client.leave(room);
+  }
+
+  /**
+   * Emit a lineup status change to all clients watching the lineup.
+   *
+   * Validates the payload with `LineupStatusEventSchema` before broadcast
+   * so a malformed call (e.g. unknown status string) fails fast in dev
+   * instead of poisoning the wire.
+   */
+  emitStatusChange(
+    lineupId: number,
+    status: LineupStatus,
+    statusChangedAt: Date,
+  ): void {
+    const start = performance.now();
+    const payload = LineupStatusEventSchema.parse({
+      lineupId,
+      status,
+      statusChangedAt: statusChangedAt.toISOString(),
+    });
+    this.server
+      .to(`lineup:${lineupId}`)
+      .emit(LineupRealtimeEventNames.Status, payload);
+    perfLog('WS', LineupRealtimeEventNames.Status, performance.now() - start, {
+      lineupId,
+      status,
+    });
+  }
+}

--- a/api/src/lineups/lineups.module.ts
+++ b/api/src/lineups/lineups.module.ts
@@ -1,10 +1,13 @@
 import { Module, forwardRef } from '@nestjs/common';
 import { BullModule } from '@nestjs/bullmq';
+import { JwtModule } from '@nestjs/jwt';
+import { ConfigModule, ConfigService } from '@nestjs/config';
 import { LineupsController } from './lineups.controller';
 import { LineupsService } from './lineups.service';
 import { LineupSteamNudgeService } from './lineup-steam-nudge.service';
 import { LineupNotificationService } from './lineup-notification.service';
 import { LineupReminderService } from './lineup-reminder.service';
+import { LineupsGateway } from './lineups.gateway';
 import { DrizzleModule } from '../drizzle/drizzle.module';
 import { ActivityLogModule } from '../activity-log/activity-log.module';
 import { NotificationModule } from '../notifications/notification.module';
@@ -28,6 +31,14 @@ import { AiSuggestionsModule } from './ai-suggestions/ai-suggestions.module';
     TiebreakerModule,
     TasteProfileModule,
     AiSuggestionsModule,
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      useFactory: (configService: ConfigService) => ({
+        secret: configService.get<string>('JWT_SECRET'),
+        signOptions: { expiresIn: '24h' },
+      }),
+      inject: [ConfigService],
+    }),
   ],
   controllers: [LineupsController],
   providers: [
@@ -37,6 +48,7 @@ import { AiSuggestionsModule } from './ai-suggestions/ai-suggestions.module';
     LineupReminderService,
     LineupPhaseQueueService,
     LineupPhaseProcessor,
+    LineupsGateway,
   ],
   exports: [LineupsService, LineupSteamNudgeService, LineupNotificationService],
 })

--- a/api/src/lineups/lineups.service.cache-invalidation.spec.ts
+++ b/api/src/lineups/lineups.service.cache-invalidation.spec.ts
@@ -67,6 +67,7 @@ jest.mock('./lineups-actions.helpers', () => ({
   runCreateLineup: jest.fn(),
   runToggleVote: jest.fn(),
   runNominate: jest.fn().mockResolvedValue({ id: 1, status: 'building' }),
+  runRemoveNomination: jest.fn().mockResolvedValue(undefined),
 }));
 jest.mock('./lineups-invitees-actions.helpers', () => ({
   runAddInvitees: jest.fn().mockResolvedValue({ id: 1, status: 'building' }),

--- a/api/src/lineups/lineups.service.cache-invalidation.spec.ts
+++ b/api/src/lineups/lineups.service.cache-invalidation.spec.ts
@@ -30,6 +30,7 @@ import { TasteProfileService } from '../taste-profile/taste-profile.service';
 import { LineupNotificationService } from './lineup-notification.service';
 import { DiscordBotClientService } from '../discord-bot/discord-bot-client.service';
 import { AiSuggestionsCacheInvalidator } from './ai-suggestions/cache.helpers';
+import { LineupsGateway } from './lineups.gateway';
 
 // Mock the matching algorithm to avoid extra DB queries in unit tests
 jest.mock('./lineups-matching.helpers', () => ({
@@ -138,6 +139,10 @@ async function buildHarness(
       {
         provide: AiSuggestionsCacheInvalidator,
         useValue: invalidator,
+      },
+      {
+        provide: LineupsGateway,
+        useValue: { emitStatusChange: jest.fn() },
       },
     ],
   }).compile();

--- a/api/src/lineups/lineups.service.remove.spec.ts
+++ b/api/src/lineups/lineups.service.remove.spec.ts
@@ -16,6 +16,7 @@ import { LineupPhaseQueueService } from './queue/lineup-phase.queue';
 import { LineupSteamNudgeService } from './lineup-steam-nudge.service';
 import { TasteProfileService } from '../taste-profile/taste-profile.service';
 import { AiSuggestionsCacheInvalidator } from './ai-suggestions/cache.helpers';
+import { LineupsGateway } from './lineups.gateway';
 import { LineupNotificationService } from './lineup-notification.service';
 import { DiscordBotClientService } from '../discord-bot/discord-bot-client.service';
 
@@ -168,6 +169,10 @@ describe('LineupsService.removeNomination', () => {
           useValue: {
             invalidateForLineup: jest.fn().mockResolvedValue(undefined),
           },
+        },
+        {
+          provide: LineupsGateway,
+          useValue: { emitStatusChange: jest.fn() },
         },
       ],
     }).compile();

--- a/api/src/lineups/lineups.service.spec.ts
+++ b/api/src/lineups/lineups.service.spec.ts
@@ -8,6 +8,7 @@ import { LineupPhaseQueueService } from './queue/lineup-phase.queue';
 import { LineupSteamNudgeService } from './lineup-steam-nudge.service';
 import { TasteProfileService } from '../taste-profile/taste-profile.service';
 import { AiSuggestionsCacheInvalidator } from './ai-suggestions/cache.helpers';
+import { LineupsGateway } from './lineups.gateway';
 import { LineupNotificationService } from './lineup-notification.service';
 import { DiscordBotClientService } from '../discord-bot/discord-bot-client.service';
 
@@ -224,6 +225,10 @@ function describeLineupsService() {
           useValue: {
             invalidateForLineup: jest.fn().mockResolvedValue(undefined),
           },
+        },
+        {
+          provide: LineupsGateway,
+          useValue: { emitStatusChange: jest.fn() },
         },
       ],
     }).compile();

--- a/api/src/lineups/lineups.service.spec.ts
+++ b/api/src/lineups/lineups.service.spec.ts
@@ -143,7 +143,9 @@ function describeLineupsService() {
   function mockUpdate() {
     mockDb.update.mockReturnValue({
       set: jest.fn().mockReturnValue({
-        where: jest.fn().mockResolvedValue(undefined),
+        where: jest.fn().mockReturnValue({
+          returning: jest.fn().mockResolvedValue([{ id: 1 }]),
+        }),
       }),
     });
   }
@@ -418,10 +420,12 @@ function describeLineupsService() {
       mockSelects(
         makeSelectChain({ groupByResult: [{ gameId: 5, voteCount: 1 }] }),
       );
-      // applyStatusUpdate (update)
+      // applyStatusUpdate (conditional update)
       mockDb.update.mockReturnValue({
         set: jest.fn().mockReturnValue({
-          where: jest.fn().mockResolvedValue(undefined),
+          where: jest.fn().mockReturnValue({
+            returning: jest.fn().mockResolvedValue([{ id: 1 }]),
+          }),
         }),
       });
       // buildDetailResponse chain (findLineupById + enrichment queries)

--- a/api/src/lineups/lineups.service.ts
+++ b/api/src/lineups/lineups.service.ts
@@ -1,10 +1,4 @@
-import {
-  BadRequestException,
-  Inject,
-  Injectable,
-  Logger,
-  NotFoundException,
-} from '@nestjs/common';
+import { Inject, Injectable, Logger } from '@nestjs/common';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import type {
   BandwagonJoinResponseDto,
@@ -27,7 +21,6 @@ import { DiscordBotClientService } from '../discord-bot/discord-bot-client.servi
 import { LineupPhaseQueueService } from './queue/lineup-phase.queue';
 import { LineupSteamNudgeService } from './lineup-steam-nudge.service';
 import { LineupNotificationService } from './lineup-notification.service';
-import { findLineupById } from './lineups-query.helpers';
 import {
   runAddInvitees,
   runRemoveInvitee,
@@ -38,11 +31,6 @@ import { runCommonGroundForBuildingLineup } from './common-ground-context.helper
 import { buildDetailResponse } from './lineups-response.helpers';
 import { findBannerLineup, buildBannerData } from './lineups-banner.helpers';
 import { buildActiveLineupSummaries } from './lineups-summary.helpers';
-import {
-  findEntry,
-  validateRemoval,
-  deleteEntry,
-} from './lineups-removal.helpers';
 import { buildGroupedMatchesResponse } from './lineups-match-response.helpers';
 import { runMetadataUpdate } from './lineups-metadata.helpers';
 import { runStatusTransition } from './lineups-transition.helpers';
@@ -50,12 +38,13 @@ import {
   runBandwagonJoin,
   runAdvanceMatch,
 } from './lineups-match-actions.helpers';
-import { fireNominationRemoved } from './lineups-notify-hooks.helpers';
 import {
   runCreateLineup,
   runToggleVote,
   runNominate,
+  runRemoveNomination,
 } from './lineups-actions.helpers';
+import { maybeAutoAdvance } from './lineups-auto-advance.helpers';
 
 /** Caller identity for authorization checks. */
 export interface CallerIdentity {
@@ -148,13 +137,13 @@ export class LineupsService {
   }
 
   /** Toggle a vote for a game in a lineup (ROK-936). */
-  toggleVote(
+  async toggleVote(
     lineupId: number,
     gameId: number,
     userId: number,
     callerRole?: string,
   ): Promise<LineupDetailResponseDto> {
-    return runToggleVote(
+    const result = await runToggleVote(
       {
         db: this.db,
         activityLog: this.activityLog,
@@ -165,6 +154,20 @@ export class LineupsService {
       userId,
       callerRole,
     );
+    void maybeAutoAdvance(this.autoAdvanceDeps(), lineupId);
+    return result;
+  }
+
+  /** Build deps for the fire-and-forget auto-advance helper (ROK-1118). */
+  private autoAdvanceDeps() {
+    return {
+      db: this.db,
+      activityLog: this.activityLog,
+      settings: this.settings,
+      phaseQueue: this.phaseQueue,
+      lineupNotifications: this.lineupNotifications,
+      logger: this.logger,
+    };
   }
 
   /** Transition a lineup to a new status. */
@@ -219,6 +222,7 @@ export class LineupsService {
       callerRole,
     );
     await this.invalidateAiCache(lineupId);
+    void maybeAutoAdvance(this.autoAdvanceDeps(), lineupId);
     return result;
   }
 
@@ -228,33 +232,19 @@ export class LineupsService {
     gameId: number,
     caller: CallerIdentity,
   ) {
-    const [lineup] = await findLineupById(this.db, lineupId);
-    if (!lineup) throw new NotFoundException('Lineup not found');
-    if (lineup.status !== 'building')
-      throw new BadRequestException('Can only remove during building');
-
-    const entry = await findEntry(this.db, lineupId, gameId);
-    validateRemoval(entry, caller);
-    await deleteEntry(this.db, lineupId, gameId);
-    await this.activityLog.log(
-      'lineup',
-      lineupId,
-      'nomination_removed',
-      caller.id,
-      { gameId },
-    );
-
-    fireNominationRemoved(
-      this.lineupNotifications,
-      this.logger,
-      this.db,
+    await runRemoveNomination(
+      {
+        db: this.db,
+        activityLog: this.activityLog,
+        lineupNotifications: this.lineupNotifications,
+        logger: this.logger,
+      },
       lineupId,
       gameId,
-      entry,
       caller,
     );
-
     await this.invalidateAiCache(lineupId);
+    void maybeAutoAdvance(this.autoAdvanceDeps(), lineupId);
   }
 
   /** Get banner data for the Games page. Returns null if no eligible lineup. */

--- a/api/src/lineups/lineups.service.ts
+++ b/api/src/lineups/lineups.service.ts
@@ -45,6 +45,7 @@ import {
   runRemoveNomination,
 } from './lineups-actions.helpers';
 import { maybeAutoAdvance } from './lineups-auto-advance.helpers';
+import { LineupsGateway } from './lineups.gateway';
 
 /** Caller identity for authorization checks. */
 export interface CallerIdentity {
@@ -86,6 +87,7 @@ export class LineupsService {
     private readonly botClient: DiscordBotClientService,
     private readonly tasteProfile: TasteProfileService,
     private readonly aiSuggestionsCache: AiSuggestionsCacheInvalidator,
+    private readonly lineupsGateway: LineupsGateway,
   ) {}
 
   /** Resolve a Discord channel name from its ID via bot cache (ROK-1064). */
@@ -166,6 +168,7 @@ export class LineupsService {
       settings: this.settings,
       phaseQueue: this.phaseQueue,
       lineupNotifications: this.lineupNotifications,
+      lineupsGateway: this.lineupsGateway,
       logger: this.logger,
     };
   }
@@ -182,6 +185,7 @@ export class LineupsService {
         settings: this.settings,
         phaseQueue: this.phaseQueue,
         lineupNotifications: this.lineupNotifications,
+        lineupsGateway: this.lineupsGateway,
         logger: this.logger,
       },
       id,

--- a/api/src/lineups/lineups.service.ts
+++ b/api/src/lineups/lineups.service.ts
@@ -154,11 +154,11 @@ export class LineupsService {
       userId,
       callerRole,
     );
-    void maybeAutoAdvance(this.autoAdvanceDeps(), lineupId);
+    await maybeAutoAdvance(this.autoAdvanceDeps(), lineupId);
     return result;
   }
 
-  /** Build deps for the fire-and-forget auto-advance helper (ROK-1118). */
+  /** Build deps for the auto-advance helper (ROK-1118). */
   private autoAdvanceDeps() {
     return {
       db: this.db,
@@ -222,7 +222,7 @@ export class LineupsService {
       callerRole,
     );
     await this.invalidateAiCache(lineupId);
-    void maybeAutoAdvance(this.autoAdvanceDeps(), lineupId);
+    await maybeAutoAdvance(this.autoAdvanceDeps(), lineupId);
     return result;
   }
 
@@ -244,7 +244,7 @@ export class LineupsService {
       caller,
     );
     await this.invalidateAiCache(lineupId);
-    void maybeAutoAdvance(this.autoAdvanceDeps(), lineupId);
+    await maybeAutoAdvance(this.autoAdvanceDeps(), lineupId);
   }
 
   /** Get banner data for the Games page. Returns null if no eligible lineup. */

--- a/api/src/lineups/quorum/quorum-check.helpers.spec.ts
+++ b/api/src/lineups/quorum/quorum-check.helpers.spec.ts
@@ -82,8 +82,6 @@ describe('checkBuildingQuorum', () => {
   it('reports not ready when there are no expected voters', async () => {
     const db = createDrizzleMock();
     setExpectedVoters([]);
-    db.groupBy.mockResolvedValueOnce(nominationsPerVoter([]));
-    db.execute.mockResolvedValueOnce(totalRow(0));
 
     const result = await checkBuildingQuorum(
       db as never,
@@ -92,7 +90,21 @@ describe('checkBuildingQuorum', () => {
     );
 
     expect(result.ready).toBe(false);
-    expect(result.reason).toContain('no expected voters');
+    expect(result.reason).toContain('solo lineup');
+  });
+
+  it('reports not ready for a solo lineup (1 expected voter)', async () => {
+    const db = createDrizzleMock();
+    setExpectedVoters([1]);
+
+    const result = await checkBuildingQuorum(
+      db as never,
+      makeSettings() as never,
+      baseLineup,
+    );
+
+    expect(result.ready).toBe(false);
+    expect(result.reason).toContain('solo lineup');
   });
 
   it('reports not ready when an expected nominator has not nominated', async () => {
@@ -245,6 +257,21 @@ describe('checkVotingQuorum', () => {
     });
 
     expect(result.ready).toBe(false);
+    expect(result.reason).toContain('solo lineup');
+  });
+
+  it('reports not ready for a solo lineup (1 expected voter)', async () => {
+    const db = createDrizzleMock();
+    setExpectedVoters([1]);
+    db.groupBy.mockResolvedValueOnce([{ userId: 1, count: 3 }]);
+
+    const result = await checkVotingQuorum(db as never, {
+      ...baseLineup,
+      status: 'voting',
+    });
+
+    expect(result.ready).toBe(false);
+    expect(result.reason).toContain('solo lineup');
   });
 
   it('reports not ready when each voter has cast 1 of 3 votes', async () => {

--- a/api/src/lineups/quorum/quorum-check.helpers.spec.ts
+++ b/api/src/lineups/quorum/quorum-check.helpers.spec.ts
@@ -1,0 +1,227 @@
+/**
+ * Unit tests for quorum predicates (ROK-1118).
+ */
+import { createDrizzleMock } from '../../common/testing/drizzle-mock';
+
+jest.mock('./quorum-voters.helpers', () => ({
+  loadExpectedVoters: jest.fn(),
+}));
+
+import { loadExpectedVoters } from './quorum-voters.helpers';
+import {
+  checkBuildingQuorum,
+  checkVotingQuorum,
+} from './quorum-check.helpers';
+import type * as schema from '../../drizzle/schema';
+
+type LineupRow = typeof schema.communityLineups.$inferSelect;
+
+const baseLineup: LineupRow = {
+  id: 42,
+  title: 'Test',
+  description: null,
+  status: 'building',
+  visibility: 'public',
+  targetDate: null,
+  decidedGameId: null,
+  linkedEventId: null,
+  createdBy: 1,
+  votingDeadline: null,
+  phaseDeadline: null,
+  phaseDurationOverride: null,
+  matchThreshold: 35,
+  maxVotesPerPlayer: 3,
+  defaultTiebreakerMode: null,
+  activeTiebreakerId: null,
+  discordCreatedChannelId: null,
+  discordCreatedMessageId: null,
+  channelOverrideId: null,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+} as unknown as LineupRow;
+
+function setExpectedVoters(ids: number[]): void {
+  (loadExpectedVoters as jest.Mock).mockResolvedValue(ids);
+}
+
+function makeNominationRows(userIds: number[]) {
+  return userIds.map((userId) => ({ userId }));
+}
+
+function makeEntryIdRows(count: number) {
+  return Array.from({ length: count }, (_, i) => ({ id: i + 1 }));
+}
+
+interface QuorumTestSettings {
+  get: jest.Mock;
+}
+
+function makeSettings(value: string | null = null): QuorumTestSettings {
+  return { get: jest.fn().mockResolvedValue(value) };
+}
+
+describe('checkBuildingQuorum', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('reports not ready when there are no expected voters', async () => {
+    const db = createDrizzleMock();
+    setExpectedVoters([]);
+    db.where.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+    const result = await checkBuildingQuorum(
+      db as never,
+      makeSettings() as never,
+      baseLineup,
+    );
+
+    expect(result.ready).toBe(false);
+    expect(result.reason).toContain('no expected voters');
+  });
+
+  it('reports not ready when an expected nominator has not nominated', async () => {
+    const db = createDrizzleMock();
+    setExpectedVoters([1, 2, 3, 4]);
+    db.where
+      .mockResolvedValueOnce(makeNominationRows([1, 2, 3]))
+      .mockResolvedValueOnce(makeEntryIdRows(3));
+
+    const result = await checkBuildingQuorum(
+      db as never,
+      makeSettings() as never,
+      baseLineup,
+    );
+
+    expect(result.ready).toBe(false);
+    expect(result.reason).toContain('missing');
+  });
+
+  it('reports not ready when nominators are covered but floor not met', async () => {
+    const db = createDrizzleMock();
+    setExpectedVoters([1, 2]);
+    db.where
+      .mockResolvedValueOnce(makeNominationRows([1, 2]))
+      .mockResolvedValueOnce(makeEntryIdRows(2));
+
+    const result = await checkBuildingQuorum(
+      db as never,
+      makeSettings() as never,
+      baseLineup,
+    );
+
+    expect(result.ready).toBe(false);
+    expect(result.reason).toContain('floor');
+  });
+
+  it('reports ready when nominators are covered and floor is just met', async () => {
+    const db = createDrizzleMock();
+    setExpectedVoters([1, 2, 3, 4]);
+    db.where
+      .mockResolvedValueOnce(makeNominationRows([1, 2, 3, 4]))
+      .mockResolvedValueOnce(makeEntryIdRows(4));
+
+    const result = await checkBuildingQuorum(
+      db as never,
+      makeSettings() as never,
+      baseLineup,
+    );
+
+    expect(result.ready).toBe(true);
+  });
+
+  it('reports ready beyond the floor', async () => {
+    const db = createDrizzleMock();
+    setExpectedVoters([1, 2, 3, 4]);
+    db.where
+      .mockResolvedValueOnce(makeNominationRows([1, 2, 3, 4]))
+      .mockResolvedValueOnce(makeEntryIdRows(7));
+
+    const result = await checkBuildingQuorum(
+      db as never,
+      makeSettings() as never,
+      baseLineup,
+    );
+
+    expect(result.ready).toBe(true);
+  });
+
+  it('honors a custom floor from settings', async () => {
+    const db = createDrizzleMock();
+    setExpectedVoters([1, 2]);
+    db.where
+      .mockResolvedValueOnce(makeNominationRows([1, 2]))
+      .mockResolvedValueOnce(makeEntryIdRows(2));
+
+    const result = await checkBuildingQuorum(
+      db as never,
+      makeSettings('2') as never,
+      baseLineup,
+    );
+
+    expect(result.ready).toBe(true);
+  });
+});
+
+describe('checkVotingQuorum', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('reports not ready when no expected voters', async () => {
+    const db = createDrizzleMock();
+    setExpectedVoters([]);
+    db.where.mockResolvedValueOnce([]);
+
+    const result = await checkVotingQuorum(
+      db as never,
+      { ...baseLineup, status: 'voting' },
+    );
+
+    expect(result.ready).toBe(false);
+  });
+
+  it('reports not ready with partial participation', async () => {
+    const db = createDrizzleMock();
+    setExpectedVoters([1, 2, 3]);
+    db.where.mockResolvedValueOnce([{ userId: 1 }, { userId: 2 }]);
+
+    const result = await checkVotingQuorum(
+      db as never,
+      { ...baseLineup, status: 'voting' },
+    );
+
+    expect(result.ready).toBe(false);
+    expect(result.reason).toContain('missing');
+  });
+
+  it('reports ready when every expected voter has voted', async () => {
+    const db = createDrizzleMock();
+    setExpectedVoters([1, 2, 3]);
+    db.where.mockResolvedValueOnce([
+      { userId: 1 },
+      { userId: 2 },
+      { userId: 3 },
+    ]);
+
+    const result = await checkVotingQuorum(
+      db as never,
+      { ...baseLineup, status: 'voting', visibility: 'private' },
+    );
+
+    expect(result.ready).toBe(true);
+  });
+
+  it('private lineup ignores extra public voters when quorum already met', async () => {
+    const db = createDrizzleMock();
+    setExpectedVoters([1, 2]);
+    db.where.mockResolvedValueOnce([
+      { userId: 1 },
+      { userId: 2 },
+      { userId: 99 },
+    ]);
+
+    const result = await checkVotingQuorum(
+      db as never,
+      { ...baseLineup, status: 'voting', visibility: 'private' },
+    );
+
+    expect(result.ready).toBe(true);
+  });
+});

--- a/api/src/lineups/quorum/quorum-check.helpers.spec.ts
+++ b/api/src/lineups/quorum/quorum-check.helpers.spec.ts
@@ -8,10 +8,7 @@ jest.mock('./quorum-voters.helpers', () => ({
 }));
 
 import { loadExpectedVoters } from './quorum-voters.helpers';
-import {
-  checkBuildingQuorum,
-  checkVotingQuorum,
-} from './quorum-check.helpers';
+import { checkBuildingQuorum, checkVotingQuorum } from './quorum-check.helpers';
 import type * as schema from '../../drizzle/schema';
 
 type LineupRow = typeof schema.communityLineups.$inferSelect;
@@ -169,10 +166,10 @@ describe('checkVotingQuorum', () => {
     setExpectedVoters([]);
     db.where.mockResolvedValueOnce([]);
 
-    const result = await checkVotingQuorum(
-      db as never,
-      { ...baseLineup, status: 'voting' },
-    );
+    const result = await checkVotingQuorum(db as never, {
+      ...baseLineup,
+      status: 'voting',
+    });
 
     expect(result.ready).toBe(false);
   });
@@ -182,10 +179,10 @@ describe('checkVotingQuorum', () => {
     setExpectedVoters([1, 2, 3]);
     db.where.mockResolvedValueOnce([{ userId: 1 }, { userId: 2 }]);
 
-    const result = await checkVotingQuorum(
-      db as never,
-      { ...baseLineup, status: 'voting' },
-    );
+    const result = await checkVotingQuorum(db as never, {
+      ...baseLineup,
+      status: 'voting',
+    });
 
     expect(result.ready).toBe(false);
     expect(result.reason).toContain('missing');
@@ -200,10 +197,11 @@ describe('checkVotingQuorum', () => {
       { userId: 3 },
     ]);
 
-    const result = await checkVotingQuorum(
-      db as never,
-      { ...baseLineup, status: 'voting', visibility: 'private' },
-    );
+    const result = await checkVotingQuorum(db as never, {
+      ...baseLineup,
+      status: 'voting',
+      visibility: 'private',
+    });
 
     expect(result.ready).toBe(true);
   });
@@ -217,10 +215,11 @@ describe('checkVotingQuorum', () => {
       { userId: 99 },
     ]);
 
-    const result = await checkVotingQuorum(
-      db as never,
-      { ...baseLineup, status: 'voting', visibility: 'private' },
-    );
+    const result = await checkVotingQuorum(db as never, {
+      ...baseLineup,
+      status: 'voting',
+      visibility: 'private',
+    });
 
     expect(result.ready).toBe(true);
   });

--- a/api/src/lineups/quorum/quorum-check.helpers.spec.ts
+++ b/api/src/lineups/quorum/quorum-check.helpers.spec.ts
@@ -1,5 +1,10 @@
 /**
  * Unit tests for quorum predicates (ROK-1118).
+ *
+ * Both predicates require participants to use their full allotment:
+ *   - building → voting: each voter has nominated ≥ minPerVoter games AND
+ *     total distinct nominations ≥ floor.
+ *   - voting → decided: each voter has cast `lineup.maxVotesPerPlayer` votes.
  */
 import { createDrizzleMock } from '../../common/testing/drizzle-mock';
 
@@ -9,6 +14,7 @@ jest.mock('./quorum-voters.helpers', () => ({
 
 import { loadExpectedVoters } from './quorum-voters.helpers';
 import { checkBuildingQuorum, checkVotingQuorum } from './quorum-check.helpers';
+import { SETTING_KEYS } from '../../drizzle/schema/app-settings';
 import type * as schema from '../../drizzle/schema';
 
 type LineupRow = typeof schema.communityLineups.$inferSelect;
@@ -41,20 +47,33 @@ function setExpectedVoters(ids: number[]): void {
   (loadExpectedVoters as jest.Mock).mockResolvedValue(ids);
 }
 
-function makeNominationRows(userIds: number[]) {
-  return userIds.map((userId) => ({ userId }));
+function nominationsPerVoter(rows: Array<{ userId: number; count: number }>) {
+  return rows;
 }
 
-function makeEntryIdRows(count: number) {
-  return Array.from({ length: count }, (_, i) => ({ id: i + 1 }));
+function totalRow(count: number) {
+  return [{ total: count }];
 }
 
 interface QuorumTestSettings {
   get: jest.Mock;
 }
 
-function makeSettings(value: string | null = null): QuorumTestSettings {
-  return { get: jest.fn().mockResolvedValue(value) };
+/**
+ * Settings mock that returns different values per key. Building reads:
+ *   1. LINEUP_AUTO_ADVANCE_MIN_NOMINATIONS (floor)
+ *   2. LINEUP_AUTO_ADVANCE_MIN_NOMINATIONS_PER_VOTER (per-voter min)
+ */
+function makeSettings(
+  overrides: Record<string, string> = {},
+): QuorumTestSettings {
+  return {
+    get: jest
+      .fn()
+      .mockImplementation((key: string) =>
+        Promise.resolve(overrides[key] ?? null),
+      ),
+  };
 }
 
 describe('checkBuildingQuorum', () => {
@@ -63,7 +82,8 @@ describe('checkBuildingQuorum', () => {
   it('reports not ready when there are no expected voters', async () => {
     const db = createDrizzleMock();
     setExpectedVoters([]);
-    db.where.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+    db.groupBy.mockResolvedValueOnce(nominationsPerVoter([]));
+    db.execute.mockResolvedValueOnce(totalRow(0));
 
     const result = await checkBuildingQuorum(
       db as never,
@@ -78,9 +98,14 @@ describe('checkBuildingQuorum', () => {
   it('reports not ready when an expected nominator has not nominated', async () => {
     const db = createDrizzleMock();
     setExpectedVoters([1, 2, 3, 4]);
-    db.where
-      .mockResolvedValueOnce(makeNominationRows([1, 2, 3]))
-      .mockResolvedValueOnce(makeEntryIdRows(3));
+    db.groupBy.mockResolvedValueOnce(
+      nominationsPerVoter([
+        { userId: 1, count: 3 },
+        { userId: 2, count: 3 },
+        { userId: 3, count: 3 },
+      ]),
+    );
+    db.execute.mockResolvedValueOnce(totalRow(9));
 
     const result = await checkBuildingQuorum(
       db as never,
@@ -89,19 +114,50 @@ describe('checkBuildingQuorum', () => {
     );
 
     expect(result.ready).toBe(false);
-    expect(result.reason).toContain('missing');
+    expect(result.reason).toMatch(/below 3 nominations/);
   });
 
-  it('reports not ready when nominators are covered but floor not met', async () => {
+  it('reports not ready when nominators have only 1 of 3 nominations each', async () => {
     const db = createDrizzleMock();
-    setExpectedVoters([1, 2]);
-    db.where
-      .mockResolvedValueOnce(makeNominationRows([1, 2]))
-      .mockResolvedValueOnce(makeEntryIdRows(2));
+    setExpectedVoters([1, 2, 3, 4]);
+    db.groupBy.mockResolvedValueOnce(
+      nominationsPerVoter([
+        { userId: 1, count: 1 },
+        { userId: 2, count: 1 },
+        { userId: 3, count: 1 },
+        { userId: 4, count: 1 },
+      ]),
+    );
+    db.execute.mockResolvedValueOnce(totalRow(4));
 
     const result = await checkBuildingQuorum(
       db as never,
       makeSettings() as never,
+      baseLineup,
+    );
+
+    expect(result.ready).toBe(false);
+    expect(result.reason).toMatch(/below 3 nominations/);
+  });
+
+  it('reports not ready when per-voter is met but total floor not met', async () => {
+    const db = createDrizzleMock();
+    // Two voters × 1 nomination each = 2 (below default floor of 4) but each
+    // hits a custom per-voter min of 1.
+    setExpectedVoters([1, 2]);
+    db.groupBy.mockResolvedValueOnce(
+      nominationsPerVoter([
+        { userId: 1, count: 1 },
+        { userId: 2, count: 1 },
+      ]),
+    );
+    db.execute.mockResolvedValueOnce(totalRow(2));
+
+    const result = await checkBuildingQuorum(
+      db as never,
+      makeSettings({
+        [SETTING_KEYS.LINEUP_AUTO_ADVANCE_MIN_NOMINATIONS_PER_VOTER]: '1',
+      }) as never,
       baseLineup,
     );
 
@@ -109,28 +165,16 @@ describe('checkBuildingQuorum', () => {
     expect(result.reason).toContain('floor');
   });
 
-  it('reports ready when nominators are covered and floor is just met', async () => {
+  it('reports ready when each voter hits the per-voter min and the floor is met', async () => {
     const db = createDrizzleMock();
-    setExpectedVoters([1, 2, 3, 4]);
-    db.where
-      .mockResolvedValueOnce(makeNominationRows([1, 2, 3, 4]))
-      .mockResolvedValueOnce(makeEntryIdRows(4));
-
-    const result = await checkBuildingQuorum(
-      db as never,
-      makeSettings() as never,
-      baseLineup,
+    setExpectedVoters([1, 2]);
+    db.groupBy.mockResolvedValueOnce(
+      nominationsPerVoter([
+        { userId: 1, count: 3 },
+        { userId: 2, count: 3 },
+      ]),
     );
-
-    expect(result.ready).toBe(true);
-  });
-
-  it('reports ready beyond the floor', async () => {
-    const db = createDrizzleMock();
-    setExpectedVoters([1, 2, 3, 4]);
-    db.where
-      .mockResolvedValueOnce(makeNominationRows([1, 2, 3, 4]))
-      .mockResolvedValueOnce(makeEntryIdRows(7));
+    db.execute.mockResolvedValueOnce(totalRow(6));
 
     const result = await checkBuildingQuorum(
       db as never,
@@ -144,13 +188,42 @@ describe('checkBuildingQuorum', () => {
   it('honors a custom floor from settings', async () => {
     const db = createDrizzleMock();
     setExpectedVoters([1, 2]);
-    db.where
-      .mockResolvedValueOnce(makeNominationRows([1, 2]))
-      .mockResolvedValueOnce(makeEntryIdRows(2));
+    db.groupBy.mockResolvedValueOnce(
+      nominationsPerVoter([
+        { userId: 1, count: 3 },
+        { userId: 2, count: 3 },
+      ]),
+    );
+    db.execute.mockResolvedValueOnce(totalRow(6));
 
     const result = await checkBuildingQuorum(
       db as never,
-      makeSettings('2') as never,
+      makeSettings({
+        [SETTING_KEYS.LINEUP_AUTO_ADVANCE_MIN_NOMINATIONS]: '2',
+      }) as never,
+      baseLineup,
+    );
+
+    expect(result.ready).toBe(true);
+  });
+
+  it('honors a custom per-voter min from settings', async () => {
+    const db = createDrizzleMock();
+    setExpectedVoters([1, 2]);
+    db.groupBy.mockResolvedValueOnce(
+      nominationsPerVoter([
+        { userId: 1, count: 1 },
+        { userId: 2, count: 1 },
+      ]),
+    );
+    db.execute.mockResolvedValueOnce(totalRow(2));
+
+    const result = await checkBuildingQuorum(
+      db as never,
+      makeSettings({
+        [SETTING_KEYS.LINEUP_AUTO_ADVANCE_MIN_NOMINATIONS]: '2',
+        [SETTING_KEYS.LINEUP_AUTO_ADVANCE_MIN_NOMINATIONS_PER_VOTER]: '1',
+      }) as never,
       baseLineup,
     );
 
@@ -164,7 +237,7 @@ describe('checkVotingQuorum', () => {
   it('reports not ready when no expected voters', async () => {
     const db = createDrizzleMock();
     setExpectedVoters([]);
-    db.where.mockResolvedValueOnce([]);
+    db.groupBy.mockResolvedValueOnce([]);
 
     const result = await checkVotingQuorum(db as never, {
       ...baseLineup,
@@ -174,10 +247,14 @@ describe('checkVotingQuorum', () => {
     expect(result.ready).toBe(false);
   });
 
-  it('reports not ready with partial participation', async () => {
+  it('reports not ready when each voter has cast 1 of 3 votes', async () => {
     const db = createDrizzleMock();
     setExpectedVoters([1, 2, 3]);
-    db.where.mockResolvedValueOnce([{ userId: 1 }, { userId: 2 }]);
+    db.groupBy.mockResolvedValueOnce([
+      { userId: 1, count: 1 },
+      { userId: 2, count: 1 },
+      { userId: 3, count: 1 },
+    ]);
 
     const result = await checkVotingQuorum(db as never, {
       ...baseLineup,
@@ -185,16 +262,34 @@ describe('checkVotingQuorum', () => {
     });
 
     expect(result.ready).toBe(false);
-    expect(result.reason).toContain('missing');
+    expect(result.reason).toMatch(/below 3 votes/);
   });
 
-  it('reports ready when every expected voter has voted', async () => {
+  it('reports not ready when one voter is one vote short', async () => {
     const db = createDrizzleMock();
     setExpectedVoters([1, 2, 3]);
-    db.where.mockResolvedValueOnce([
-      { userId: 1 },
-      { userId: 2 },
-      { userId: 3 },
+    db.groupBy.mockResolvedValueOnce([
+      { userId: 1, count: 3 },
+      { userId: 2, count: 3 },
+      { userId: 3, count: 2 },
+    ]);
+
+    const result = await checkVotingQuorum(db as never, {
+      ...baseLineup,
+      status: 'voting',
+    });
+
+    expect(result.ready).toBe(false);
+    expect(result.reason).toMatch(/below 3 votes/);
+  });
+
+  it('reports ready when every voter has used their full allotment', async () => {
+    const db = createDrizzleMock();
+    setExpectedVoters([1, 2, 3]);
+    db.groupBy.mockResolvedValueOnce([
+      { userId: 1, count: 3 },
+      { userId: 2, count: 3 },
+      { userId: 3, count: 3 },
     ]);
 
     const result = await checkVotingQuorum(db as never, {
@@ -209,10 +304,10 @@ describe('checkVotingQuorum', () => {
   it('private lineup ignores extra public voters when quorum already met', async () => {
     const db = createDrizzleMock();
     setExpectedVoters([1, 2]);
-    db.where.mockResolvedValueOnce([
-      { userId: 1 },
-      { userId: 2 },
-      { userId: 99 },
+    db.groupBy.mockResolvedValueOnce([
+      { userId: 1, count: 3 },
+      { userId: 2, count: 3 },
+      { userId: 99, count: 1 },
     ]);
 
     const result = await checkVotingQuorum(db as never, {
@@ -220,6 +315,26 @@ describe('checkVotingQuorum', () => {
       status: 'voting',
       visibility: 'private',
     });
+
+    expect(result.ready).toBe(true);
+  });
+
+  it('honors a custom maxVotesPerPlayer on the lineup', async () => {
+    const db = createDrizzleMock();
+    setExpectedVoters([1, 2]);
+    db.groupBy.mockResolvedValueOnce([
+      { userId: 1, count: 5 },
+      { userId: 2, count: 5 },
+    ]);
+
+    const result = await checkVotingQuorum(
+      db as never,
+      {
+        ...baseLineup,
+        status: 'voting',
+        maxVotesPerPlayer: 5,
+      } as LineupRow,
+    );
 
     expect(result.ready).toBe(true);
   });

--- a/api/src/lineups/quorum/quorum-check.helpers.ts
+++ b/api/src/lineups/quorum/quorum-check.helpers.ts
@@ -39,8 +39,10 @@ export async function checkBuildingQuorum(
   lineup: LineupRow,
 ): Promise<QuorumResult> {
   const expected = await loadExpectedVoters(db, lineup);
-  if (expected.length === 0) {
-    return { ready: false, reason: 'no expected voters' };
+  if (expected.length < 2) {
+    // Solo lineup (creator alone or no participants yet) — manual advance only.
+    // Auto-advancing here would surprise the operator who's still setting up.
+    return { ready: false, reason: 'solo lineup; manual advance required' };
   }
   const perVoterCounts = await countNominationsPerVoter(db, lineup.id);
   const minPerVoter = await readMinNominationsPerVoter(settings);
@@ -71,8 +73,9 @@ export async function checkVotingQuorum(
 ): Promise<QuorumResult> {
   const expected = await loadExpectedVoters(db, lineup);
   const perVoterCounts = await countVotesPerVoter(db, lineup.id);
-  if (expected.length === 0) {
-    return { ready: false, reason: 'no expected voters' };
+  if (expected.length < 2) {
+    // Solo lineup — manual advance only. Same reasoning as building quorum.
+    return { ready: false, reason: 'solo lineup; manual advance required' };
   }
   const required = lineup.maxVotesPerPlayer ?? 3;
   const short = expected.filter(

--- a/api/src/lineups/quorum/quorum-check.helpers.ts
+++ b/api/src/lineups/quorum/quorum-check.helpers.ts
@@ -40,7 +40,10 @@ export async function checkBuildingQuorum(
   const nominatorSet = new Set(nominators);
   const missing = expected.filter((id) => !nominatorSet.has(id));
   if (missing.length > 0) {
-    return { ready: false, reason: `${missing.length} expected nominator(s) missing` };
+    return {
+      ready: false,
+      reason: `${missing.length} expected nominator(s) missing`,
+    };
   }
   if (totalNominations < floor) {
     return {
@@ -66,7 +69,10 @@ export async function checkVotingQuorum(
   const voterSet = new Set(voters);
   const missing = expected.filter((id) => !voterSet.has(id));
   if (missing.length > 0) {
-    return { ready: false, reason: `${missing.length} expected voter(s) missing` };
+    return {
+      ready: false,
+      reason: `${missing.length} expected voter(s) missing`,
+    };
   }
   return { ready: true };
 }
@@ -102,7 +108,9 @@ async function countNominations(db: Db, lineupId: number): Promise<number> {
 }
 
 async function readMinNominations(settings: SettingsService): Promise<number> {
-  const raw = await settings.get(SETTING_KEYS.LINEUP_AUTO_ADVANCE_MIN_NOMINATIONS);
+  const raw = await settings.get(
+    SETTING_KEYS.LINEUP_AUTO_ADVANCE_MIN_NOMINATIONS,
+  );
   if (!raw) return DEFAULT_MIN_NOMINATIONS;
   const parsed = parseInt(raw, 10);
   return Number.isNaN(parsed) || parsed < 1 ? DEFAULT_MIN_NOMINATIONS : parsed;

--- a/api/src/lineups/quorum/quorum-check.helpers.ts
+++ b/api/src/lineups/quorum/quorum-check.helpers.ts
@@ -1,0 +1,109 @@
+/**
+ * Quorum predicates for lineup auto-advance (ROK-1118).
+ *
+ * Building quorum: every expected voter has nominated ≥1 entry AND
+ *   total distinct nominations ≥ floor (settings, default 4).
+ * Voting quorum: every expected voter has cast ≥1 vote.
+ */
+import { eq } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from '../../drizzle/schema';
+import { SETTING_KEYS } from '../../drizzle/schema/app-settings';
+import type { SettingsService } from '../../settings/settings.service';
+import { loadExpectedVoters } from './quorum-voters.helpers';
+
+type Db = PostgresJsDatabase<typeof schema>;
+type LineupRow = typeof schema.communityLineups.$inferSelect;
+
+const DEFAULT_MIN_NOMINATIONS = 4;
+
+export interface QuorumResult {
+  ready: boolean;
+  reason?: string;
+}
+
+/** Building → voting quorum predicate. */
+export async function checkBuildingQuorum(
+  db: Db,
+  settings: SettingsService,
+  lineup: LineupRow,
+): Promise<QuorumResult> {
+  const [expected, nominators, totalNominations, floor] = await Promise.all([
+    loadExpectedVoters(db, lineup),
+    loadDistinctNominatorIds(db, lineup.id),
+    countNominations(db, lineup.id),
+    readMinNominations(settings),
+  ]);
+  if (expected.length === 0) {
+    return { ready: false, reason: 'no expected voters' };
+  }
+  const nominatorSet = new Set(nominators);
+  const missing = expected.filter((id) => !nominatorSet.has(id));
+  if (missing.length > 0) {
+    return { ready: false, reason: `${missing.length} expected nominator(s) missing` };
+  }
+  if (totalNominations < floor) {
+    return {
+      ready: false,
+      reason: `nomination floor not met (${totalNominations}/${floor})`,
+    };
+  }
+  return { ready: true };
+}
+
+/** Voting → decided quorum predicate. */
+export async function checkVotingQuorum(
+  db: Db,
+  lineup: LineupRow,
+): Promise<QuorumResult> {
+  const [expected, voters] = await Promise.all([
+    loadExpectedVoters(db, lineup),
+    loadDistinctVoterIds(db, lineup.id),
+  ]);
+  if (expected.length === 0) {
+    return { ready: false, reason: 'no expected voters' };
+  }
+  const voterSet = new Set(voters);
+  const missing = expected.filter((id) => !voterSet.has(id));
+  if (missing.length > 0) {
+    return { ready: false, reason: `${missing.length} expected voter(s) missing` };
+  }
+  return { ready: true };
+}
+
+async function loadDistinctNominatorIds(
+  db: Db,
+  lineupId: number,
+): Promise<number[]> {
+  const rows = await db
+    .select({ userId: schema.communityLineupEntries.nominatedBy })
+    .from(schema.communityLineupEntries)
+    .where(eq(schema.communityLineupEntries.lineupId, lineupId));
+  return Array.from(new Set(rows.map((r) => r.userId)));
+}
+
+async function loadDistinctVoterIds(
+  db: Db,
+  lineupId: number,
+): Promise<number[]> {
+  const rows = await db
+    .select({ userId: schema.communityLineupVotes.userId })
+    .from(schema.communityLineupVotes)
+    .where(eq(schema.communityLineupVotes.lineupId, lineupId));
+  return Array.from(new Set(rows.map((r) => r.userId)));
+}
+
+async function countNominations(db: Db, lineupId: number): Promise<number> {
+  const rows = await db
+    .select({ id: schema.communityLineupEntries.id })
+    .from(schema.communityLineupEntries)
+    .where(eq(schema.communityLineupEntries.lineupId, lineupId));
+  return rows.length;
+}
+
+async function readMinNominations(settings: SettingsService): Promise<number> {
+  const raw = await settings.get(SETTING_KEYS.LINEUP_AUTO_ADVANCE_MIN_NOMINATIONS);
+  if (!raw) return DEFAULT_MIN_NOMINATIONS;
+  const parsed = parseInt(raw, 10);
+  return Number.isNaN(parsed) || parsed < 1 ? DEFAULT_MIN_NOMINATIONS : parsed;
+}

--- a/api/src/lineups/quorum/quorum-check.helpers.ts
+++ b/api/src/lineups/quorum/quorum-check.helpers.ts
@@ -1,14 +1,20 @@
 /**
  * Quorum predicates for lineup auto-advance (ROK-1118).
  *
- * Building quorum: every expected voter has nominated ≥1 entry AND
- *   total distinct nominations ≥ floor (settings, default 4).
- * Voting quorum: every expected voter has cast ≥1 vote.
+ * Building quorum: every expected voter has nominated ≥ minPerVoter games
+ *   AND total distinct nominations ≥ floor (settings).
+ * Voting quorum: every expected voter has cast their FULL vote allotment
+ *   (`lineup.maxVotesPerPlayer`).
+ *
+ * The ≥1 / ≥1 thresholds were too eager — operator confirmed a private
+ * lineup auto-advanced after each voter cast 1 of 3 votes. Both predicates
+ * now require participants to use their full allotment so people can't
+ * skip the room ahead by being first.
  */
-import { eq } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import * as schema from '../../drizzle/schema';
-import { SETTING_KEYS } from '../../drizzle/schema/app-settings';
+import { SETTING_KEYS, type SettingKey } from '../../drizzle/schema/app-settings';
 import type { SettingsService } from '../../settings/settings.service';
 import { loadExpectedVoters } from './quorum-voters.helpers';
 
@@ -16,6 +22,7 @@ type Db = PostgresJsDatabase<typeof schema>;
 type LineupRow = typeof schema.communityLineups.$inferSelect;
 
 const DEFAULT_MIN_NOMINATIONS = 4;
+const DEFAULT_MIN_NOMINATIONS_PER_VOTER = 3;
 
 export interface QuorumResult {
   ready: boolean;
@@ -28,23 +35,23 @@ export async function checkBuildingQuorum(
   settings: SettingsService,
   lineup: LineupRow,
 ): Promise<QuorumResult> {
-  const [expected, nominators, totalNominations, floor] = await Promise.all([
-    loadExpectedVoters(db, lineup),
-    loadDistinctNominatorIds(db, lineup.id),
-    countNominations(db, lineup.id),
-    readMinNominations(settings),
-  ]);
+  const expected = await loadExpectedVoters(db, lineup);
   if (expected.length === 0) {
     return { ready: false, reason: 'no expected voters' };
   }
-  const nominatorSet = new Set(nominators);
-  const missing = expected.filter((id) => !nominatorSet.has(id));
-  if (missing.length > 0) {
+  const perVoterCounts = await countNominationsPerVoter(db, lineup.id);
+  const minPerVoter = await readMinNominationsPerVoter(settings);
+  const short = expected.filter(
+    (id) => (perVoterCounts.get(id) ?? 0) < minPerVoter,
+  );
+  if (short.length > 0) {
     return {
       ready: false,
-      reason: `${missing.length} expected nominator(s) missing`,
+      reason: `${short.length} expected nominator(s) below ${minPerVoter} nominations`,
     };
   }
+  const totalNominations = await countNominations(db, lineup.id);
+  const floor = await readMinNominations(settings);
   if (totalNominations < floor) {
     return {
       ready: false,
@@ -59,59 +66,88 @@ export async function checkVotingQuorum(
   db: Db,
   lineup: LineupRow,
 ): Promise<QuorumResult> {
-  const [expected, voters] = await Promise.all([
-    loadExpectedVoters(db, lineup),
-    loadDistinctVoterIds(db, lineup.id),
-  ]);
+  const expected = await loadExpectedVoters(db, lineup);
+  const perVoterCounts = await countVotesPerVoter(db, lineup.id);
   if (expected.length === 0) {
     return { ready: false, reason: 'no expected voters' };
   }
-  const voterSet = new Set(voters);
-  const missing = expected.filter((id) => !voterSet.has(id));
-  if (missing.length > 0) {
+  const required = lineup.maxVotesPerPlayer ?? 3;
+  const short = expected.filter(
+    (id) => (perVoterCounts.get(id) ?? 0) < required,
+  );
+  if (short.length > 0) {
     return {
       ready: false,
-      reason: `${missing.length} expected voter(s) missing`,
+      reason: `${short.length} expected voter(s) below ${required} votes`,
     };
   }
   return { ready: true };
 }
 
-async function loadDistinctNominatorIds(
+async function countNominationsPerVoter(
   db: Db,
   lineupId: number,
-): Promise<number[]> {
+): Promise<Map<number, number>> {
   const rows = await db
-    .select({ userId: schema.communityLineupEntries.nominatedBy })
+    .select({
+      userId: schema.communityLineupEntries.nominatedBy,
+      count: sql<number>`count(*)::int`,
+    })
     .from(schema.communityLineupEntries)
-    .where(eq(schema.communityLineupEntries.lineupId, lineupId));
-  return Array.from(new Set(rows.map((r) => r.userId)));
+    .where(eq(schema.communityLineupEntries.lineupId, lineupId))
+    .groupBy(schema.communityLineupEntries.nominatedBy);
+  return new Map(rows.map((r) => [r.userId, Number(r.count)]));
 }
 
-async function loadDistinctVoterIds(
+async function countVotesPerVoter(
   db: Db,
   lineupId: number,
-): Promise<number[]> {
+): Promise<Map<number, number>> {
   const rows = await db
-    .select({ userId: schema.communityLineupVotes.userId })
+    .select({
+      userId: schema.communityLineupVotes.userId,
+      count: sql<number>`count(*)::int`,
+    })
     .from(schema.communityLineupVotes)
-    .where(eq(schema.communityLineupVotes.lineupId, lineupId));
-  return Array.from(new Set(rows.map((r) => r.userId)));
+    .where(eq(schema.communityLineupVotes.lineupId, lineupId))
+    .groupBy(schema.communityLineupVotes.userId);
+  return new Map(rows.map((r) => [r.userId, Number(r.count)]));
 }
 
 async function countNominations(db: Db, lineupId: number): Promise<number> {
   const rows = await db
-    .select({ id: schema.communityLineupEntries.id })
+    .select({ total: sql<number>`count(*)::int` })
     .from(schema.communityLineupEntries)
-    .where(eq(schema.communityLineupEntries.lineupId, lineupId));
-  return rows.length;
+    .where(eq(schema.communityLineupEntries.lineupId, lineupId))
+    .execute();
+  return Number(rows[0]?.total ?? 0);
 }
 
 async function readMinNominations(settings: SettingsService): Promise<number> {
-  const raw = await settings.get(
+  return readPositiveSetting(
+    settings,
     SETTING_KEYS.LINEUP_AUTO_ADVANCE_MIN_NOMINATIONS,
+    DEFAULT_MIN_NOMINATIONS,
   );
-  if (!raw) return DEFAULT_MIN_NOMINATIONS;
+}
+
+async function readMinNominationsPerVoter(
+  settings: SettingsService,
+): Promise<number> {
+  return readPositiveSetting(
+    settings,
+    SETTING_KEYS.LINEUP_AUTO_ADVANCE_MIN_NOMINATIONS_PER_VOTER,
+    DEFAULT_MIN_NOMINATIONS_PER_VOTER,
+  );
+}
+
+async function readPositiveSetting(
+  settings: SettingsService,
+  key: SettingKey,
+  fallback: number,
+): Promise<number> {
+  const raw = await settings.get(key);
+  if (!raw) return fallback;
   const parsed = parseInt(raw, 10);
-  return Number.isNaN(parsed) || parsed < 1 ? DEFAULT_MIN_NOMINATIONS : parsed;
+  return Number.isNaN(parsed) || parsed < 1 ? fallback : parsed;
 }

--- a/api/src/lineups/quorum/quorum-check.helpers.ts
+++ b/api/src/lineups/quorum/quorum-check.helpers.ts
@@ -14,7 +14,10 @@
 import { eq, sql } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import * as schema from '../../drizzle/schema';
-import { SETTING_KEYS, type SettingKey } from '../../drizzle/schema/app-settings';
+import {
+  SETTING_KEYS,
+  type SettingKey,
+} from '../../drizzle/schema/app-settings';
 import type { SettingsService } from '../../settings/settings.service';
 import { loadExpectedVoters } from './quorum-voters.helpers';
 

--- a/api/src/lineups/quorum/quorum-voters.helpers.ts
+++ b/api/src/lineups/quorum/quorum-voters.helpers.ts
@@ -1,14 +1,16 @@
 /**
  * Expected-voter resolution for lineup quorum checks (ROK-1118).
  *
- * Public lineups: every distinct nominator + every actual voter +
- *   the creator (via `findLineupVoterIds`).
- * Private lineups: creator + invitee roster.
+ * Public lineups: every user who has actually participated — either
+ *   nominated an entry or cast a vote. Creators don't gate quorum unless
+ *   they participate, otherwise no public lineup could ever advance.
+ * Private lineups: creator + invitee roster — these are the only people
+ *   who CAN participate, so they're the gating set regardless of whether
+ *   they have yet.
  */
 import { eq } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import * as schema from '../../drizzle/schema';
-import { findLineupVoterIds } from '../lineups-query.helpers';
 
 type Db = PostgresJsDatabase<typeof schema>;
 type LineupRow = typeof schema.communityLineups.$inferSelect;
@@ -28,11 +30,11 @@ async function loadPublicExpectedVoters(
   db: Db,
   lineupId: number,
 ): Promise<number[]> {
-  const [voters, nominators] = await Promise.all([
-    findLineupVoterIds(db, lineupId),
+  const [nominators, voters] = await Promise.all([
     findDistinctNominators(db, lineupId),
+    findDistinctVoters(db, lineupId),
   ]);
-  return Array.from(new Set([...voters, ...nominators]));
+  return Array.from(new Set([...nominators, ...voters]));
 }
 
 async function loadPrivateExpectedVoters(
@@ -56,5 +58,13 @@ async function findDistinctNominators(
     .select({ userId: schema.communityLineupEntries.nominatedBy })
     .from(schema.communityLineupEntries)
     .where(eq(schema.communityLineupEntries.lineupId, lineupId));
+  return Array.from(new Set(rows.map((r) => r.userId)));
+}
+
+async function findDistinctVoters(db: Db, lineupId: number): Promise<number[]> {
+  const rows = await db
+    .select({ userId: schema.communityLineupVotes.userId })
+    .from(schema.communityLineupVotes)
+    .where(eq(schema.communityLineupVotes.lineupId, lineupId));
   return Array.from(new Set(rows.map((r) => r.userId)));
 }

--- a/api/src/lineups/quorum/quorum-voters.helpers.ts
+++ b/api/src/lineups/quorum/quorum-voters.helpers.ts
@@ -43,7 +43,9 @@ async function loadPrivateExpectedVoters(
     .select({ userId: schema.communityLineupInvitees.userId })
     .from(schema.communityLineupInvitees)
     .where(eq(schema.communityLineupInvitees.lineupId, lineup.id));
-  return Array.from(new Set([lineup.createdBy, ...invitees.map((r) => r.userId)]));
+  return Array.from(
+    new Set([lineup.createdBy, ...invitees.map((r) => r.userId)]),
+  );
 }
 
 async function findDistinctNominators(

--- a/api/src/lineups/quorum/quorum-voters.helpers.ts
+++ b/api/src/lineups/quorum/quorum-voters.helpers.ts
@@ -1,0 +1,58 @@
+/**
+ * Expected-voter resolution for lineup quorum checks (ROK-1118).
+ *
+ * Public lineups: every distinct nominator + every actual voter +
+ *   the creator (via `findLineupVoterIds`).
+ * Private lineups: creator + invitee roster.
+ */
+import { eq } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from '../../drizzle/schema';
+import { findLineupVoterIds } from '../lineups-query.helpers';
+
+type Db = PostgresJsDatabase<typeof schema>;
+type LineupRow = typeof schema.communityLineups.$inferSelect;
+
+/** Resolve the set of users whose participation gates auto-advance. */
+export async function loadExpectedVoters(
+  db: Db,
+  lineup: LineupRow,
+): Promise<number[]> {
+  if (lineup.visibility === 'private') {
+    return loadPrivateExpectedVoters(db, lineup);
+  }
+  return loadPublicExpectedVoters(db, lineup.id);
+}
+
+async function loadPublicExpectedVoters(
+  db: Db,
+  lineupId: number,
+): Promise<number[]> {
+  const [voters, nominators] = await Promise.all([
+    findLineupVoterIds(db, lineupId),
+    findDistinctNominators(db, lineupId),
+  ]);
+  return Array.from(new Set([...voters, ...nominators]));
+}
+
+async function loadPrivateExpectedVoters(
+  db: Db,
+  lineup: LineupRow,
+): Promise<number[]> {
+  const invitees = await db
+    .select({ userId: schema.communityLineupInvitees.userId })
+    .from(schema.communityLineupInvitees)
+    .where(eq(schema.communityLineupInvitees.lineupId, lineup.id));
+  return Array.from(new Set([lineup.createdBy, ...invitees.map((r) => r.userId)]));
+}
+
+async function findDistinctNominators(
+  db: Db,
+  lineupId: number,
+): Promise<number[]> {
+  const rows = await db
+    .select({ userId: schema.communityLineupEntries.nominatedBy })
+    .from(schema.communityLineupEntries)
+    .where(eq(schema.communityLineupEntries.lineupId, lineupId));
+  return Array.from(new Set(rows.map((r) => r.userId)));
+}

--- a/packages/contract/src/index.ts
+++ b/packages/contract/src/index.ts
@@ -144,3 +144,6 @@ export * from './discovery-categories.schema.js';
 
 // Community Insights (ROK-1099)
 export * from './community-insights.schema.js';
+
+// Community Lineup Realtime WS Events (ROK-1118)
+export * from './lineups/index.js';

--- a/packages/contract/src/lineups/index.ts
+++ b/packages/contract/src/lineups/index.ts
@@ -1,0 +1,2 @@
+// Community Lineup realtime WebSocket schemas (ROK-1118)
+export * from './realtime.js';

--- a/packages/contract/src/lineups/realtime.ts
+++ b/packages/contract/src/lineups/realtime.ts
@@ -1,0 +1,31 @@
+import { z } from 'zod';
+import { LineupStatusSchema } from '../lineup.schema.js';
+
+// ============================================================
+// Lineup Realtime WebSocket Events (ROK-1118)
+// ============================================================
+//
+// Server (`/lineups` namespace) emits `lineup:status` to room
+// `lineup:<id>` whenever the lineup advances phase. Clients
+// join/leave the room with bare `subscribe` / `unsubscribe`
+// messages. The `lineup:votes` event is intentionally deferred
+// until there is a real consumer.
+
+export const LineupRealtimeEventNames = {
+    // Server -> client
+    Status: 'lineup:status',
+    // Client -> server (bare names — no namespace prefix)
+    Subscribe: 'subscribe',
+    Unsubscribe: 'unsubscribe',
+} as const;
+
+export type LineupRealtimeEventName =
+    (typeof LineupRealtimeEventNames)[keyof typeof LineupRealtimeEventNames];
+
+export const LineupStatusEventSchema = z.object({
+    lineupId: z.number().int(),
+    status: LineupStatusSchema,
+    statusChangedAt: z.string().datetime(),
+});
+
+export type LineupStatusEvent = z.infer<typeof LineupStatusEventSchema>;

--- a/scripts/smoke/lineup-auto-advance.smoke.spec.ts
+++ b/scripts/smoke/lineup-auto-advance.smoke.spec.ts
@@ -1,0 +1,147 @@
+/**
+ * Lineup auto-advance live UI refresh smoke test (ROK-1118).
+ *
+ * AC: when the lineup phase changes, a user already on the detail page must
+ * see the LineupStatusBadge update within seconds — no navigation required.
+ *
+ * Strategy: open the detail page in a Playwright page (User B). Trigger a
+ * phase transition via the REST API from the test runner (User A). Assert
+ * that the badge text on User B's already-open page flips from "Voting" to
+ * "Scheduling" (the user-facing label for the `decided` status — see
+ * web/src/components/lineups/LineupStatusBadge.tsx).
+ *
+ * TDD gate: this test fails today. Without the LineupsGateway + the
+ * useLineupRealtime hook the page only refetches every 30s, so the badge
+ * does NOT update within the 5-second window. The dev agent's job is to
+ * make this assertion pass.
+ *
+ * Determinism: never use sleep(). We rely on Playwright's auto-retrying
+ * `expect(...).toBeVisible({ timeout })` to poll until the badge text
+ * updates or the timeout window elapses.
+ */
+import { test, expect } from './base';
+import { getAdminToken, apiGet, apiPatch, apiPost } from './api-helpers';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Cancel pending BullMQ phase-transition jobs for a lineup (ROK-1007). */
+async function cancelPhaseJobs(token: string, id: number): Promise<void> {
+    await apiPost(token, '/admin/test/cancel-lineup-phase-jobs', { lineupId: id });
+}
+
+/**
+ * Drive any active lineup all the way to archived so the next create call
+ * starts from a clean slate.
+ */
+async function archiveActiveLineup(token: string): Promise<void> {
+    const banner = await apiGet(token, '/lineups/banner');
+    if (!banner || typeof banner.id !== 'number') return;
+    await cancelPhaseJobs(token, banner.id);
+    const detail = await apiGet(token, `/lineups/${banner.id}`);
+    if (!detail) return;
+    const transitions: Record<string, string[]> = {
+        building: ['voting', 'decided', 'archived'],
+        voting: ['decided', 'archived'],
+        decided: ['archived'],
+    };
+    const steps = transitions[detail.status] ?? [];
+    for (const status of steps) {
+        const body: Record<string, unknown> = { status };
+        if (status === 'decided' && detail.entries?.length > 0) {
+            body.decidedGameId = detail.entries[0].gameId;
+        }
+        await apiPatch(token, `/lineups/${banner.id}/status`, body);
+    }
+}
+
+/**
+ * Create a lineup parked in `voting` status so the live transition we want
+ * to observe is voting → decided (user-facing label flip "Voting" →
+ * "Scheduling").
+ */
+async function createVotingLineup(token: string): Promise<{
+    lineupId: number;
+    decidedGameId: number;
+}> {
+    await archiveActiveLineup(token);
+
+    // Pull a couple of game IDs to nominate.
+    const games = await apiGet(token, '/admin/settings/games');
+    const gameIds = (games?.data?.slice(0, 2) ?? []).map(
+        (g: { id: number }) => g.id,
+    );
+    if (gameIds.length < 2) {
+        throw new Error('Demo data missing — need at least 2 configured games');
+    }
+
+    const created = (await apiPost(token, '/lineups', {
+        title: 'Auto Advance Smoke',
+        buildingDurationHours: 720,
+        votingDurationHours: 720,
+        decidedDurationHours: 720,
+    })) as { id: number };
+    const lineupId = created.id;
+
+    for (const gid of gameIds) {
+        await apiPost(token, `/lineups/${lineupId}/nominate`, { gameId: gid });
+    }
+    await apiPatch(token, `/lineups/${lineupId}/status`, { status: 'voting' });
+
+    return { lineupId, decidedGameId: gameIds[0] };
+}
+
+// ---------------------------------------------------------------------------
+// Test
+// ---------------------------------------------------------------------------
+
+test.describe('Lineup live UI refresh (ROK-1118)', () => {
+    let adminToken: string;
+    let lineupId: number;
+    let decidedGameId: number;
+
+    test.beforeAll(async () => {
+        adminToken = await getAdminToken();
+        const ctx = await createVotingLineup(adminToken);
+        lineupId = ctx.lineupId;
+        decidedGameId = ctx.decidedGameId;
+    });
+
+    test('badge flips Voting → Scheduling within 5s without navigation', async ({
+        page,
+    }) => {
+        // User B opens the detail page while the lineup is in voting phase.
+        await page.goto(`/community-lineup/${lineupId}`);
+        await expect(page.locator('body')).not.toHaveText(
+            /something went wrong/i,
+            { timeout: 10_000 },
+        );
+
+        // The badge must be in Voting state initially.
+        const votingBadge = page
+            .locator('span')
+            .filter({ hasText: /^Voting$/ })
+            .first();
+        await expect(votingBadge).toBeVisible({ timeout: 15_000 });
+
+        // User A advances the phase via REST. User B does NOT navigate.
+        await apiPatch(adminToken, `/lineups/${lineupId}/status`, {
+            status: 'decided',
+            decidedGameId,
+        });
+
+        // User B's still-open page should reflect the new status within 5s
+        // courtesy of the `lineup:status` socket event + query invalidation.
+        // NOTE: 'decided' renders as label "Scheduling" — see
+        // web/src/components/lineups/LineupStatusBadge.tsx.
+        const scheduledBadge = page
+            .locator('span')
+            .filter({ hasText: /^Scheduling$/ })
+            .first();
+        await expect(scheduledBadge).toBeVisible({ timeout: 5_000 });
+
+        // And the old badge must be gone.
+        await expect(votingBadge).not.toBeVisible({ timeout: 1_000 });
+    });
+});

--- a/web/src/hooks/use-lineup-realtime.test.ts
+++ b/web/src/hooks/use-lineup-realtime.test.ts
@@ -7,8 +7,13 @@
  * Behaviors covered:
  *   1. When the underlying socket emits `lineup:status`, the hook invalidates
  *      the React Query detail key `['lineups', 'detail', lineupId]`.
- *   2. The hook subscribes on mount (`emit('lineup:subscribe', { lineupId })`)
- *      and unsubscribes on unmount (`emit('lineup:unsubscribe', { lineupId })`).
+ *   2. The hook subscribes on mount (`emit('subscribe', { lineupId })`)
+ *      and unsubscribes on unmount (`emit('unsubscribe', { lineupId })`).
+ *
+ * Note: Phase A contract (`LineupRealtimeEventNames`) and Phase C gateway
+ * (`@SubscribeMessage('subscribe')`) use bare client→server names per the
+ * architect correction. The earlier draft of this test asserted on the
+ * `lineup:`-prefixed names, which would never be matched by the server.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
@@ -126,18 +131,18 @@ describe('useLineupRealtime (ROK-1118)', () => {
 
         const { unmount } = renderHook(() => useLineupRealtime(42), { wrapper });
 
-        // After mount the hook should have emitted 'lineup:subscribe' once.
+        // After mount the hook should have emitted 'subscribe' once.
         const subscribeCalls = mockEmit.mock.calls.filter(
-            ([event]) => event === 'lineup:subscribe',
+            ([event]) => event === 'subscribe',
         );
         expect(subscribeCalls).toHaveLength(1);
         expect(subscribeCalls[0][1]).toEqual({ lineupId: 42 });
 
-        // After unmount the hook should emit 'lineup:unsubscribe'.
+        // After unmount the hook should emit 'unsubscribe'.
         unmount();
 
         const unsubscribeCalls = mockEmit.mock.calls.filter(
-            ([event]) => event === 'lineup:unsubscribe',
+            ([event]) => event === 'unsubscribe',
         );
         expect(unsubscribeCalls).toHaveLength(1);
         expect(unsubscribeCalls[0][1]).toEqual({ lineupId: 42 });

--- a/web/src/hooks/use-lineup-realtime.test.ts
+++ b/web/src/hooks/use-lineup-realtime.test.ts
@@ -1,0 +1,145 @@
+/**
+ * useLineupRealtime hook tests (ROK-1118).
+ *
+ * TDD gate: the hook does not exist yet. Importing it must fail until the
+ * dev agent creates `web/src/hooks/use-lineup-realtime.ts`.
+ *
+ * Behaviors covered:
+ *   1. When the underlying socket emits `lineup:status`, the hook invalidates
+ *      the React Query detail key `['lineups', 'detail', lineupId]`.
+ *   2. The hook subscribes on mount (`emit('lineup:subscribe', { lineupId })`)
+ *      and unsubscribes on unmount (`emit('lineup:unsubscribe', { lineupId })`).
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
+
+// --- Socket mock ----------------------------------------------------------
+//
+// We capture every socket.io callback the hook registers via `on(event, cb)`
+// in `socketHandlers` so the test can fire events synthetically.
+
+type Handler = (...args: unknown[]) => void;
+
+const socketHandlers = new Map<string, Handler>();
+const mockEmit = vi.fn();
+const mockOn = vi.fn((event: string, cb: Handler) => {
+    socketHandlers.set(event, cb);
+});
+const mockOff = vi.fn((event: string) => {
+    socketHandlers.delete(event);
+});
+const mockDisconnect = vi.fn();
+
+const mockSocket = {
+    emit: mockEmit,
+    on: mockOn,
+    off: mockOff,
+    disconnect: mockDisconnect,
+    connected: true,
+};
+
+// `socket.io-client` is the real package the hook will pull in. We mock
+// `io(...)` to return the controllable socket above.
+const mockIo = vi.fn(() => mockSocket);
+vi.mock('socket.io-client', () => ({
+    io: (...args: unknown[]) => mockIo(...args),
+    Socket: class {},
+}));
+
+// --- Test harness ---------------------------------------------------------
+
+function createTestHarness() {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false, gcTime: Infinity, staleTime: Infinity },
+            mutations: { retry: false },
+        },
+    });
+
+    // Seed the cache so invalidation has a target to act on.
+    queryClient.setQueryData(['lineups', 'detail', 42], { id: 42, status: 'voting' });
+
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    function wrapper({ children }: { children: ReactNode }) {
+        return createElement(QueryClientProvider, { client: queryClient }, children);
+    }
+
+    return { queryClient, invalidateSpy, wrapper };
+}
+
+/** Fire a captured socket event with the given payload. */
+function fireSocketEvent(event: string, payload: unknown) {
+    const handler = socketHandlers.get(event);
+    if (!handler) {
+        throw new Error(`No handler registered for ${event}`);
+    }
+    handler(payload);
+}
+
+// --- Tests ----------------------------------------------------------------
+
+describe('useLineupRealtime (ROK-1118)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        socketHandlers.clear();
+    });
+
+    it('invalidates the lineup detail query when socket emits lineup:status', async () => {
+        const { invalidateSpy, wrapper } = createTestHarness();
+
+        // Import inside the test so the vi.mock for 'socket.io-client' is
+        // already in effect. Importing at top level before the hook exists
+        // would explode the whole file.
+        const mod = await import('./use-lineup-realtime');
+        const useLineupRealtime = mod.useLineupRealtime;
+
+        renderHook(() => useLineupRealtime(42), { wrapper });
+
+        // Hook should have registered a 'lineup:status' handler with the
+        // socket. Fire it synthetically to simulate a server broadcast.
+        await act(async () => {
+            fireSocketEvent('lineup:status', {
+                lineupId: 42,
+                status: 'decided',
+                statusChangedAt: new Date().toISOString(),
+            });
+        });
+
+        // The detail query for this lineup must be invalidated so React
+        // Query refetches the new phase.
+        const detailCalls = invalidateSpy.mock.calls.filter(
+            ([opts]) =>
+                JSON.stringify(opts?.queryKey) ===
+                JSON.stringify(['lineups', 'detail', 42]),
+        );
+        expect(detailCalls.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('subscribes on mount and unsubscribes on unmount', async () => {
+        const { wrapper } = createTestHarness();
+
+        const mod = await import('./use-lineup-realtime');
+        const useLineupRealtime = mod.useLineupRealtime;
+
+        const { unmount } = renderHook(() => useLineupRealtime(42), { wrapper });
+
+        // After mount the hook should have emitted 'lineup:subscribe' once.
+        const subscribeCalls = mockEmit.mock.calls.filter(
+            ([event]) => event === 'lineup:subscribe',
+        );
+        expect(subscribeCalls).toHaveLength(1);
+        expect(subscribeCalls[0][1]).toEqual({ lineupId: 42 });
+
+        // After unmount the hook should emit 'lineup:unsubscribe'.
+        unmount();
+
+        const unsubscribeCalls = mockEmit.mock.calls.filter(
+            ([event]) => event === 'lineup:unsubscribe',
+        );
+        expect(unsubscribeCalls).toHaveLength(1);
+        expect(unsubscribeCalls[0][1]).toEqual({ lineupId: 42 });
+    });
+});

--- a/web/src/hooks/use-lineup-realtime.ts
+++ b/web/src/hooks/use-lineup-realtime.ts
@@ -1,0 +1,63 @@
+import { useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { io, type Socket } from 'socket.io-client';
+import { LineupRealtimeEventNames } from '@raid-ledger/contract';
+import { DETAIL_KEY, LINEUPS_PREFIX } from './use-lineups';
+
+const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:3000';
+
+function createLineupSocket(lineupId: number): Socket {
+  const token = localStorage.getItem('raid_ledger_token');
+  const socket = io(`${API_BASE}/lineups`, {
+    auth: token ? { token } : undefined,
+    transports: ['websocket', 'polling'],
+    reconnection: true,
+    reconnectionAttempts: 5,
+    reconnectionDelay: 1000,
+  });
+
+  if (socket.connected) {
+    socket.emit(LineupRealtimeEventNames.Subscribe, { lineupId });
+  } else {
+    socket.on('connect', () => {
+      socket.emit(LineupRealtimeEventNames.Subscribe, { lineupId });
+    });
+  }
+
+  return socket;
+}
+
+/**
+ * Hook for real-time lineup status updates via WebSocket (ROK-1118).
+ *
+ * Connects to the `/lineups` namespace, subscribes to phase-change events for
+ * the given lineup, and invalidates the React Query detail/list caches when
+ * the server broadcasts `lineup:status`. Per-hook lifecycle: each call owns
+ * its own socket and tears it down on unmount.
+ */
+export function useLineupRealtime(lineupId: number | undefined): void {
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (lineupId === undefined) return;
+
+    const socket = createLineupSocket(lineupId);
+
+    const handleStatus = () => {
+      void queryClient.invalidateQueries({
+        queryKey: [...DETAIL_KEY, lineupId],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: [...LINEUPS_PREFIX],
+      });
+    };
+
+    socket.on(LineupRealtimeEventNames.Status, handleStatus);
+
+    return () => {
+      socket.emit(LineupRealtimeEventNames.Unsubscribe, { lineupId });
+      socket.off(LineupRealtimeEventNames.Status, handleStatus);
+      socket.disconnect();
+    };
+  }, [lineupId, queryClient]);
+}

--- a/web/src/hooks/use-lineups.ts
+++ b/web/src/hooks/use-lineups.ts
@@ -34,11 +34,11 @@ const ACTIVE_LINEUP_KEY = ['lineups', 'active'] as const;
 /** Query key for the banner. */
 const BANNER_KEY = ['lineups', 'banner'] as const;
 /** Query key prefix for lineup detail queries. */
-const DETAIL_KEY = ['lineups', 'detail'] as const;
+export const DETAIL_KEY = ['lineups', 'detail'] as const;
 /** Query key prefix for common ground queries. */
 const COMMON_GROUND_KEY = ['common-ground'] as const;
 /** Shared prefix for all lineup query invalidation. */
-const LINEUPS_PREFIX = ['lineups'] as const;
+export const LINEUPS_PREFIX = ['lineups'] as const;
 
 /**
  * Hook for fetching every currently active lineup (ROK-1065).

--- a/web/src/pages/lineup-detail-page.tsx
+++ b/web/src/pages/lineup-detail-page.tsx
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react';
 import type { JSX } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { useLineupDetail } from '../hooks/use-lineups';
+import { useLineupRealtime } from '../hooks/use-lineup-realtime';
 import { useTiebreakerDetail } from '../hooks/use-tiebreaker';
 import { LineupDetailHeader } from '../components/lineups/LineupDetailHeader';
 import { InviteeList } from '../components/lineups/InviteeList';
@@ -73,6 +74,7 @@ export function LineupDetailPage(): JSX.Element {
   const { id } = useParams<{ id: string }>();
   const lineupId = id ? parseInt(id, 10) : undefined;
   const { data: lineup, isLoading, error } = useLineupDetail(lineupId);
+  useLineupRealtime(lineupId);
   const { data: tiebreaker } = useTiebreakerDetail(lineupId);
   const { user } = useAuth();
   const [modalOpen, setModalOpen] = useState(false);


### PR DESCRIPTION
## Summary

Closes a long-standing UX bug: lineups didn't advance phases automatically when participants finished, and the page didn't update without a manual refresh.

- **Auto-advance** — after every vote/nomination/removeNomination, the service checks the participation quorum and routes through `runStatusTransition` if ready. Voting → decided requires every expected voter to cast `lineup.maxVotesPerPlayer` votes (default 3). Building → voting requires every voter ≥ `LINEUP_AUTO_ADVANCE_MIN_NOMINATIONS_PER_VOTER` (new setting, default 3) AND total ≥ existing `LINEUP_AUTO_ADVANCE_MIN_NOMINATIONS` floor (default 4). Manual operator advance still works as override.
- **Live UI refresh** — new `LineupsGateway` (socket.io, `/lineups` namespace, mirrors `AdHocEventsGateway`). Emits `lineup:status` to room `lineup:<id>` after every successful status update. Frontend `useLineupRealtime` invalidates `['lineups','detail',id]` on event; page badge flips within ~2s without navigation.
- **Concurrency safety** — `applyStatusUpdate` now uses a conditional `WHERE id=? AND status=$expectedPre` UPDATE; throws `ConflictException` on `rowCount=0` so racing voters can't double-fire notifications/embeds/queue jobs.
- **Discord DM embeds** — unchanged path. Auto-advance routes through `runStatusTransition` so `fireVotingOpen` / `fireDecidedNotifications` post fresh embeds exactly as the manual flow does.

## Linear

ROK-1118 (parent ROK-929)

## Test plan

- [x] 13 new unit tests for `quorum-check` predicates (voting + building, full allotment + edge cases)
- [x] 5 integration tests in `lineups-auto-advance.integration.spec.ts` including explicit "1 of 3 votes does not advance" regression for operator's reported bug
- [x] 11 unit tests for `lineups.gateway` (JWT handshake, room scoping, payload validation)
- [x] 2 Vitest tests for `useLineupRealtime` (subscribe/unsubscribe + invalidation)
- [x] Playwright dual-context smoke (desktop + mobile) at `scripts/smoke/lineup-auto-advance.smoke.spec.ts` — passes consistently in 5+ runs locally
- [x] `./scripts/validate-ci.sh --full` green: build, ts, lint, 5661 unit, 801 integration
- [x] Operator browser-tested locally and approved
- [x] 3-agent code review (security/correctness, tests/contract, perf/style) — all APPROVED, 0 blockers, 0 auto-fixes
- [x] Architect POST_REVIEW APPROVED — all 6 PRE_DEV corrections applied
- [x] Lead smoke green (build + ts + 60/60 lineup unit + 2/2 hook)

## Architecture notes

- **No `lineup:votes` event** — deferred per architect rec; only `lineup:status` shipped. Add later when there's a real consumer.
- **Per-hook socket lifecycle** on the frontend, not a singleton — mirrors `use-voice-roster.ts`.
- **Single-instance gateway** (no Redis adapter), same caveat as `AdHocEventsGateway`. Documented in gateway docstring.
- **Spec reconciled** — quorum thresholds were tightened mid-build after operator browser-test feedback (the original ≥1-vote/≥1-nom thresholds let voters skip the room ahead by being first).

## Tech debt (filed separately)

9 items raised by `reviewer-style`, all non-blocking — will create a follow-up Linear story.

🤖 Generated with [Claude Code](https://claude.com/claude-code)