### PR TITLE
ROK-1084: fix DM Search by Game picks wrong game variant

### DIFF
--- a/api/src/discord-bot/ai-chat/tree/events.tree.spec.ts
+++ b/api/src/discord-bot/ai-chat/tree/events.tree.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * Tests for searchEventsByGame multi-variant fan-out (ROK-1084).
+ *
+ * Reproduces the prod incident where the DM "Search by Game" flow picked
+ * the wrong sibling row from `searchLocalGames` and returned 0 events even
+ * though events existed on a sibling gameId. Fix: query the top 5 ranked
+ * matches and merge events; update empty copy to multi-id phrasing.
+ *
+ * These tests will FAIL until events.tree.searchEventsByGame fans out across
+ * the top 5 games and uses the new empty-message wording.
+ */
+import { Logger } from '@nestjs/common';
+import { handleEvents } from './events.tree';
+import type { AiChatDeps, TreeSession } from './tree.types';
+
+interface FakeGame {
+  id: number;
+  name: string;
+}
+
+interface FindAllArgs {
+  gameId?: string;
+  page?: number;
+  limit?: number;
+  upcoming?: string;
+}
+
+/** Build a minimal AiChatDeps with only the services exercised by this path. */
+function makeDeps(opts: {
+  searchLocalGames: jest.Mock;
+  findAll: jest.Mock;
+}): AiChatDeps {
+  return {
+    logger: new Logger('events.tree.spec'),
+    eventsService: { findAll: opts.findAll } as unknown as AiChatDeps['eventsService'],
+    usersService: {} as AiChatDeps['usersService'],
+    llmService: {} as AiChatDeps['llmService'],
+    settingsService: {} as AiChatDeps['settingsService'],
+    igdbService: {
+      searchLocalGames: opts.searchLocalGames,
+    } as unknown as AiChatDeps['igdbService'],
+    lineupsService: {} as AiChatDeps['lineupsService'],
+    schedulingService: {} as AiChatDeps['schedulingService'],
+    analyticsService: {} as AiChatDeps['analyticsService'],
+    clientUrl: 'https://test.example.com',
+  };
+}
+
+function makeSession(): TreeSession {
+  return {
+    currentPath: 'events:search',
+    isOperator: false,
+    userId: 1,
+    lastActiveAt: Date.now(),
+  };
+}
+
+/** Five sibling rows mirroring the prod scenario. id 101 is the row that holds the events. */
+const FIVE_GAMES: FakeGame[] = [
+  { id: 100, name: 'World of Warcraft' },
+  { id: 101, name: 'World of Warcraft: Burning Crusade Classic - Anniversary Edition' },
+  { id: 102, name: 'World of Warcraft: Burning Crusade Classic' },
+  { id: 103, name: 'World of Warcraft: Wrath of the Lich King Classic' },
+  { id: 104, name: 'World of Warcraft Classic' },
+];
+
+describe('events.tree — searchEventsByGame fan-out (ROK-1084)', () => {
+  it('queries findAll for ALL top-5 ranked games, not just games[0]', async () => {
+    const searchLocalGames = jest.fn().mockResolvedValue({
+      games: FIVE_GAMES,
+      cached: true,
+      source: 'local',
+    });
+    // Every gameId returns no events for this test — we only care that the
+    // tree handler asked about every game id, not just games[0].
+    const findAll = jest.fn().mockResolvedValue({ data: [], total: 0 });
+    const deps = makeDeps({ searchLocalGames, findAll });
+
+    await handleEvents(
+      'events:search:world of warcraft',
+      deps,
+      makeSession(),
+    );
+
+    const calledGameIds = findAll.mock.calls.map(
+      ([arg]: [FindAllArgs]) => arg?.gameId,
+    );
+    // Today the handler only fans out to games[0] (gameId='100'). The fix must
+    // call findAll for every top-5 ranked game id.
+    expect(calledGameIds).toEqual(
+      expect.arrayContaining(['100', '101', '102', '103', '104']),
+    );
+    expect(findAll).toHaveBeenCalledTimes(5);
+  });
+
+  it('merges events from ranked matches when the chosen gameId differs from games[0]', async () => {
+    const searchLocalGames = jest.fn().mockResolvedValue({
+      games: FIVE_GAMES,
+      cached: true,
+      source: 'local',
+    });
+    // Mirrors the prod bug: only the sibling at index 1 (id=101) actually has
+    // events. Today's handler only checks games[0] and returns "no events".
+    const findAll = jest.fn().mockImplementation(({ gameId }: FindAllArgs) => {
+      if (gameId === '101') {
+        return Promise.resolve({
+          data: [
+            {
+              id: 7777,
+              title: 'BRD Anniversary Run',
+              startTime: '2026-05-01T20:00:00.000Z',
+            },
+          ],
+          total: 1,
+        });
+      }
+      return Promise.resolve({ data: [], total: 0 });
+    });
+    const deps = makeDeps({ searchLocalGames, findAll });
+
+    const result = await handleEvents(
+      'events:search:world of warcraft',
+      deps,
+      makeSession(),
+    );
+
+    // The merged response surfaces the seeded event title. Today this
+    // assertion fails because games[0] (id=100) returns no events and the
+    // handler short-circuits with the static "No upcoming events" message.
+    const message = result.emptyMessage ?? result.data ?? '';
+    expect(message).toContain('BRD Anniversary Run');
+    expect(message.toLowerCase()).toContain('upcoming events');
+  });
+
+  it('uses multi-id empty phrasing when no ranked match has events', async () => {
+    const searchLocalGames = jest.fn().mockResolvedValue({
+      games: FIVE_GAMES,
+      cached: true,
+      source: 'local',
+    });
+    const findAll = jest.fn().mockResolvedValue({ data: [], total: 0 });
+    const deps = makeDeps({ searchLocalGames, findAll });
+
+    const result = await handleEvents(
+      'events:search:world of warcraft',
+      deps,
+      makeSession(),
+    );
+
+    // The new empty copy must reference the search term, not a single
+    // matched game name. Today's copy is `No upcoming events for ${games[0].name}`,
+    // which mis-attributes the "no results" to a single sibling row and
+    // fails this assertion.
+    expect(result.emptyMessage).toBe(
+      'No upcoming events for any game matching "world of warcraft".',
+    );
+    expect(result.isLeaf).toBe(true);
+  });
+});

