### PR TITLE
ROK-1117: fix: veto/tiebreaker open notifications + late-join voting

### DIFF
--- a/api/src/cron-jobs/cron-job.constants.ts
+++ b/api/src/cron-jobs/cron-job.constants.ts
@@ -180,4 +180,9 @@ export const CORE_JOB_METADATA: Record<string, CoreJobMetadata> = {
       'Rebuilds the community insights snapshot (radar, engagement, churn, social graph, temporal, key insights) daily at 06:30 UTC',
     category: 'Data Sync',
   },
+  LineupReminderService_checkTiebreakerReminders: {
+    description:
+      'DMs lineup tiebreaker participants 24h and 1h before round deadline every 5 minutes',
+    category: 'Notifications',
+  },
 };

--- a/api/src/lineups/lineup-notification-dm-batch.helpers.ts
+++ b/api/src/lineups/lineup-notification-dm-batch.helpers.ts
@@ -121,6 +121,7 @@ export async function fanOutTiebreakerOpenDMs(
   dedupService: NotificationDedupService,
   lineup: LineupInfo,
   tiebreaker: TiebreakerNotificationInfo,
+  clientUrl?: string,
 ): Promise<void> {
   const [row] = await db
     .select()
@@ -138,6 +139,7 @@ export async function fanOutTiebreakerOpenDMs(
       lineup,
       tiebreaker,
       member,
+      clientUrl,
     );
   }
 }

--- a/api/src/lineups/lineup-notification-dm-batch.helpers.ts
+++ b/api/src/lineups/lineup-notification-dm-batch.helpers.ts
@@ -22,9 +22,16 @@ import {
 import { dispatchMatchMemberDM } from './lineup-notification-dms.helpers';
 import {
   findDiscordLinkedMembers,
+  findDiscordMembersByUserIds,
   findInviteeDiscordMembers,
   findMatchMemberUsers,
 } from './lineup-notification-targets.helpers';
+import { eq } from 'drizzle-orm';
+import { loadExpectedVoters } from './quorum/quorum-voters.helpers';
+import {
+  sendTiebreakerOpenDM,
+  type TiebreakerNotificationInfo,
+} from './lineup-notification-private-dm.helpers';
 
 type Db = PostgresJsDatabase<typeof schema>;
 
@@ -95,6 +102,41 @@ export async function fanOutLineupCreatedDMsToInvitees(
       notificationService,
       dedupService,
       lineup,
+      member,
+    );
+  }
+}
+
+/**
+ * Fan-out tiebreaker-open DMs (ROK-1117).
+ *
+ * Visibility-aware via `loadExpectedVoters`: public lineups DM
+ * nominators ∪ voters; private lineups DM creator + invitees. We then
+ * adapt those user IDs to `DiscordMember` rows (skipping users without
+ * a Discord link) and reuse the shared per-user DM sender.
+ */
+export async function fanOutTiebreakerOpenDMs(
+  db: Db,
+  notificationService: NotificationService,
+  dedupService: NotificationDedupService,
+  lineup: LineupInfo,
+  tiebreaker: TiebreakerNotificationInfo,
+): Promise<void> {
+  const [row] = await db
+    .select()
+    .from(schema.communityLineups)
+    .where(eq(schema.communityLineups.id, lineup.id))
+    .limit(1);
+  if (!row) return;
+  const userIds = await loadExpectedVoters(db, row);
+  if (userIds.length === 0) return;
+  const members = await findDiscordMembersByUserIds(db, userIds);
+  for (const member of members) {
+    await sendTiebreakerOpenDM(
+      notificationService,
+      dedupService,
+      lineup,
+      tiebreaker,
       member,
     );
   }

--- a/api/src/lineups/lineup-notification-embed.helpers.ts
+++ b/api/src/lineups/lineup-notification-embed.helpers.ts
@@ -328,3 +328,23 @@ export function buildTiebreakerStartedEmbed(
   applyChrome(embed, ctx, 'Tiebreaker');
   return { embed, row: ctaButton(ctx, cta) };
 }
+
+/** Tiebreaker reminder (24h or 1h before round deadline) — ROK-1117. */
+export function buildTiebreakerReminderEmbed(
+  ctx: EmbedContext,
+  mode: 'bracket' | 'veto',
+  deadline: Date,
+  threshold: '24h' | '1h',
+): EmbedWithRow {
+  const cta = mode === 'veto' ? 'Cast Your Vetoes' : 'Vote in Bracket';
+  const headline =
+    threshold === '1h'
+      ? '⏰ Tiebreaker closing in 1 hour — cast your vote!'
+      : "⏰ Tiebreaker closing in 24 hours — don't miss your chance to vote.";
+  const embed = new EmbedBuilder()
+    .setTitle(resolveEmbedTitle(ctx, '⏰', 'Tiebreaker Reminder'))
+    .setDescription(`${headline}\n\n**Closes** ${discordTs(deadline)}`)
+    .setColor(EMBED_COLORS.ANNOUNCEMENT);
+  applyChrome(embed, ctx, 'Tiebreaker Reminder');
+  return { embed, row: ctaButton(ctx, cta) };
+}

--- a/api/src/lineups/lineup-notification-private-dm.helpers.ts
+++ b/api/src/lineups/lineup-notification-private-dm.helpers.ts
@@ -15,6 +15,13 @@ import type {
 } from './lineup-notification-dm.helpers';
 import { DEDUP_TTL } from './lineup-notification.constants';
 
+/** Tiebreaker shape needed by the open-notification DM (ROK-1117). */
+export interface TiebreakerNotificationInfo {
+  id: number;
+  mode: 'bracket' | 'veto';
+  roundDeadline?: Date | null;
+}
+
 /** Send the per-invitee nomination-milestone DM (ROK-1115). */
 export async function sendMilestoneDM(
   notificationService: NotificationService,
@@ -102,6 +109,45 @@ function formatEventWhen(eventDate: Date): string {
     day: 'numeric',
     hour: 'numeric',
     minute: '2-digit',
+  });
+}
+
+/**
+ * Send the per-user tiebreaker-open DM (ROK-1117).
+ *
+ * Used for both public (every expected voter) and private (creator +
+ * invitees) lineups since the body is the same. Dedup key includes the
+ * tiebreaker id so a future re-open fires its own DM.
+ */
+export async function sendTiebreakerOpenDM(
+  notificationService: NotificationService,
+  dedupService: NotificationDedupService,
+  lineup: LineupDmInfo,
+  tiebreaker: TiebreakerNotificationInfo,
+  member: DiscordMember,
+): Promise<void> {
+  const key = `lineup-tiebreaker-open-dm:${tiebreaker.id}:${member.userId}`;
+  if (await dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
+  const titleSuffix = lineup.title ? ` — ${lineup.title}` : '';
+  const cta =
+    tiebreaker.mode === 'veto' ? 'Cast your veto now' : 'Vote in the bracket';
+  const deadlineLine = tiebreaker.roundDeadline
+    ? ` Round closes <t:${Math.floor(tiebreaker.roundDeadline.getTime() / 1000)}:R>.`
+    : '';
+
+  await notificationService.create({
+    userId: member.userId,
+    type: 'community_lineup',
+    title: `Tiebreaker open${titleSuffix}`,
+    message:
+      `It's a tie! A ${tiebreaker.mode} tiebreaker is now running. ` +
+      `${cta}.${deadlineLine}`,
+    payload: {
+      subtype: 'lineup_tiebreaker_open',
+      lineupId: lineup.id,
+      tiebreakerId: tiebreaker.id,
+      mode: tiebreaker.mode,
+    },
   });
 }
 

--- a/api/src/lineups/lineup-notification-private-dm.helpers.ts
+++ b/api/src/lineups/lineup-notification-private-dm.helpers.ts
@@ -20,6 +20,29 @@ export interface TiebreakerNotificationInfo {
   id: number;
   mode: 'bracket' | 'veto';
   roundDeadline?: Date | null;
+  /** Tied games surfaced as deep-linked markdown in the DM body (ROK-1117). */
+  tiedGames?: ReadonlyArray<{ id: number; name: string }>;
+}
+
+/**
+ * Render up to 15 tied games as a bulleted list of deep links, mirroring
+ * the voting-open ballot pattern. Falls back to plain bold names when no
+ * `clientUrl` is configured.
+ */
+export function buildTiedGamesList(
+  games: ReadonlyArray<{ id: number; name: string }>,
+  clientUrl?: string,
+): string {
+  if (games.length === 0) return '';
+  const lines = games.slice(0, 15).map((g) => {
+    const label = clientUrl
+      ? `[**${g.name}**](${clientUrl}/games/${g.id})`
+      : `**${g.name}**`;
+    return `\u{1F3AE} ${label}`;
+  });
+  const overflow =
+    games.length > 15 ? `\n*...and ${games.length - 15} more*` : '';
+  return `\n\n**Tied Games**\n${lines.join('\n')}${overflow}`;
 }
 
 /** Send the per-invitee nomination-milestone DM (ROK-1115). */
@@ -112,6 +135,27 @@ function formatEventWhen(eventDate: Date): string {
   });
 }
 
+/** Compose the tiebreaker-open DM body with tied-game links + CTA (ROK-1117). */
+function composeTiebreakerOpenMessage(
+  lineup: LineupDmInfo,
+  tiebreaker: TiebreakerNotificationInfo,
+  clientUrl?: string,
+): string {
+  const cta =
+    tiebreaker.mode === 'veto' ? 'Cast your veto now' : 'Vote in the bracket';
+  const deadlineLine = tiebreaker.roundDeadline
+    ? ` Round closes <t:${Math.floor(tiebreaker.roundDeadline.getTime() / 1000)}:R>.`
+    : '';
+  const ballot = buildTiedGamesList(tiebreaker.tiedGames ?? [], clientUrl);
+  const ctaLink = clientUrl
+    ? `\n\n[${cta}](${clientUrl}/community-lineup/${lineup.id})`
+    : '';
+  return (
+    `It's a tie! A ${tiebreaker.mode} tiebreaker is now running. ` +
+    `${cta}.${deadlineLine}${ballot}${ctaLink}`
+  );
+}
+
 /**
  * Send the per-user tiebreaker-open DM (ROK-1117).
  *
@@ -125,23 +169,17 @@ export async function sendTiebreakerOpenDM(
   lineup: LineupDmInfo,
   tiebreaker: TiebreakerNotificationInfo,
   member: DiscordMember,
+  clientUrl?: string,
 ): Promise<void> {
   const key = `lineup-tiebreaker-open-dm:${tiebreaker.id}:${member.userId}`;
   if (await dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
   const titleSuffix = lineup.title ? ` — ${lineup.title}` : '';
-  const cta =
-    tiebreaker.mode === 'veto' ? 'Cast your veto now' : 'Vote in the bracket';
-  const deadlineLine = tiebreaker.roundDeadline
-    ? ` Round closes <t:${Math.floor(tiebreaker.roundDeadline.getTime() / 1000)}:R>.`
-    : '';
 
   await notificationService.create({
     userId: member.userId,
     type: 'community_lineup',
     title: `Tiebreaker open${titleSuffix}`,
-    message:
-      `It's a tie! A ${tiebreaker.mode} tiebreaker is now running. ` +
-      `${cta}.${deadlineLine}`,
+    message: composeTiebreakerOpenMessage(lineup, tiebreaker, clientUrl),
     payload: {
       subtype: 'lineup_tiebreaker_open',
       lineupId: lineup.id,

--- a/api/src/lineups/lineup-notification-targets.helpers.ts
+++ b/api/src/lineups/lineup-notification-targets.helpers.ts
@@ -2,7 +2,7 @@
  * Target resolution queries for Community Lineup notifications (ROK-932).
  * Finds Discord-linked members and match members for DM dispatch.
  */
-import { eq, sql } from 'drizzle-orm';
+import { and, eq, inArray, isNotNull, sql } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import * as schema from '../drizzle/schema';
 import type { DiscordMember } from './lineup-notification-dm.helpers';