--- a/api/src/discord-bot/ai-chat/tree/events.tree.spec.ts
+++ b/api/src/discord-bot/ai-chat/tree/events.tree.spec.ts
@@ -32,7 +32,9 @@ function makeDeps(opts: {
 }): AiChatDeps {
   return {
     logger: new Logger('events.tree.spec'),
-    eventsService: { findAll: opts.findAll } as unknown as AiChatDeps['eventsService'],
+    eventsService: {
+      findAll: opts.findAll,
+    } as unknown as AiChatDeps['eventsService'],
     usersService: {} as AiChatDeps['usersService'],
     llmService: {} as AiChatDeps['llmService'],
     settingsService: {} as AiChatDeps['settingsService'],
@@ -58,7 +60,10 @@ function makeSession(): TreeSession {
 /** Five sibling rows mirroring the prod scenario. id 101 is the row that holds the events. */
 const FIVE_GAMES: FakeGame[] = [
   { id: 100, name: 'World of Warcraft' },
-  { id: 101, name: 'World of Warcraft: Burning Crusade Classic - Anniversary Edition' },
+  {
+    id: 101,
+    name: 'World of Warcraft: Burning Crusade Classic - Anniversary Edition',
+  },
   { id: 102, name: 'World of Warcraft: Burning Crusade Classic' },
   { id: 103, name: 'World of Warcraft: Wrath of the Lich King Classic' },
   { id: 104, name: 'World of Warcraft Classic' },
@@ -76,11 +81,7 @@ describe('events.tree — searchEventsByGame fan-out (ROK-1084)', () => {
     const findAll = jest.fn().mockResolvedValue({ data: [], total: 0 });
     const deps = makeDeps({ searchLocalGames, findAll });
 
-    await handleEvents(
-      'events:search:world of warcraft',
-      deps,
-      makeSession(),
-    );
+    await handleEvents('events:search:world of warcraft', deps, makeSession());
 
     const calledGameIds = findAll.mock.calls.map(
       ([arg]: [FindAllArgs]) => arg?.gameId,

--- a/api/src/discord-bot/ai-chat/tree/events.tree.ts
+++ b/api/src/discord-bot/ai-chat/tree/events.tree.ts
@@ -81,33 +81,101 @@ function nextWeekRange(): { start: Date; end: Date } {
   return { start, end };
 }
 
-/** Search events by game name — returns formatted list, no LLM. */
+interface RankedEvent {
+  id: number;
+  title: string;
+  startTime: string;
+  gameName: string;
+}
+
+/** Merge fan-out results into a deduped, time-sorted RankedEvent list. */
+function mergeRankedEvents(
+  settled: PromiseSettledResult<{
+    data?: { id: number; title: string; startTime: string }[];
+  }>[],
+  games: { id: number; name: string }[],
+): RankedEvent[] {
+  const merged = new Map<number, RankedEvent>();
+  settled.forEach((s, i) => {
+    if (s.status !== 'fulfilled') return;
+    for (const e of s.value.data ?? []) {
+      if (merged.has(e.id)) continue;
+      merged.set(e.id, {
+        id: e.id,
+        title: e.title,
+        startTime: e.startTime,
+        gameName: games[i].name,
+      });
+    }
+  });
+  return [...merged.values()]
+    .sort(
+      (a, b) =>
+        new Date(a.startTime).getTime() - new Date(b.startTime).getTime(),
+    )
+    .slice(0, 10);
+}
+
+/** Fan out findAll across the top 5 ranked games (ROK-1084). */
+async function fetchEventsForTopGames(
+  deps: AiChatDeps,
+  games: { id: number; name: string }[],
+): Promise<RankedEvent[]> {
+  const top = games.slice(0, 5);
+  const settled = await Promise.allSettled(
+    top.map((g) =>
+      deps.eventsService.findAll({
+        gameId: String(g.id),
+        page: 1,
+        limit: 10,
+        upcoming: 'true',
+      }),
+    ),
+  );
+  if (settled.every((s) => s.status === 'rejected')) {
+    throw new Error('all-rejected');
+  }
+  return mergeRankedEvents(settled, top);
+}
+
+/** Format the merged event list, using single- or multi-game header. */
+function formatMergedEvents(events: RankedEvent[], query: string): string {
+  const uniqueNames = new Set(events.map((e) => e.gameName));
+  if (uniqueNames.size === 1) {
+    const list = events
+      .map(
+        (e) => `• ${e.title} — ${new Date(e.startTime).toLocaleDateString()}`,
+      )
+      .join('\n');
+    return `**Upcoming events for ${events[0].gameName}:**\n${list}`;
+  }
+  const list = events
+    .map(
+      (e) =>
+        `• ${e.title} — ${new Date(e.startTime).toLocaleDateString()} (${e.gameName})`,
+    )
+    .join('\n');
+  return `**Upcoming events matching "${query}":**\n${list}`;
+}
+
+/** Search events by game name — fans out to top 5 ranked games (ROK-1084). */
 async function searchEventsByGame(
   deps: AiChatDeps,
   query: string,
 ): Promise<TreeResult> {
   try {
     const games = await deps.igdbService.searchLocalGames(query);
-    const match = games.games?.[0];
-    if (!match) {
+    if (!games.games?.length) {
       return staticLeaf(`No games found matching "${query}".`, deps);
     }
-    const result = await deps.eventsService.findAll({
-      gameId: String(match.id),
-      page: 1,
-      limit: 10,
-      upcoming: 'true',
-    });
-    const events = result.data ?? [];
-    if (events.length === 0) {
-      return staticLeaf(`No upcoming events for ${match.name}.`, deps);
+    const merged = await fetchEventsForTopGames(deps, games.games);
+    if (merged.length === 0) {
+      return staticLeaf(
+        `No upcoming events for any game matching "${query}".`,
+        deps,
+      );
     }
-    const list = events
-      .map(
-        (e) => `• ${e.title} — ${new Date(e.startTime).toLocaleDateString()}`,
-      )
-      .join('\n');
-    return staticLeaf(`**Upcoming events for ${match.name}:**\n${list}`, deps);
+    return staticLeaf(formatMergedEvents(merged, query), deps);
   } catch {
     return staticLeaf('Unable to search events right now.', deps);
   }

--- a/api/src/igdb/igdb-search-sort.helpers.spec.ts
+++ b/api/src/igdb/igdb-search-sort.helpers.spec.ts
@@ -1,0 +1,198 @@
+/**
+ * Tests for ranking inside IgdbService.searchLocalGames (ROK-1084).
+ *
+ * Prod incident: DM "Search by Game" picks the wrong game variant when a
+ * search term matches multiple sibling rows. The downstream events tree
+ * uses games[0]; if the unsorted DB result does not surface the most
+ * relevant row first, the chosen gameId is wrong and events are missed.
+ *
+ * The fix lives in two layers:
+ *   1) Service-level: searchLocalGames must apply sortByRelevance so that
+ *      exact-name matches outrank partial matches.
+ *   2) Tree-level: searchEventsByGame must merge events from the top 5
+ *      ranked games (covered in events.tree.spec.ts).
+ *
+ * These tests exercise (1). They will FAIL until IgdbService.searchLocalGames
+ * pipes its result through sortByRelevance.
+ */
+import { Test, TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import { getQueueToken } from '@nestjs/bullmq';
+import { IgdbService } from './igdb.service';
+import { IGDB_SYNC_QUEUE } from './igdb-sync.constants';
+import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
+import { REDIS_CLIENT } from '../redis/redis.module';
+import { SettingsService } from '../settings/settings.service';
+import { CronJobService } from '../cron-jobs/cron-job.service';
+import { ItadService } from '../itad/itad.service';
+import { GameTasteService } from '../game-taste/game-taste.service';
+
+interface ThenableQuery {
+  then: (
+    resolve: (v: unknown[]) => void,
+    reject?: (e: unknown) => void,
+  ) => Promise<void>;
+  limit: jest.Mock;
+  orderBy: jest.Mock;
+  groupBy: jest.Mock;
+  where: jest.Mock;
+}
+
+function thenableResult(data: unknown[]): ThenableQuery {
+  const obj: ThenableQuery = {
+    then: (resolve, reject?) => Promise.resolve(data).then(resolve, reject),
+    limit: jest.fn().mockImplementation(() => thenableResult(data)),
+    orderBy: jest.fn().mockImplementation(() => thenableResult(data)),
+    groupBy: jest.fn().mockImplementation(() => thenableResult(data)),
+    where: jest.fn().mockImplementation(() => thenableResult(data)),
+  };
+  return obj;
+}
+
+/**
+ * Build a minimal games row. Only the fields searchLocalGames + mapDbRowToDetail
+ * touch are meaningful here; the rest exist to satisfy the type.
+ */
+function gameRow(overrides: { id: number; name: string }) {
+  return {
+    id: overrides.id,
+    igdbId: 1000 + overrides.id,
+    name: overrides.name,
+    slug: overrides.name.toLowerCase().replace(/[^a-z0-9]+/g, '-'),
+    coverUrl: null,
+    genres: [],
+    summary: null,
+    rating: null,
+    aggregatedRating: null,
+    popularity: null,
+    gameModes: [],
+    themes: [],
+    platforms: [],
+    screenshots: [],
+    videos: [],
+    firstReleaseDate: null,
+    playerCount: null,
+    twitchGameId: null,
+    crossplay: null,
+    cachedAt: new Date(),
+    hidden: false,
+    banned: false,
+  };
+}
+
+describe('IgdbService.searchLocalGames — relevance ranking (ROK-1084)', () => {
+  let service: IgdbService;
+  let mockDb: {
+    select: jest.Mock;
+    insert: jest.Mock;
+  };
+  let selectResults: unknown[];
+
+  beforeEach(async () => {
+    /**
+     * Three sibling rows. Order returned by the DB is intentionally NOT
+     * the desired output order: the partial-match "Wrath of the Lich King"
+     * comes first, the exact match "World of Warcraft" comes last. Without
+     * sortByRelevance the service would surface the wrong row to the
+     * events tree, exactly mirroring the prod BC Classic / Anniversary
+     * Edition bug from ROK-1084.
+     */
+    selectResults = [
+      gameRow({ id: 11, name: 'World of Warcraft: Wrath of the Lich King' }),
+      gameRow({ id: 12, name: 'World of Warcraft: Burning Crusade Classic' }),
+      gameRow({ id: 13, name: 'World of Warcraft' }),
+    ];
+
+    mockDb = {
+      select: jest.fn().mockImplementation(() => ({
+        from: jest.fn().mockImplementation(() => ({
+          where: jest
+            .fn()
+            .mockImplementation(() => thenableResult(selectResults)),
+        })),
+      })),
+      insert: jest.fn(),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        IgdbService,
+        { provide: DrizzleAsyncProvider, useValue: mockDb },
+        {
+          provide: REDIS_CLIENT,
+          useValue: {
+            get: jest.fn().mockResolvedValue(null),
+            setex: jest.fn().mockResolvedValue('OK'),
+          },
+        },
+        {
+          provide: ConfigService,
+          useValue: { get: jest.fn().mockReturnValue(undefined) },
+        },
+        {
+          provide: SettingsService,
+          useValue: {
+            get: jest.fn().mockResolvedValue(null),
+            getIgdbConfig: jest.fn().mockResolvedValue(null),
+            isIgdbConfigured: jest.fn().mockResolvedValue(false),
+          },
+        },
+        {
+          provide: getQueueToken(IGDB_SYNC_QUEUE),
+          useValue: { add: jest.fn(), name: 'igdb-sync' },
+        },
+        {
+          provide: CronJobService,
+          useValue: {
+            executeWithTracking: jest.fn(
+              (_n: string, fn: () => Promise<void>) => fn(),
+            ),
+          },
+        },
+        {
+          provide: ItadService,
+          useValue: {
+            searchGames: jest.fn().mockResolvedValue([]),
+            lookupSteamAppIds: jest.fn().mockResolvedValue(new Map()),
+          },
+        },
+        {
+          provide: GameTasteService,
+          useValue: { enqueueRecompute: jest.fn().mockResolvedValue(undefined) },
+        },
+      ],
+    }).compile();
+
+    service = module.get<IgdbService>(IgdbService);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('places the exact-name match first', async () => {
+    const result = await service.searchLocalGames('world of warcraft');
+
+    expect(result.games.length).toBe(3);
+    // The exact-match row must surface first so downstream callers
+    // (events tree, lineup tree) pick the correct gameId. With no
+    // sortByRelevance applied, this assertion fails — DB returns
+    // "Wrath of the Lich King" at index 0.
+    expect(result.games[0].name).toBe('World of Warcraft');
+    expect(result.games[0].id).toBe(13);
+  });
+
+  it('orders sibling rows by relevance, not insertion order', async () => {
+    const result = await service.searchLocalGames('world of warcraft');
+
+    const names = result.games.map((g) => g.name);
+    // Relevance scores: exact=4, contains=2, contains=2.
+    // Exact match wins; the other two tie at relevance 2 and fall back
+    // to alphabetical: Burning Crusade Classic before Wrath of the Lich King.
+    expect(names).toEqual([
+      'World of Warcraft',
+      'World of Warcraft: Burning Crusade Classic',
+      'World of Warcraft: Wrath of the Lich King',
+    ]);
+  });
+});

--- a/api/src/igdb/igdb-search-sort.helpers.spec.ts
+++ b/api/src/igdb/igdb-search-sort.helpers.spec.ts
@@ -158,7 +158,9 @@ describe('IgdbService.searchLocalGames — relevance ranking (ROK-1084)', () => 
         },
         {
           provide: GameTasteService,
-          useValue: { enqueueRecompute: jest.fn().mockResolvedValue(undefined) },
+          useValue: {
+            enqueueRecompute: jest.fn().mockResolvedValue(undefined),
+          },
         },
       ],
     }).compile();

--- a/api/src/igdb/igdb.service.ts
+++ b/api/src/igdb/igdb.service.ts
@@ -215,7 +215,12 @@ export class IgdbService {
   }
 
   async searchLocalGames(query: string): Promise<SearchResult> {
-    return searchLocalGames(this.db, query, await this.isAdultFilterEnabled());
+    const result = await searchLocalGames(
+      this.db,
+      query,
+      await this.isAdultFilterEnabled(),
+    );
+    return sortByRelevance(this.db, result, this.normalizeQuery(query));
   }
   async getGameById(id: number): Promise<IgdbGameDto | null> {
     return lookupGameById(this.db, id);

--- a/tools/test-bot/src/smoke/tests/ai-chat.test.ts
+++ b/tools/test-bot/src/smoke/tests/ai-chat.test.ts
@@ -445,10 +445,13 @@ const searchByGameMultiVariant: SmokeTest = {
   name: 'AI Chat: [Search by Game] surfaces events on sibling game variants (ROK-1084)',
   category: 'dm',
   async run(ctx) {
-    // Find sibling WoW rows. Two are needed: one would be ranked first by the
-    // current naive picker; we attach the event to the OTHER one so the bug
-    // is triggered if the handler only looks at games[0].
-    const wowRows = ctx.games.filter((g) =>
+    // ctx.games carries placeholder names (ROK-1084 fix scope). Query the
+    // admin games endpoint directly to get real names + ids for sibling
+    // detection.
+    const wowRes = await ctx.api.get<{
+      data: { id: number; name: string }[];
+    }>('/admin/settings/games?search=warcraft&limit=20');
+    const wowRows = (wowRes.data ?? []).filter((g) =>
       g.name.toLowerCase().includes('warcraft'),
     );
     if (wowRows.length < 2) {

--- a/tools/test-bot/src/smoke/tests/ai-chat.test.ts
+++ b/tools/test-bot/src/smoke/tests/ai-chat.test.ts
@@ -427,6 +427,94 @@ const backAndHomeNavigation: SmokeTest = {
   },
 };
 
+// ── ROK-1084: Search by Game finds events on sibling game variants ──
+
+/**
+ * Reproduces the prod incident where a search term matches multiple sibling
+ * rows in the games table (e.g. "World of Warcraft" vs "WoW: Burning Crusade
+ * Classic - Anniversary Edition"). The current single-id search picks games[0]
+ * and misses events tagged to a sibling row. The fix queries the top 5 ranked
+ * matches and merges results.
+ *
+ * Strategy: pick a non-first WoW sibling from the seeded games list, attach an
+ * event to it, then trigger the AI chat events:search flow with a query that
+ * `searchLocalGames` returns multiple rows for. The merged response must
+ * surface the seeded event title.
+ */
+const searchByGameMultiVariant: SmokeTest = {
+  name: 'AI Chat: [Search by Game] surfaces events on sibling game variants (ROK-1084)',
+  category: 'dm',
+  async run(ctx) {
+    // Find sibling WoW rows. Two are needed: one would be ranked first by the
+    // current naive picker; we attach the event to the OTHER one so the bug
+    // is triggered if the handler only looks at games[0].
+    const wowRows = ctx.games.filter((g) =>
+      g.name.toLowerCase().includes('warcraft'),
+    );
+    if (wowRows.length < 2) {
+      throw new Error(
+        `Expected at least 2 WoW variants in seed data for ROK-1084 repro, got ${wowRows.length}: ` +
+          JSON.stringify(wowRows.map((g) => g.name)),
+      );
+    }
+    // Prefer the most-specific variant (longest name) — current picker tends
+    // to surface the shortest exact-match row first, so the longer sibling is
+    // the one the bug hides events behind.
+    const targetGame = [...wowRows].sort(
+      (a, b) => b.name.length - a.name.length,
+    )[0];
+
+    const ev = await createEvent(ctx.api, 'rok1084-search', {
+      gameId: targetGame.id,
+      startTime: futureTime(60),
+      endTime: futureTime(120),
+    });
+    try {
+      await awaitProcessing(ctx.api);
+
+      // Step 1: open the events:search node so the session expects text input.
+      await simulate(ctx, {
+        discordUserId: ctx.testBotDiscordId,
+        buttonId: 'ai:events:search',
+      });
+
+      // Step 2: send a query that matches multiple sibling rows. Poll because
+      // events index updates may lag the create call.
+      const searchTerm = 'world of warcraft';
+      const finalRes = await pollForCondition(
+        async () => {
+          const r = await simulate(ctx, {
+            discordUserId: ctx.testBotDiscordId,
+            text: searchTerm,
+          });
+          const text = allText(r);
+          if (text.includes(ev.title.toLowerCase())) return r;
+          return null;
+        },
+        SIM_TIMEOUT,
+      );
+
+      const finalText = allText(finalRes);
+      // The merged response must surface the event title and use the
+      // "Upcoming events" copy. Today this fails because games[0] is a
+      // sibling row with no events and the handler short-circuits.
+      if (!finalText.includes(ev.title.toLowerCase())) {
+        throw new Error(
+          `Search for "${searchTerm}" did not return the event tagged to gameId=${targetGame.id} ("${targetGame.name}"). ` +
+            `Expected response to include "${ev.title}". Got: "${finalText.slice(0, 300)}"`,
+        );
+      }
+      if (!finalText.includes('upcoming events')) {
+        throw new Error(
+          `Search response missing "Upcoming events" header. Got: "${finalText.slice(0, 300)}"`,
+        );
+      }
+    } finally {
+      await deleteEvent(ctx.api, ev.id);
+    }
+  },
+};
+
 export const aiChatTests: SmokeTest[] = [
   enableAiChat,
   welcomeMenuMember,
@@ -439,4 +527,5 @@ export const aiChatTests: SmokeTest[] = [
   sessionTimeout,
   featureGateDisabled,
   backAndHomeNavigation,
+  searchByGameMultiVariant,
 ];


### PR DESCRIPTION
## Summary
- DM bot's events search resolved a game variant by display name then queried for events on that single id. Sibling rows in the games table (e.g. "WoW: BC Classic" vs "WoW: BC Classic - Anniversary Edition") meant the picked variant could differ from where the user's events were FK'd, returning empty.
- Now: `IgdbService.searchLocalGames` applies the existing `sortByRelevance` so results are deterministic; `searchEventsByGame` fans out `findAll` across the top 5 ranked games via `Promise.allSettled`, dedupes by event id, sorts by start time, and caps the merged list at 10. Multi-game responses get a new header (`**Upcoming events matching "<query>":**`) with each line tagged by game name.
- Empty multi-id case now reads `No upcoming events for any game matching "<query>".`

## Linear
ROK-1084

## Root cause (confirmed via prod admin API probes)
- BRD events on prod were FK'd to `gameId=9378` ("WoW: Burning Crusade Classic - Anniversary Edition")
- Search displayed `gameId=9372` ("WoW: Burning Crusade Classic" — base, no suffix)
- Both rows are legitimate IGDB entries (igdb 143683 vs 390778), neither hidden
- Filter `eq(events.gameId, 9372)` correctly returned nothing because BRD lived on 9378

No dedupe migration needed; no `addUpcomingCondition` change (the upcoming filter is fine — root cause was sibling-row mismatch, not a filter bug).

## Test plan
- [x] Unit tests added (Jest): 5 cases covering ranking, top-5 fan-out, multi-id empty copy
- [x] Discord smoke test added (\`searchByGameMultiVariant\` in \`tools/test-bot/src/smoke/tests/ai-chat.test.ts\`)
- [x] Local CI passed (api scope: build, tsc, lint, 5651 unit tests, 796 integration tests)
- [x] Discord smoke green locally (1.2s); 4 pre-existing flakes (Discord embed timing + ROK-985 fixture issue) unrelated to changed files
- [x] End-to-end probes via \`/admin/test/ai-chat-simulate\` — verified single-game header, multi-game header, multi-id empty copy
- [x] Operator approved local deploy
- [x] Code review approved (planning-artifacts/review-ROK-1084.md)