@@ -75,4 +75,33 @@ export async function findMatchMemberUsers(
     WHERE lmm.match_id = ${matchId}
       AND u.discord_id IS NOT NULL
   `)) as unknown as DiscordMember[];
+}
+
+/**
+ * Resolve a list of user IDs into Discord-linked member rows (ROK-1117).
+ *
+ * Adapter for `loadExpectedVoters` (which returns bare user IDs) so we can
+ * feed the same DM-fan-out helpers everything else uses. Filters out users
+ * that have no `discord_id`, because they cannot receive a Discord DM.
+ */
+export async function findDiscordMembersByUserIds(
+  db: Db,
+  userIds: ReadonlyArray<number>,
+): Promise<DiscordMember[]> {
+  if (userIds.length === 0) return [];
+  const rows = await db
+    .select({
+      id: schema.users.id,
+      userId: schema.users.id,
+      displayName: sql<string>`COALESCE(${schema.users.displayName}, ${schema.users.username})`,
+      discordId: schema.users.discordId,
+    })
+    .from(schema.users)
+    .where(
+      and(
+        isNotNull(schema.users.discordId),
+        inArray(schema.users.id, [...userIds]),
+      ),
+    );
+  return rows as DiscordMember[];
 }

--- a/api/src/lineups/lineup-notification-tiebreaker.helpers.ts
+++ b/api/src/lineups/lineup-notification-tiebreaker.helpers.ts
@@ -1,0 +1,83 @@
+/**
+ * Tiebreaker-open notification orchestrator (ROK-1117).
+ *
+ * Mirrors `notifyVotingOpen` but for the bracket / veto tiebreaker
+ * round: DMs every expected voter (public = nominators ∪ voters,
+ * private = creator + invitees, via `loadExpectedVoters`) and posts
+ * a channel embed for public lineups only. Private lineups suppress
+ * the channel embed (ROK-1065 routing).
+ *
+ * Extracted into its own file so `lineup-notification.service.ts`
+ * stays under the 300-line ESLint ceiling.
+ */
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from '../drizzle/schema';
+import type { NotificationService } from '../notifications/notification.service';
+import type { NotificationDedupService } from '../notifications/notification-dedup.service';
+import type { SettingsService } from '../settings/settings.service';
+import type { DiscordBotClientService } from '../discord-bot/discord-bot-client.service';
+import { buildTiebreakerStartedEmbed } from './lineup-notification-embed.helpers';
+import {
+  postChannelEmbed,
+  resolveEmbedCtx,
+  type DispatchDeps,
+} from './lineup-notification-dispatch.helpers';
+import { fanOutTiebreakerOpenDMs } from './lineup-notification-dm-batch.helpers';
+import { resolveLineupVisibility } from './lineup-notification-routing.helpers';
+import type { LineupInfo } from './lineup-notification.service';
+import type { TiebreakerNotificationInfo } from './lineup-notification-private-dm.helpers';
+
+export type { TiebreakerNotificationInfo } from './lineup-notification-private-dm.helpers';
+
+type Db = PostgresJsDatabase<typeof schema>;
+
+/** Composed deps for the tiebreaker-open orchestrator. */
+export interface TiebreakerOpenDeps {
+  db: Db;
+  notificationService: NotificationService;
+  dedupService: NotificationDedupService;
+  botClient: DiscordBotClientService;
+  settingsService: SettingsService;
+}
+
+function dispatchDeps(deps: TiebreakerOpenDeps): DispatchDeps {
+  const { db, settingsService, botClient, dedupService } = deps;
+  return { db, settingsService, botClient, dedupService };
+}
+
+/**
+ * Orchestrate the tiebreaker-open dispatch:
+ *   1. Fan-out DMs to every expected voter (visibility-aware via
+ *      `loadExpectedVoters`).
+ *   2. Post the channel embed for public lineups only (private lineups
+ *      suppress the embed; DMs already covered the invitees).
+ */
+export async function notifyTiebreakerOpen(
+  deps: TiebreakerOpenDeps,
+  lineup: LineupInfo,
+  tiebreaker: TiebreakerNotificationInfo,
+): Promise<void> {
+  await fanOutTiebreakerOpenDMs(
+    deps.db,
+    deps.notificationService,
+    deps.dedupService,
+    lineup,
+    tiebreaker,
+  );
+
+  const visibility = await resolveLineupVisibility(deps.db, lineup);
+  if (visibility !== 'public') return;
+
+  const ctx = await resolveEmbedCtx(dispatchDeps(deps), lineup.id, 'voting');
+  await postChannelEmbed(
+    dispatchDeps(deps),
+    `lineup-tiebreaker-open:${tiebreaker.id}`,
+    () =>
+      buildTiebreakerStartedEmbed(
+        ctx,
+        tiebreaker.mode,
+        tiebreaker.roundDeadline ?? undefined,
+      ),
+    ctx,
+  );
+}

--- a/api/src/lineups/lineup-notification-tiebreaker.helpers.ts
+++ b/api/src/lineups/lineup-notification-tiebreaker.helpers.ts
@@ -26,6 +26,7 @@ import { fanOutTiebreakerOpenDMs } from './lineup-notification-dm-batch.helpers'
 import { resolveLineupVisibility } from './lineup-notification-routing.helpers';
 import type { LineupInfo } from './lineup-notification.service';
 import type { TiebreakerNotificationInfo } from './lineup-notification-private-dm.helpers';
+import { findGamesByIds } from './lineups-query.helpers';
 
 export type { TiebreakerNotificationInfo } from './lineup-notification-private-dm.helpers';
 
@@ -46,6 +47,21 @@ function dispatchDeps(deps: TiebreakerOpenDeps): DispatchDeps {
 }
 
 /**
+ * Enrich tiebreaker info with tied-game id+name for the DM ballot list
+ * (ROK-1117). Falls back to the input when tiedGameIds is missing/empty
+ * so older callers stay backwards-compatible during the rollout.
+ */
+async function enrichTiebreakerWithGames(
+  db: Db,
+  tiebreaker: TiebreakerNotificationInfo,
+  tiedGameIds: ReadonlyArray<number> | undefined,
+): Promise<TiebreakerNotificationInfo> {
+  if (!tiedGameIds || tiedGameIds.length === 0) return tiebreaker;
+  const games = await findGamesByIds(db, tiedGameIds);
+  return { ...tiebreaker, tiedGames: games };
+}
+
+/**
  * Orchestrate the tiebreaker-open dispatch:
  *   1. Fan-out DMs to every expected voter (visibility-aware via
  *      `loadExpectedVoters`).
@@ -56,13 +72,21 @@ export async function notifyTiebreakerOpen(
   deps: TiebreakerOpenDeps,
   lineup: LineupInfo,
   tiebreaker: TiebreakerNotificationInfo,
+  tiedGameIds?: ReadonlyArray<number>,
 ): Promise<void> {
+  const clientUrl = await deps.settingsService.getClientUrl();
+  const enriched = await enrichTiebreakerWithGames(
+    deps.db,
+    tiebreaker,
+    tiedGameIds,
+  );
   await fanOutTiebreakerOpenDMs(
     deps.db,
     deps.notificationService,
     deps.dedupService,
     lineup,
-    tiebreaker,
+    enriched,
+    clientUrl,
   );
 
   const visibility = await resolveLineupVisibility(deps.db, lineup);

--- a/api/src/lineups/lineup-notification-tiebreaker.integration.spec.ts
+++ b/api/src/lineups/lineup-notification-tiebreaker.integration.spec.ts
@@ -200,6 +200,21 @@ function describeTiebreakerNotifications() {
       .where(eq(schema.notifications.userId, userId));
   }
 
+  /**
+   * Pick the tiebreaker-open DM row for a given user (ROK-1117 rework).
+   * Returns `undefined` when no matching DM was created so the
+   * `toBeTruthy` assertion gives a clear failure.
+   */
+  async function findTiebreakerOpenDM(
+    userId: number,
+  ): Promise<{ message: string; payload: unknown } | undefined> {
+    const rows = (await notificationsForUser(userId)) as Array<{
+      message: string;
+      payload: { subtype?: string } | null;
+    }>;
+    return rows.find((r) => r.payload?.subtype === 'lineup_tiebreaker_open');
+  }
+
   function dedupKeysSeen(): string[] {
     return dedupSpy.mock.calls.map((c) => String(c[0]));
   }
@@ -207,7 +222,7 @@ function describeTiebreakerNotifications() {
   // ── AC: public lineup → DMs + channel embed ────────────────────────────
 
   it('public tiebreaker.start() DMs every expected voter and posts channel embed', async () => {
-    const { lineupId, participantIds } = await setupPublicLineup();
+    const { lineupId, participantIds, tiedGameIds } = await setupPublicLineup();
 
     const tiebreaker = await tiebreakerService.start(lineupId, {
       mode: 'veto',
@@ -230,6 +245,22 @@ function describeTiebreakerNotifications() {
     // Dedup key for the channel embed is `lineup-tiebreaker-open:<tbId>`.
     const expectedKey = `lineup-tiebreaker-open:${tiebreaker.id}`;
     expect(dedupKeysSeen()).toContain(expectedKey);
+
+    // ROK-1117 rework: the open-DM body lists tied games as deep links
+    // and ends with a CTA pointing at the lineup detail page.
+    const openDmRow = await findTiebreakerOpenDM(participantIds[0]);
+    expect(openDmRow).toBeTruthy();
+    const message = openDmRow!.message;
+    for (const gameId of tiedGameIds) {
+      expect(message).toMatch(
+        new RegExp(`🎮 \\[\\*\\*.+\\*\\*\\]\\(.+/games/${gameId}\\)`),
+      );
+    }
+    expect(message).toMatch(
+      new RegExp(
+        `\\[(Cast your veto( now)?|Vote in the bracket)\\]\\(.+/community-lineup/${lineupId}\\)`,
+      ),
+    );
   });
 
   // ── AC: private lineup → DMs only, no channel embed ────────────────────
@@ -361,7 +392,9 @@ function describeTiebreakerReminders() {
     await reminderService.checkTiebreakerReminders();
 
     // Each expected voter should have received at least one reminder
-    // notification with the tiebreaker-reminder subtype.
+    // notification with the tiebreaker-reminder subtype. The DM body
+    // must list the tied games as deep links and end with a CTA
+    // pointing at the lineup detail page (ROK-1117 rework).
     for (const userId of participantIds) {
       const rows = await testApp.db
         .select()
@@ -372,6 +405,13 @@ function describeTiebreakerReminders() {
         return payload?.subtype === 'lineup_tiebreaker_reminder';
       });
       expect(reminderRows.length).toBeGreaterThan(0);
+      const message = reminderRows[0].message;
+      expect(message).toMatch(/🎮 \[\*\*.+\*\*\]\(.+\/games\/\d+\)/);
+      expect(message).toMatch(
+        new RegExp(
+          `\\[(Cast your veto|Vote in the bracket)\\]\\(.+/community-lineup/${lineupId}\\)`,
+        ),
+      );
     }
   });
 

--- a/api/src/lineups/lineup-notification-tiebreaker.integration.spec.ts
+++ b/api/src/lineups/lineup-notification-tiebreaker.integration.spec.ts
@@ -1,0 +1,260 @@
+/**
+ * ROK-1117 — Tiebreaker open notifications (integration).
+ *
+ * TDD gate: these tests pin down the spec for tiebreaker-open
+ * notification fan-out. They MUST fail until the dev agent wires
+ * `LineupNotificationService.notifyTiebreakerOpen` into
+ * `TiebreakerService.start()`.
+ *
+ * Coverage:
+ *   - Public lineup tiebreaker.start() → DMs fan out to every user
+ *     returned by `loadExpectedVoters` (nominators ∪ voters), and a
+ *     channel embed is posted with dedup key
+ *     `lineup-tiebreaker-open:<tbId>`.
+ *   - Private lineup tiebreaker.start() → DMs fan out to invitees +
+ *     creator, channel embed is suppressed (mirrors ROK-1065 routing).
+ *
+ * Strategy:
+ *   - Real DB (Testcontainers) for lineup / entries / votes / users.
+ *   - Stub `DiscordBotClientService.sendEmbed` so we can assert whether
+ *     the channel-embed path was invoked.
+ *   - Drive `TiebreakerService.start()` directly (deterministic), then
+ *     read notification rows + the sendEmbed spy.
+ */
+import { eq } from 'drizzle-orm';
+import { getTestApp, type TestApp } from '../common/testing/test-app';
+import {
+  truncateAllTables,
+  loginAsAdmin,
+} from '../common/testing/integration-helpers';
+import * as schema from '../drizzle/schema';
+import { TiebreakerService } from './tiebreaker/tiebreaker.service';
+import { DiscordBotClientService } from '../discord-bot/discord-bot-client.service';
+import { SettingsService } from '../settings/settings.service';
+import { NotificationDedupService } from '../notifications/notification-dedup.service';
+
+interface PublicLineupSetup {
+  lineupId: number;
+  tiedGameIds: [number, number];
+  participantIds: number[];
+}
+
+interface PrivateLineupSetup {
+  lineupId: number;
+  tiedGameIds: [number, number];
+  inviteeIds: number[];
+  creatorId: number;
+}
+
+function describeTiebreakerNotifications() {
+  let testApp: TestApp;
+  let adminToken: string;
+  let tiebreakerService: TiebreakerService;
+  let botClient: DiscordBotClientService;
+  let settings: SettingsService;
+  let dedup: NotificationDedupService;
+  let sendEmbedSpy: jest.SpyInstance;
+  let dedupSpy: jest.SpyInstance;
+
+  beforeAll(async () => {
+    testApp = await getTestApp();
+    adminToken = await loginAsAdmin(testApp.request, testApp.seed);
+    tiebreakerService = testApp.app.get(TiebreakerService);
+    botClient = testApp.app.get(DiscordBotClientService);
+    settings = testApp.app.get(SettingsService);
+    dedup = testApp.app.get(NotificationDedupService);
+    void adminToken;
+  });
+
+  beforeEach(async () => {
+    sendEmbedSpy = jest
+      .spyOn(botClient, 'sendEmbed')
+      .mockResolvedValue({ id: 'mock-msg-tb' } as never);
+    dedupSpy = jest.spyOn(dedup, 'checkAndMarkSent');
+    // Bind a default channel so the channel-dispatch path WOULD fire if
+    // visibility were public — needed for the public-channel assertion.
+    await settings.setDiscordBotDefaultChannel('test-channel-tb-1117');
+  });
+
+  afterEach(async () => {
+    sendEmbedSpy.mockRestore();
+    dedupSpy.mockRestore();
+    testApp.seed = await truncateAllTables(testApp.db);
+    adminToken = await loginAsAdmin(testApp.request, testApp.seed);
+  });
+
+  // ── Helpers ────────────────────────────────────────────────────────────
+
+  async function createMember(tag: string): Promise<number> {
+    const [user] = await testApp.db
+      .insert(schema.users)
+      .values({
+        discordId: `discord:${tag}`,
+        username: `mem-${tag}`,
+        role: 'member',
+      })
+      .returning();
+    return user.id;
+  }
+
+  async function createGame(name: string): Promise<number> {
+    const [g] = await testApp.db
+      .insert(schema.games)
+      .values({ name, slug: `${name.toLowerCase()}-${Date.now()}` })
+      .returning();
+    return g.id;
+  }
+
+  /**
+   * Build a public lineup in voting status with two tied games and
+   * three distinct participants (one nominator-only, two voters).
+   * The expected DM target = nominators ∪ voters.
+   */
+  async function setupPublicLineup(): Promise<PublicLineupSetup> {
+    const nominator = await createMember('pub-nom-1117');
+    const voterA = await createMember('pub-voter-a-1117');
+    const voterB = await createMember('pub-voter-b-1117');
+    const gameAId = await createGame('TBGameA-1117');
+    const gameBId = await createGame('TBGameB-1117');
+
+    const [lineup] = await testApp.db
+      .insert(schema.communityLineups)
+      .values({
+        title: 'ROK-1117 public',
+        status: 'voting',
+        visibility: 'public',
+        createdBy: testApp.seed.adminUser.id,
+      })
+      .returning();
+
+    // Nominate both games (nominator owns gameA, voterA owns gameB).
+    await testApp.db.insert(schema.communityLineupEntries).values([
+      { lineupId: lineup.id, gameId: gameAId, nominatedBy: nominator },
+      { lineupId: lineup.id, gameId: gameBId, nominatedBy: voterA },
+    ]);
+    // Cast equal votes to produce a tie.
+    await testApp.db.insert(schema.communityLineupVotes).values([
+      { lineupId: lineup.id, gameId: gameAId, userId: voterA },
+      { lineupId: lineup.id, gameId: gameBId, userId: voterB },
+    ]);
+
+    return {
+      lineupId: lineup.id,
+      tiedGameIds: [gameAId, gameBId],
+      participantIds: Array.from(new Set([nominator, voterA, voterB])),
+    };
+  }
+
+  /**
+   * Build a private lineup in voting status with two tied games and
+   * two invitees + creator. Expected DM target = creator ∪ invitees.
+   */
+  async function setupPrivateLineup(): Promise<PrivateLineupSetup> {
+    const inviteeA = await createMember('priv-inv-a-1117');
+    const inviteeB = await createMember('priv-inv-b-1117');
+    const gameAId = await createGame('TBPrivA-1117');
+    const gameBId = await createGame('TBPrivB-1117');
+    const creatorId = testApp.seed.adminUser.id;
+
+    const [lineup] = await testApp.db
+      .insert(schema.communityLineups)
+      .values({
+        title: 'ROK-1117 private',
+        status: 'voting',
+        visibility: 'private',
+        createdBy: creatorId,
+      })
+      .returning();
+    await testApp.db.insert(schema.communityLineupInvitees).values([
+      { lineupId: lineup.id, userId: inviteeA },
+      { lineupId: lineup.id, userId: inviteeB },
+    ]);
+    await testApp.db.insert(schema.communityLineupEntries).values([
+      { lineupId: lineup.id, gameId: gameAId, nominatedBy: creatorId },
+      { lineupId: lineup.id, gameId: gameBId, nominatedBy: inviteeA },
+    ]);
+    await testApp.db.insert(schema.communityLineupVotes).values([
+      { lineupId: lineup.id, gameId: gameAId, userId: inviteeA },
+      { lineupId: lineup.id, gameId: gameBId, userId: inviteeB },
+    ]);
+
+    // Give the creator a discordId so they qualify for DM dispatch.
+    await testApp.db
+      .update(schema.users)
+      .set({ discordId: 'discord:admin-1117' })
+      .where(eq(schema.users.id, creatorId));
+
+    return {
+      lineupId: lineup.id,
+      tiedGameIds: [gameAId, gameBId],
+      inviteeIds: [inviteeA, inviteeB],
+      creatorId,
+    };
+  }
+
+  async function notificationsForUser(userId: number): Promise<unknown[]> {
+    return testApp.db
+      .select()
+      .from(schema.notifications)
+      .where(eq(schema.notifications.userId, userId));
+  }
+
+  function dedupKeysSeen(): string[] {
+    return dedupSpy.mock.calls.map((c) => String(c[0]));
+  }
+
+  // ── AC: public lineup → DMs + channel embed ────────────────────────────
+
+  it('public tiebreaker.start() DMs every expected voter and posts channel embed', async () => {
+    const { lineupId, participantIds } = await setupPublicLineup();
+
+    const tiebreaker = await tiebreakerService.start(lineupId, {
+      mode: 'veto',
+      roundDurationHours: 24,
+    });
+    expect(tiebreaker).toBeTruthy();
+
+    // Wait briefly for fire-and-forget hook to settle.
+    await new Promise((r) => setImmediate(r));
+
+    // Every expected voter receives a community_lineup notification row.
+    for (const userId of participantIds) {
+      const rows = await notificationsForUser(userId);
+      expect(rows.length).toBeGreaterThan(0);
+    }
+
+    // Public lineup → channel embed dispatched.
+    expect(sendEmbedSpy).toHaveBeenCalled();
+
+    // Dedup key for the channel embed is `lineup-tiebreaker-open:<tbId>`.
+    const expectedKey = `lineup-tiebreaker-open:${tiebreaker.id}`;
+    expect(dedupKeysSeen()).toContain(expectedKey);
+  });
+
+  // ── AC: private lineup → DMs only, no channel embed ────────────────────
+
+  it('private tiebreaker.start() DMs invitees + creator and suppresses channel embed', async () => {
+    const { lineupId, inviteeIds, creatorId } = await setupPrivateLineup();
+
+    const tiebreaker = await tiebreakerService.start(lineupId, {
+      mode: 'bracket',
+      roundDurationHours: 24,
+    });
+    expect(tiebreaker).toBeTruthy();
+
+    await new Promise((r) => setImmediate(r));
+
+    expect(sendEmbedSpy).not.toHaveBeenCalled();
+
+    // Every invitee + creator receives a notification row.
+    for (const userId of [...inviteeIds, creatorId]) {
+      const rows = await notificationsForUser(userId);
+      expect(rows.length).toBeGreaterThan(0);
+    }
+  });
+}
+
+describe(
+  'Lineup tiebreaker-open notifications (integration, ROK-1117)',
+  describeTiebreakerNotifications,
+);

--- a/api/src/lineups/lineup-notification-tiebreaker.integration.spec.ts
+++ b/api/src/lineups/lineup-notification-tiebreaker.integration.spec.ts
@@ -32,6 +32,7 @@ import { TiebreakerService } from './tiebreaker/tiebreaker.service';
 import { DiscordBotClientService } from '../discord-bot/discord-bot-client.service';
 import { SettingsService } from '../settings/settings.service';
 import { NotificationDedupService } from '../notifications/notification-dedup.service';
+import { LineupReminderService } from './lineup-reminder.service';
 
 interface PublicLineupSetup {
   lineupId: number;
@@ -257,4 +258,132 @@ function describeTiebreakerNotifications() {
 describe(
   'Lineup tiebreaker-open notifications (integration, ROK-1117)',
   describeTiebreakerNotifications,
+);
+
+// ── ROK-1117: Tiebreaker reminder cron (integration) ──────────────────────
+
+function describeTiebreakerReminders() {
+  let testApp: TestApp;
+  let tiebreakerService: TiebreakerService;
+  let reminderService: LineupReminderService;
+  let dedup: NotificationDedupService;
+
+  beforeAll(async () => {
+    testApp = await getTestApp();
+    tiebreakerService = testApp.app.get(TiebreakerService);
+    reminderService = testApp.app.get(LineupReminderService);
+    dedup = testApp.app.get(NotificationDedupService);
+    // Stub the bot's sendEmbed so the start() side-effects don't fail.
+    jest
+      .spyOn(testApp.app.get(DiscordBotClientService), 'sendEmbed')
+      .mockResolvedValue({ id: 'mock-msg-tb-rem' } as never);
+  });
+
+  afterEach(async () => {
+    jest.useRealTimers();
+    testApp.seed = await truncateAllTables(testApp.db);
+    // Clear dedup keys so the next test isn't blocked by prior ones.
+    jest.spyOn(dedup, 'checkAndMarkSent').mockResolvedValue(false);
+  });
+
+  async function createMember(tag: string): Promise<number> {
+    const [user] = await testApp.db
+      .insert(schema.users)
+      .values({
+        discordId: `discord:${tag}`,
+        username: `mem-${tag}`,
+        role: 'member',
+      })
+      .returning();
+    return user.id;
+  }
+
+  async function createGame(name: string): Promise<number> {
+    const [g] = await testApp.db
+      .insert(schema.games)
+      .values({ name, slug: `${name.toLowerCase()}-${Date.now()}` })
+      .returning();
+    return g.id;
+  }
+
+  async function setupLineupWithActiveTiebreaker(): Promise<{
+    lineupId: number;
+    participantIds: number[];
+  }> {
+    const nominator = await createMember('rem-nom-1117');
+    const voterA = await createMember('rem-voter-a-1117');
+    const voterB = await createMember('rem-voter-b-1117');
+    const gameAId = await createGame('TBRemA-1117');
+    const gameBId = await createGame('TBRemB-1117');
+
+    const [lineup] = await testApp.db
+      .insert(schema.communityLineups)
+      .values({
+        title: 'ROK-1117 reminder',
+        status: 'voting',
+        visibility: 'public',
+        createdBy: testApp.seed.adminUser.id,
+      })
+      .returning();
+    await testApp.db.insert(schema.communityLineupEntries).values([
+      { lineupId: lineup.id, gameId: gameAId, nominatedBy: nominator },
+      { lineupId: lineup.id, gameId: gameBId, nominatedBy: voterA },
+    ]);
+    await testApp.db.insert(schema.communityLineupVotes).values([
+      { lineupId: lineup.id, gameId: gameAId, userId: voterA },
+      { lineupId: lineup.id, gameId: gameBId, userId: voterB },
+    ]);
+    await tiebreakerService.start(lineup.id, {
+      mode: 'veto',
+      roundDurationHours: 1,
+    });
+    return {
+      lineupId: lineup.id,
+      participantIds: [nominator, voterA, voterB],
+    };
+  }
+
+  it('checkTiebreakerReminders DMs every non-engaged expected voter at the 1h threshold', async () => {
+    const { lineupId, participantIds } =
+      await setupLineupWithActiveTiebreaker();
+
+    // Move the round_deadline to ~50 minutes from now so classifyThreshold
+    // returns '1h' and the cron path fires reminders.
+    const newDeadline = new Date(Date.now() + 50 * 60 * 1000);
+    await testApp.db
+      .update(schema.communityLineupTiebreakers)
+      .set({ roundDeadline: newDeadline })
+      .where(eq(schema.communityLineupTiebreakers.lineupId, lineupId));
+
+    // Reset the dedup spy so the open-DMs from start() don't bleed.
+    jest.spyOn(dedup, 'checkAndMarkSent').mockResolvedValue(false);
+
+    await reminderService.checkTiebreakerReminders();
+
+    // Each expected voter should have received at least one reminder
+    // notification with the tiebreaker-reminder subtype.
+    for (const userId of participantIds) {
+      const rows = await testApp.db
+        .select()
+        .from(schema.notifications)
+        .where(eq(schema.notifications.userId, userId));
+      const reminderRows = rows.filter((r) => {
+        const payload = r.payload as { subtype?: string } | null;
+        return payload?.subtype === 'lineup_tiebreaker_reminder';
+      });
+      expect(reminderRows.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('checkTiebreakerReminders is a no-op when no tiebreakers are active', async () => {
+    // No setup: empty DB. Just verify it doesn't throw.
+    await expect(
+      reminderService.checkTiebreakerReminders(),
+    ).resolves.toBeUndefined();
+  });
+}
+
+describe(
+  'Lineup tiebreaker reminder cron (integration, ROK-1117)',
+  describeTiebreakerReminders,
 );

--- a/api/src/lineups/lineup-notification.service.ts
+++ b/api/src/lineups/lineup-notification.service.ts
@@ -47,6 +47,11 @@ import {
   orchestrateEventCreated,
   type OrchestrationDeps,
 } from './lineup-notification-public-dispatch.helpers';
+import {
+  notifyTiebreakerOpen,
+  type TiebreakerNotificationInfo,
+  type TiebreakerOpenDeps,
+} from './lineup-notification-tiebreaker.helpers';
 
 /** Shape of a lineup passed to notification methods. */
 export interface LineupInfo {
@@ -216,6 +221,21 @@ export class LineupNotificationService {
       games,
       clientUrl,
     );
+  }
+
+  /** ROK-1117: Post tiebreaker-open channel embed + DMs to expected voters. */
+  async notifyTiebreakerOpen(
+    lineup: LineupInfo,
+    tiebreaker: TiebreakerNotificationInfo,
+  ): Promise<void> {
+    const deps: TiebreakerOpenDeps = {
+      db: this.db,
+      notificationService: this.notificationService,
+      dedupService: this.dedupService,
+      botClient: this.botClient,
+      settingsService: this.settingsService,
+    };
+    await notifyTiebreakerOpen(deps, lineup, tiebreaker);
   }
 
   /** AC-5: Post combined tier embed + per-member DMs when matches are found. */

--- a/api/src/lineups/lineup-notification.service.ts
+++ b/api/src/lineups/lineup-notification.service.ts
@@ -227,6 +227,7 @@ export class LineupNotificationService {
   async notifyTiebreakerOpen(
     lineup: LineupInfo,
     tiebreaker: TiebreakerNotificationInfo,
+    tiedGameIds?: ReadonlyArray<number>,
   ): Promise<void> {
     const deps: TiebreakerOpenDeps = {
       db: this.db,
@@ -235,7 +236,7 @@ export class LineupNotificationService {
       botClient: this.botClient,
       settingsService: this.settingsService,
     };
-    await notifyTiebreakerOpen(deps, lineup, tiebreaker);
+    await notifyTiebreakerOpen(deps, lineup, tiebreaker, tiedGameIds);
   }
 
   /** AC-5: Post combined tier embed + per-member DMs when matches are found. */

--- a/api/src/lineups/lineup-reminder.service.spec.ts
+++ b/api/src/lineups/lineup-reminder.service.spec.ts
@@ -9,6 +9,7 @@ import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
 import { NotificationService } from '../notifications/notification.service';
 import { NotificationDedupService } from '../notifications/notification-dedup.service';
 import { SettingsService } from '../settings/settings.service';
+import { CronJobService } from '../cron-jobs/cron-job.service';
 
 // ---------------------------------------------------------------------------
 // Shared mocks
@@ -42,6 +43,14 @@ async function createTestModule() {
   const mockDedupService = makeMockDedupService();
   const mockSettingsService = makeMockSettingsService();
 
+  const mockCronJobService = {
+    executeWithTracking: jest
+      .fn()
+      .mockImplementation(async (_name: string, fn: () => Promise<void>) => {
+        await fn();
+      }),
+  };
+
   const module: TestingModule = await Test.createTestingModule({
     providers: [
       LineupReminderService,
@@ -49,6 +58,7 @@ async function createTestModule() {
       { provide: NotificationService, useValue: mockNotificationService },
       { provide: NotificationDedupService, useValue: mockDedupService },
       { provide: SettingsService, useValue: mockSettingsService },
+      { provide: CronJobService, useValue: mockCronJobService },
     ],
   }).compile();
 
@@ -58,6 +68,7 @@ async function createTestModule() {
     mockNotificationService,
     mockDedupService,
     mockSettingsService,
+    mockCronJobService,
   };
 }
 

--- a/api/src/lineups/lineup-reminder.service.spec.ts
+++ b/api/src/lineups/lineup-reminder.service.spec.ts
@@ -8,6 +8,7 @@ import { LineupReminderService } from './lineup-reminder.service';
 import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
 import { NotificationService } from '../notifications/notification.service';
 import { NotificationDedupService } from '../notifications/notification-dedup.service';
+import { SettingsService } from '../settings/settings.service';
 
 // ---------------------------------------------------------------------------
 // Shared mocks
@@ -25,6 +26,12 @@ function makeMockDedupService() {
   return { checkAndMarkSent: jest.fn().mockResolvedValue(false) };
 }
 
+function makeMockSettingsService() {
+  return {
+    getClientUrl: jest.fn().mockResolvedValue('https://rl.test'),
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Test module builder
 // ---------------------------------------------------------------------------
@@ -33,6 +40,7 @@ async function createTestModule() {
   const mockDb = makeMockDb();
   const mockNotificationService = makeMockNotificationService();
   const mockDedupService = makeMockDedupService();
+  const mockSettingsService = makeMockSettingsService();
 
   const module: TestingModule = await Test.createTestingModule({
     providers: [
@@ -40,6 +48,7 @@ async function createTestModule() {
       { provide: DrizzleAsyncProvider, useValue: mockDb },
       { provide: NotificationService, useValue: mockNotificationService },
       { provide: NotificationDedupService, useValue: mockDedupService },
+      { provide: SettingsService, useValue: mockSettingsService },
     ],
   }).compile();
 
@@ -48,6 +57,7 @@ async function createTestModule() {
     mockDb,
     mockNotificationService,
     mockDedupService,
+    mockSettingsService,
   };
 }
 
@@ -333,6 +343,7 @@ describe('LineupReminderService', () => {
     function makeActiveTiebreakerRow(
       hoursUntilDeadline: number,
       mode: 'bracket' | 'veto' = 'bracket',
+      tiedGameIds: number[] = [],
     ) {
       const deadline = new Date(NOW.getTime() + hoursUntilDeadline * 3600_000);
       return {
@@ -341,6 +352,7 @@ describe('LineupReminderService', () => {
         mode,
         roundDeadline: deadline,
         currentRound: 1,
+        tiedGameIds,
       };
     }
 
@@ -520,6 +532,44 @@ describe('LineupReminderService', () => {
           }),
         }),
       );
+    });
+
+    // ROK-1117 rework: reminder DM body lists tied games as deep links
+    // and ends with a CTA pointing at the lineup detail page.
+    it('renders tied-game deep-link list and lineup CTA in the DM body', async () => {
+      const tb = makeActiveTiebreakerRow(20, 'veto', [101, 202]);
+      mockDb.execute.mockResolvedValueOnce([tb]);
+      mockChainedSelect([
+        // resolveReminderTargets — community_lineups lookup
+        [makePublicLineupRow()],
+        // findDistinctNominators
+        [{ userId: 50 }],
+        // findDistinctVoters
+        [],
+        // findVetoEngagedUserIds — none
+        [],
+        // findGamesByIds — id+name pairs for the ballot
+        [
+          { id: 101, name: 'Civ VI' },
+          { id: 202, name: 'Stellaris' },
+        ],
+      ]);
+
+      await service.checkTiebreakerReminders();
+
+      const call = mockNotificationService.create.mock.calls[0][0] as {
+        message: string;
+      };
+      expect(call.message).toMatch(
+        /🎮 \[\*\*Civ VI\*\*\]\(https:\/\/rl\.test\/games\/101\)/,
+      );
+      expect(call.message).toMatch(
+        /🎮 \[\*\*Stellaris\*\*\]\(https:\/\/rl\.test\/games\/202\)/,
+      );
+      expect(call.message).toContain(
+        `[Cast your veto](https://rl.test/community-lineup/${LINEUP_ID})`,
+      );
+      expect(call.message).toContain('Tiebreaker closing in 24 hours');
     });
   });
 });

--- a/api/src/lineups/lineup-reminder.service.spec.ts
+++ b/api/src/lineups/lineup-reminder.service.spec.ts
@@ -325,4 +325,201 @@ describe('LineupReminderService', () => {
       );
     });
   });
+
+  // -----------------------------------------------------------------------
+  // ROK-1117: Tiebreaker reminders at 24h and 1h before round deadline
+  // -----------------------------------------------------------------------
+  describe('tiebreaker reminders', () => {
+    function makeActiveTiebreakerRow(
+      hoursUntilDeadline: number,
+      mode: 'bracket' | 'veto' = 'bracket',
+    ) {
+      const deadline = new Date(NOW.getTime() + hoursUntilDeadline * 3600_000);
+      return {
+        tiebreakerId: 77,
+        lineupId: LINEUP_ID,
+        mode,
+        roundDeadline: deadline,
+        currentRound: 1,
+      };
+    }
+
+    function makePublicLineupRow() {
+      return {
+        id: LINEUP_ID,
+        visibility: 'public',
+        createdBy: 100,
+      };
+    }
+
+    function makePrivateLineupRow() {
+      return {
+        id: LINEUP_ID,
+        visibility: 'private',
+        createdBy: 100,
+      };
+    }
+
+    /**
+     * Mock the chained `.select().from().where().limit()` pattern used by
+     * `loadExpectedVoters` and `resolveReminderTargets`. We sequence the
+     * resolved values so each call returns a specific result.
+     */
+    function mockChainedSelect(results: unknown[][]) {
+      let i = 0;
+      const select = jest.fn(() => ({
+        from: jest.fn(() => ({
+          where: jest.fn(() => {
+            const result = results[i] ?? [];
+            const ret = {
+              limit: jest.fn().mockResolvedValue(result),
+              then: (resolve: (v: unknown[]) => unknown) => resolve(result),
+            };
+            i += 1;
+            return ret;
+          }),
+        })),
+      }));
+      (mockDb as unknown as { select: jest.Mock }).select = select;
+    }
+
+    it('fires 24h threshold for active tiebreakers approaching deadline', async () => {
+      const tb = makeActiveTiebreakerRow(20);
+      mockDb.execute
+        // findActiveTiebreakersWithDeadline
+        .mockResolvedValueOnce([tb])
+        // loadVoteCountsPerUser (bracket mode, no votes yet)
+        .mockResolvedValueOnce([]);
+      mockChainedSelect([
+        // resolveReminderTargets — community_lineups lookup
+        [makePublicLineupRow()],
+        // findDistinctNominators
+        [{ userId: 1 }],
+        // findDistinctVoters
+        [{ userId: 2 }],
+        // findBracketEngagedUserIds — countActiveRoundMatchups (no matchups)
+        [],
+      ]);
+
+      await service.checkTiebreakerReminders();
+
+      expect(mockDedupService.checkAndMarkSent).toHaveBeenCalledWith(
+        expect.stringContaining('tiebreaker-reminder:77:24h:'),
+        expect.anything(),
+      );
+      expect(mockNotificationService.create).toHaveBeenCalled();
+    });
+
+    it('fires 1h threshold when <= 1h remains', async () => {
+      const tb = makeActiveTiebreakerRow(0.5);
+      mockDb.execute.mockResolvedValueOnce([tb]).mockResolvedValueOnce([]); // bracket vote counts
+      mockChainedSelect([
+        [makePublicLineupRow()],
+        [{ userId: 5 }],
+        [{ userId: 6 }],
+        [], // no matchups
+      ]);
+
+      await service.checkTiebreakerReminders();
+
+      expect(mockDedupService.checkAndMarkSent).toHaveBeenCalledWith(
+        expect.stringContaining('tiebreaker-reminder:77:1h:'),
+        expect.anything(),
+      );
+    });
+
+    it('is a no-op when no active tiebreakers exist', async () => {
+      mockDb.execute.mockResolvedValueOnce([]);
+
+      await service.checkTiebreakerReminders();
+
+      expect(mockNotificationService.create).not.toHaveBeenCalled();
+    });
+
+    it('skips users who have already vetoed (veto mode)', async () => {
+      const tb = makeActiveTiebreakerRow(20, 'veto');
+      mockDb.execute.mockResolvedValueOnce([tb]);
+      mockChainedSelect([
+        [makePublicLineupRow()],
+        [{ userId: 7 }, { userId: 8 }], // nominators
+        [], // voters
+        [{ userId: 7 }], // already vetoed
+      ]);
+
+      await service.checkTiebreakerReminders();
+
+      // Only user 8 receives a reminder (user 7 already engaged)
+      expect(mockNotificationService.create).toHaveBeenCalledTimes(1);
+      expect(mockNotificationService.create).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: 8 }),
+      );
+    });
+
+    it('targets nominators ∪ voters minus already-engaged for public lineup', async () => {
+      const tb = makeActiveTiebreakerRow(12, 'veto');
+      mockDb.execute.mockResolvedValueOnce([tb]);
+      mockChainedSelect([
+        [makePublicLineupRow()],
+        [{ userId: 11 }], // nominator
+        [{ userId: 12 }, { userId: 11 }], // voters (11 also voted)
+        [], // no vetoes yet
+      ]);
+
+      await service.checkTiebreakerReminders();
+
+      const targets = mockNotificationService.create.mock.calls.map(
+        (c) => (c[0] as { userId: number }).userId,
+      );
+      expect(new Set(targets)).toEqual(new Set([11, 12]));
+    });
+
+    it('targets invitees + creator minus already-engaged for private lineup', async () => {
+      const tb = makeActiveTiebreakerRow(12, 'veto');
+      mockDb.execute.mockResolvedValueOnce([tb]);
+      mockChainedSelect([
+        [makePrivateLineupRow()],
+        // private branch: invitees query
+        [{ userId: 21 }, { userId: 22 }],
+        [], // no vetoes
+      ]);
+
+      await service.checkTiebreakerReminders();
+
+      const targets = mockNotificationService.create.mock.calls.map(
+        (c) => (c[0] as { userId: number }).userId,
+      );
+      // creator (100) + invitees (21, 22)
+      expect(new Set(targets)).toEqual(new Set([100, 21, 22]));
+    });
+
+    it('dedup key prevents double-fire for the same threshold', async () => {
+      const tb = makeActiveTiebreakerRow(20, 'veto');
+      mockDb.execute.mockResolvedValueOnce([tb]);
+      mockChainedSelect([[makePublicLineupRow()], [{ userId: 30 }], [], []]);
+      mockDedupService.checkAndMarkSent.mockResolvedValueOnce(true);
+
+      await service.checkTiebreakerReminders();
+
+      expect(mockNotificationService.create).not.toHaveBeenCalled();
+    });
+
+    it('uses subtype lineup_tiebreaker_reminder in notification payload', async () => {
+      const tb = makeActiveTiebreakerRow(20, 'veto');
+      mockDb.execute.mockResolvedValueOnce([tb]);
+      mockChainedSelect([[makePublicLineupRow()], [{ userId: 40 }], [], []]);
+
+      await service.checkTiebreakerReminders();
+
+      expect(mockNotificationService.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'community_lineup',
+          payload: expect.objectContaining({
+            subtype: 'lineup_tiebreaker_reminder',
+            tiebreakerId: 77,
+            threshold: '24h',
+          }),
+        }),
+      );
+    });
+  });
 });

--- a/api/src/lineups/lineup-reminder.service.ts
+++ b/api/src/lineups/lineup-reminder.service.ts
@@ -1,9 +1,11 @@
 /**
- * Cron-driven reminder service for Community Lineup (ROK-932).
- * Sends vote reminders (24h + 1h before voting deadline) and
- * scheduling reminders (24h + 1h before decided phase end).
+ * Cron-driven reminder service for Community Lineup (ROK-932, ROK-1117).
+ * Sends vote reminders (24h + 1h before voting deadline), scheduling
+ * reminders (24h + 1h before decided phase end), and tiebreaker reminders
+ * (24h + 1h before round deadline).
  */
 import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
 import { sql } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
@@ -11,6 +13,12 @@ import * as schema from '../drizzle/schema';
 import { NotificationService } from '../notifications/notification.service';
 import { NotificationDedupService } from '../notifications/notification-dedup.service';
 import { DEDUP_TTL } from './lineup-notification.constants';
+import {
+  findActiveTiebreakersWithDeadline,
+  resolveReminderTargets,
+  classifyThreshold,
+  type ActiveTiebreakerRow,
+} from './lineup-tiebreaker-reminder.helpers';
 
 /** Shape of a lineup returned from reminder queries. */
 interface ReminderLineup {
@@ -62,6 +70,22 @@ export class LineupReminderService {
     const lineups = await this.getDecidedLineups();
     for (const lineup of lineups) {
       await this.processSchedulingReminder(lineup);
+    }
+  }
+
+  /**
+   * Check and send tiebreaker reminders for active tiebreakers
+   * approaching their round deadline (ROK-1117). Targets users who
+   * have not yet engaged with this tiebreaker (vetoed or voted on
+   * every active-round matchup).
+   */
+  @Cron(CronExpression.EVERY_5_MINUTES, {
+    name: 'LineupReminderService_checkTiebreakerReminders',
+  })
+  async checkTiebreakerReminders(): Promise<void> {
+    const tiebreakers = await findActiveTiebreakersWithDeadline(this.db);
+    for (const tb of tiebreakers) {
+      await this.processTiebreakerReminder(tb);
     }
   }
 
@@ -141,6 +165,47 @@ export class LineupReminderService {
       payload: {
         subtype: 'lineup_scheduling_reminder',
         matchId: voter.matchId,
+      },
+    });
+  }
+
+  // ─── Private: tiebreaker reminders (ROK-1117) ─────────────
+
+  /** Process a single active tiebreaker for reminder dispatch. */
+  private async processTiebreakerReminder(
+    tb: ActiveTiebreakerRow,
+  ): Promise<void> {
+    const threshold = classifyThreshold(this.hoursUntil(tb.roundDeadline));
+    if (!threshold) return;
+    const userIds = await resolveReminderTargets(this.db, tb);
+    for (const userId of userIds) {
+      await this.sendTiebreakerReminder(tb, userId, threshold);
+    }
+  }
+
+  /** Send a single tiebreaker reminder DM. */
+  private async sendTiebreakerReminder(
+    tb: ActiveTiebreakerRow,
+    userId: number,
+    threshold: '24h' | '1h',
+  ): Promise<void> {
+    const key = `tiebreaker-reminder:${tb.tiebreakerId}:${threshold}:${userId}`;
+    if (await this.dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
+    const headline =
+      threshold === '1h'
+        ? 'Tiebreaker closing in 1 hour — cast your vote!'
+        : "Tiebreaker closing in 24 hours — don't miss your chance to vote.";
+    await this.notificationService.create({
+      userId,
+      type: 'community_lineup',
+      title: 'Tiebreaker Reminder',
+      message: headline,
+      payload: {
+        subtype: 'lineup_tiebreaker_reminder',
+        lineupId: tb.lineupId,
+        tiebreakerId: tb.tiebreakerId,
+        mode: tb.mode,
+        threshold,
       },
     });
   }

--- a/api/src/lineups/lineup-reminder.service.ts
+++ b/api/src/lineups/lineup-reminder.service.ts
@@ -13,6 +13,7 @@ import * as schema from '../drizzle/schema';
 import { NotificationService } from '../notifications/notification.service';
 import { NotificationDedupService } from '../notifications/notification-dedup.service';
 import { SettingsService } from '../settings/settings.service';
+import { CronJobService } from '../cron-jobs/cron-job.service';
 import { DEDUP_TTL } from './lineup-notification.constants';
 import {
   findActiveTiebreakersWithDeadline,
@@ -58,6 +59,7 @@ export class LineupReminderService {
     private readonly notificationService: NotificationService,
     private readonly dedupService: NotificationDedupService,
     private readonly settingsService: SettingsService,
+    private readonly cronJobService: CronJobService,
   ) {}
 
   /** Check and send vote reminders for active voting lineups. */
@@ -86,6 +88,14 @@ export class LineupReminderService {
     name: 'LineupReminderService_checkTiebreakerReminders',
   })
   async checkTiebreakerReminders(): Promise<void> {
+    await this.cronJobService.executeWithTracking(
+      'LineupReminderService_checkTiebreakerReminders',
+      () => this.runTiebreakerReminders(),
+    );
+  }
+
+  /** Inner body — wrapped by `executeWithTracking` for cron-jobs admin visibility. */
+  private async runTiebreakerReminders(): Promise<void> {
     const tiebreakers = await findActiveTiebreakersWithDeadline(this.db);
     for (const tb of tiebreakers) {
       try {

--- a/api/src/lineups/lineup-reminder.service.ts
+++ b/api/src/lineups/lineup-reminder.service.ts
@@ -12,11 +12,13 @@ import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
 import * as schema from '../drizzle/schema';
 import { NotificationService } from '../notifications/notification.service';
 import { NotificationDedupService } from '../notifications/notification-dedup.service';
+import { SettingsService } from '../settings/settings.service';
 import { DEDUP_TTL } from './lineup-notification.constants';
 import {
   findActiveTiebreakersWithDeadline,
   resolveReminderTargets,
   classifyThreshold,
+  buildTiebreakerReminderMessage,
   type ActiveTiebreakerRow,
 } from './lineup-tiebreaker-reminder.helpers';
 
@@ -55,6 +57,7 @@ export class LineupReminderService {
     private readonly db: PostgresJsDatabase<typeof schema>,
     private readonly notificationService: NotificationService,
     private readonly dedupService: NotificationDedupService,
+    private readonly settingsService: SettingsService,
   ) {}
 
   /** Check and send vote reminders for active voting lineups. */
@@ -191,15 +194,18 @@ export class LineupReminderService {
   ): Promise<void> {
     const key = `tiebreaker-reminder:${tb.tiebreakerId}:${threshold}:${userId}`;
     if (await this.dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
-    const headline =
-      threshold === '1h'
-        ? 'Tiebreaker closing in 1 hour — cast your vote!'
-        : "Tiebreaker closing in 24 hours — don't miss your chance to vote.";
+    const clientUrl = await this.settingsService.getClientUrl();
+    const message = await buildTiebreakerReminderMessage(
+      this.db,
+      tb,
+      threshold,
+      clientUrl,
+    );
     await this.notificationService.create({
       userId,
       type: 'community_lineup',
       title: 'Tiebreaker Reminder',
-      message: headline,
+      message,
       payload: {
         subtype: 'lineup_tiebreaker_reminder',
         lineupId: tb.lineupId,

--- a/api/src/lineups/lineup-reminder.service.ts
+++ b/api/src/lineups/lineup-reminder.service.ts
@@ -88,7 +88,14 @@ export class LineupReminderService {
   async checkTiebreakerReminders(): Promise<void> {
     const tiebreakers = await findActiveTiebreakersWithDeadline(this.db);
     for (const tb of tiebreakers) {
-      await this.processTiebreakerReminder(tb);
+      try {
+        await this.processTiebreakerReminder(tb);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        this.logger.warn(
+          `Tiebreaker reminder failed for tb ${tb.tiebreakerId} (lineup ${tb.lineupId}): ${msg}`,
+        );
+      }
     }
   }
 

--- a/api/src/lineups/lineup-tiebreaker-reminder.helpers.ts
+++ b/api/src/lineups/lineup-tiebreaker-reminder.helpers.ts
@@ -1,0 +1,181 @@
+/**
+ * Tiebreaker reminder helpers (ROK-1117).
+ *
+ * Resolves the target user set for the tiebreaker reminder cron and
+ * filters out users who have already engaged (vetoed for veto mode, or
+ * voted on every active-round matchup for bracket mode). Kept in its
+ * own file so `lineup-reminder.service.ts` stays under the 300-line
+ * ESLint ceiling.
+ */
+import { and, eq, sql } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from '../drizzle/schema';
+import { loadExpectedVoters } from './quorum/quorum-voters.helpers';
+
+type Db = PostgresJsDatabase<typeof schema>;
+
+/** Active tiebreaker + parent lineup row needed by the reminder cron. */
+export interface ActiveTiebreakerRow {
+  tiebreakerId: number;
+  lineupId: number;
+  mode: 'bracket' | 'veto';
+  roundDeadline: Date;
+  currentRound: number;
+}
+
+interface RawTiebreakerRow {
+  tiebreakerId: number;
+  lineupId: number;
+  mode: 'bracket' | 'veto';
+  roundDeadline: Date | string;
+  currentRound: number;
+}
+
+/**
+ * Find every lineup with an active tiebreaker that has a future
+ * `round_deadline`. We re-derive the `currentRound` from the maximum
+ * matchup round so the bracket-engagement filter only counts votes on
+ * the round that is currently open.
+ */
+export async function findActiveTiebreakersWithDeadline(
+  db: Db,
+): Promise<ActiveTiebreakerRow[]> {
+  const rows = (await db.execute(sql`
+    SELECT t.id        AS "tiebreakerId",
+           t.lineup_id AS "lineupId",
+           t.mode      AS "mode",
+           t.round_deadline AS "roundDeadline",
+           COALESCE(MAX(m.round), 1) AS "currentRound"
+      FROM community_lineup_tiebreakers t
+      LEFT JOIN community_lineup_tiebreaker_bracket_matchups m
+        ON m.tiebreaker_id = t.id
+     WHERE t.status = 'active'
+       AND t.round_deadline IS NOT NULL
+       AND t.round_deadline > NOW()
+     GROUP BY t.id
+  `)) as unknown as RawTiebreakerRow[];
+  return rows.map(normalizeTiebreakerRow);
+}
+
+function normalizeTiebreakerRow(r: RawTiebreakerRow): ActiveTiebreakerRow {
+  return {
+    ...r,
+    roundDeadline:
+      r.roundDeadline instanceof Date
+        ? r.roundDeadline
+        : new Date(r.roundDeadline),
+    currentRound: Number(r.currentRound) || 1,
+  };
+}
+
+/** Find user IDs who have submitted a veto for this tiebreaker. */
+async function findVetoEngagedUserIds(
+  db: Db,
+  tiebreakerId: number,
+): Promise<Set<number>> {
+  const rows = await db
+    .select({ userId: schema.communityLineupTiebreakerVetoes.userId })
+    .from(schema.communityLineupTiebreakerVetoes)
+    .where(
+      eq(schema.communityLineupTiebreakerVetoes.tiebreakerId, tiebreakerId),
+    );
+  return new Set(rows.map((r) => r.userId));
+}
+
+/**
+ * Find user IDs who have voted on every matchup in the active round.
+ * Users still missing votes on at least one matchup are NOT engaged
+ * and remain valid reminder targets.
+ */
+async function findBracketEngagedUserIds(
+  db: Db,
+  tiebreakerId: number,
+  currentRound: number,
+): Promise<Set<number>> {
+  const matchupCount = await countActiveRoundMatchups(
+    db,
+    tiebreakerId,
+    currentRound,
+  );
+  if (matchupCount === 0) return new Set();
+  const counts = await loadVoteCountsPerUser(db, tiebreakerId, currentRound);
+  return new Set(
+    counts.filter((c) => Number(c.voted) >= matchupCount).map((c) => c.userId),
+  );
+}
+
+async function countActiveRoundMatchups(
+  db: Db,
+  tiebreakerId: number,
+  round: number,
+): Promise<number> {
+  const rows = await db
+    .select({ id: schema.communityLineupTiebreakerBracketMatchups.id })
+    .from(schema.communityLineupTiebreakerBracketMatchups)
+    .where(
+      and(
+        eq(
+          schema.communityLineupTiebreakerBracketMatchups.tiebreakerId,
+          tiebreakerId,
+        ),
+        eq(schema.communityLineupTiebreakerBracketMatchups.round, round),
+        eq(schema.communityLineupTiebreakerBracketMatchups.isBye, false),
+      ),
+    );
+  return rows.length;
+}
+
+async function loadVoteCountsPerUser(
+  db: Db,
+  tiebreakerId: number,
+  round: number,
+): Promise<Array<{ userId: number; voted: number }>> {
+  return (await db.execute(sql`
+    SELECT user_id AS "userId", COUNT(DISTINCT matchup_id)::int AS "voted"
+      FROM community_lineup_tiebreaker_bracket_votes
+     WHERE matchup_id IN (
+       SELECT id FROM community_lineup_tiebreaker_bracket_matchups
+        WHERE tiebreaker_id = ${tiebreakerId}
+          AND round = ${round}
+          AND is_bye = false
+     )
+     GROUP BY user_id
+  `)) as unknown as Array<{ userId: number; voted: number }>;
+}
+
+/** Resolve already-engaged user IDs for a tiebreaker (mode-aware). */
+export async function findEngagedUserIds(
+  db: Db,
+  tb: ActiveTiebreakerRow,
+): Promise<Set<number>> {
+  if (tb.mode === 'veto') return findVetoEngagedUserIds(db, tb.tiebreakerId);
+  return findBracketEngagedUserIds(db, tb.tiebreakerId, tb.currentRound);
+}
+
+/**
+ * Resolve the candidate target user IDs for a tiebreaker reminder:
+ * `loadExpectedVoters` (visibility-aware) minus users who have already
+ * engaged with this tiebreaker.
+ */
+export async function resolveReminderTargets(
+  db: Db,
+  tb: ActiveTiebreakerRow,
+): Promise<number[]> {
+  const [lineup] = await db
+    .select()
+    .from(schema.communityLineups)
+    .where(eq(schema.communityLineups.id, tb.lineupId))
+    .limit(1);
+  if (!lineup) return [];
+  const [expected, engaged] = await Promise.all([
+    loadExpectedVoters(db, lineup),
+    findEngagedUserIds(db, tb),
+  ]);
+  return expected.filter((id) => !engaged.has(id));
+}
+
+/** Classify the reminder threshold from hours-until-deadline. */
+export function classifyThreshold(hoursLeft: number): '24h' | '1h' | null {
+  if (hoursLeft <= 0 || hoursLeft > 24) return null;
+  return hoursLeft <= 1 ? '1h' : '24h';
+}

--- a/api/src/lineups/lineup-tiebreaker-reminder.helpers.ts
+++ b/api/src/lineups/lineup-tiebreaker-reminder.helpers.ts
@@ -11,6 +11,8 @@ import { and, eq, sql } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import * as schema from '../drizzle/schema';
 import { loadExpectedVoters } from './quorum/quorum-voters.helpers';
+import { findGamesByIds } from './lineups-query.helpers';
+import { buildTiedGamesList } from './lineup-notification-private-dm.helpers';
 
 type Db = PostgresJsDatabase<typeof schema>;
 
@@ -21,6 +23,8 @@ export interface ActiveTiebreakerRow {
   mode: 'bracket' | 'veto';
   roundDeadline: Date;
   currentRound: number;
+  /** Tied game IDs surfaced as a deep-linked list in the reminder DM (ROK-1117). */
+  tiedGameIds: number[];
 }
 
 interface RawTiebreakerRow {
@@ -29,6 +33,7 @@ interface RawTiebreakerRow {
   mode: 'bracket' | 'veto';
   roundDeadline: Date | string;
   currentRound: number;
+  tiedGameIds: number[] | null;
 }
 
 /**
@@ -45,6 +50,7 @@ export async function findActiveTiebreakersWithDeadline(
            t.lineup_id AS "lineupId",
            t.mode      AS "mode",
            t.round_deadline AS "roundDeadline",
+           t.tied_game_ids  AS "tiedGameIds",
            COALESCE(MAX(m.round), 1) AS "currentRound"
       FROM community_lineup_tiebreakers t
       LEFT JOIN community_lineup_tiebreaker_bracket_matchups m
@@ -65,6 +71,7 @@ function normalizeTiebreakerRow(r: RawTiebreakerRow): ActiveTiebreakerRow {
         ? r.roundDeadline
         : new Date(r.roundDeadline),
     currentRound: Number(r.currentRound) || 1,
+    tiedGameIds: Array.isArray(r.tiedGameIds) ? r.tiedGameIds : [],
   };
 }
 
@@ -178,4 +185,27 @@ export async function resolveReminderTargets(
 export function classifyThreshold(hoursLeft: number): '24h' | '1h' | null {
   if (hoursLeft <= 0 || hoursLeft > 24) return null;
   return hoursLeft <= 1 ? '1h' : '24h';
+}
+
+/**
+ * Compose the tiebreaker-reminder DM body with the headline, tied-game
+ * deep-link list, and a CTA pointing at the lineup detail page (ROK-1117).
+ */
+export async function buildTiebreakerReminderMessage(
+  db: Db,
+  tb: ActiveTiebreakerRow,
+  threshold: '24h' | '1h',
+  clientUrl?: string,
+): Promise<string> {
+  const headline =
+    threshold === '1h'
+      ? 'Tiebreaker closing in 1 hour — cast your vote!'
+      : "Tiebreaker closing in 24 hours — don't miss your chance to vote.";
+  const games = await findGamesByIds(db, tb.tiedGameIds);
+  const ballot = buildTiedGamesList(games, clientUrl);
+  const ctaText = tb.mode === 'veto' ? 'Cast your veto' : 'Vote in the bracket';
+  const ctaLink = clientUrl
+    ? `\n\n[${ctaText}](${clientUrl}/community-lineup/${tb.lineupId})`
+    : '';
+  return `${headline}${ballot}${ctaLink}`;
 }

--- a/api/src/lineups/lineups-notify-hooks.helpers.ts
+++ b/api/src/lineups/lineups-notify-hooks.helpers.ts
@@ -117,6 +117,46 @@ async function loadLineupForHook(
   return row ?? null;
 }
 
+/**
+ * Fire tiebreaker-open notifications (channel embed + DMs) (ROK-1117).
+ *
+ * Mirrors `fireVotingOpen`: loads the lineup row, fetches the tiebreaker
+ * row for mode + roundDeadline, then dispatches via
+ * `notifyTiebreakerOpen`. Errors are swallowed and logged so the
+ * tiebreaker.start() flow never blocks on Discord.
+ */
+export function fireTiebreakerOpen(
+  svc: LineupNotificationService,
+  logger: Logger,
+  db: Db,
+  lineupId: number,
+  tiebreakerId: number,
+): void {
+  loadLineupForHook(db, lineupId)
+    .then(async (lineup) => {
+      if (!lineup) return;
+      const [tb] = await db
+        .select({
+          id: schema.communityLineupTiebreakers.id,
+          mode: schema.communityLineupTiebreakers.mode,
+          roundDeadline: schema.communityLineupTiebreakers.roundDeadline,
+        })
+        .from(schema.communityLineupTiebreakers)
+        .where(eq(schema.communityLineupTiebreakers.id, tiebreakerId))
+        .limit(1);
+      if (!tb) return;
+      await svc.notifyTiebreakerOpen(
+        {
+          id: lineup.id,
+          title: lineup.title,
+          visibility: lineup.visibility,
+        },
+        { id: tb.id, mode: tb.mode, roundDeadline: tb.roundDeadline },
+      );
+    })
+    .catch(logError(logger, 'tiebreaker-open'));
+}
+
 /** Fire decided-phase notifications (channel embed). */
 export function fireDecidedNotifications(
   svc: LineupNotificationService,

--- a/api/src/lineups/lineups-notify-hooks.helpers.ts
+++ b/api/src/lineups/lineups-notify-hooks.helpers.ts
@@ -117,6 +117,27 @@ async function loadLineupForHook(
   return row ?? null;
 }
 
+/** Load tiebreaker row fields needed for the open-dispatch payload. */
+async function loadTiebreakerForHook(
+  db: Db,
+  tiebreakerId: number,
+): Promise<{
+  id: number;
+  mode: 'bracket' | 'veto';
+  roundDeadline: Date | null;
+} | null> {
+  const [tb] = await db
+    .select({
+      id: schema.communityLineupTiebreakers.id,
+      mode: schema.communityLineupTiebreakers.mode,
+      roundDeadline: schema.communityLineupTiebreakers.roundDeadline,
+    })
+    .from(schema.communityLineupTiebreakers)
+    .where(eq(schema.communityLineupTiebreakers.id, tiebreakerId))
+    .limit(1);
+  return tb ?? null;
+}
+
 /**
  * Fire tiebreaker-open notifications (channel embed + DMs) (ROK-1117).
  *
@@ -132,25 +153,14 @@ export function fireTiebreakerOpen(
   lineupId: number,
   tiebreakerId: number,
 ): void {
-  loadLineupForHook(db, lineupId)
-    .then(async (lineup) => {
-      if (!lineup) return;
-      const [tb] = await db
-        .select({
-          id: schema.communityLineupTiebreakers.id,
-          mode: schema.communityLineupTiebreakers.mode,
-          roundDeadline: schema.communityLineupTiebreakers.roundDeadline,
-        })
-        .from(schema.communityLineupTiebreakers)
-        .where(eq(schema.communityLineupTiebreakers.id, tiebreakerId))
-        .limit(1);
-      if (!tb) return;
-      await svc.notifyTiebreakerOpen(
-        {
-          id: lineup.id,
-          title: lineup.title,
-          visibility: lineup.visibility,
-        },
+  Promise.all([
+    loadLineupForHook(db, lineupId),
+    loadTiebreakerForHook(db, tiebreakerId),
+  ])
+    .then(([lineup, tb]) => {
+      if (!lineup || !tb) return;
+      return svc.notifyTiebreakerOpen(
+        { id: lineup.id, title: lineup.title, visibility: lineup.visibility },
         { id: tb.id, mode: tb.mode, roundDeadline: tb.roundDeadline },
       );
     })

--- a/api/src/lineups/lineups-notify-hooks.helpers.ts
+++ b/api/src/lineups/lineups-notify-hooks.helpers.ts
@@ -117,56 +117,6 @@ async function loadLineupForHook(
   return row ?? null;
 }
 
-/** Load tiebreaker row fields needed for the open-dispatch payload. */
-async function loadTiebreakerForHook(
-  db: Db,
-  tiebreakerId: number,
-): Promise<{
-  id: number;
-  mode: 'bracket' | 'veto';
-  roundDeadline: Date | null;
-} | null> {
-  const [tb] = await db
-    .select({
-      id: schema.communityLineupTiebreakers.id,
-      mode: schema.communityLineupTiebreakers.mode,
-      roundDeadline: schema.communityLineupTiebreakers.roundDeadline,
-    })
-    .from(schema.communityLineupTiebreakers)
-    .where(eq(schema.communityLineupTiebreakers.id, tiebreakerId))
-    .limit(1);
-  return tb ?? null;
-}
-
-/**
- * Fire tiebreaker-open notifications (channel embed + DMs) (ROK-1117).
- *
- * Mirrors `fireVotingOpen`: loads the lineup row, fetches the tiebreaker
- * row for mode + roundDeadline, then dispatches via
- * `notifyTiebreakerOpen`. Errors are swallowed and logged so the
- * tiebreaker.start() flow never blocks on Discord.
- */
-export function fireTiebreakerOpen(
-  svc: LineupNotificationService,
-  logger: Logger,
-  db: Db,
-  lineupId: number,
-  tiebreakerId: number,
-): void {
-  Promise.all([
-    loadLineupForHook(db, lineupId),
-    loadTiebreakerForHook(db, tiebreakerId),
-  ])
-    .then(([lineup, tb]) => {
-      if (!lineup || !tb) return;
-      return svc.notifyTiebreakerOpen(
-        { id: lineup.id, title: lineup.title, visibility: lineup.visibility },
-        { id: tb.id, mode: tb.mode, roundDeadline: tb.roundDeadline },
-      );
-    })
-    .catch(logError(logger, 'tiebreaker-open'));
-}
-
 /** Fire decided-phase notifications (channel embed). */
 export function fireDecidedNotifications(
   svc: LineupNotificationService,

--- a/api/src/lineups/lineups-query.helpers.ts
+++ b/api/src/lineups/lineups-query.helpers.ts
@@ -219,6 +219,18 @@ export async function findNominatedGames(
     .where(eq(schema.communityLineupEntries.lineupId, lineupId));
 }
 
+/** Batch-fetch id + name for a set of game IDs (ROK-1117). */
+export async function findGamesByIds(
+  db: PostgresJsDatabase<typeof schema>,
+  gameIds: ReadonlyArray<number>,
+): Promise<{ id: number; name: string }[]> {
+  if (gameIds.length === 0) return [];
+  return db
+    .select({ id: schema.games.id, name: schema.games.name })
+    .from(schema.games)
+    .where(inArray(schema.games.id, [...gameIds]));
+}
+
 /** Validate the decided game exists in the lineup entries. */
 export async function validateDecidedGame(
   db: PostgresJsDatabase<typeof schema>,

--- a/api/src/lineups/lineups.gateway.spec.ts
+++ b/api/src/lineups/lineups.gateway.spec.ts
@@ -124,6 +124,54 @@ function testEmitStatusChangeRejectsUnknownStatus() {
   expect(mockEmit).not.toHaveBeenCalled();
 }
 
+// ─── ROK-1117: tiebreaker-open event ─────────────────────────────────────
+//
+// `emitTiebreakerOpen(lineupId, tiebreakerId, mode)` must validate its
+// payload with a zod schema and broadcast `lineup:tiebreaker:open` to
+// the room `lineup:<id>`. These tests will fail until the dev agent
+// adds the method on the gateway and the contract event name + schema.
+
+type LineupsGatewayWithTiebreaker = LineupsGateway & {
+  emitTiebreakerOpen: (
+    lineupId: number,
+    tiebreakerId: number,
+    mode: 'bracket' | 'veto',
+  ) => void;
+};
+
+function tbGateway(): LineupsGatewayWithTiebreaker {
+  return gateway as LineupsGatewayWithTiebreaker;
+}
+
+function testEmitTiebreakerOpenBracket() {
+  tbGateway().emitTiebreakerOpen(42, 7, 'bracket');
+  expect(mockServer.to).toHaveBeenCalledWith('lineup:42');
+  expect(mockEmit).toHaveBeenCalledWith('lineup:tiebreaker:open', {
+    lineupId: 42,
+    tiebreakerId: 7,
+    mode: 'bracket',
+  });
+}
+
+function testEmitTiebreakerOpenVeto() {
+  tbGateway().emitTiebreakerOpen(99, 13, 'veto');
+  expect(mockServer.to).toHaveBeenCalledWith('lineup:99');
+  expect(mockEmit).toHaveBeenCalledWith('lineup:tiebreaker:open', {
+    lineupId: 99,
+    tiebreakerId: 13,
+    mode: 'veto',
+  });
+}
+
+function testEmitTiebreakerOpenRejectsUnknownMode() {
+  // Sanity: the method must exist before we assert on validation.
+  expect(typeof tbGateway().emitTiebreakerOpen).toBe('function');
+  expect(() =>
+    tbGateway().emitTiebreakerOpen(1, 2, 'bogus' as unknown as 'bracket'),
+  ).toThrow();
+  expect(mockEmit).not.toHaveBeenCalled();
+}
+
 beforeEach(() => setupEach());
 
 describe('LineupsGateway — connection', () => {
@@ -146,4 +194,13 @@ describe('LineupsGateway — emit', () => {
   it('emits decided status', () => testEmitStatusChangeDecided());
   it('rejects unknown status before emit', () =>
     testEmitStatusChangeRejectsUnknownStatus());
+});
+
+describe('LineupsGateway — emitTiebreakerOpen (ROK-1117)', () => {
+  it('broadcasts bracket tiebreaker-open to the correct room', () =>
+    testEmitTiebreakerOpenBracket());
+  it('broadcasts veto tiebreaker-open to the correct room', () =>
+    testEmitTiebreakerOpenVeto());
+  it('rejects unknown mode before emit', () =>
+    testEmitTiebreakerOpenRejectsUnknownMode());
 });

--- a/api/src/lineups/lineups.gateway.ts
+++ b/api/src/lineups/lineups.gateway.ts
@@ -13,6 +13,7 @@ import { Server, Socket } from 'socket.io';
 import {
   LineupRealtimeEventNames,
   LineupStatusEventSchema,
+  LineupTiebreakerOpenEventSchema,
 } from '@raid-ledger/contract';
 import type { LineupStatus } from '../drizzle/schema';
 import { perfLog } from '../common/perf-logger';
@@ -115,5 +116,34 @@ export class LineupsGateway
       lineupId,
       status,
     });
+  }
+
+  /**
+   * Emit a tiebreaker-open event to all clients watching the lineup
+   * (ROK-1117). Validates the payload with `LineupTiebreakerOpenEventSchema`
+   * before broadcast so a malformed call (e.g. unknown mode) fails fast.
+   */
+  emitTiebreakerOpen(
+    lineupId: number,
+    tiebreakerId: number,
+    mode: 'bracket' | 'veto',
+    roundDeadline?: Date | null,
+  ): void {
+    const start = performance.now();
+    const payload = LineupTiebreakerOpenEventSchema.parse({
+      lineupId,
+      tiebreakerId,
+      mode,
+      roundDeadline: roundDeadline ? roundDeadline.toISOString() : undefined,
+    });
+    this.server
+      .to(`lineup:${lineupId}`)
+      .emit(LineupRealtimeEventNames.TiebreakerOpen, payload);
+    perfLog(
+      'WS',
+      LineupRealtimeEventNames.TiebreakerOpen,
+      performance.now() - start,
+      { lineupId, tiebreakerId, mode },
+    );
   }
 }

--- a/api/src/lineups/lineups.module.ts
+++ b/api/src/lineups/lineups.module.ts
@@ -19,6 +19,7 @@ import { LineupPhaseProcessor } from './queue/lineup-phase.processor';
 import { TiebreakerModule } from './tiebreaker/tiebreaker.module';
 import { TasteProfileModule } from '../taste-profile/taste-profile.module';
 import { AiSuggestionsModule } from './ai-suggestions/ai-suggestions.module';
+import { CronJobModule } from '../cron-jobs/cron-job.module';
 
 @Module({
   imports: [
@@ -27,6 +28,7 @@ import { AiSuggestionsModule } from './ai-suggestions/ai-suggestions.module';
     NotificationModule,
     forwardRef(() => DiscordBotModule),
     SettingsModule,
+    CronJobModule,
     BullModule.registerQueue({ name: LINEUP_PHASE_QUEUE }),
     forwardRef(() => TiebreakerModule),
     TasteProfileModule,

--- a/api/src/lineups/lineups.module.ts
+++ b/api/src/lineups/lineups.module.ts
@@ -28,7 +28,7 @@ import { AiSuggestionsModule } from './ai-suggestions/ai-suggestions.module';
     forwardRef(() => DiscordBotModule),
     SettingsModule,
     BullModule.registerQueue({ name: LINEUP_PHASE_QUEUE }),
-    TiebreakerModule,
+    forwardRef(() => TiebreakerModule),
     TasteProfileModule,
     AiSuggestionsModule,
     JwtModule.registerAsync({
@@ -50,6 +50,11 @@ import { AiSuggestionsModule } from './ai-suggestions/ai-suggestions.module';
     LineupPhaseProcessor,
     LineupsGateway,
   ],
-  exports: [LineupsService, LineupSteamNudgeService, LineupNotificationService],
+  exports: [
+    LineupsService,
+    LineupSteamNudgeService,
+    LineupNotificationService,
+    LineupsGateway,
+  ],
 })
 export class LineupsModule {}

--- a/api/src/lineups/tiebreaker/tiebreaker-dispatch.helpers.ts
+++ b/api/src/lineups/tiebreaker/tiebreaker-dispatch.helpers.ts
@@ -74,6 +74,11 @@ async function runTiebreakerOpenNotify(
     .where(eq(schema.communityLineups.id, payload.lineupId))
     .limit(1);
   if (!lineupRow) return;
+  const [tbRow] = await db
+    .select({ tiedGameIds: schema.communityLineupTiebreakers.tiedGameIds })
+    .from(schema.communityLineupTiebreakers)
+    .where(eq(schema.communityLineupTiebreakers.id, payload.tiebreakerId))
+    .limit(1);
   await notificationService.notifyTiebreakerOpen(
     {
       id: lineupRow.id,
@@ -85,5 +90,6 @@ async function runTiebreakerOpenNotify(
       mode: payload.mode,
       roundDeadline: payload.roundDeadline,
     },
+    tbRow?.tiedGameIds,
   );
 }

--- a/api/src/lineups/tiebreaker/tiebreaker-dispatch.helpers.ts
+++ b/api/src/lineups/tiebreaker/tiebreaker-dispatch.helpers.ts
@@ -1,0 +1,89 @@
+/**
+ * Tiebreaker-open dispatch helper (ROK-1117).
+ *
+ * Wraps the fire-and-forget DM/embed hook + the WebSocket broadcast so
+ * `TiebreakerService.start()` stays a single line of dispatch and the
+ * service file stays under the 300-line ESLint ceiling.
+ */
+import type { Logger } from '@nestjs/common';
+import { eq } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from '../../drizzle/schema';
+import type { LineupNotificationService } from '../lineup-notification.service';
+import type { LineupsGateway } from '../lineups.gateway';
+
+type Db = PostgresJsDatabase<typeof schema>;
+
+export interface TiebreakerOpenDispatch {
+  lineupId: number;
+  tiebreakerId: number;
+  mode: 'bracket' | 'veto';
+  roundDeadline: Date | null;
+}
+
+/**
+ * Dispatch DM/embed notifications + WebSocket broadcast for a freshly
+ * activated tiebreaker. Both side effects are awaited (with errors
+ * swallowed) so consumers can rely on the fan-out being complete by
+ * the time `start()` returns. The DM/embed pipeline itself still
+ * dedups, so a slow consumer never blocks anything else.
+ */
+export async function dispatchTiebreakerOpen(
+  notificationService: LineupNotificationService,
+  lineupsGateway: LineupsGateway,
+  logger: Logger,
+  db: Db,
+  payload: TiebreakerOpenDispatch,
+): Promise<void> {
+  try {
+    await runTiebreakerOpenNotify(notificationService, db, payload);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.warn(
+      `notifyTiebreakerOpen failed for lineup ${payload.lineupId}: ${msg}`,
+    );
+  }
+  try {
+    lineupsGateway.emitTiebreakerOpen(
+      payload.lineupId,
+      payload.tiebreakerId,
+      payload.mode,
+      payload.roundDeadline ?? undefined,
+    );
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.warn(
+      `emitTiebreakerOpen failed for lineup ${payload.lineupId}: ${msg}`,
+    );
+  }
+}
+
+async function runTiebreakerOpenNotify(
+  notificationService: LineupNotificationService,
+  db: Db,
+  payload: TiebreakerOpenDispatch,
+): Promise<void> {
+  // Re-use the lineup row helper from notify-hooks for visibility / title.
+  const [lineupRow] = await db
+    .select({
+      id: schema.communityLineups.id,
+      title: schema.communityLineups.title,
+      visibility: schema.communityLineups.visibility,
+    })
+    .from(schema.communityLineups)
+    .where(eq(schema.communityLineups.id, payload.lineupId))
+    .limit(1);
+  if (!lineupRow) return;
+  await notificationService.notifyTiebreakerOpen(
+    {
+      id: lineupRow.id,
+      title: lineupRow.title,
+      visibility: lineupRow.visibility,
+    },
+    {
+      id: payload.tiebreakerId,
+      mode: payload.mode,
+      roundDeadline: payload.roundDeadline,
+    },
+  );
+}

--- a/api/src/lineups/tiebreaker/tiebreaker.module.ts
+++ b/api/src/lineups/tiebreaker/tiebreaker.module.ts
@@ -1,13 +1,19 @@
 /**
  * Tiebreaker NestJS module (ROK-938).
+ *
+ * Imports `LineupsModule` (forwardRef'd to break the cycle with
+ * lineups → tiebreaker) so `TiebreakerService` can inject
+ * `LineupNotificationService` and `LineupsGateway` for the open-
+ * notification dispatch path (ROK-1117).
  */
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TiebreakerController } from './tiebreaker.controller';
 import { TiebreakerService } from './tiebreaker.service';
 import { DrizzleModule } from '../../drizzle/drizzle.module';
+import { LineupsModule } from '../lineups.module';
 
 @Module({
-  imports: [DrizzleModule],
+  imports: [DrizzleModule, forwardRef(() => LineupsModule)],
   controllers: [TiebreakerController],
   providers: [TiebreakerService],
   exports: [TiebreakerService],

--- a/api/src/lineups/tiebreaker/tiebreaker.service.ts
+++ b/api/src/lineups/tiebreaker/tiebreaker.service.ts
@@ -8,6 +8,7 @@ import {
   Injectable,
   Logger,
   NotFoundException,
+  forwardRef,
 } from '@nestjs/common';
 import { eq } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
@@ -19,6 +20,9 @@ import type {
 } from '@raid-ledger/contract';
 import { DrizzleAsyncProvider } from '../../drizzle/drizzle.module';
 import * as schema from '../../drizzle/schema';
+import { LineupNotificationService } from '../lineup-notification.service';
+import { LineupsGateway } from '../lineups.gateway';
+import { dispatchTiebreakerOpen } from './tiebreaker-dispatch.helpers';
 import { detectTies } from './tiebreaker-detect.helpers';
 import { runMatchingAlgorithm } from '../lineups-lifecycle.helpers';
 import {
@@ -49,6 +53,10 @@ export class TiebreakerService {
   constructor(
     @Inject(DrizzleAsyncProvider)
     private readonly db: Db,
+    @Inject(forwardRef(() => LineupNotificationService))
+    private readonly notificationService: LineupNotificationService,
+    @Inject(forwardRef(() => LineupsGateway))
+    private readonly lineupsGateway: LineupsGateway,
   ) {}
 
   /** Get tiebreaker detail for a lineup. */
@@ -91,10 +99,28 @@ export class TiebreakerService {
       `Tiebreaker ${tiebreaker.id} started (${dto.mode}) for lineup ${lineupId}`,
     );
 
-    return buildTiebreakerDetail(this.db, {
-      ...tiebreaker,
-      status: 'active',
-    });
+    await this.dispatchOpen(
+      lineupId,
+      tiebreaker.id,
+      dto.mode,
+      tiebreaker.roundDeadline,
+    );
+    return buildTiebreakerDetail(this.db, { ...tiebreaker, status: 'active' });
+  }
+
+  private async dispatchOpen(
+    lineupId: number,
+    tiebreakerId: number,
+    mode: 'bracket' | 'veto',
+    roundDeadline: Date | null,
+  ): Promise<void> {
+    await dispatchTiebreakerOpen(
+      this.notificationService,
+      this.lineupsGateway,
+      this.logger,
+      this.db,
+      { lineupId, tiebreakerId, mode, roundDeadline },
+    );
   }
 
   /** Dismiss tiebreaker — proceed to decided without resolution. */

--- a/packages/contract/src/lineups/realtime.ts
+++ b/packages/contract/src/lineups/realtime.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { LineupStatusSchema } from '../lineup.schema.js';
+import { TiebreakerModeSchema } from '../lineup-tiebreaker.schema.js';
 
 // ============================================================
 // Lineup Realtime WebSocket Events (ROK-1118)
@@ -14,6 +15,7 @@ import { LineupStatusSchema } from '../lineup.schema.js';
 export const LineupRealtimeEventNames = {
     // Server -> client
     Status: 'lineup:status',
+    TiebreakerOpen: 'lineup:tiebreaker:open',
     // Client -> server (bare names — no namespace prefix)
     Subscribe: 'subscribe',
     Unsubscribe: 'unsubscribe',
@@ -29,3 +31,12 @@ export const LineupStatusEventSchema = z.object({
 });
 
 export type LineupStatusEvent = z.infer<typeof LineupStatusEventSchema>;
+
+export const LineupTiebreakerOpenEventSchema = z.object({
+    lineupId: z.number().int(),
+    tiebreakerId: z.number().int(),
+    mode: TiebreakerModeSchema,
+    roundDeadline: z.string().datetime().nullable().optional(),
+});
+
+export type LineupTiebreakerOpenEvent = z.infer<typeof LineupTiebreakerOpenEventSchema>;

--- a/scripts/smoke/lineup-tiebreaker-late-join.smoke.spec.ts
+++ b/scripts/smoke/lineup-tiebreaker-late-join.smoke.spec.ts
@@ -1,0 +1,253 @@
+/**
+ * ROK-1117 — Late-join tiebreaker voting (Playwright smoke).
+ *
+ * AC: A user who navigates to the lineup URL AFTER the tiebreaker has
+ * started can still cast a veto, as long as the round is `active`.
+ * We mirror the setup helpers from `lineup-tiebreaker.smoke.spec.ts`
+ * (create lineup → nominate → vote-tied → start tiebreaker), and then
+ * exercise the FRESH page-open after start.
+ *
+ * TDD gate: this test fails until the dev agent implements the
+ * "late-join" path on `VetoView` (current spec confirms the form
+ * works for the admin operator, but we also assert that the API
+ * accepts a veto from a late arrival and the tiebreaker remains
+ * active afterwards).
+ */
+import { test, expect } from './base';
+import { API_BASE, getAdminToken, apiPost, apiGet } from './api-helpers';
+
+async function apiPatch(
+    token: string,
+    path: string,
+    body: Record<string, unknown>,
+) {
+    const res = await fetch(`${API_BASE}${path}`, {
+        method: 'PATCH',
+        headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+        const t = await res.text().catch(() => '');
+        throw new Error(`PATCH ${path} failed: ${res.status} ${t}`);
+    }
+    return res.json();
+}
+
+async function fetchGameIds(token: string, count: number): Promise<number[]> {
+    const res = await fetch(`${API_BASE}/games/configured`, {
+        headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) throw new Error(`fetchGameIds failed: ${res.status}`);
+    const body = (await res.json()) as { data: { id: number }[] };
+    if (!body.data?.length) throw new Error('No configured games in DB');
+    return body.data.slice(0, count).map((g) => g.id);
+}
+
+async function transitionVotingToDecided(
+    token: string,
+    id: number,
+    entries: { gameId: number }[],
+): Promise<void> {
+    const decidedGameId = entries?.[0]?.gameId;
+    try {
+        await apiPatch(token, `/lineups/${id}/status`, {
+            status: 'decided',
+            ...(decidedGameId ? { decidedGameId } : {}),
+        });
+    } catch {
+        await apiPost(token, `/lineups/${id}/tiebreaker`, {
+            mode: 'bracket',
+            roundDurationHours: 1,
+        }).catch(() => {});
+        await apiPost(token, `/lineups/${id}/tiebreaker/resolve`).catch(() => {});
+        await apiPatch(token, `/lineups/${id}/status`, { status: 'decided' });
+    }
+}
+
+async function archiveActiveLineup(token: string): Promise<void> {
+    for (let attempt = 0; attempt < 3; attempt++) {
+        const banner = await apiGet(token, '/lineups/banner');
+        if (!banner || typeof banner.id !== 'number') return;
+        await apiPost(token, '/admin/test/cancel-lineup-phase-jobs', {
+            lineupId: banner.id,
+        }).catch(() => {});
+        const detail = await apiGet(token, `/lineups/${banner.id}`);
+        if (!detail) return;
+        const id = banner.id;
+        try {
+            if (detail.status === 'voting') {
+                await transitionVotingToDecided(token, id, detail.entries ?? []);
+                await apiPatch(token, `/lineups/${id}/status`, {
+                    status: 'archived',
+                });
+            } else if (detail.status === 'decided') {
+                await apiPatch(token, `/lineups/${id}/status`, {
+                    status: 'archived',
+                });
+            } else if (detail.status === 'building') {
+                await apiPatch(token, `/lineups/${id}/status`, {
+                    status: 'voting',
+                });
+                await apiPatch(token, `/lineups/${id}/status`, {
+                    status: 'decided',
+                });
+                await apiPatch(token, `/lineups/${id}/status`, {
+                    status: 'archived',
+                });
+            }
+        } catch {
+            /* try again */
+        }
+        const check = await apiGet(token, '/lineups/banner');
+        if (!check || typeof check.id !== 'number') return;
+    }
+}
+
+/**
+ * Build a voting lineup with a tied vote AND an ALREADY-STARTED veto
+ * tiebreaker. Returns once the tiebreaker is `active` server-side.
+ */
+async function startVetoTiebreaker(
+    token: string,
+): Promise<{ lineupId: number; tiebreakerId: number; gameIds: number[] }> {
+    await archiveActiveLineup(token);
+
+    const gameIds = await fetchGameIds(token, 4);
+
+    const createRes = (await apiPost(token, '/lineups', {
+        title: 'ROK-1117 Late-Join Smoke',
+        buildingDurationHours: 720,
+        votingDurationHours: 720,
+        decidedDurationHours: 720,
+        matchThreshold: 10,
+    })) as { id?: number };
+    const lineupId =
+        createRes?.id ?? (await apiGet(token, '/lineups/banner'))?.id;
+    if (!lineupId) throw new Error('Failed to create lineup');
+
+    for (const gid of gameIds) {
+        await apiPost(token, `/lineups/${lineupId}/nominate`, { gameId: gid });
+    }
+    await apiPatch(token, `/lineups/${lineupId}/status`, { status: 'voting' });
+
+    // Cast equal votes on top 2 games to force a tie.
+    await apiPost(token, `/lineups/${lineupId}/vote`, { gameId: gameIds[0] });
+    await apiPost(token, `/lineups/${lineupId}/vote`, { gameId: gameIds[1] });
+
+    // Start the tiebreaker BEFORE we navigate. This is the whole point
+    // of the late-join test: the page-open happens AFTER start.
+    const tb = (await apiPost(token, `/lineups/${lineupId}/tiebreaker`, {
+        mode: 'veto',
+        roundDurationHours: 24,
+    })) as { id?: number };
+    const tiebreakerId = tb?.id ?? 0;
+
+    return { lineupId, tiebreakerId, gameIds };
+}
+
+let adminToken: string;
+
+test.beforeAll(async () => {
+    adminToken = await getAdminToken();
+});
+
+test.describe('Late-join tiebreaker voting (ROK-1117)', () => {
+    let lineupId: number;
+    let gameIds: number[];
+
+    test.beforeAll(async () => {
+        const result = await startVetoTiebreaker(adminToken);
+        lineupId = result.lineupId;
+        gameIds = result.gameIds;
+    });
+
+    test('user opens lineup URL after tiebreaker started → veto form visible', async ({
+        page,
+    }) => {
+        // Sanity: confirm the tiebreaker is `active` BEFORE we navigate.
+        const tb = await apiGet(adminToken, `/lineups/${lineupId}/tiebreaker`);
+        expect(tb).not.toBeNull();
+        expect(tb.status).toBe('active');
+
+        await page.goto(`/community-lineup/${lineupId}`);
+        await expect(page.locator('body')).not.toHaveText(
+            /something went wrong/i,
+            { timeout: 10_000 },
+        );
+
+        // AC: late-arriving user sees the veto form.
+        const vetoView = page.locator('[data-testid="veto-view"]');
+        await expect(vetoView).toBeVisible({ timeout: 15_000 });
+
+        const vetoButtons = vetoView.locator('[data-testid="veto-button"]');
+        const buttonCount = await vetoButtons.count();
+        expect(buttonCount).toBeGreaterThan(0);
+    });
+
+    test('late-join user can submit a veto and the round stays active', async ({
+        page,
+    }) => {
+        await page.goto(`/community-lineup/${lineupId}`);
+        await expect(page.locator('body')).not.toHaveText(
+            /something went wrong/i,
+            { timeout: 10_000 },
+        );
+
+        // AC: the late-join veto submission succeeds (HTTP 2xx) and the
+        // tiebreaker remains `active` (single-voter auto-resolve is the
+        // existing behavior — once a real second voter exists this stays
+        // active until both have voted).
+        const vetoResponse = await apiPost(
+            adminToken,
+            `/lineups/${lineupId}/tiebreaker/veto`,
+            { gameId: gameIds[0] },
+        );
+        expect(vetoResponse).toBeTruthy();
+
+        const tb = await apiGet(adminToken, `/lineups/${lineupId}/tiebreaker`);
+        // Late-join AC: round.status still 'active' (or already
+        // 'resolved' is acceptable for single-voter auto-resolve, but
+        // the late-join veto MUST have been accepted — i.e. either the
+        // user's veto is recorded OR the round resolved as a result.)
+        expect(['active', 'resolved']).toContain(tb.status);
+        expect(tb.vetoStatus).not.toBeNull();
+    });
+});
+
+// ─── ROK-1117 AC: "Vote closed at HH:MM" empty state after resolution ───
+//
+// When the tiebreaker has resolved or been dismissed, a user who navigates
+// to the lineup URL must see a clear "Vote closed at HH:MM" message instead
+// of the live veto form. This is NEW UI that doesn't exist yet — the test
+// must fail until the dev agent adds the closed state to VetoView /
+// BracketView.
+
+test.describe('Tiebreaker resolved → "Vote closed" UI (ROK-1117)', () => {
+    let lineupId: number;
+
+    test.beforeAll(async () => {
+        const result = await startVetoTiebreaker(adminToken);
+        lineupId = result.lineupId;
+        // Force-resolve so status === 'resolved' before navigation.
+        await apiPost(adminToken, `/lineups/${lineupId}/tiebreaker/resolve`);
+    });
+
+    test('shows "Vote closed at HH:MM" when status is resolved', async ({
+        page,
+    }) => {
+        await page.goto(`/community-lineup/${lineupId}`);
+        await expect(page.locator('body')).not.toHaveText(
+            /something went wrong/i,
+            { timeout: 10_000 },
+        );
+
+        // AC: late-arrival users who navigate after resolution must see
+        // a "Vote closed at HH:MM" empty state. Format is locally
+        // formatted time — match the prefix loosely.
+        const closedNotice = page.getByText(/vote closed at/i);
+        await expect(closedNotice).toBeVisible({ timeout: 15_000 });
+    });
+});

--- a/scripts/smoke/lineup-tiebreaker.smoke.spec.ts
+++ b/scripts/smoke/lineup-tiebreaker.smoke.spec.ts
@@ -320,8 +320,14 @@ test.describe('Bracket tiebreaker flow', () => {
             expect(voteButtonCount).toBeGreaterThanOrEqual(1);
 
             await voteButtons.first().click();
+            // Single-voter setup auto-resolves the bracket as soon as the last
+            // expected voter casts. Once that happens, lineup transitions to
+            // 'decided' and ROK-1117's gate replaces BracketView with the
+            // TiebreakerClosedNotice — `bracket-matchup-card[data-voted=true]`
+            // is no longer rendered. Either outcome is a valid AC pass.
             const votedCard = bracketView.locator('[data-testid="bracket-matchup-card"][data-voted="true"]');
-            await expect(votedCard.first()).toBeVisible({ timeout: 5_000 });
+            const closedNotice = page.locator('[data-testid="tiebreaker-vote-closed"]');
+            await expect(votedCard.first().or(closedNotice)).toBeVisible({ timeout: 5_000 });
         } else {
             // All matchups may be byes or already completed — still valid
             const matchupCards = bracketView.locator('[data-testid="bracket-matchup-card"]');

--- a/tools/test-bot/src/smoke/run.ts
+++ b/tools/test-bot/src/smoke/run.ts
@@ -27,6 +27,7 @@ import { scheduledEventCompletionTests } from './tests/scheduled-event-completio
 import { aiChatTests } from './tests/ai-chat.test.js';
 import { lineupTitleTests } from './tests/lineup-title.test.js';
 import { privateLineupTests } from './tests/private-lineup.test.js';
+import { lineupTiebreakerOpenTests } from './tests/lineup-tiebreaker-open.test.js';
 
 /** Build a TestResult from a test, status, and timing info. */
 function buildResult(
@@ -143,6 +144,7 @@ function collectTests(filterCat?: string): SmokeTest[] {
     ...aiChatTests,
     ...lineupTitleTests,
     ...privateLineupTests,
+    ...lineupTiebreakerOpenTests,
   ].filter((t) => !filterCat || t.category === filterCat);
 }
 

--- a/tools/test-bot/src/smoke/tests/lineup-tiebreaker-open.test.ts
+++ b/tools/test-bot/src/smoke/tests/lineup-tiebreaker-open.test.ts
@@ -107,10 +107,18 @@ async function waitForTiebreakerDM(
   );
 }
 
-/** Build a public lineup ready for a tiebreaker. */
+/** Build a public lineup ready for a tiebreaker.
+ *
+ * For PUBLIC lineups, `loadExpectedVoters` returns nominators ∪ voters.
+ * The smoke bot's `dmRecipientUserId` must be in that set, otherwise no
+ * tiebreaker-open DM is dispatched to them. We use the DEMO_MODE-only
+ * `/admin/test/nominate-game` endpoint to record a nomination on the
+ * dmRecipientUserId's behalf so they show up as a participant.
+ */
 async function buildPublicLineupWithTie(
   api: ApiClient,
   title: string,
+  dmRecipientUserId: number,
 ): Promise<{ lineup: LineupPayload; gameIds: number[] }> {
   const created = await api.post<LineupPayload>('/lineups', {
     title,
@@ -132,6 +140,19 @@ async function buildPublicLineupWithTie(
   for (const gid of gameIds) {
     await api.post(`/lineups/${created.id}/nominate`, { gameId: gid });
   }
+
+  // Add dmRecipientUserId as a nominator (DEMO_MODE-only test endpoint) so
+  // they enter the public-lineup expected-voters set and receive the DM.
+  if (gameIds[0]) {
+    await api
+      .post('/admin/test/nominate-game', {
+        lineupId: created.id,
+        gameId: gameIds[0],
+        userId: dmRecipientUserId,
+      })
+      .catch(() => null);
+  }
+
   await api.patch(`/lineups/${created.id}/status`, { status: 'voting' });
 
   // Cast equal votes on top 2 to force a tie.
@@ -150,7 +171,11 @@ const publicTiebreakerOpenDmsAndEmbed: SmokeTest = {
     await archiveAllLineups(ctx.api);
 
     const title = `Public TB Open ${Date.now()}`;
-    const { lineup } = await buildPublicLineupWithTie(ctx.api, title);
+    const { lineup } = await buildPublicLineupWithTie(
+      ctx.api,
+      title,
+      ctx.dmRecipientUserId,
+    );
 
     try {
       // Start the tiebreaker — this is the trigger under test.

--- a/tools/test-bot/src/smoke/tests/lineup-tiebreaker-open.test.ts
+++ b/tools/test-bot/src/smoke/tests/lineup-tiebreaker-open.test.ts
@@ -1,0 +1,264 @@
+/**
+ * ROK-1117 — Tiebreaker open Discord smoke tests.
+ *
+ * AC:
+ *   - Public lineup: when a tiebreaker is started, every expected voter
+ *     (loadExpectedVoters) gets a community_lineup notification with
+ *     `subtype === 'lineup_tiebreaker_open'`, AND a channel embed is
+ *     posted to the lineup's bound channel.
+ *   - Private lineup: when a tiebreaker is started, invitees + creator
+ *     get the DM, channel embed is suppressed.
+ *
+ * TDD gate: these tests must FAIL until the dev agent wires
+ * `LineupNotificationService.notifyTiebreakerOpen` from
+ * `TiebreakerService.start()`.
+ *
+ * Strategy mirrors `private-lineup.test.ts`: we poll
+ * `/admin/test/notifications?userId=<invitee>&type=community_lineup`
+ * for the new notification subtype, and `pollForEmbed` for the channel
+ * embed. The companion bot can't receive DMs from another bot, so the
+ * in-app notification row is the canonical proof of dispatch.
+ */
+import { readLastMessages } from '../../helpers/messages.js';
+import {
+  awaitProcessing,
+  assertConditionNeverMet,
+} from '../fixtures.js';
+import {
+  pollForCondition,
+  pollForEmbed,
+} from '../../helpers/polling.js';
+import type { SmokeTest, TestContext } from '../types.js';
+import type { ApiClient } from '../api.js';
+
+interface LineupPayload {
+  id: number;
+  title?: string;
+  visibility?: string;
+  invitees?: unknown[];
+  [k: string]: unknown;
+}
+
+interface TestNotification {
+  id: number;
+  type: string;
+  title?: string;
+  message?: string;
+  payload?: { subtype?: string; lineupId?: number; tiebreakerId?: number } | null;
+  createdAt?: string;
+}
+
+async function archiveAllLineups(api: ApiClient): Promise<void> {
+  try {
+    const res = await api.get<
+      { id: number }[] | { id: number } | null
+    >('/lineups/active');
+    const list = Array.isArray(res) ? res : res ? [res] : [];
+    for (const row of list) {
+      if (!row?.id) continue;
+      await api
+        .patch(`/lineups/${row.id}/status`, { status: 'archived' })
+        .catch(() => null);
+    }
+  } catch {
+    /* no active lineups */
+  }
+}
+
+async function deleteLineup(api: ApiClient, id: number): Promise<void> {
+  await api.delete(`/lineups/${id}`).catch(() => {
+    return api
+      .patch(`/lineups/${id}/status`, { status: 'archived' })
+      .catch(() => null);
+  });
+}
+
+async function fetchNotifications(
+  api: ApiClient,
+  userId: number,
+): Promise<TestNotification[]> {
+  const res = await api
+    .get<TestNotification[]>(
+      `/admin/test/notifications?userId=${userId}&type=community_lineup&limit=25`,
+    )
+    .catch(() => [] as TestNotification[]);
+  return Array.isArray(res) ? res : [];
+}
+
+async function waitForTiebreakerDM(
+  ctx: TestContext,
+  userId: number,
+  lineupId: number,
+  timeoutMs: number,
+): Promise<TestNotification> {
+  return pollForCondition(
+    async () => {
+      const list = await fetchNotifications(ctx.api, userId);
+      return (
+        list.find(
+          (n) =>
+            n.payload?.subtype === 'lineup_tiebreaker_open' &&
+            n.payload.lineupId === lineupId,
+        ) ?? null
+      );
+    },
+    timeoutMs,
+    { intervalMs: 1500 },
+  );
+}
+
+/** Build a public lineup ready for a tiebreaker. */
+async function buildPublicLineupWithTie(
+  api: ApiClient,
+  title: string,
+): Promise<{ lineup: LineupPayload; gameIds: number[] }> {
+  const created = await api.post<LineupPayload>('/lineups', {
+    title,
+    description: 'ROK-1117 tiebreaker-open smoke',
+    buildingDurationHours: 720,
+    votingDurationHours: 720,
+    decidedDurationHours: 720,
+    matchThreshold: 10,
+  });
+
+  const gamesRes = await api.get<{ data: { id: number }[] }>(
+    '/games/configured',
+  );
+  const gameIds = (gamesRes?.data ?? []).slice(0, 4).map((g) => g.id);
+  if (gameIds.length < 2) {
+    throw new Error(`Need at least 2 configured games, got ${gameIds.length}`);
+  }
+
+  for (const gid of gameIds) {
+    await api.post(`/lineups/${created.id}/nominate`, { gameId: gid });
+  }
+  await api.patch(`/lineups/${created.id}/status`, { status: 'voting' });
+
+  // Cast equal votes on top 2 to force a tie.
+  await api.post(`/lineups/${created.id}/vote`, { gameId: gameIds[0] });
+  await api.post(`/lineups/${created.id}/vote`, { gameId: gameIds[1] });
+
+  return { lineup: created, gameIds };
+}
+
+// ── AC 1: Public lineup tiebreaker → DMs + channel embed ───────────────
+
+const publicTiebreakerOpenDmsAndEmbed: SmokeTest = {
+  name: 'Public tiebreaker open DMs participants and posts channel embed (ROK-1117)',
+  category: 'dm',
+  async run(ctx: TestContext) {
+    await archiveAllLineups(ctx.api);
+
+    const title = `Public TB Open ${Date.now()}`;
+    const { lineup } = await buildPublicLineupWithTie(ctx.api, title);
+
+    try {
+      // Start the tiebreaker — this is the trigger under test.
+      const tb = await ctx.api.post<{ id: number; status: string }>(
+        `/lineups/${lineup.id}/tiebreaker`,
+        { mode: 'veto', roundDurationHours: 24 },
+      );
+      await awaitProcessing(ctx.api);
+
+      // (a) Expected-voter DM landed for the test bot's user.
+      await waitForTiebreakerDM(
+        ctx,
+        ctx.dmRecipientUserId,
+        lineup.id,
+        ctx.config.timeoutMs,
+      );
+
+      // (b) Channel embed for tiebreaker-open posted to the bound channel.
+      // We match on the tiebreaker title pattern (Veto / Bracket).
+      await pollForEmbed(
+        ctx.defaultChannelId,
+        (m) =>
+          m.embeds.some((e) => {
+            const hay = [e.title ?? '', e.description ?? ''].join(' ');
+            return /tiebreaker/i.test(hay) && /veto|cast your veto/i.test(hay);
+          }),
+        ctx.config.timeoutMs,
+      );
+
+      void tb;
+    } finally {
+      await deleteLineup(ctx.api, lineup.id);
+    }
+  },
+};
+
+// ── AC 2: Private lineup tiebreaker → DM only, channel embed suppressed ─
+
+const privateTiebreakerOpenSuppressesChannel: SmokeTest = {
+  name: 'Private tiebreaker open DMs invitee and suppresses channel embed (ROK-1117)',
+  category: 'dm',
+  async run(ctx: TestContext) {
+    await archiveAllLineups(ctx.api);
+
+    const title = `Private TB Open ${Date.now()}`;
+    const created = await ctx.api.post<LineupPayload>('/lineups', {
+      title,
+      description: 'ROK-1117 private tiebreaker smoke',
+      visibility: 'private',
+      inviteeUserIds: [ctx.dmRecipientUserId],
+      buildingDurationHours: 720,
+      votingDurationHours: 720,
+      decidedDurationHours: 720,
+      matchThreshold: 10,
+    });
+    const lineupId = created.id;
+
+    try {
+      const gamesRes = await ctx.api.get<{ data: { id: number }[] }>(
+        '/games/configured',
+      );
+      const gameIds = (gamesRes?.data ?? []).slice(0, 4).map((g) => g.id);
+      if (gameIds.length < 2) {
+        throw new Error(`Need ≥2 configured games, got ${gameIds.length}`);
+      }
+      for (const gid of gameIds) {
+        await ctx.api.post(`/lineups/${lineupId}/nominate`, { gameId: gid });
+      }
+      await ctx.api.patch(`/lineups/${lineupId}/status`, { status: 'voting' });
+      await ctx.api.post(`/lineups/${lineupId}/vote`, { gameId: gameIds[0] });
+      await ctx.api.post(`/lineups/${lineupId}/vote`, { gameId: gameIds[1] });
+
+      await ctx.api.post(`/lineups/${lineupId}/tiebreaker`, {
+        mode: 'bracket',
+        roundDurationHours: 24,
+      });
+      await awaitProcessing(ctx.api);
+
+      // (a) Invitee receives the tiebreaker-open DM.
+      await waitForTiebreakerDM(
+        ctx,
+        ctx.dmRecipientUserId,
+        lineupId,
+        ctx.config.timeoutMs,
+      );
+
+      // (b) Channel must NOT receive a tiebreaker-open embed.
+      await assertConditionNeverMet(
+        async () => {
+          const msgs = await readLastMessages(ctx.defaultChannelId, 25);
+          return msgs.some((m) =>
+            m.embeds.some((e) => {
+              const hay = [e.title ?? '', e.description ?? ''].join(' ');
+              return /tiebreaker/i.test(hay) && hay.includes(title);
+            }),
+          );
+        },
+        8_000,
+        `Channel received a tiebreaker-open embed for private lineup "${title}" — expected none`,
+        { intervalMs: 2000 },
+      );
+    } finally {
+      await deleteLineup(ctx.api, lineupId);
+    }
+  },
+};
+
+export const lineupTiebreakerOpenTests: SmokeTest[] = [
+  publicTiebreakerOpenDmsAndEmbed,
+  privateTiebreakerOpenSuppressesChannel,
+];

--- a/tools/test-bot/src/smoke/tests/lineup-tiebreaker-open.test.ts
+++ b/tools/test-bot/src/smoke/tests/lineup-tiebreaker-open.test.ts
@@ -137,20 +137,21 @@ async function buildPublicLineupWithTie(
     throw new Error(`Need at least 2 configured games, got ${gameIds.length}`);
   }
 
-  for (const gid of gameIds) {
+  // Admin nominates the first three games; dmRecipientUserId nominates the
+  // fourth via the DEMO_MODE-only test endpoint so they enter the public
+  // expected-voters set (loadExpectedVoters returns nominators ∪ voters).
+  // The (lineupId, gameId) uniqueness constraint means each game can only be
+  // nominated once, so the two paths must operate on different games.
+  for (const gid of gameIds.slice(0, gameIds.length - 1)) {
     await api.post(`/lineups/${created.id}/nominate`, { gameId: gid });
   }
-
-  // Add dmRecipientUserId as a nominator (DEMO_MODE-only test endpoint) so
-  // they enter the public-lineup expected-voters set and receive the DM.
-  if (gameIds[0]) {
-    await api
-      .post('/admin/test/nominate-game', {
-        lineupId: created.id,
-        gameId: gameIds[0],
-        userId: dmRecipientUserId,
-      })
-      .catch(() => null);
+  const dmRecipientGame = gameIds[gameIds.length - 1];
+  if (dmRecipientGame !== undefined) {
+    await api.post('/admin/test/nominate-game', {
+      lineupId: created.id,
+      gameId: dmRecipientGame,
+      userId: dmRecipientUserId,
+    });
   }
 
   await api.patch(`/lineups/${created.id}/status`, { status: 'voting' });

--- a/web/src/components/lineups/LineupVoteBanner.tsx
+++ b/web/src/components/lineups/LineupVoteBanner.tsx
@@ -5,6 +5,7 @@
 import type { JSX } from 'react';
 import { Link } from 'react-router-dom';
 import { useLineupBanner, useLineupDetail, useToggleVote } from '../../hooks/use-lineups';
+import { useTiebreakerDetail } from '../../hooks/use-tiebreaker';
 
 interface Props {
   gameId: number;
@@ -22,6 +23,15 @@ export function LineupVoteBanner({ gameId }: Props): JSX.Element | null {
   }
 
   if (banner.status === 'voting') {
+    if (banner.tiebreakerActive) {
+      return (
+        <TiebreakerOrVotingBanner
+          lineupId={banner.id}
+          gameId={gameId}
+          gameName={entry.gameName}
+        />
+      );
+    }
     return <VotingBanner lineupId={banner.id} gameId={gameId} gameName={entry.gameName} />;
   }
 
@@ -30,6 +40,43 @@ export function LineupVoteBanner({ gameId }: Props): JSX.Element | null {
   }
 
   return null;
+}
+
+/**
+ * Routes to the tiebreaker banner when this game is among the tied games,
+ * else falls back to the regular voting banner. The lookup is lazy — we
+ * only fetch tiebreaker detail when banner.tiebreakerActive is true.
+ */
+function TiebreakerOrVotingBanner({ lineupId, gameId, gameName }: {
+  lineupId: number; gameId: number; gameName: string;
+}): JSX.Element {
+  const { data: tiebreaker } = useTiebreakerDetail(lineupId);
+  const isTiedGame = tiebreaker?.tiedGameIds?.includes(gameId) ?? false;
+  if (tiebreaker && isTiedGame && tiebreaker.status === 'active') {
+    return (
+      <TiebreakerBanner
+        lineupId={lineupId}
+        gameName={gameName}
+        mode={tiebreaker.mode}
+        hasEngaged={hasEngaged(tiebreaker, gameId)}
+      />
+    );
+  }
+  return <VotingBanner lineupId={lineupId} gameId={gameId} gameName={gameName} />;
+}
+
+/** Whether the current user has already engaged with the tiebreaker. */
+function hasEngaged(
+  tiebreaker: NonNullable<ReturnType<typeof useTiebreakerDetail>['data']>,
+  _gameId: number,
+): boolean {
+  if (tiebreaker.mode === 'veto') {
+    return tiebreaker.vetoStatus?.myVetoGameId != null;
+  }
+  // Bracket: engaged when every active matchup has a myVote
+  const matchups = tiebreaker.matchups ?? [];
+  if (matchups.length === 0) return false;
+  return matchups.every((m) => m.isCompleted || m.myVote != null);
 }
 
 function NominatedBadge({ lineupId }: { lineupId: number }): JSX.Element {
@@ -85,6 +132,29 @@ function VotingBanner({ lineupId, gameId, gameName }: {
           View Lineup →
         </Link>
       </div>
+    </div>
+  );
+}
+
+function TiebreakerBanner({ lineupId, gameName, mode, hasEngaged }: {
+  lineupId: number; gameName: string; mode: 'bracket' | 'veto'; hasEngaged: boolean;
+}): JSX.Element {
+  const cta = mode === 'veto' ? 'Cast your veto' : 'Vote in bracket';
+  const action = mode === 'veto' ? 'veto tiebreaker' : 'bracket tiebreaker';
+  const message = hasEngaged
+    ? `${gameName} is in a ${action} — you've already cast your vote.`
+    : `${gameName} is in a ${action} — ${cta.toLowerCase()} now!`;
+  return (
+    <div className="mb-6 rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-3 flex items-center justify-between gap-3 flex-wrap">
+      <span className="text-sm text-amber-300">
+        🎲 <strong>{message}</strong>
+      </span>
+      <Link
+        to={`/community-lineup/${lineupId}`}
+        className="text-sm font-medium text-amber-400 hover:text-amber-300 whitespace-nowrap"
+      >
+        {hasEngaged ? 'View Lineup →' : `${cta} →`}
+      </Link>
     </div>
   );
 }

--- a/web/src/components/lineups/LineupVoteBanner.tsx
+++ b/web/src/components/lineups/LineupVoteBanner.tsx
@@ -58,7 +58,7 @@ function TiebreakerOrVotingBanner({ lineupId, gameId, gameName }: {
         lineupId={lineupId}
         gameName={gameName}
         mode={tiebreaker.mode}
-        hasEngaged={hasEngaged(tiebreaker, gameId)}
+        hasEngaged={hasEngaged(tiebreaker)}
       />
     );
   }
@@ -68,7 +68,6 @@ function TiebreakerOrVotingBanner({ lineupId, gameId, gameName }: {
 /** Whether the current user has already engaged with the tiebreaker. */
 function hasEngaged(
   tiebreaker: NonNullable<ReturnType<typeof useTiebreakerDetail>['data']>,
-  _gameId: number,
 ): boolean {
   if (tiebreaker.mode === 'veto') {
     return tiebreaker.vetoStatus?.myVetoGameId != null;

--- a/web/src/components/lineups/tiebreaker/BracketView.tsx
+++ b/web/src/components/lineups/tiebreaker/BracketView.tsx
@@ -6,6 +6,7 @@ import type { JSX } from 'react';
 import type { TiebreakerDetailDto } from '@raid-ledger/contract';
 import { BracketTree } from './BracketTree';
 import { BracketMatchupCard } from './BracketMatchupCard';
+import { TiebreakerClosedNotice } from './TiebreakerClosedNotice';
 import { useForceResolve } from '../../../hooks/use-tiebreaker';
 
 interface Props {
@@ -18,6 +19,15 @@ export function BracketView({ tiebreaker, lineupId }: Props): JSX.Element {
     const matchups = tiebreaker.matchups ?? [];
     const currentRound = tiebreaker.currentRound ?? 1;
     const totalRounds = tiebreaker.totalRounds ?? 1;
+
+    if (tiebreaker.status !== 'active') {
+        return (
+            <TiebreakerClosedNotice
+                title="Bracket Tiebreaker"
+                resolvedAt={tiebreaker.resolvedAt}
+            />
+        );
+    }
 
     return (
         <div data-testid="bracket-view" className="mt-4">

--- a/web/src/components/lineups/tiebreaker/TiebreakerClosedNotice.tsx
+++ b/web/src/components/lineups/tiebreaker/TiebreakerClosedNotice.tsx
@@ -1,0 +1,30 @@
+/**
+ * TiebreakerClosedNotice (ROK-1117).
+ * Renders the late-join "Vote closed at HH:MM" empty state shown when the
+ * tiebreaker is no longer accepting votes (status: 'resolved' | 'dismissed').
+ */
+import type { JSX } from 'react';
+
+interface Props {
+    title: string;
+    resolvedAt: string | null | undefined;
+}
+
+function formatClosedTime(resolvedAt: string | null | undefined): string {
+    if (!resolvedAt) return '';
+    const date = new Date(resolvedAt);
+    if (Number.isNaN(date.getTime())) return '';
+    return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
+export function TiebreakerClosedNotice({ title, resolvedAt }: Props): JSX.Element {
+    const closedAt = formatClosedTime(resolvedAt);
+    return (
+        <div className="mt-4">
+            <h3 className="text-base font-semibold text-foreground mb-2">{title}</h3>
+            <p data-testid="tiebreaker-vote-closed" className="text-sm text-muted">
+                {closedAt ? `Vote closed at ${closedAt}` : 'Vote closed'}
+            </p>
+        </div>
+    );
+}

--- a/web/src/components/lineups/tiebreaker/VetoView.tsx
+++ b/web/src/components/lineups/tiebreaker/VetoView.tsx
@@ -5,6 +5,7 @@
 import type { JSX } from 'react';
 import type { TiebreakerDetailDto } from '@raid-ledger/contract';
 import { VetoGameCard } from './VetoGameCard';
+import { TiebreakerClosedNotice } from './TiebreakerClosedNotice';
 import { useCastVeto, useForceResolve } from '../../../hooks/use-tiebreaker';
 
 interface Props {
@@ -17,6 +18,15 @@ export function VetoView({ tiebreaker, lineupId }: Props): JSX.Element {
     const forceResolve = useForceResolve();
     const veto = tiebreaker.vetoStatus;
     if (!veto) return <div>No veto data</div>;
+
+    if (tiebreaker.status === 'resolved' || tiebreaker.status === 'dismissed') {
+        return (
+            <TiebreakerClosedNotice
+                title="Veto Elimination"
+                resolvedAt={tiebreaker.resolvedAt}
+            />
+        );
+    }
 
     const remaining = veto.vetoCap - veto.totalVetoes;
     const canVeto = tiebreaker.status === 'active' && !veto.myVetoGameId && remaining > 0;

--- a/web/src/hooks/use-lineup-realtime.test.ts
+++ b/web/src/hooks/use-lineup-realtime.test.ts
@@ -148,3 +148,61 @@ describe('useLineupRealtime (ROK-1118)', () => {
         expect(unsubscribeCalls[0][1]).toEqual({ lineupId: 42 });
     });
 });
+
+// ─── ROK-1117: tiebreaker-open event ─────────────────────────────────────
+//
+// When the gateway emits `lineup:tiebreaker:open`, the hook must invalidate
+// the tiebreaker detail query (`['tiebreaker', lineupId]`) so that any UI
+// using `useTiebreakerDetail` re-fetches and the late-join voting form
+// becomes visible without a manual reload.
+
+describe('useLineupRealtime — tiebreaker:open (ROK-1117)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        socketHandlers.clear();
+    });
+
+    it('invalidates the tiebreaker detail query on lineup:tiebreaker:open', async () => {
+        const queryClient = new QueryClient({
+            defaultOptions: {
+                queries: { retry: false, gcTime: Infinity, staleTime: Infinity },
+                mutations: { retry: false },
+            },
+        });
+        // Seed the tiebreaker cache so invalidation has a target.
+        queryClient.setQueryData(['tiebreaker', 42], {
+            id: 1,
+            mode: 'veto',
+            status: 'active',
+        });
+        const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+        function wrapper({ children }: { children: ReactNode }) {
+            return createElement(
+                QueryClientProvider,
+                { client: queryClient },
+                children,
+            );
+        }
+
+        const mod = await import('./use-lineup-realtime');
+        const useLineupRealtime = mod.useLineupRealtime;
+
+        renderHook(() => useLineupRealtime(42), { wrapper });
+
+        await act(async () => {
+            fireSocketEvent('lineup:tiebreaker:open', {
+                lineupId: 42,
+                tiebreakerId: 1,
+                mode: 'veto',
+            });
+        });
+
+        const tbCalls = invalidateSpy.mock.calls.filter(
+            ([opts]) =>
+                JSON.stringify(opts?.queryKey) ===
+                JSON.stringify(['tiebreaker', 42]),
+        );
+        expect(tbCalls.length).toBeGreaterThanOrEqual(1);
+    });
+});

--- a/web/src/hooks/use-lineup-realtime.ts
+++ b/web/src/hooks/use-lineup-realtime.ts
@@ -3,6 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { io, type Socket } from 'socket.io-client';
 import { LineupRealtimeEventNames } from '@raid-ledger/contract';
 import { DETAIL_KEY, LINEUPS_PREFIX } from './use-lineups';
+import { TIEBREAKER_KEY } from './use-tiebreaker';
 
 const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:3000';
 
@@ -52,11 +53,19 @@ export function useLineupRealtime(lineupId: number | undefined): void {
       });
     };
 
+    const handleTiebreakerOpen = () => {
+      void queryClient.invalidateQueries({
+        queryKey: [...TIEBREAKER_KEY, lineupId],
+      });
+    };
+
     socket.on(LineupRealtimeEventNames.Status, handleStatus);
+    socket.on(LineupRealtimeEventNames.TiebreakerOpen, handleTiebreakerOpen);
 
     return () => {
       socket.emit(LineupRealtimeEventNames.Unsubscribe, { lineupId });
       socket.off(LineupRealtimeEventNames.Status, handleStatus);
+      socket.off(LineupRealtimeEventNames.TiebreakerOpen, handleTiebreakerOpen);
       socket.disconnect();
     };
   }, [lineupId, queryClient]);

--- a/web/src/hooks/use-tiebreaker.ts
+++ b/web/src/hooks/use-tiebreaker.ts
@@ -12,7 +12,7 @@ import {
     forceResolveTiebreaker,
 } from '../lib/api/tiebreaker-api';
 
-const TIEBREAKER_KEY = ['tiebreaker'] as const;
+export const TIEBREAKER_KEY = ['tiebreaker'] as const;
 const LINEUPS_PREFIX = ['lineups'] as const;
 
 /** Fetch tiebreaker detail for a lineup. */

--- a/web/src/pages/__tests__/lineup-detail-page-tiebreaker-closed.test.tsx
+++ b/web/src/pages/__tests__/lineup-detail-page-tiebreaker-closed.test.tsx
@@ -167,14 +167,16 @@ describe('LineupDetailPage tiebreaker closed notice (ROK-1117)', () => {
         vi.clearAllMocks();
     });
 
-    it('renders TiebreakerClosedNotice for decided lineup with resolved tiebreaker', () => {
+    it('renders TiebreakerClosedNotice ABOVE DecidedView for decided lineup with resolved tiebreaker', () => {
         mockLineup = makeLineup({ status: 'decided' });
         mockTiebreaker = makeTiebreaker({ status: 'resolved' });
 
         renderPage();
 
+        // Both the historical tiebreaker context AND the decided podium are
+        // shown. The closed notice is a banner above the decided view.
         expect(screen.getByTestId('tiebreaker-vote-closed')).toBeInTheDocument();
-        expect(screen.queryByTestId('decided-view')).not.toBeInTheDocument();
+        expect(screen.getByTestId('decided-view')).toBeInTheDocument();
     });
 
     it('falls back to DecidedView when no tiebreaker exists', () => {

--- a/web/src/pages/__tests__/lineup-detail-page-tiebreaker-closed.test.tsx
+++ b/web/src/pages/__tests__/lineup-detail-page-tiebreaker-closed.test.tsx
@@ -1,0 +1,202 @@
+/**
+ * lineup-detail-page-tiebreaker-closed.test.tsx (ROK-1117)
+ *
+ * Verifies the late-join "Vote closed at HH:MM" empty state renders for
+ * users who navigate to a lineup whose tiebreaker has resolved and the
+ * lineup has already advanced to 'decided'.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+// ─── Hook mocks ────────────────────────────────────────────────────────────
+
+let mockLineup: unknown = null;
+let mockTiebreaker: unknown = null;
+
+vi.mock('../../hooks/use-lineups', () => ({
+    useLineupDetail: () => ({ data: mockLineup, isLoading: false, error: null }),
+}));
+
+vi.mock('../../hooks/use-lineup-realtime', () => ({
+    useLineupRealtime: () => {},
+}));
+
+vi.mock('../../hooks/use-tiebreaker', () => ({
+    useTiebreakerDetail: () => ({ data: mockTiebreaker }),
+    useForceResolve: () => ({ mutate: vi.fn(), isPending: false }),
+    useCastVeto: () => ({ mutate: vi.fn() }),
+    useCastBracketVote: () => ({ mutate: vi.fn() }),
+    useDismissTiebreaker: () => ({ mutate: vi.fn(), isPending: false }),
+    useStartTiebreaker: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock('../../hooks/use-auth', () => ({
+    useAuth: () => ({ user: { id: 1, username: 'Tester' }, isAuthenticated: true }),
+    isOperatorOrAdmin: () => false,
+}));
+
+vi.mock('../../hooks/use-ai-suggestions', () => ({
+    useAiSuggestions: () => ({ data: null }),
+}));
+
+vi.mock('../../hooks/use-ai-suggestions-available', () => ({
+    useAiSuggestionsAvailable: () => false,
+}));
+
+vi.mock('../../hooks/use-steam-paste', () => ({
+    useSteamPasteDetection: () => {},
+}));
+
+vi.mock('../../lib/lineup-eligibility', () => ({
+    canParticipateInLineup: () => true,
+}));
+
+// ─── Component mocks (silence everything not under test) ──────────────────
+
+vi.mock('../../components/lineups/LineupDetailHeader', () => ({
+    LineupDetailHeader: () => <div data-testid="lineup-header" />,
+}));
+vi.mock('../../components/lineups/InviteeList', () => ({
+    InviteeList: () => null,
+}));
+vi.mock('../../components/lineups/AddInviteesButton', () => ({
+    AddInviteesButton: () => null,
+}));
+vi.mock('../../components/lineups/NominationGrid', () => ({
+    NominationGrid: () => null,
+}));
+vi.mock('../../components/lineups/VotingLeaderboard', () => ({
+    VotingLeaderboard: () => null,
+}));
+vi.mock('../../components/lineups/LineupEmptyState', () => ({
+    LineupEmptyState: () => null,
+}));
+vi.mock('../../components/lineups/LineupDetailSkeleton', () => ({
+    LineupDetailSkeleton: () => null,
+}));
+vi.mock('../../components/lineups/CommonGroundPanel', () => ({
+    CommonGroundPanel: () => null,
+}));
+vi.mock('../../components/lineups/NominateModal', () => ({
+    NominateModal: () => null,
+}));
+vi.mock('../../components/lineups/PastLineups', () => ({
+    PastLineups: () => null,
+}));
+vi.mock('../../components/lineups/decided/DecidedView', () => ({
+    DecidedView: () => <div data-testid="decided-view" />,
+}));
+vi.mock('../../components/common/ActivityTimeline', () => ({
+    ActivityTimeline: () => null,
+}));
+vi.mock('../../components/lineups/SteamNudgeBanner', () => ({
+    SteamNudgeBanner: () => null,
+}));
+vi.mock('../../components/lineups/tiebreaker/TiebreakerPromptModal', () => ({
+    TiebreakerPromptModal: () => null,
+}));
+
+// Import after mocks
+import { LineupDetailPage } from '../lineup-detail-page';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────
+
+function makeLineup(overrides: Record<string, unknown> = {}) {
+    return {
+        id: 7,
+        title: 'Test Lineup',
+        status: 'decided',
+        visibility: 'public',
+        entries: [],
+        invitees: [],
+        myVotes: [],
+        totalVoters: 0,
+        totalMembers: 0,
+        maxVotesPerPlayer: 3,
+        createdBy: { id: 99 },
+        ...overrides,
+    };
+}
+
+function makeTiebreaker(overrides: Record<string, unknown> = {}) {
+    return {
+        id: 1,
+        lineupId: 7,
+        mode: 'bracket',
+        status: 'resolved',
+        tiedGameIds: [10, 20],
+        originalVoteCount: 5,
+        winnerGameId: 10,
+        roundDeadline: null,
+        resolvedAt: '2026-04-27T15:30:00Z',
+        currentRound: 1,
+        totalRounds: 1,
+        matchups: [],
+        vetoStatus: null,
+        ...overrides,
+    };
+}
+
+function renderPage() {
+    const qc = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false, gcTime: Infinity },
+            mutations: { retry: false },
+        },
+    });
+    return render(
+        <QueryClientProvider client={qc}>
+            <MemoryRouter initialEntries={['/community-lineup/7']}>
+                <Routes>
+                    <Route
+                        path="/community-lineup/:id"
+                        element={<LineupDetailPage />}
+                    />
+                </Routes>
+            </MemoryRouter>
+        </QueryClientProvider>,
+    );
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────
+
+describe('LineupDetailPage tiebreaker closed notice (ROK-1117)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders TiebreakerClosedNotice for decided lineup with resolved tiebreaker', () => {
+        mockLineup = makeLineup({ status: 'decided' });
+        mockTiebreaker = makeTiebreaker({ status: 'resolved' });
+
+        renderPage();
+
+        expect(screen.getByTestId('tiebreaker-vote-closed')).toBeInTheDocument();
+        expect(screen.queryByTestId('decided-view')).not.toBeInTheDocument();
+    });
+
+    it('falls back to DecidedView when no tiebreaker exists', () => {
+        mockLineup = makeLineup({ status: 'decided' });
+        mockTiebreaker = null;
+
+        renderPage();
+
+        expect(screen.queryByTestId('tiebreaker-vote-closed')).not.toBeInTheDocument();
+        expect(screen.getByTestId('decided-view')).toBeInTheDocument();
+    });
+
+    it('does not render closed notice for decided lineup with non-resolved tiebreaker', () => {
+        // After dismiss, server returns null (findPendingOrActiveTiebreaker
+        // filters dismissed). Just be defensive: even if a stale dismissed row
+        // surfaced, the gate must not render the notice for it.
+        mockLineup = makeLineup({ status: 'decided' });
+        mockTiebreaker = makeTiebreaker({ status: 'dismissed' });
+
+        renderPage();
+
+        expect(screen.queryByTestId('tiebreaker-vote-closed')).not.toBeInTheDocument();
+        expect(screen.getByTestId('decided-view')).toBeInTheDocument();
+    });
+});

--- a/web/src/pages/lineup-detail-page.tsx
+++ b/web/src/pages/lineup-detail-page.tsx
@@ -111,7 +111,16 @@ export function LineupDetailPage(): JSX.Element {
   if (error || !lineup) return <LineupNotFound />;
 
   const hasEntries = lineup.entries.length > 0;
-  const hasTiebreaker = lineup.status === 'voting' && tiebreaker && ['active', 'pending', 'resolved'].includes(tiebreaker.status);
+  // ROK-1117: also render when the lineup has already advanced to 'decided'
+  // and the tiebreaker is 'resolved' so late-arriving users see the
+  // "Vote closed at HH:MM" notice instead of jumping straight to results.
+  // Dismissed tiebreakers are intentionally excluded — findPendingOrActiveTiebreaker
+  // filters them out server-side, so the API never returns a dismissed row here.
+  const hasTiebreaker =
+    !!tiebreaker &&
+    ((lineup.status === 'voting' &&
+      ['active', 'pending', 'resolved'].includes(tiebreaker.status)) ||
+      (lineup.status === 'decided' && tiebreaker.status === 'resolved'));
   const isOperator = isOperatorOrAdmin(user);
 
   // Tiebreaker prompt: server-created pending tiebreaker OR operator tried to advance with ties

--- a/web/src/pages/lineup-detail-page.tsx
+++ b/web/src/pages/lineup-detail-page.tsx
@@ -19,6 +19,7 @@ import { DecidedView } from '../components/lineups/decided/DecidedView';
 import { ActivityTimeline } from '../components/common/ActivityTimeline';
 import { SteamNudgeBanner } from '../components/lineups/SteamNudgeBanner';
 import { TiebreakerView } from '../components/lineups/tiebreaker/TiebreakerView';
+import { TiebreakerClosedNotice } from '../components/lineups/tiebreaker/TiebreakerClosedNotice';
 import { TiebreakerPromptModal } from '../components/lineups/tiebreaker/TiebreakerPromptModal';
 import { useAuth, isOperatorOrAdmin } from '../hooks/use-auth';
 import { useAiSuggestions } from '../hooks/use-ai-suggestions';
@@ -116,11 +117,19 @@ export function LineupDetailPage(): JSX.Element {
   // "Vote closed at HH:MM" notice instead of jumping straight to results.
   // Dismissed tiebreakers are intentionally excluded — findPendingOrActiveTiebreaker
   // filters them out server-side, so the API never returns a dismissed row here.
+  // Voting branch: show TiebreakerView when a tiebreaker is in flight.
   const hasTiebreaker =
     !!tiebreaker &&
-    ((lineup.status === 'voting' &&
-      ['active', 'pending', 'resolved'].includes(tiebreaker.status)) ||
-      (lineup.status === 'decided' && tiebreaker.status === 'resolved'));
+    lineup.status === 'voting' &&
+    ['active', 'pending', 'resolved'].includes(tiebreaker.status);
+
+  // Decided branch: render the "Vote closed at HH:MM" banner above the
+  // DecidedView so users who arrive after a tiebreaker resolved see both
+  // the historical tiebreaker context AND the decided podium (ROK-1117).
+  const showDecidedTiebreakerNotice =
+    !!tiebreaker &&
+    lineup.status === 'decided' &&
+    tiebreaker.status === 'resolved';
   const isOperator = isOperatorOrAdmin(user);
 
   // Tiebreaker prompt: server-created pending tiebreaker OR operator tried to advance with ties
@@ -188,7 +197,15 @@ export function LineupDetailPage(): JSX.Element {
       {hasTiebreaker && (tiebreaker?.status === 'active' || tiebreaker?.status === 'resolved') ? (
         <TiebreakerView tiebreaker={tiebreaker} lineupId={lineup.id} />
       ) : lineup.status === 'decided' ? (
-        <DecidedView lineup={lineup} />
+        <>
+          {showDecidedTiebreakerNotice && tiebreaker && (
+            <TiebreakerClosedNotice
+              title={tiebreaker.mode === 'veto' ? 'Veto Elimination' : 'Bracket Tiebreaker'}
+              resolvedAt={tiebreaker.resolvedAt}
+            />
+          )}
+          <DecidedView lineup={lineup} />
+        </>
       ) : lineup.status === 'voting' && hasEntries ? (
         <VotingLeaderboard
           entries={lineup.entries}


### PR DESCRIPTION
## Summary

- Dispatch DM + channel-embed when a tiebreaker (veto OR bracket) opens, gated on visibility — public lineups DM all participants (nominators ∪ voters) and post a channel embed; private lineups DM invitees + creator only and suppress the channel embed
- Late-join UI: users who navigate to the lineup after a tiebreaker has started see the veto/bracket form and can submit; users who arrive after resolution see a "Vote closed at HH:MM" notice
- New realtime event `lineup:tiebreaker:open` on `LineupsGateway`; the React `useLineupRealtime` hook subscribes and invalidates the tiebreaker query for live UI flip without reload
- New `checkTiebreakerReminders()` cron on `LineupReminderService` (every 5 min, 24h + 1h thresholds) — DMs filter to participants who haven't engaged (vetoed for veto mode, voted on every active matchup for bracket mode) and dedup per `tiebreakerId × threshold × user`
- Both DMs (open + reminder) include the tied games as deep-link markdown plus a CTA link to the lineup
- Game-detail banner now surfaces tiebreaker status — the green "Voted" badge was misleading on tied games while a tiebreaker was active; new amber `TiebreakerBanner` makes the next action obvious

## Linear

ROK-1117

## Test plan

- [x] Unit + integration tests added (api Jest: 24 new test cases across `lineup-notification-tiebreaker.integration.spec.ts`, `lineups.gateway.spec.ts`, `lineup-reminder.service.spec.ts`)
- [x] Vitest hook test for `useLineupRealtime` tiebreaker invalidation
- [x] Vitest test for `LineupDetailPage` rendering `TiebreakerClosedNotice` on decided lineups
- [x] Playwright smoke `lineup-tiebreaker-late-join.smoke.spec.ts` (desktop + mobile per operator rule)
- [x] Discord companion-bot smoke `lineup-tiebreaker-open.test.ts`
- [x] `./scripts/validate-ci.sh --full` clean (Build / TS / Lint / Unit + coverage / Integration)
- [x] Operator browser-tested + Discord-DM-verified locally
- [x] Code review (3-agent parallel split): security/correctness APPROVED WITH FIXES (auto-fix commit included), tests APPROVED, perf/style APPROVED

## Notes

- `LineupReminderService` cron methods do not yet wrap in `cronJobService.executeWithTracking` — pre-existing tech-debt symmetric across `checkVoteReminders`, `checkSchedulingReminders`, and the new `checkTiebreakerReminders`. Best fixed for all three at once in ROK-1126.
- Architect PRE_DEV review identified that `buildTiebreakerStartedEmbed` was already in the codebase as dead code (defined but never called) — reused it instead of creating a new builder, saving ~30 lines.