### PR TITLE
ROK-1130: feat: sync WoW character professions + manual entry + roster pills

### DIFF
--- a/api/scripts/seed-testing.helpers.ts
+++ b/api/scripts/seed-testing.helpers.ts
@@ -1,0 +1,170 @@
+/**
+ * Seed-time helpers for `seed-testing.ts`.
+ *
+ * Extracted into its own module so the helpers can be unit-tested without
+ * triggering the script's top-level `bootstrap()` (which connects to Postgres).
+ * Mirrors the contract `CharacterProfessionsDto` shape from
+ * `packages/contract/src/characters.schema.ts`.
+ */
+
+interface ProfessionTier {
+  id: number;
+  name: string;
+  skillLevel: number;
+  maxSkillLevel: number;
+}
+
+interface ProfessionEntry {
+  id: number;
+  name: string;
+  slug: string;
+  skillLevel: number;
+  maxSkillLevel: number;
+  tiers: ProfessionTier[];
+}
+
+interface CharacterProfessions {
+  primary: ProfessionEntry[];
+  secondary: ProfessionEntry[];
+  syncedAt: string;
+}
+
+type ProfessionRow = readonly [
+  name: string,
+  skillLevel: number,
+  maxSkillLevel: number,
+  retailTier: string | null,
+  retailTierMax: number | null,
+];
+
+type ClassProfessionMap = Record<
+  string,
+  { primary: readonly ProfessionRow[]; secondary: readonly ProfessionRow[] }
+>;
+
+// Per-class realistic profession assignments (Wrath-era cap of 450 for primaries,
+// Cataclysm Cooking 200 cap for secondaries). Retail tier name reflects an
+// expansion-era tier so the panel renders nested tier rows.
+const CLASS_PROFESSIONS: ClassProfessionMap = {
+  Mage: {
+    primary: [
+      ['Tailoring', 450, 450, 'Dragon Isles Tailoring', 100],
+      ['Enchanting', 425, 450, 'Dragon Isles Enchanting', 100],
+    ],
+    secondary: [['Cooking', 150, 150, null, null]],
+  },
+  Warrior: {
+    primary: [
+      ['Mining', 450, 450, 'Dragon Isles Mining', 100],
+      ['Blacksmithing', 440, 450, 'Dragon Isles Blacksmithing', 100],
+    ],
+    secondary: [['Fishing', 100, 150, null, null]],
+  },
+  Priest: {
+    primary: [
+      ['Tailoring', 450, 450, 'Dragon Isles Tailoring', 100],
+      ['Enchanting', 450, 450, 'Dragon Isles Enchanting', 100],
+    ],
+    secondary: [['Cooking', 200, 200, null, null]],
+  },
+  Rogue: {
+    primary: [
+      ['Skinning', 450, 450, 'Dragon Isles Skinning', 100],
+      ['Leatherworking', 430, 450, 'Dragon Isles Leatherworking', 100],
+    ],
+    secondary: [['Cooking', 175, 200, null, null]],
+  },
+  Druid: {
+    primary: [
+      ['Herbalism', 450, 450, 'Dragon Isles Herbalism', 100],
+      ['Alchemy', 425, 450, 'Dragon Isles Alchemy', 100],
+    ],
+    secondary: [['Cooking', 150, 200, null, null]],
+  },
+  Paladin: {
+    primary: [
+      ['Mining', 450, 450, 'Dragon Isles Mining', 100],
+      ['Blacksmithing', 425, 450, 'Dragon Isles Blacksmithing', 100],
+    ],
+    secondary: [['Fishing', 100, 150, null, null]],
+  },
+  'Death Knight': {
+    primary: [
+      ['Mining', 450, 450, 'Dragon Isles Mining', 100],
+      ['Engineering', 425, 450, 'Dragon Isles Engineering', 100],
+    ],
+    secondary: [['Cooking', 150, 200, null, null]],
+  },
+  Warlock: {
+    primary: [
+      ['Tailoring', 450, 450, 'Dragon Isles Tailoring', 100],
+      ['Enchanting', 425, 450, 'Dragon Isles Enchanting', 100],
+    ],
+    secondary: [['Cooking', 100, 200, null, null]],
+  },
+};
+
+const RETAIL_GAME_SLUG = 'world-of-warcraft';
+const CLASSIC_GAME_SLUG = 'world-of-warcraft-classic';
+
+/** Stable synthetic id derived from string — enough for seed determinism. */
+function hashId(input: string): number {
+  let h = 0;
+  for (let i = 0; i < input.length; i++) h = (h * 31 + input.charCodeAt(i)) | 0;
+  return Math.abs(h);
+}
+
+function slugify(name: string): string {
+  return name.toLowerCase().replace(/\s+/g, '-');
+}
+
+function buildEntry(
+  row: ProfessionRow,
+  includeRetailTier: boolean,
+): ProfessionEntry {
+  const [name, skillLevel, maxSkillLevel, tierName, tierMax] = row;
+  const slug = slugify(name);
+  const tiers: ProfessionTier[] =
+    includeRetailTier && tierName && tierMax !== null
+      ? [
+          {
+            id: hashId(`${slug}:${tierName}`),
+            name: tierName,
+            skillLevel: tierMax,
+            maxSkillLevel: tierMax,
+          },
+        ]
+      : [];
+  return {
+    id: hashId(slug),
+    name,
+    slug,
+    skillLevel,
+    maxSkillLevel,
+    tiers,
+  };
+}
+
+/**
+ * Build a `CharacterProfessions` blob for a seed character.
+ * Returns `null` for non-WoW games (Valheim, FFXIV, etc.).
+ *
+ * Retail (`world-of-warcraft`): each primary gets one nested tier row.
+ * Classic (`world-of-warcraft-classic`): tiers are empty arrays.
+ */
+export function buildSeedProfessions(
+  charClass: string,
+  gameSlug: string,
+): CharacterProfessions | null {
+  if (gameSlug !== RETAIL_GAME_SLUG && gameSlug !== CLASSIC_GAME_SLUG) {
+    return null;
+  }
+  const map = CLASS_PROFESSIONS[charClass];
+  if (!map) return null;
+  const includeRetailTier = gameSlug === RETAIL_GAME_SLUG;
+  return {
+    primary: map.primary.map((row) => buildEntry(row, includeRetailTier)),
+    secondary: map.secondary.map((row) => buildEntry(row, includeRetailTier)),
+    syncedAt: new Date().toISOString(),
+  };
+}

--- a/api/scripts/seed-testing.ts
+++ b/api/scripts/seed-testing.ts
@@ -6,6 +6,7 @@ import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { eq } from 'drizzle-orm';
 import * as schema from '../src/drizzle/schema';
 import * as dotenv from 'dotenv';
+import { buildSeedProfessions } from './seed-testing.helpers';
 
 dotenv.config();
 
@@ -150,6 +151,7 @@ async function bootstrap() {
                         isMain,
                         avatarUrl: getClassIconUrl(charData.wowClass),
                         displayOrder: isMain ? 0 : 1,
+                        professions: buildSeedProfessions(charData.class, charData.gameSlug),
                     });
                     const tag = isMain ? 'MAIN' : 'ALT';
                     console.log(`  ✅ Created ${charData.charName} [${charData.class}/${charData.spec}] (${game.name}) [${tag}]`);

--- a/api/src/characters/characters-crud.helpers.ts
+++ b/api/src/characters/characters-crud.helpers.ts
@@ -257,7 +257,7 @@ async function performCharacterSync(
     return 'skipped';
   }
   const nsPrefix = await resolveNsPrefix(db, char.gameId);
-  const { profile, talents, equipment } = await fetchFullProfile(
+  const { profile, talents, equipment, professions } = await fetchFullProfile(
     adapter,
     char.name,
     char.realm!,
@@ -266,7 +266,7 @@ async function performCharacterSync(
   );
   await db
     .update(schema.characters)
-    .set(buildSyncUpdateFields(profile, equipment, talents))
+    .set(buildSyncUpdateFields(profile, equipment, talents, professions))
     .where(eq(schema.characters.id, char.id));
   return 'synced';
 }

--- a/api/src/characters/characters-import.helpers.ts
+++ b/api/src/characters/characters-import.helpers.ts
@@ -11,6 +11,7 @@ import type {
   ImportWowCharacterDto,
 } from '@raid-ledger/contract';
 import type { CharacterSyncAdapter } from '../plugins/plugin-host/extension-points';
+import type { ExternalCharacterProfessions } from '../plugins/plugin-host/extension-types';
 import { variantToNamespacePrefix } from '../plugins/wow-common/blizzard.constants';
 import {
   fetchFullProfile,
@@ -98,12 +99,14 @@ export function buildImportInsertValues(
   dto: ImportWowCharacterDto,
   equipment: unknown,
   talents: unknown,
+  professions: ExternalCharacterProfessions | null,
   shouldBeMain: boolean,
 ) {
   const syncFields = buildSyncUpdateFields(
     profile as never,
     equipment,
     talents,
+    professions,
     { region: dto.region, gameVariant: dto.gameVariant },
   );
   return {
@@ -143,6 +146,7 @@ export async function executeImportTx(
   dto: ImportWowCharacterDto,
   equipment: unknown,
   talents: unknown,
+  professions: ExternalCharacterProfessions | null,
   logger: Logger,
 ): Promise<CharacterDto> {
   await checkDuplicateClaim(tx, gameId, userId, profile.name, profile.realm);
@@ -159,6 +163,7 @@ export async function executeImportTx(
     dto,
     equipment,
     talents,
+    professions,
     shouldBeMain,
   );
   const [character] = await tx
@@ -203,6 +208,7 @@ export async function mergeIntoExisting(
   dto: ImportWowCharacterDto,
   equipment: unknown,
   talents: unknown,
+  professions: ExternalCharacterProfessions | null,
   logger: Logger,
 ): Promise<CharacterDto> {
   const existing = await findExistingByProfile(
@@ -216,10 +222,13 @@ export async function mergeIntoExisting(
     throw new ConflictException(
       `Character ${profile.name} on ${profile.realm} already exists`,
     );
-  const fields = buildSyncUpdateFields(profile as never, equipment, talents, {
-    region: dto.region,
-    gameVariant: dto.gameVariant,
-  });
+  const fields = buildSyncUpdateFields(
+    profile as never,
+    equipment,
+    talents,
+    professions,
+    { region: dto.region, gameVariant: dto.gameVariant },
+  );
   const [merged] = await db
     .update(schema.characters)
     .set(fields)
@@ -251,6 +260,7 @@ export async function insertOrMergeImport(
         dto,
         fetched.equipment,
         fetched.talents,
+        fetched.professions,
         logger,
       ),
     );
@@ -264,6 +274,7 @@ export async function insertOrMergeImport(
         dto,
         fetched.equipment,
         fetched.talents,
+        fetched.professions,
         logger,
       );
     throw error;

--- a/api/src/characters/characters-mapping.helpers.ts
+++ b/api/src/characters/characters-mapping.helpers.ts
@@ -42,6 +42,7 @@ function mapExtendedFields(row: typeof schema.characters.$inferSelect) {
     gameVariant: row.gameVariant ?? null,
     equipment: (row.equipment as CharacterDto['equipment']) ?? null,
     talents: row.talents ?? null,
+    professions: (row.professions as CharacterDto['professions']) ?? null,
     displayOrder: row.displayOrder,
     createdAt: row.createdAt.toISOString(),
     updatedAt: row.updatedAt.toISOString(),

--- a/api/src/characters/characters-sync.helpers.ts
+++ b/api/src/characters/characters-sync.helpers.ts
@@ -3,6 +3,7 @@
  * Extracted from characters.service.ts for file size compliance (ROK-711).
  */
 import type { CharacterSyncAdapter } from '../plugins/plugin-host/extension-points';
+import type { ExternalCharacterProfessions } from '../plugins/plugin-host/extension-types';
 
 /** Profile with enriched spec/role/talents from adapter. */
 export interface EnrichedProfile {
@@ -22,11 +23,16 @@ export interface EnrichedProfile {
   };
   talents: unknown;
   equipment: unknown;
+  professions: ExternalCharacterProfessions | null;
 }
 
 /**
- * Fetch profile, specialization, and equipment from an adapter.
+ * Fetch profile, specialization, equipment, and professions from an adapter.
  * Shared across importExternal, refreshExternal, and syncAllCharacters.
+ *
+ * Equipment + professions are fetched in parallel. Adapters without the
+ * optional `fetchProfessions` method resolve to `null`, which the
+ * orchestrator interprets as "leave the prior `professions` column alone."
  * @param apiNamespacePrefix - The game's namespace prefix (null for retail)
  */
 export async function fetchFullProfile(
@@ -53,15 +59,27 @@ export async function fetchFullProfile(
     talents = inferred.talents ?? null;
   }
 
-  const equipment = await adapter.fetchEquipment(name, realm, region, nsArg);
-  return { profile, talents, equipment };
+  const [equipment, professions] = await Promise.all([
+    adapter.fetchEquipment(name, realm, region, nsArg),
+    adapter.fetchProfessions
+      ? adapter.fetchProfessions(name, realm, region, nsArg)
+      : Promise.resolve(null),
+  ]);
+  return { profile, talents, equipment, professions };
 }
 
-/** Build the set fields for a character sync update. */
+/**
+ * Build the set fields for a character sync update.
+ *
+ * The `professions` column is **only** included when the value is non-null.
+ * A null signals that the adapter encountered a non-404 failure (5xx, timeout,
+ * etc.) and the prior column value should be preserved (architect §3).
+ */
 export function buildSyncUpdateFields(
   profile: EnrichedProfile['profile'],
   equipment: unknown,
   talents: unknown,
+  professions: ExternalCharacterProfessions | null,
   extra?: { region?: string; gameVariant?: string },
 ): Record<string, unknown> {
   return {
@@ -78,6 +96,7 @@ export function buildSyncUpdateFields(
     profileUrl: profile.profileUrl,
     equipment,
     talents,
+    ...(professions !== null ? { professions } : {}),
     updatedAt: new Date(),
     ...(extra?.region ? { region: extra.region } : {}),
     ...(extra?.gameVariant ? { gameVariant: extra.gameVariant } : {}),

--- a/api/src/characters/characters.integration.spec.ts
+++ b/api/src/characters/characters.integration.spec.ts
@@ -610,3 +610,304 @@ function describeCharactersUserManagement() {
 }
 describe('Characters & User Management (integration)', () =>
   describeCharactersUserManagement());
+
+// =====================================================================
+// ROK-1130 — WoW profession sync persistence
+//
+// Verifies that BlizzardService.fetchCharacterProfessions feeds the
+// orchestrator (AC #2), re-sync overwrites instead of appending (AC #10),
+// and the architect-required 5xx-leaves-prior-value contract holds
+// (architect §3 / brief mandatory correction #1 + #5). The test exercises
+// the cron-style `syncAllCharacters` path directly so it does not need
+// the `RequirePlugin('blizzard')` HTTP guard.
+// =====================================================================
+
+import { CharactersService } from './characters.service';
+import { BlizzardService } from '../plugins/wow-common/blizzard.service';
+
+interface ProfessionFixture {
+  primary: Array<{
+    id: number;
+    name: string;
+    slug: string;
+    skillLevel: number;
+    maxSkillLevel: number;
+    tiers: Array<{
+      id: number;
+      name: string;
+      skillLevel: number;
+      maxSkillLevel: number;
+    }>;
+  }>;
+  secondary: Array<{
+    id: number;
+    name: string;
+    slug: string;
+    skillLevel: number;
+    maxSkillLevel: number;
+    tiers: unknown[];
+  }>;
+  syncedAt: string;
+}
+
+function buildFixture(
+  primaryName: string,
+  primarySkill: number,
+): ProfessionFixture {
+  return {
+    primary: [
+      {
+        id: 197,
+        name: primaryName,
+        slug: primaryName.toLowerCase().replace(/\s+/g, '-'),
+        skillLevel: primarySkill,
+        maxSkillLevel: 450,
+        tiers: [
+          {
+            id: 2823,
+            name: 'Dragon Isles Tailoring',
+            skillLevel: 100,
+            maxSkillLevel: 100,
+          },
+        ],
+      },
+    ],
+    secondary: [
+      {
+        id: 185,
+        name: 'Cooking',
+        slug: 'cooking',
+        skillLevel: 150,
+        maxSkillLevel: 150,
+        tiers: [],
+      },
+    ],
+    syncedAt: '2026-04-28T00:00:00.000Z',
+  };
+}
+
+async function ensureWowGame(testApp: TestApp): Promise<number> {
+  const existing = await testApp.db
+    .select()
+    .from(schema.games)
+    .where(eq(schema.games.slug, 'world-of-warcraft'))
+    .limit(1);
+  if (existing[0]) return existing[0].id;
+  const [game] = await testApp.db
+    .insert(schema.games)
+    .values({
+      name: 'World of Warcraft',
+      slug: 'world-of-warcraft',
+      coverUrl: null,
+      igdbId: null,
+    })
+    .returning();
+  return game.id;
+}
+
+async function insertSyncableCharacter(
+  testApp: TestApp,
+  userId: number,
+  gameId: number,
+  overrides: Partial<typeof schema.characters.$inferInsert> = {},
+): Promise<typeof schema.characters.$inferSelect> {
+  const [char] = await testApp.db
+    .insert(schema.characters)
+    .values({
+      userId,
+      gameId,
+      name: 'Profsync',
+      realm: 'area-52',
+      class: 'Mage',
+      spec: 'Frost',
+      role: 'dps',
+      isMain: true,
+      region: 'us',
+      gameVariant: 'retail',
+      ...overrides,
+    })
+    .returning();
+  return char;
+}
+
+function describeProfessionSync() {
+  let testApp: TestApp;
+  let blizzard: BlizzardService;
+  let charactersService: CharactersService;
+  let userId: number;
+  let gameId: number;
+
+  beforeAll(async () => {
+    testApp = await getTestApp();
+    blizzard = testApp.app.get(BlizzardService);
+    charactersService = testApp.app.get(CharactersService);
+  });
+
+  beforeEach(async () => {
+    testApp.seed = await truncateAllTables(testApp.db);
+    gameId = await ensureWowGame(testApp);
+    const created = await createMemberAndLogin(
+      testApp,
+      'profowner',
+      'profowner@test.local',
+    );
+    userId = created.userId;
+    // Stable returns for non-profession Blizzard calls so syncAllCharacters
+    // doesn't error out before reaching fetchCharacterProfessions.
+    jest.spyOn(blizzard, 'fetchCharacterProfile').mockResolvedValue({
+      name: 'Profsync',
+      realm: 'area-52',
+      class: 'Mage',
+      spec: 'Frost',
+      role: 'dps',
+      level: 80,
+      race: 'Gnome',
+      faction: 'alliance',
+      itemLevel: 480,
+      avatarUrl: null,
+      renderUrl: null,
+      profileUrl: null,
+    });
+    jest
+      .spyOn(blizzard, 'fetchCharacterSpecializations')
+      .mockResolvedValue({ spec: 'Frost', role: 'dps', talents: null });
+    jest.spyOn(blizzard, 'fetchCharacterEquipment').mockResolvedValue({
+      equippedItemLevel: 480,
+      items: [],
+      syncedAt: '2026-04-28T00:00:00.000Z',
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('persists professions JSONB when service returns a fixture (AC #2)', async () => {
+    const fixture = buildFixture('Tailoring', 450);
+    jest
+      .spyOn(blizzard, 'fetchCharacterProfessions')
+      .mockResolvedValue(fixture);
+
+    const char = await insertSyncableCharacter(testApp, userId, gameId);
+    await charactersService.syncAllCharacters();
+
+    const [reloaded] = await testApp.db
+      .select()
+      .from(schema.characters)
+      .where(eq(schema.characters.id, char.id))
+      .limit(1);
+    expect(reloaded.professions).toEqual(fixture);
+  });
+
+  it('overwrites prior professions on re-sync — no concat (AC #10)', async () => {
+    const first = buildFixture('Tailoring', 200);
+    const second = buildFixture('Enchanting', 425);
+    const spy = jest
+      .spyOn(blizzard, 'fetchCharacterProfessions')
+      .mockResolvedValueOnce(first)
+      .mockResolvedValueOnce(second);
+
+    const char = await insertSyncableCharacter(testApp, userId, gameId);
+    await charactersService.syncAllCharacters();
+    await charactersService.syncAllCharacters();
+
+    const [reloaded] = await testApp.db
+      .select()
+      .from(schema.characters)
+      .where(eq(schema.characters.id, char.id))
+      .limit(1);
+    expect(spy).toHaveBeenCalledTimes(2);
+    expect(reloaded.professions).toEqual(second);
+    // Defensive: not a concat / not duplicated
+    const professions = reloaded.professions as ProfessionFixture | null;
+    expect(professions?.primary).toHaveLength(1);
+    expect(professions?.primary[0].name).toBe('Enchanting');
+  });
+
+  it('leaves prior professions untouched when service returns null (5xx — architect §3)', async () => {
+    const prior = buildFixture('Mining', 300);
+
+    // Pre-populate professions on the row.
+    const char = await insertSyncableCharacter(testApp, userId, gameId, {
+      professions: prior,
+    });
+
+    // Service returns null (signals 5xx / network failure).
+    jest
+      .spyOn(blizzard, 'fetchCharacterProfessions')
+      .mockResolvedValue(null);
+
+    await charactersService.syncAllCharacters();
+
+    const [reloaded] = await testApp.db
+      .select()
+      .from(schema.characters)
+      .where(eq(schema.characters.id, char.id))
+      .limit(1);
+    expect(reloaded.professions).toEqual(prior);
+  });
+
+  it('persists empty arrays when service returns the 404-graceful payload (AC #2 edge case)', async () => {
+    const empty = {
+      primary: [],
+      secondary: [],
+      syncedAt: '2026-04-28T00:00:00.000Z',
+    };
+    jest
+      .spyOn(blizzard, 'fetchCharacterProfessions')
+      .mockResolvedValue(empty);
+
+    const char = await insertSyncableCharacter(testApp, userId, gameId);
+    await charactersService.syncAllCharacters();
+
+    const [reloaded] = await testApp.db
+      .select()
+      .from(schema.characters)
+      .where(eq(schema.characters.id, char.id))
+      .limit(1);
+    expect(reloaded.professions).toEqual(empty);
+  });
+}
+
+describe('Character profession sync (ROK-1130 integration)', () =>
+  describeProfessionSync());
+
+// AC #14 — seed-testing.ts populates professions on each WoW seed character.
+//
+// The Phase D1 dev brief mandates a `buildSeedProfessions(charClass, gameSlug)`
+// helper inside seed-testing.ts (per-class profession map). To make that
+// helper unit-testable without triggering the script's top-level `bootstrap()`,
+// dev must extract it into a small importable module — e.g.
+// `api/scripts/seed-testing.helpers.ts` — that seed-testing.ts then consumes.
+// This test pins the contract; the import will fail until the helper module
+// exists, which is the TDD signal.
+describe('seed-testing buildSeedProfessions (ROK-1130, AC #14)', () => {
+  it('produces a CharacterProfessions shape for retail WoW classes', async () => {
+    const { buildSeedProfessions } = await import(
+      '../../scripts/seed-testing.helpers'
+    );
+    const result = buildSeedProfessions('Mage', 'world-of-warcraft');
+    expect(result).not.toBeNull();
+    expect(Array.isArray(result!.primary)).toBe(true);
+    expect(result!.primary.length).toBeGreaterThan(0);
+    expect(result!.primary[0].tiers.length).toBeGreaterThan(0);
+    expect(typeof result!.syncedAt).toBe('string');
+  });
+
+  it('produces empty tiers for classic WoW characters', async () => {
+    const { buildSeedProfessions } = await import(
+      '../../scripts/seed-testing.helpers'
+    );
+    const result = buildSeedProfessions('Mage', 'world-of-warcraft-classic');
+    expect(result).not.toBeNull();
+    expect(result!.primary[0].tiers).toEqual([]);
+  });
+
+  it('returns null for non-WoW games', async () => {
+    const { buildSeedProfessions } = await import(
+      '../../scripts/seed-testing.helpers'
+    );
+    const result = buildSeedProfessions('Monk', 'valheim');
+    expect(result).toBeNull();
+  });
+});

--- a/api/src/characters/characters.integration.spec.ts
+++ b/api/src/characters/characters.integration.spec.ts
@@ -645,7 +645,12 @@ interface ProfessionFixture {
     slug: string;
     skillLevel: number;
     maxSkillLevel: number;
-    tiers: unknown[];
+    tiers: Array<{
+      id: number;
+      name: string;
+      skillLevel: number;
+      maxSkillLevel: number;
+    }>;
   }>;
   syncedAt: string;
 }
@@ -833,9 +838,7 @@ function describeProfessionSync() {
     });
 
     // Service returns null (signals 5xx / network failure).
-    jest
-      .spyOn(blizzard, 'fetchCharacterProfessions')
-      .mockResolvedValue(null);
+    jest.spyOn(blizzard, 'fetchCharacterProfessions').mockResolvedValue(null);
 
     await charactersService.syncAllCharacters();
 
@@ -853,9 +856,7 @@ function describeProfessionSync() {
       secondary: [],
       syncedAt: '2026-04-28T00:00:00.000Z',
     };
-    jest
-      .spyOn(blizzard, 'fetchCharacterProfessions')
-      .mockResolvedValue(empty);
+    jest.spyOn(blizzard, 'fetchCharacterProfessions').mockResolvedValue(empty);
 
     const char = await insertSyncableCharacter(testApp, userId, gameId);
     await charactersService.syncAllCharacters();
@@ -883,9 +884,8 @@ describe('Character profession sync (ROK-1130 integration)', () =>
 // exists, which is the TDD signal.
 describe('seed-testing buildSeedProfessions (ROK-1130, AC #14)', () => {
   it('produces a CharacterProfessions shape for retail WoW classes', async () => {
-    const { buildSeedProfessions } = await import(
-      '../../scripts/seed-testing.helpers'
-    );
+    const { buildSeedProfessions } =
+      await import('../../scripts/seed-testing.helpers');
     const result = buildSeedProfessions('Mage', 'world-of-warcraft');
     expect(result).not.toBeNull();
     expect(Array.isArray(result!.primary)).toBe(true);
@@ -895,18 +895,16 @@ describe('seed-testing buildSeedProfessions (ROK-1130, AC #14)', () => {
   });
 
   it('produces empty tiers for classic WoW characters', async () => {
-    const { buildSeedProfessions } = await import(
-      '../../scripts/seed-testing.helpers'
-    );
+    const { buildSeedProfessions } =
+      await import('../../scripts/seed-testing.helpers');
     const result = buildSeedProfessions('Mage', 'world-of-warcraft-classic');
     expect(result).not.toBeNull();
     expect(result!.primary[0].tiers).toEqual([]);
   });
 
   it('returns null for non-WoW games', async () => {
-    const { buildSeedProfessions } = await import(
-      '../../scripts/seed-testing.helpers'
-    );
+    const { buildSeedProfessions } =
+      await import('../../scripts/seed-testing.helpers');
     const result = buildSeedProfessions('Monk', 'valheim');
     expect(result).toBeNull();
   });

--- a/api/src/characters/characters.integration.spec.ts
+++ b/api/src/characters/characters.integration.spec.ts
@@ -885,7 +885,7 @@ describe('Character profession sync (ROK-1130 integration)', () =>
 describe('seed-testing buildSeedProfessions (ROK-1130, AC #14)', () => {
   it('produces a CharacterProfessions shape for retail WoW classes', async () => {
     const { buildSeedProfessions } =
-      await import('../../scripts/seed-testing.helpers');
+      await import('../../scripts/seed-testing.helpers.js');
     const result = buildSeedProfessions('Mage', 'world-of-warcraft');
     expect(result).not.toBeNull();
     expect(Array.isArray(result!.primary)).toBe(true);
@@ -896,7 +896,7 @@ describe('seed-testing buildSeedProfessions (ROK-1130, AC #14)', () => {
 
   it('produces empty tiers for classic WoW characters', async () => {
     const { buildSeedProfessions } =
-      await import('../../scripts/seed-testing.helpers');
+      await import('../../scripts/seed-testing.helpers.js');
     const result = buildSeedProfessions('Mage', 'world-of-warcraft-classic');
     expect(result).not.toBeNull();
     expect(result!.primary[0].tiers).toEqual([]);
@@ -904,7 +904,7 @@ describe('seed-testing buildSeedProfessions (ROK-1130, AC #14)', () => {
 
   it('returns null for non-WoW games', async () => {
     const { buildSeedProfessions } =
-      await import('../../scripts/seed-testing.helpers');
+      await import('../../scripts/seed-testing.helpers.js');
     const result = buildSeedProfessions('Monk', 'valheim');
     expect(result).toBeNull();
   });

--- a/api/src/characters/characters.service.ts
+++ b/api/src/characters/characters.service.ts
@@ -209,7 +209,7 @@ export class CharactersService {
       (v) => this.findCharacterSyncAdapter(v),
     );
     const nsPrefix = await crudH.resolveNsPrefix(this.db, character.gameId);
-    const fetched = await fetchFullProfile(
+    const { profile, talents, equipment, professions } = await fetchFullProfile(
       adapter,
       character.name,
       character.realm ?? '',
@@ -217,10 +217,14 @@ export class CharactersService {
       nsPrefix,
     );
     const fields = buildSyncUpdateFields(
-      fetched.profile,
-      fetched.equipment,
-      fetched.talents,
-      { region, gameVariant },
+      profile,
+      equipment,
+      talents,
+      professions,
+      {
+        region,
+        gameVariant,
+      },
     );
     const result = await crudH.applyRefreshUpdate(
       this.db,

--- a/api/src/drizzle/migrations/0132_equal_mandarin.sql
+++ b/api/src/drizzle/migrations/0132_equal_mandarin.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "characters" ADD COLUMN "professions" jsonb;

--- a/api/src/drizzle/migrations/meta/0132_snapshot.json
+++ b/api/src/drizzle/migrations/meta/0132_snapshot.json
@@ -1,0 +1,7300 @@
+{
+  "id": "02552cd8-b9f8-4b56-aa83-d668969affe0",
+  "prevId": "e5fab1a1-f6f2-48ed-a538-ab525c78a6c4",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_id": {
+          "name": "steam_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_avatar_url": {
+          "name": "custom_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_time_confirmed_at": {
+          "name": "game_time_confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_discord_id_unique": {
+          "name": "users_discord_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_id"
+          ]
+        },
+        "users_steam_id_unique": {
+          "name": "users_steam_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "steam_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "display_name_length": {
+          "name": "display_name_length",
+          "value": "\"users\".\"display_name\" IS NULL OR (LENGTH(\"users\".\"display_name\") >= 2 AND LENGTH(\"users\".\"display_name\") <= 30)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "tsrange",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_config": {
+          "name": "slot_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_attendees": {
+          "name": "max_attendees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_unbench": {
+          "name": "auto_unbench",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "recurrence_group_id": {
+          "name": "recurrence_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_rule": {
+          "name": "recurrence_rule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_instances": {
+          "name": "content_instances",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_15min": {
+          "name": "reminder_15min",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_1hour": {
+          "name": "reminder_1hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_24hour": {
+          "name": "reminder_24hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_ad_hoc": {
+          "name": "is_ad_hoc",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ad_hoc_status": {
+          "name": "ad_hoc_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_binding_id": {
+          "name": "channel_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_scheduled_event_id": {
+          "name": "discord_scheduled_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extended_until": {
+          "name": "extended_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_channel_override": {
+          "name": "notification_channel_override",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rescheduling_poll_id": {
+          "name": "rescheduling_poll_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_events_creator_id": {
+          "name": "idx_events_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_game_id": {
+          "name": "idx_events_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_ad_hoc_binding": {
+          "name": "idx_events_ad_hoc_binding",
+          "columns": [
+            {
+              "expression": "channel_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_ad_hoc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_recurrence_group_id": {
+          "name": "idx_events_recurrence_group_id",
+          "columns": [
+            {
+              "expression": "recurrence_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_cancelled_at": {
+          "name": "idx_events_cancelled_at",
+          "columns": [
+            {
+              "expression": "cancelled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_discord_scheduled_event_id": {
+          "name": "idx_events_discord_scheduled_event_id",
+          "columns": [
+            {
+              "expression": "discord_scheduled_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_game_id_games_id_fk": {
+          "name": "events_game_id_games_id_fk",
+          "tableFrom": "events",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_creator_id_users_id_fk": {
+          "name": "events_creator_id_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_channel_binding_id_channel_bindings_id_fk": {
+          "name": "events_channel_binding_id_channel_bindings_id_fk",
+          "tableFrom": "events",
+          "tableTo": "channel_bindings",
+          "columnsFrom": [
+            "channel_binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_types": {
+      "name": "event_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_player_cap": {
+          "name": "default_player_cap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_duration_minutes": {
+          "name": "default_duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_composition": {
+          "name": "requires_composition",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_event_types_game_id": {
+          "name": "idx_event_types_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_types_game_id_games_id_fk": {
+          "name": "event_types_game_id_games_id_fk",
+          "tableFrom": "event_types",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_types_game_slug_unique": {
+          "name": "event_types_game_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "game_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "igdb_id": {
+          "name": "igdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregated_rating": {
+          "name": "aggregated_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "popularity": {
+          "name": "popularity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_modes": {
+          "name": "game_modes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "themes": {
+          "name": "themes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "platforms": {
+          "name": "platforms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "screenshots": {
+          "name": "screenshots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "videos": {
+          "name": "videos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "first_release_date": {
+          "name": "first_release_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_count": {
+          "name": "player_count",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitch_game_id": {
+          "name": "twitch_game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_app_id": {
+          "name": "steam_app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crossplay": {
+          "name": "crossplay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color_hex": {
+          "name": "color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_roles": {
+          "name": "has_roles",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_specs": {
+          "name": "has_specs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "itad_game_id": {
+          "name": "itad_game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_boxart_url": {
+          "name": "itad_boxart_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_tags": {
+          "name": "itad_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "max_characters_per_user": {
+          "name": "max_characters_per_user",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "api_namespace_prefix": {
+          "name": "api_namespace_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_current_price": {
+          "name": "itad_current_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_current_cut": {
+          "name": "itad_current_cut",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_current_shop": {
+          "name": "itad_current_shop",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_current_url": {
+          "name": "itad_current_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_lowest_price": {
+          "name": "itad_lowest_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_lowest_cut": {
+          "name": "itad_lowest_cut",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_price_updated_at": {
+          "name": "itad_price_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "early_access": {
+          "name": "early_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "igdb_enrichment_status": {
+          "name": "igdb_enrichment_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "igdb_enrichment_retry_count": {
+          "name": "igdb_enrichment_retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "games_igdb_id_unique": {
+          "name": "games_igdb_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "igdb_id"
+          ]
+        },
+        "games_slug_unique": {
+          "name": "games_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "games_itad_game_id_unique": {
+          "name": "games_itad_game_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "itad_game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_signups": {
+      "name": "event_signups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_avatar_hash": {
+          "name": "discord_avatar_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation_status": {
+          "name": "confirmation_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'signed_up'"
+        },
+        "preferred_roles": {
+          "name": "preferred_roles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attendance_status": {
+          "name": "attendance_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attendance_recorded_at": {
+          "name": "attendance_recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roached_out_at": {
+          "name": "roached_out_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_up_at": {
+          "name": "signed_up_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_event_signups_event_id": {
+          "name": "idx_event_signups_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_signups_discord_user_id": {
+          "name": "idx_event_signups_discord_user_id",
+          "columns": [
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_signups_user_id": {
+          "name": "idx_event_signups_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_signups_event_id_status": {
+          "name": "idx_event_signups_event_id_status",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_signups_event_id_events_id_fk": {
+          "name": "event_signups_event_id_events_id_fk",
+          "tableFrom": "event_signups",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_signups_user_id_users_id_fk": {
+          "name": "event_signups_user_id_users_id_fk",
+          "tableFrom": "event_signups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_signups_character_id_characters_id_fk": {
+          "name": "event_signups_character_id_characters_id_fk",
+          "tableFrom": "event_signups",
+          "tableTo": "characters",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_user": {
+          "name": "unique_event_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id"
+          ]
+        },
+        "unique_event_discord_user": {
+          "name": "unique_event_discord_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "discord_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_or_discord": {
+          "name": "user_or_discord",
+          "value": "\"event_signups\".\"user_id\" IS NOT NULL OR \"event_signups\".\"discord_user_id\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.characters": {
+      "name": "characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "realm": {
+          "name": "realm",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class": {
+          "name": "class",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_override": {
+          "name": "role_override",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_main": {
+          "name": "is_main",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "item_level": {
+          "name": "item_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "render_url": {
+          "name": "render_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "race": {
+          "name": "race",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faction": {
+          "name": "faction",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_url": {
+          "name": "profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_variant": {
+          "name": "game_variant",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "equipment": {
+          "name": "equipment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "talents": {
+          "name": "talents",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "professions": {
+          "name": "professions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_one_main_per_game": {
+          "name": "idx_one_main_per_game",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"characters\".\"is_main\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_characters_user_id": {
+          "name": "idx_characters_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_characters_user_id_name": {
+          "name": "idx_characters_user_id_name",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "characters_user_id_users_id_fk": {
+          "name": "characters_user_id_users_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "characters_game_id_games_id_fk": {
+          "name": "characters_game_id_games_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_game_character": {
+          "name": "unique_user_game_character",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id",
+            "name",
+            "realm"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.local_credentials": {
+      "name": "local_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "local_credentials_user_id_users_id_fk": {
+          "name": "local_credentials_user_id_users_id_fk",
+          "tableFrom": "local_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "local_credentials_email_unique": {
+          "name": "local_credentials_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.availability": {
+      "name": "availability",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_range": {
+          "name": "time_range",
+          "type": "tsrange",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_availability_user_id": {
+          "name": "idx_availability_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "availability_user_id_users_id_fk": {
+          "name": "availability_user_id_users_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "availability_game_id_games_id_fk": {
+          "name": "availability_game_id_games_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "availability_source_event_id_events_id_fk": {
+          "name": "availability_source_event_id_events_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "events",
+          "columnsFrom": [
+            "source_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roster_assignments": {
+      "name": "roster_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signup_id": {
+          "name": "signup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "is_override": {
+          "name": "is_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_roster_assignments_event_id": {
+          "name": "idx_roster_assignments_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_roster_assignments_signup_id": {
+          "name": "idx_roster_assignments_signup_id",
+          "columns": [
+            {
+              "expression": "signup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roster_assignments_event_id_events_id_fk": {
+          "name": "roster_assignments_event_id_events_id_fk",
+          "tableFrom": "roster_assignments",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "roster_assignments_signup_id_event_signups_id_fk": {
+          "name": "roster_assignments_signup_id_event_signups_id_fk",
+          "tableFrom": "roster_assignments",
+          "tableTo": "event_signups",
+          "columnsFrom": [
+            "signup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_signup": {
+          "name": "unique_event_signup",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "signup_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_settings_key_unique": {
+          "name": "app_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_expires_at": {
+          "name": "idx_notifications_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_preferences": {
+      "name": "user_notification_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_prefs": {
+          "name": "channel_prefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"slot_vacated\":{\"inApp\":true,\"push\":true,\"discord\":true},\"event_reminder\":{\"inApp\":true,\"push\":true,\"discord\":true},\"new_event\":{\"inApp\":true,\"push\":true,\"discord\":true},\"subscribed_game\":{\"inApp\":true,\"push\":true,\"discord\":true},\"achievement_unlocked\":{\"inApp\":true,\"push\":false,\"discord\":false},\"level_up\":{\"inApp\":true,\"push\":false,\"discord\":false},\"missed_event_nudge\":{\"inApp\":true,\"push\":true,\"discord\":true},\"event_rescheduled\":{\"inApp\":true,\"push\":true,\"discord\":true},\"bench_promoted\":{\"inApp\":true,\"push\":true,\"discord\":true},\"event_cancelled\":{\"inApp\":true,\"push\":true,\"discord\":true},\"roster_reassigned\":{\"inApp\":true,\"push\":true,\"discord\":true},\"tentative_displaced\":{\"inApp\":true,\"push\":true,\"discord\":true},\"member_returned\":{\"inApp\":true,\"push\":true,\"discord\":true},\"recruitment_reminder\":{\"inApp\":true,\"push\":true,\"discord\":true},\"role_gap_alert\":{\"inApp\":true,\"push\":true,\"discord\":true},\"lineup_steam_nudge\":{\"inApp\":true,\"push\":false,\"discord\":true},\"community_lineup\":{\"inApp\":true,\"push\":true,\"discord\":true},\"system\":{\"inApp\":true,\"push\":false,\"discord\":false}}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_preferences_user_id_users_id_fk": {
+          "name": "user_notification_preferences_user_id_users_id_fk",
+          "tableFrom": "user_notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_preference_key": {
+          "name": "unique_user_preference_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_time_templates": {
+      "name": "game_time_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_hour": {
+          "name": "start_hour",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_time_templates_user_id_idx": {
+          "name": "game_time_templates_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_time_templates_user_id_users_id_fk": {
+          "name": "game_time_templates_user_id_users_id_fk",
+          "tableFrom": "game_time_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_game_time_slot": {
+          "name": "unique_user_game_time_slot",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "day_of_week",
+            "start_hour"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_time_absences": {
+      "name": "game_time_absences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_time_absences_user_id_idx": {
+          "name": "game_time_absences_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_time_absences_user_id_users_id_fk": {
+          "name": "game_time_absences_user_id_users_id_fk",
+          "tableFrom": "game_time_absences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_time_overrides": {
+      "name": "game_time_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hour": {
+          "name": "hour",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_time_overrides_user_id_idx": {
+          "name": "game_time_overrides_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_time_overrides_user_id_users_id_fk": {
+          "name": "game_time_overrides_user_id_users_id_fk",
+          "tableFrom": "game_time_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_override_date_hour": {
+          "name": "unique_user_override_date_hour",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "date",
+            "hour"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_interests": {
+      "name": "game_interests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "playtime_forever": {
+          "name": "playtime_forever",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playtime_2weeks": {
+          "name": "playtime_2weeks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_game_interests_game_id": {
+          "name": "idx_game_interests_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_interests_user_id_users_id_fk": {
+          "name": "game_interests_user_id_users_id_fk",
+          "tableFrom": "game_interests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_interests_game_id_games_id_fk": {
+          "name": "game_interests_game_id_games_id_fk",
+          "tableFrom": "game_interests",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_user_game_interest_source": {
+          "name": "uq_user_game_interest_source",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id",
+            "source"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_reminders_sent": {
+      "name": "event_reminders_sent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reminder_type": {
+          "name": "reminder_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_reminders_sent_event_id_events_id_fk": {
+          "name": "event_reminders_sent_event_id_events_id_fk",
+          "tableFrom": "event_reminders_sent",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_reminders_sent_user_id_users_id_fk": {
+          "name": "event_reminders_sent_user_id_users_id_fk",
+          "tableFrom": "event_reminders_sent",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_user_reminder": {
+          "name": "unique_event_user_reminder",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id",
+            "reminder_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_templates": {
+      "name": "event_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_templates_user_id_users_id_fk": {
+          "name": "event_templates_user_id_users_id_fk",
+          "tableFrom": "event_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plugins": {
+      "name": "plugins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config_json": {
+          "name": "config_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plugins_slug_unique": {
+          "name": "plugins_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_user_id_users_id_fk": {
+          "name": "feedback_user_id_users_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pug_slots": {
+      "name": "pug_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_avatar_hash": {
+          "name": "discord_avatar_hash",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class": {
+          "name": "class",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "server_invite_url": {
+          "name": "server_invite_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_event_pug": {
+          "name": "unique_event_pug",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pug_slots\".\"discord_username\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_invite_code": {
+          "name": "unique_invite_code",
+          "columns": [
+            {
+              "expression": "invite_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pug_slots\".\"invite_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pug_slots_event_id_events_id_fk": {
+          "name": "pug_slots_event_id_events_id_fk",
+          "tableFrom": "pug_slots",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pug_slots_claimed_by_user_id_users_id_fk": {
+          "name": "pug_slots_claimed_by_user_id_users_id_fk",
+          "tableFrom": "pug_slots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "claimed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pug_slots_created_by_users_id_fk": {
+          "name": "pug_slots_created_by_users_id_fk",
+          "tableFrom": "pug_slots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cron_jobs": {
+      "name": "cron_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_slug": {
+          "name": "plugin_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Other'"
+        },
+        "paused": {
+          "name": "paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cron_jobs_name_unique": {
+          "name": "cron_jobs_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cron_job_executions": {
+      "name": "cron_job_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cron_job_id": {
+          "name": "cron_job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cron_job_executions_job_started_idx": {
+          "name": "cron_job_executions_job_started_idx",
+          "columns": [
+            {
+              "expression": "cron_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cron_job_executions_cron_job_id_cron_jobs_id_fk": {
+          "name": "cron_job_executions_cron_job_id_cron_jobs_id_fk",
+          "tableFrom": "cron_job_executions",
+          "tableTo": "cron_jobs",
+          "columnsFrom": [
+            "cron_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_event_messages": {
+      "name": "discord_event_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embed_state": {
+          "name": "embed_state",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'posted'"
+        },
+        "bump_message_id": {
+          "name": "bump_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_discord_event_messages_event": {
+          "name": "idx_discord_event_messages_event",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_discord_event_messages_message": {
+          "name": "idx_discord_event_messages_message",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_event_messages_event_id_events_id_fk": {
+          "name": "discord_event_messages_event_id_events_id_fk",
+          "tableFrom": "discord_event_messages",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_channel_message": {
+          "name": "unique_event_channel_message",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "channel_id",
+            "message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_bindings": {
+      "name": "channel_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding_purpose": {
+          "name": "binding_purpose",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_group_id": {
+          "name": "recurrence_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_bindings_guild_channel_series_unique": {
+          "name": "channel_bindings_guild_channel_series_unique",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurrence_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_bindings_guild": {
+          "name": "idx_channel_bindings_guild",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_bindings_game": {
+          "name": "idx_channel_bindings_game",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_bindings_recurrence_group": {
+          "name": "idx_channel_bindings_recurrence_group",
+          "columns": [
+            {
+              "expression": "recurrence_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_bindings_game_id_games_id_fk": {
+          "name": "channel_bindings_game_id_games_id_fk",
+          "tableFrom": "channel_bindings",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_event_reminders_sent": {
+      "name": "post_event_reminders_sent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pug_slot_id": {
+          "name": "pug_slot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_event_reminders_sent_event_id_events_id_fk": {
+          "name": "post_event_reminders_sent_event_id_events_id_fk",
+          "tableFrom": "post_event_reminders_sent",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_event_reminders_sent_pug_slot_id_pug_slots_id_fk": {
+          "name": "post_event_reminders_sent_pug_slot_id_pug_slots_id_fk",
+          "tableFrom": "post_event_reminders_sent",
+          "tableTo": "pug_slots",
+          "columnsFrom": [
+            "pug_slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_post_event_pug_reminder": {
+          "name": "unique_post_event_pug_reminder",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "pug_slot_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_plans": {
+      "name": "event_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slot_config": {
+          "name": "slot_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_attendees": {
+          "name": "max_attendees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_unbench": {
+          "name": "auto_unbench",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_options": {
+          "name": "poll_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_duration_hours": {
+          "name": "poll_duration_hours",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_mode": {
+          "name": "poll_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "poll_round": {
+          "name": "poll_round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "poll_channel_id": {
+          "name": "poll_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_message_id": {
+          "name": "poll_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "winning_option": {
+          "name": "winning_option",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_event_id": {
+          "name": "created_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_instances": {
+          "name": "content_instances",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_15min": {
+          "name": "reminder_15min",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_1hour": {
+          "name": "reminder_1hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_24hour": {
+          "name": "reminder_24hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "poll_started_at": {
+          "name": "poll_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_ends_at": {
+          "name": "poll_ends_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_event_plans_creator_id": {
+          "name": "idx_event_plans_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_plans_status": {
+          "name": "idx_event_plans_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_plans_creator_id_users_id_fk": {
+          "name": "event_plans_creator_id_users_id_fk",
+          "tableFrom": "event_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_plans_game_id_games_id_fk": {
+          "name": "event_plans_game_id_games_id_fk",
+          "tableFrom": "event_plans",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "event_plans_created_event_id_events_id_fk": {
+          "name": "event_plans_created_event_id_events_id_fk",
+          "tableFrom": "event_plans",
+          "tableTo": "events",
+          "columnsFrom": [
+            "created_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_dungeon_quests": {
+      "name": "wow_classic_dungeon_quests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dungeon_instance_id": {
+          "name": "dungeon_instance_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quest_level": {
+          "name": "quest_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_level": {
+          "name": "required_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expansion": {
+          "name": "expansion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quest_giver_npc": {
+          "name": "quest_giver_npc",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quest_giver_zone": {
+          "name": "quest_giver_zone",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_quest_id": {
+          "name": "prev_quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_quest_id": {
+          "name": "next_quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewards_json": {
+          "name": "rewards_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objectives": {
+          "name": "objectives",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_restriction": {
+          "name": "class_restriction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "race_restriction": {
+          "name": "race_restriction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_inside_dungeon": {
+          "name": "starts_inside_dungeon",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sharable": {
+          "name": "sharable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reward_xp": {
+          "name": "reward_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_gold": {
+          "name": "reward_gold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_type": {
+          "name": "reward_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wow_classic_dungeon_quests_quest_id_unique": {
+          "name": "wow_classic_dungeon_quests_quest_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "quest_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_boss_loot": {
+      "name": "wow_classic_boss_loot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "boss_id": {
+          "name": "boss_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot": {
+          "name": "slot",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality": {
+          "name": "quality",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_level": {
+          "name": "item_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drop_rate": {
+          "name": "drop_rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expansion": {
+          "name": "expansion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_restrictions": {
+          "name": "class_restrictions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_subclass": {
+          "name": "item_subclass",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wow_classic_boss_loot_boss_id_wow_classic_bosses_id_fk": {
+          "name": "wow_classic_boss_loot_boss_id_wow_classic_bosses_id_fk",
+          "tableFrom": "wow_classic_boss_loot",
+          "tableTo": "wow_classic_bosses",
+          "columnsFrom": [
+            "boss_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_loot_boss_item_expansion": {
+          "name": "uq_loot_boss_item_expansion",
+          "nullsNotDistinct": false,
+          "columns": [
+            "boss_id",
+            "item_id",
+            "expansion"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_bosses": {
+      "name": "wow_classic_bosses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expansion": {
+          "name": "expansion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sod_modified": {
+          "name": "sod_modified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_boss_instance_name_expansion": {
+          "name": "uq_boss_instance_name_expansion",
+          "nullsNotDistinct": false,
+          "columns": [
+            "instance_id",
+            "name",
+            "expansion"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_quest_progress": {
+      "name": "wow_classic_quest_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picked_up": {
+          "name": "picked_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wow_classic_quest_progress_event_id_events_id_fk": {
+          "name": "wow_classic_quest_progress_event_id_events_id_fk",
+          "tableFrom": "wow_classic_quest_progress",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wow_classic_quest_progress_user_id_users_id_fk": {
+          "name": "wow_classic_quest_progress_user_id_users_id_fk",
+          "tableFrom": "wow_classic_quest_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_quest_progress_event_user_quest": {
+          "name": "uq_quest_progress_event_user_quest",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id",
+            "quest_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_activity_sessions": {
+      "name": "game_activity_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_activity_name": {
+          "name": "discord_activity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "game_activity_sessions_user_game_started_idx": {
+          "name": "game_activity_sessions_user_game_started_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "game_activity_sessions_game_started_idx": {
+          "name": "game_activity_sessions_game_started_idx",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_activity_sessions_user_id_users_id_fk": {
+          "name": "game_activity_sessions_user_id_users_id_fk",
+          "tableFrom": "game_activity_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_activity_sessions_game_id_games_id_fk": {
+          "name": "game_activity_sessions_game_id_games_id_fk",
+          "tableFrom": "game_activity_sessions",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_activity_rollups": {
+      "name": "game_activity_rollups",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period": {
+          "name": "period",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_seconds": {
+          "name": "total_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "game_activity_rollups_game_period_start_idx": {
+          "name": "game_activity_rollups_game_period_start_idx",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_activity_rollups_user_id_users_id_fk": {
+          "name": "game_activity_rollups_user_id_users_id_fk",
+          "tableFrom": "game_activity_rollups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_activity_rollups_game_id_games_id_fk": {
+          "name": "game_activity_rollups_game_id_games_id_fk",
+          "tableFrom": "game_activity_rollups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "game_activity_rollups_user_game_period_unique": {
+          "name": "game_activity_rollups_user_game_period_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id",
+            "period",
+            "period_start"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_game_mappings": {
+      "name": "discord_game_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "discord_activity_name": {
+          "name": "discord_activity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "discord_game_mappings_game_id_games_id_fk": {
+          "name": "discord_game_mappings_game_id_games_id_fk",
+          "tableFrom": "discord_game_mappings",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_game_mappings_discord_activity_name_unique": {
+          "name": "discord_game_mappings_discord_activity_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_activity_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ad_hoc_participants": {
+      "name": "ad_hoc_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_avatar_hash": {
+          "name": "discord_avatar_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_duration_seconds": {
+          "name": "total_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "ad_hoc_participants_event_discord_user_unique": {
+          "name": "ad_hoc_participants_event_discord_user_unique",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ad_hoc_participants_event": {
+          "name": "idx_ad_hoc_participants_event",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ad_hoc_participants_user": {
+          "name": "idx_ad_hoc_participants_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ad_hoc_participants_event_id_events_id_fk": {
+          "name": "ad_hoc_participants_event_id_events_id_fk",
+          "tableFrom": "ad_hoc_participants",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ad_hoc_participants_user_id_users_id_fk": {
+          "name": "ad_hoc_participants_user_id_users_id_fk",
+          "tableFrom": "ad_hoc_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_interest_suppressions": {
+      "name": "game_interest_suppressions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suppressed_at": {
+          "name": "suppressed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_interest_suppressions_user_id_users_id_fk": {
+          "name": "game_interest_suppressions_user_id_users_id_fk",
+          "tableFrom": "game_interest_suppressions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_interest_suppressions_game_id_games_id_fk": {
+          "name": "game_interest_suppressions_game_id_games_id_fk",
+          "tableFrom": "game_interest_suppressions",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_user_game_suppression": {
+          "name": "uq_user_game_suppression",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_voice_sessions": {
+      "name": "event_voice_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_join_at": {
+          "name": "first_join_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_leave_at": {
+          "name": "last_leave_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_duration_sec": {
+          "name": "total_duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "segments": {
+          "name": "segments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "event_voice_sessions_event_discord_user_unique": {
+          "name": "event_voice_sessions_event_discord_user_unique",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_voice_sessions_event": {
+          "name": "idx_event_voice_sessions_event",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_voice_sessions_event_id_events_id_fk": {
+          "name": "event_voice_sessions_event_id_events_id_fk",
+          "tableFrom": "event_voice_sessions",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_voice_sessions_user_id_users_id_fk": {
+          "name": "event_voice_sessions_user_id_users_id_fk",
+          "tableFrom": "event_voice_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrichments": {
+      "name": "enrichments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enricher_key": {
+          "name": "enricher_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_enrichments_entity": {
+          "name": "idx_enrichments_entity",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_entity_enricher": {
+          "name": "unique_entity_enricher",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "enricher_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_request_logs": {
+      "name": "ai_request_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "feature": {
+          "name": "feature",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ai_request_logs_created_at": {
+          "name": "idx_ai_request_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_request_logs_feature_created_at": {
+          "name": "idx_ai_request_logs_feature_created_at",
+          "columns": [
+            {
+              "expression": "feature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_request_logs_user_id_users_id_fk": {
+          "name": "ai_request_logs_user_id_users_id_fk",
+          "tableFrom": "ai_request_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_entries": {
+      "name": "community_lineup_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nominated_by": {
+          "name": "nominated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carried_over_from": {
+          "name": "carried_over_from",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_entries_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_entries_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_entries",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_entries_game_id_games_id_fk": {
+          "name": "community_lineup_entries_game_id_games_id_fk",
+          "tableFrom": "community_lineup_entries",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_entries_nominated_by_users_id_fk": {
+          "name": "community_lineup_entries_nominated_by_users_id_fk",
+          "tableFrom": "community_lineup_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "nominated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_entries_carried_over_from_community_lineups_id_fk": {
+          "name": "community_lineup_entries_carried_over_from_community_lineups_id_fk",
+          "tableFrom": "community_lineup_entries",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "carried_over_from"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lineup_entry_game": {
+          "name": "uq_lineup_entry_game",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineup_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_invitees": {
+      "name": "community_lineup_invitees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_invitees_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_invitees_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_invitees",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_invitees_user_id_users_id_fk": {
+          "name": "community_lineup_invitees_user_id_users_id_fk",
+          "tableFrom": "community_lineup_invitees",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lineup_invitee_user": {
+          "name": "uq_lineup_invitee_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineup_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_votes": {
+      "name": "community_lineup_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_votes_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_votes_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_votes",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_votes_user_id_users_id_fk": {
+          "name": "community_lineup_votes_user_id_users_id_fk",
+          "tableFrom": "community_lineup_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_votes_game_id_games_id_fk": {
+          "name": "community_lineup_votes_game_id_games_id_fk",
+          "tableFrom": "community_lineup_votes",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lineup_vote_user_game": {
+          "name": "uq_lineup_vote_user_game",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineup_id",
+            "user_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineups": {
+      "name": "community_lineups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'building'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_game_id": {
+          "name": "decided_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_event_id": {
+          "name": "linked_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voting_deadline": {
+          "name": "voting_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase_deadline": {
+          "name": "phase_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase_duration_override": {
+          "name": "phase_duration_override",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_threshold": {
+          "name": "match_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 35
+        },
+        "max_votes_per_player": {
+          "name": "max_votes_per_player",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "default_tiebreaker_mode": {
+          "name": "default_tiebreaker_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_tiebreaker_id": {
+          "name": "active_tiebreaker_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_created_channel_id": {
+          "name": "discord_created_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_created_message_id": {
+          "name": "discord_created_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_override_id": {
+          "name": "channel_override_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineups_decided_game_id_games_id_fk": {
+          "name": "community_lineups_decided_game_id_games_id_fk",
+          "tableFrom": "community_lineups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "decided_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_lineups_linked_event_id_events_id_fk": {
+          "name": "community_lineups_linked_event_id_events_id_fk",
+          "tableFrom": "community_lineups",
+          "tableTo": "events",
+          "columnsFrom": [
+            "linked_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_lineups_created_by_users_id_fk": {
+          "name": "community_lineups_created_by_users_id_fk",
+          "tableFrom": "community_lineups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_tiebreaker_bracket_matchups": {
+      "name": "community_lineup_tiebreaker_bracket_matchups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tiebreaker_id": {
+          "name": "tiebreaker_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_a_id": {
+          "name": "game_a_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_b_id": {
+          "name": "game_b_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "winner_game_id": {
+          "name": "winner_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bye": {
+          "name": "is_bye",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_tiebreaker_bracket_matchups_tiebreaker_id_community_lineup_tiebreakers_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_matchups_tiebreaker_id_community_lineup_tiebreakers_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_matchups",
+          "tableTo": "community_lineup_tiebreakers",
+          "columnsFrom": [
+            "tiebreaker_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_matchups_game_a_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_matchups_game_a_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_matchups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_matchups_game_b_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_matchups_game_b_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_matchups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_matchups_winner_game_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_matchups_winner_game_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_matchups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "winner_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_tiebreaker_matchup_round_pos": {
+          "name": "uq_tiebreaker_matchup_round_pos",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tiebreaker_id",
+            "round",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_tiebreaker_bracket_votes": {
+      "name": "community_lineup_tiebreaker_bracket_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "matchup_id": {
+          "name": "matchup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_tiebreaker_bracket_votes_matchup_id_community_lineup_tiebreaker_bracket_matchups_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_votes_matchup_id_community_lineup_tiebreaker_bracket_matchups_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_votes",
+          "tableTo": "community_lineup_tiebreaker_bracket_matchups",
+          "columnsFrom": [
+            "matchup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_votes_user_id_users_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_votes_user_id_users_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_votes_game_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_votes_game_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_votes",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_tiebreaker_bracket_vote": {
+          "name": "uq_tiebreaker_bracket_vote",
+          "nullsNotDistinct": false,
+          "columns": [
+            "matchup_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_tiebreaker_vetoes": {
+      "name": "community_lineup_tiebreaker_vetoes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tiebreaker_id": {
+          "name": "tiebreaker_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revealed": {
+          "name": "revealed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_tiebreaker_vetoes_tiebreaker_id_community_lineup_tiebreakers_id_fk": {
+          "name": "community_lineup_tiebreaker_vetoes_tiebreaker_id_community_lineup_tiebreakers_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_vetoes",
+          "tableTo": "community_lineup_tiebreakers",
+          "columnsFrom": [
+            "tiebreaker_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_vetoes_user_id_users_id_fk": {
+          "name": "community_lineup_tiebreaker_vetoes_user_id_users_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_vetoes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_vetoes_game_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_vetoes_game_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_vetoes",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_tiebreaker_veto_user": {
+          "name": "uq_tiebreaker_veto_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tiebreaker_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_tiebreakers": {
+      "name": "community_lineup_tiebreakers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "tied_game_ids": {
+          "name": "tied_game_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_vote_count": {
+          "name": "original_vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "winner_game_id": {
+          "name": "winner_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round_deadline": {
+          "name": "round_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_tiebreakers_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_tiebreakers_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_tiebreakers",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreakers_winner_game_id_games_id_fk": {
+          "name": "community_lineup_tiebreakers_winner_game_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreakers",
+          "tableTo": "games",
+          "columnsFrom": [
+            "winner_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_match_members": {
+      "name": "community_lineup_match_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_match_members_match_id_community_lineup_matches_id_fk": {
+          "name": "community_lineup_match_members_match_id_community_lineup_matches_id_fk",
+          "tableFrom": "community_lineup_match_members",
+          "tableTo": "community_lineup_matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_match_members_user_id_users_id_fk": {
+          "name": "community_lineup_match_members_user_id_users_id_fk",
+          "tableFrom": "community_lineup_match_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_match_member_user": {
+          "name": "uq_match_member_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_matches": {
+      "name": "community_lineup_matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'suggested'"
+        },
+        "threshold_met": {
+          "name": "threshold_met",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "vote_percentage": {
+          "name": "vote_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fit_type": {
+          "name": "fit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_event_id": {
+          "name": "linked_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_message_id": {
+          "name": "embed_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_channel_id": {
+          "name": "embed_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_vote_threshold": {
+          "name": "min_vote_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threshold_notified_at": {
+          "name": "threshold_notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_matches_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_matches_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_matches",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_matches_game_id_games_id_fk": {
+          "name": "community_lineup_matches_game_id_games_id_fk",
+          "tableFrom": "community_lineup_matches",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_matches_linked_event_id_events_id_fk": {
+          "name": "community_lineup_matches_linked_event_id_events_id_fk",
+          "tableFrom": "community_lineup_matches",
+          "tableTo": "events",
+          "columnsFrom": [
+            "linked_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lineup_match_game": {
+          "name": "uq_lineup_match_game",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineup_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_schedule_slots": {
+      "name": "community_lineup_schedule_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_time": {
+          "name": "proposed_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overlap_score": {
+          "name": "overlap_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_by": {
+          "name": "suggested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_schedule_slots_match_id_community_lineup_matches_id_fk": {
+          "name": "community_lineup_schedule_slots_match_id_community_lineup_matches_id_fk",
+          "tableFrom": "community_lineup_schedule_slots",
+          "tableTo": "community_lineup_matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_schedule_votes": {
+      "name": "community_lineup_schedule_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slot_id": {
+          "name": "slot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_schedule_votes_slot_id_community_lineup_schedule_slots_id_fk": {
+          "name": "community_lineup_schedule_votes_slot_id_community_lineup_schedule_slots_id_fk",
+          "tableFrom": "community_lineup_schedule_votes",
+          "tableTo": "community_lineup_schedule_slots",
+          "columnsFrom": [
+            "slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_schedule_votes_user_id_users_id_fk": {
+          "name": "community_lineup_schedule_votes_user_id_users_id_fk",
+          "tableFrom": "community_lineup_schedule_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_schedule_vote_user": {
+          "name": "uq_schedule_vote_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slot_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_activity_log_entity": {
+          "name": "idx_activity_log_entity",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_actor_id_users_id_fk": {
+          "name": "activity_log_actor_id_users_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_dedup": {
+      "name": "notification_dedup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_notification_dedup_key": {
+          "name": "uq_notification_dedup_key",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_dedup_expires_at": {
+          "name": "idx_notification_dedup_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consumed_intent_tokens": {
+      "name": "consumed_intent_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_consumed_intent_tokens_consumed_at": {
+          "name": "idx_consumed_intent_tokens_consumed_at",
+          "columns": [
+            {
+              "expression": "consumed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "consumed_intent_tokens_token_hash_unique": {
+          "name": "consumed_intent_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_taste_vectors": {
+      "name": "player_taste_vectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vector": {
+          "name": "vector",
+          "type": "vector(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intensity_metrics": {
+          "name": "intensity_metrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archetype": {
+          "name": "archetype",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "signal_hash": {
+          "name": "signal_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "player_taste_vectors_computed_at_idx": {
+          "name": "player_taste_vectors_computed_at_idx",
+          "columns": [
+            {
+              "expression": "computed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "player_taste_vectors_user_id_users_id_fk": {
+          "name": "player_taste_vectors_user_id_users_id_fk",
+          "tableFrom": "player_taste_vectors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "player_taste_vectors_user_id_unique": {
+          "name": "player_taste_vectors_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_intensity_snapshots": {
+      "name": "player_intensity_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_start": {
+          "name": "week_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_hours": {
+          "name": "total_hours",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_breakdown": {
+          "name": "game_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unique_games": {
+          "name": "unique_games",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longest_session_hours": {
+          "name": "longest_session_hours",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longest_session_game_id": {
+          "name": "longest_session_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "player_intensity_snapshots_week_start_idx": {
+          "name": "player_intensity_snapshots_week_start_idx",
+          "columns": [
+            {
+              "expression": "week_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "player_intensity_snapshots_user_id_users_id_fk": {
+          "name": "player_intensity_snapshots_user_id_users_id_fk",
+          "tableFrom": "player_intensity_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "player_intensity_snapshots_longest_session_game_id_games_id_fk": {
+          "name": "player_intensity_snapshots_longest_session_game_id_games_id_fk",
+          "tableFrom": "player_intensity_snapshots",
+          "tableTo": "games",
+          "columnsFrom": [
+            "longest_session_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_player_intensity_user_week": {
+          "name": "uq_player_intensity_user_week",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "week_start"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_co_play": {
+      "name": "player_co_play",
+      "schema": "",
+      "columns": {
+        "user_id_a": {
+          "name": "user_id_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id_b": {
+          "name": "user_id_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_minutes": {
+          "name": "total_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_played_at": {
+          "name": "last_played_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "games_played": {
+          "name": "games_played",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "player_co_play_user_id_a_users_id_fk": {
+          "name": "player_co_play_user_id_a_users_id_fk",
+          "tableFrom": "player_co_play",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id_a"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "player_co_play_user_id_b_users_id_fk": {
+          "name": "player_co_play_user_id_b_users_id_fk",
+          "tableFrom": "player_co_play",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id_b"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "player_co_play_user_id_a_user_id_b_pk": {
+          "name": "player_co_play_user_id_a_user_id_b_pk",
+          "columns": [
+            "user_id_a",
+            "user_id_b"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_player_co_play_canonical_order": {
+          "name": "chk_player_co_play_canonical_order",
+          "value": "\"player_co_play\".\"user_id_a\" < \"player_co_play\".\"user_id_b\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.game_taste_vectors": {
+      "name": "game_taste_vectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vector": {
+          "name": "vector",
+          "type": "vector(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "signal_hash": {
+          "name": "signal_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "game_taste_vectors_computed_at_idx": {
+          "name": "game_taste_vectors_computed_at_idx",
+          "columns": [
+            {
+              "expression": "computed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_taste_vectors_game_id_games_id_fk": {
+          "name": "game_taste_vectors_game_id_games_id_fk",
+          "tableFrom": "game_taste_vectors",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "game_taste_vectors_game_id_unique": {
+          "name": "game_taste_vectors_game_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lineup_ai_suggestions": {
+      "name": "lineup_ai_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_set_hash": {
+          "name": "voter_set_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lineup_ai_suggestions_lineup_generated_at_idx": {
+          "name": "lineup_ai_suggestions_lineup_generated_at_idx",
+          "columns": [
+            {
+              "expression": "lineup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lineup_ai_suggestions_lineup_id_community_lineups_id_fk": {
+          "name": "lineup_ai_suggestions_lineup_id_community_lineups_id_fk",
+          "tableFrom": "lineup_ai_suggestions",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lineup_ai_suggestion_voter_set": {
+          "name": "uq_lineup_ai_suggestion_voter_set",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineup_id",
+            "voter_set_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discovery_category_suggestions": {
+      "name": "discovery_category_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_type": {
+          "name": "category_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "theme_vector": {
+          "name": "theme_vector",
+          "type": "vector(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter_criteria": {
+          "name": "filter_criteria",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "candidate_game_ids": {
+          "name": "candidate_game_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "population_strategy": {
+          "name": "population_strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1000
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discovery_category_status_idx": {
+          "name": "discovery_category_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_category_sort_idx": {
+          "name": "discovery_category_sort_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"discovery_category_suggestions\".\"status\" = 'approved'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discovery_category_suggestions_reviewed_by_users_id_fk": {
+          "name": "discovery_category_suggestions_reviewed_by_users_id_fk",
+          "tableFrom": "discovery_category_suggestions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_insights_snapshots": {
+      "name": "community_insights_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "radar_payload": {
+          "name": "radar_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "engagement_payload": {
+          "name": "engagement_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "churn_payload": {
+          "name": "churn_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "social_graph_payload": {
+          "name": "social_graph_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "temporal_payload": {
+          "name": "temporal_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_insights_payload": {
+          "name": "key_insights_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_community_insights_snapshots_created_at": {
+          "name": "idx_community_insights_snapshots_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_insights_snapshots_snapshot_date_unique": {
+          "name": "community_insights_snapshots_snapshot_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "snapshot_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/src/drizzle/migrations/meta/_journal.json
+++ b/api/src/drizzle/migrations/meta/_journal.json
@@ -925,6 +925,13 @@
       "when": 1777593600000,
       "tag": "0131_pg_stat_statements_extension",
       "breakpoints": true
+    },
+    {
+      "idx": 132,
+      "version": "7",
+      "when": 1777593700000,
+      "tag": "0132_equal_mandarin",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/drizzle/schema/characters.ts
+++ b/api/src/drizzle/schema/characters.ts
@@ -72,6 +72,8 @@ export const characters = pgTable(
     equipment: jsonb('equipment'),
     /** Raw talent tree data from Blizzard API (JSONB) */
     talents: jsonb('talents'),
+    /** Normalized profession data from Blizzard API (JSONB) */
+    professions: jsonb('professions'),
     /** Display order for drag-to-reorder UI */
     displayOrder: integer('display_order').default(0).notNull(),
     createdAt: timestamp('created_at').defaultNow().notNull(),

--- a/api/src/events/signup-response.helpers.ts
+++ b/api/src/events/signup-response.helpers.ts
@@ -1,6 +1,7 @@
 import type {
   SignupResponseDto,
   SignupCharacterDto,
+  CharacterProfessionsDto,
   ConfirmationStatus,
   SignupStatus,
   RosterRole,
@@ -33,6 +34,7 @@ export function buildCharacterDto(character: CharacterRow): SignupCharacterDto {
     avatarUrl: character.avatarUrl,
     race: character.race,
     faction: character.faction as 'alliance' | 'horde' | null,
+    professions: (character.professions as CharacterProfessionsDto | null) ?? null,
   };
 }
 

--- a/api/src/events/signups-roster.helpers.ts
+++ b/api/src/events/signups-roster.helpers.ts
@@ -11,6 +11,7 @@ import type {
   RosterRole,
   RosterAssignmentResponse,
   SignupCharacterDto,
+  CharacterProfessionsDto,
   AttendanceStatus,
 } from '@raid-ledger/contract';
 
@@ -91,6 +92,7 @@ export function buildCharacterDto(
     avatarUrl: character.avatarUrl,
     race: character.race,
     faction: character.faction as 'alliance' | 'horde' | null,
+    professions: (character.professions as CharacterProfessionsDto | null) ?? null,
   };
 }
 

--- a/api/src/plugins/plugin-host/extension-points.ts
+++ b/api/src/plugins/plugin-host/extension-points.ts
@@ -8,6 +8,7 @@ import type {
   ExternalCharacterProfile,
   ExternalInferredSpecialization,
   ExternalCharacterEquipment,
+  ExternalCharacterProfessions,
   ExternalRealm,
   ExternalContentInstance,
   ExternalContentInstanceDetail,
@@ -37,6 +38,12 @@ export interface CharacterSyncAdapter {
     region: string,
     gameVariant?: string,
   ): Promise<ExternalCharacterEquipment>;
+  fetchProfessions?(
+    name: string,
+    realm: string,
+    region: string,
+    gameVariant?: string | null,
+  ): Promise<ExternalCharacterProfessions | null>;
 }
 
 /** Provides game content data (realms, instances) */

--- a/api/src/plugins/plugin-host/extension-types.ts
+++ b/api/src/plugins/plugin-host/extension-types.ts
@@ -43,6 +43,32 @@ export interface ExternalCharacterEquipment {
   syncedAt: string;
 }
 
+/** Profession tier (e.g., "Dragon Isles Tailoring") */
+export interface ExternalProfessionTier {
+  id: number;
+  name: string;
+  skillLevel: number;
+  maxSkillLevel: number;
+}
+
+/** Single profession entry (primary or secondary) */
+export interface ExternalProfessionEntry {
+  id: number;
+  name: string;
+  /** Lowercased name with spaces replaced by '-' */
+  slug: string;
+  skillLevel: number;
+  maxSkillLevel: number;
+  tiers: ExternalProfessionTier[];
+}
+
+/** Profession data returned from an external game API */
+export interface ExternalCharacterProfessions {
+  primary: ExternalProfessionEntry[];
+  secondary: ExternalProfessionEntry[];
+  syncedAt: string;
+}
+
 /** Character profile data returned from an external game API */
 export interface ExternalCharacterProfile {
   name: string;

--- a/api/src/plugins/wow-common/blizzard-character-sync.adapter.spec.ts
+++ b/api/src/plugins/wow-common/blizzard-character-sync.adapter.spec.ts
@@ -179,16 +179,19 @@ describe('BlizzardCharacterSyncAdapter — fetchProfessions', () => {
     mockBlizzardService.fetchCharacterProfessions.mockResolvedValue(
       mockProfessions,
     );
-    const result = await adapter.fetchProfessions!(
+    const result = await adapter.fetchProfessions(
       'Thrall',
       'area-52',
       'us',
       'classic1x',
     );
     expect(result).toBe(mockProfessions);
-    expect(
-      mockBlizzardService.fetchCharacterProfessions,
-    ).toHaveBeenCalledWith('Thrall', 'area-52', 'us', 'classic1x');
+    expect(mockBlizzardService.fetchCharacterProfessions).toHaveBeenCalledWith(
+      'Thrall',
+      'area-52',
+      'us',
+      'classic1x',
+    );
   });
 
   it('should pass null gameVariant through when retail (no variant)', async () => {
@@ -197,15 +200,18 @@ describe('BlizzardCharacterSyncAdapter — fetchProfessions', () => {
       secondary: [],
       syncedAt: '2026-04-28T00:00:00.000Z',
     });
-    await adapter.fetchProfessions!('Thrall', 'area-52', 'us');
-    expect(
-      mockBlizzardService.fetchCharacterProfessions,
-    ).toHaveBeenCalledWith('Thrall', 'area-52', 'us', null);
+    await adapter.fetchProfessions('Thrall', 'area-52', 'us');
+    expect(mockBlizzardService.fetchCharacterProfessions).toHaveBeenCalledWith(
+      'Thrall',
+      'area-52',
+      'us',
+      null,
+    );
   });
 
   it('should pass through null when BlizzardService returns null (no fallback — architect §3)', async () => {
     mockBlizzardService.fetchCharacterProfessions.mockResolvedValue(null);
-    const result = await adapter.fetchProfessions!(
+    const result = await adapter.fetchProfessions(
       'Thrall',
       'area-52',
       'us',

--- a/api/src/plugins/wow-common/blizzard-character-sync.adapter.spec.ts
+++ b/api/src/plugins/wow-common/blizzard-character-sync.adapter.spec.ts
@@ -8,6 +8,7 @@ let mockBlizzardService: {
   fetchCharacterProfile: jest.Mock;
   fetchCharacterSpecializations: jest.Mock;
   fetchCharacterEquipment: jest.Mock;
+  fetchCharacterProfessions: jest.Mock;
 };
 
 async function setupEach() {
@@ -15,6 +16,7 @@ async function setupEach() {
     fetchCharacterProfile: jest.fn(),
     fetchCharacterSpecializations: jest.fn(),
     fetchCharacterEquipment: jest.fn(),
+    fetchCharacterProfessions: jest.fn(),
   };
   const module: TestingModule = await Test.createTestingModule({
     providers: [
@@ -144,5 +146,71 @@ describe('BlizzardCharacterSyncAdapter — fetchEquipment', () => {
     );
     expect(result.equippedItemLevel).toBeNull();
     expect(result.items).toEqual([]);
+  });
+});
+
+/**
+ * ROK-1130 — fetchProfessions adapter tests.
+ *
+ * Architect §3 (mandatory correction): the adapter must NOT fall back to
+ * empty arrays. It is a thin pass-through to BlizzardService. The
+ * orchestrator's `if (professions !== null)` check is the *only* source
+ * of "skip the column" behavior. Returning empty arrays here would erase
+ * the 5xx-skip signal before the orchestrator ever saw it.
+ */
+describe('BlizzardCharacterSyncAdapter — fetchProfessions', () => {
+  beforeEach(() => setupEach());
+
+  it('should delegate to BlizzardService with apiNamespacePrefix', async () => {
+    const mockProfessions = {
+      primary: [
+        {
+          id: 197,
+          name: 'Tailoring',
+          slug: 'tailoring',
+          skillLevel: 450,
+          maxSkillLevel: 450,
+          tiers: [],
+        },
+      ],
+      secondary: [],
+      syncedAt: '2026-04-28T00:00:00.000Z',
+    };
+    mockBlizzardService.fetchCharacterProfessions.mockResolvedValue(
+      mockProfessions,
+    );
+    const result = await adapter.fetchProfessions!(
+      'Thrall',
+      'area-52',
+      'us',
+      'classic1x',
+    );
+    expect(result).toBe(mockProfessions);
+    expect(
+      mockBlizzardService.fetchCharacterProfessions,
+    ).toHaveBeenCalledWith('Thrall', 'area-52', 'us', 'classic1x');
+  });
+
+  it('should pass null gameVariant through when retail (no variant)', async () => {
+    mockBlizzardService.fetchCharacterProfessions.mockResolvedValue({
+      primary: [],
+      secondary: [],
+      syncedAt: '2026-04-28T00:00:00.000Z',
+    });
+    await adapter.fetchProfessions!('Thrall', 'area-52', 'us');
+    expect(
+      mockBlizzardService.fetchCharacterProfessions,
+    ).toHaveBeenCalledWith('Thrall', 'area-52', 'us', null);
+  });
+
+  it('should pass through null when BlizzardService returns null (no fallback — architect §3)', async () => {
+    mockBlizzardService.fetchCharacterProfessions.mockResolvedValue(null);
+    const result = await adapter.fetchProfessions!(
+      'Thrall',
+      'area-52',
+      'us',
+      'classic1x',
+    );
+    expect(result).toBeNull();
   });
 });

--- a/api/src/plugins/wow-common/blizzard-character-sync.adapter.ts
+++ b/api/src/plugins/wow-common/blizzard-character-sync.adapter.ts
@@ -5,6 +5,7 @@ import type {
   ExternalCharacterProfile,
   ExternalInferredSpecialization,
   ExternalCharacterEquipment,
+  ExternalCharacterProfessions,
 } from '../plugin-host/extension-types';
 import { ALL_WOW_GAME_SLUGS } from './manifest';
 
@@ -73,6 +74,25 @@ export class BlizzardCharacterSyncAdapter implements CharacterSyncAdapter {
         items: [],
         syncedAt: new Date().toISOString(),
       }
+    );
+  }
+
+  /**
+   * Thin pass-through: returns the service result as-is, including null
+   * (architect §3 — orchestrator's `if (professions !== null)` is the only
+   * source of "skip the column" behavior; do NOT fall back to empty arrays).
+   */
+  async fetchProfessions(
+    name: string,
+    realm: string,
+    region: string,
+    gameVariant?: string | null,
+  ): Promise<ExternalCharacterProfessions | null> {
+    return this.blizzardService.fetchCharacterProfessions(
+      name,
+      realm,
+      region,
+      gameVariant ?? null,
     );
   }
 }

--- a/api/src/plugins/wow-common/blizzard-professions.helpers.spec.ts
+++ b/api/src/plugins/wow-common/blizzard-professions.helpers.spec.ts
@@ -60,7 +60,7 @@ function mockFetchOnce(status: number, body: unknown) {
   global.fetch = jest.fn().mockResolvedValueOnce({
     ok: status >= 200 && status < 300,
     status,
-    json: async () => body,
+    json: () => Promise.resolve(body),
   } as Response) as unknown as typeof fetch;
 }
 

--- a/api/src/plugins/wow-common/blizzard-professions.helpers.spec.ts
+++ b/api/src/plugins/wow-common/blizzard-professions.helpers.spec.ts
@@ -159,7 +159,9 @@ describe('fetchCharacterProfessions — graceful handling', () => {
   it('returns null when fetch throws (network/timeout)', async () => {
     global.fetch = jest
       .fn()
-      .mockRejectedValueOnce(new Error('ECONNRESET')) as unknown as typeof fetch;
+      .mockRejectedValueOnce(
+        new Error('ECONNRESET'),
+      ) as unknown as typeof fetch;
 
     const result = await fetchCharacterProfessions(
       'X',

--- a/api/src/plugins/wow-common/blizzard-professions.helpers.spec.ts
+++ b/api/src/plugins/wow-common/blizzard-professions.helpers.spec.ts
@@ -1,0 +1,211 @@
+/**
+ * Unit tests for blizzard-professions.helpers (ROK-1130).
+ *
+ * Mirrors the structural template of blizzard-equipment.helpers (parser +
+ * single fetch + 404-vs-5xx handling). Architect §3 requires the helper
+ * to return a normalized payload for 404 (`{ primary: [], secondary: [], syncedAt }`)
+ * and `null` for any other failure (5xx, network) — the orchestrator uses
+ * the null signal to leave prior column values alone.
+ */
+import { fetchCharacterProfessions } from './blizzard-professions.helpers';
+
+const RETAIL_PAYLOAD = {
+  _links: {},
+  character: { name: 'thrall' },
+  primaries: [
+    {
+      profession: { name: 'Tailoring', id: 197 },
+      skill_points: 450,
+      max_skill_points: 450,
+      specializations: [
+        {
+          specialization_name: 'Spellfire Tailoring',
+          specialization_id: 12,
+          points_spent: 25,
+        },
+      ],
+      tiers: [
+        {
+          tier: { name: 'Dragon Isles Tailoring', id: 2823 },
+          skill_points: 100,
+          max_skill_points: 100,
+          known_recipes: [{ name: 'Frostweave Bag', id: 1 }],
+        },
+      ],
+    },
+  ],
+  secondaries: [
+    {
+      profession: { name: 'Cooking', id: 185 },
+      skill_points: 150,
+      max_skill_points: 150,
+    },
+  ],
+};
+
+const fakeLogger = {
+  warn: jest.fn(),
+  log: jest.fn(),
+  debug: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.restoreAllMocks();
+  fakeLogger.warn.mockClear();
+  fakeLogger.log.mockClear();
+  fakeLogger.debug.mockClear();
+});
+
+function mockFetchOnce(status: number, body: unknown) {
+  global.fetch = jest.fn().mockResolvedValueOnce({
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response) as unknown as typeof fetch;
+}
+
+describe('fetchCharacterProfessions — happy path', () => {
+  it('parses a retail payload into the normalized shape', async () => {
+    mockFetchOnce(200, RETAIL_PAYLOAD);
+
+    const result = await fetchCharacterProfessions(
+      'Thrall',
+      'Area 52',
+      'us',
+      null,
+      'token-1',
+      fakeLogger,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.primary).toHaveLength(1);
+    expect(result!.primary[0].name).toBe('Tailoring');
+    expect(result!.primary[0].id).toBe(197);
+    expect(result!.primary[0].slug).toBe('tailoring');
+    expect(result!.primary[0].skillLevel).toBe(450);
+    expect(result!.primary[0].maxSkillLevel).toBe(450);
+    expect(result!.primary[0].tiers).toHaveLength(1);
+    expect(result!.primary[0].tiers[0].name).toBe('Dragon Isles Tailoring');
+    expect(result!.primary[0].tiers[0].id).toBe(2823);
+    expect(result!.primary[0].tiers[0].skillLevel).toBe(100);
+    expect(result!.primary[0].tiers[0].maxSkillLevel).toBe(100);
+    expect(result!.secondary).toHaveLength(1);
+    expect(result!.secondary[0].name).toBe('Cooking');
+    expect(result!.secondary[0].slug).toBe('cooking');
+    expect(result!.secondary[0].tiers).toEqual([]);
+    expect(typeof result!.syncedAt).toBe('string');
+    expect(result!.syncedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('derives slugs by lowercasing and replacing spaces with hyphens', async () => {
+    mockFetchOnce(200, {
+      primaries: [
+        {
+          profession: { name: 'Dragon Isles Mining', id: 999 },
+          skill_points: 10,
+          max_skill_points: 100,
+          tiers: [],
+        },
+      ],
+      secondaries: [],
+    });
+    const result = await fetchCharacterProfessions(
+      'X',
+      'Y',
+      'us',
+      null,
+      't',
+      fakeLogger,
+    );
+    expect(result!.primary[0].slug).toBe('dragon-isles-mining');
+  });
+});
+
+describe('fetchCharacterProfessions — graceful handling', () => {
+  it('returns empty arrays + syncedAt on 404 (no throw)', async () => {
+    mockFetchOnce(404, { code: 404, detail: 'not found' });
+
+    const result = await fetchCharacterProfessions(
+      'Ghost',
+      'Area 52',
+      'us',
+      null,
+      'token-1',
+      fakeLogger,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.primary).toEqual([]);
+    expect(result!.secondary).toEqual([]);
+    expect(typeof result!.syncedAt).toBe('string');
+  });
+
+  it('returns null on 500 (signals orchestrator to leave prior value alone)', async () => {
+    mockFetchOnce(500, { error: 'upstream' });
+
+    const result = await fetchCharacterProfessions(
+      'X',
+      'Y',
+      'us',
+      null,
+      't',
+      fakeLogger,
+    );
+
+    expect(result).toBeNull();
+    expect(fakeLogger.warn).toHaveBeenCalled();
+  });
+
+  it('returns null when fetch throws (network/timeout)', async () => {
+    global.fetch = jest
+      .fn()
+      .mockRejectedValueOnce(new Error('ECONNRESET')) as unknown as typeof fetch;
+
+    const result = await fetchCharacterProfessions(
+      'X',
+      'Y',
+      'us',
+      null,
+      't',
+      fakeLogger,
+    );
+
+    expect(result).toBeNull();
+    expect(fakeLogger.warn).toHaveBeenCalled();
+  });
+
+  it('treats missing primaries/secondaries arrays as empty', async () => {
+    mockFetchOnce(200, {});
+
+    const result = await fetchCharacterProfessions(
+      'X',
+      'Y',
+      'us',
+      null,
+      't',
+      fakeLogger,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.primary).toEqual([]);
+    expect(result!.secondary).toEqual([]);
+  });
+
+  it('drops top-level specializations array (only nested tiers persisted)', async () => {
+    mockFetchOnce(200, RETAIL_PAYLOAD);
+
+    const result = await fetchCharacterProfessions(
+      'Thrall',
+      'Area 52',
+      'us',
+      null,
+      'token-1',
+      fakeLogger,
+    );
+
+    // The output type does not expose a `specializations` key on entries.
+    expect(result!.primary[0]).not.toHaveProperty('specializations');
+    // And known_recipes must NOT leak through onto tiers.
+    expect(result!.primary[0].tiers[0]).not.toHaveProperty('known_recipes');
+  });
+});

--- a/api/src/plugins/wow-common/blizzard-professions.helpers.spec.ts
+++ b/api/src/plugins/wow-common/blizzard-professions.helpers.spec.ts
@@ -122,7 +122,7 @@ describe('fetchCharacterProfessions — happy path', () => {
 });
 
 describe('fetchCharacterProfessions — graceful handling', () => {
-  it('returns empty arrays + syncedAt on 404 (no throw)', async () => {
+  it('returns null on 404 (leaves prior column / manual entry alone)', async () => {
     mockFetchOnce(404, { code: 404, detail: 'not found' });
 
     const result = await fetchCharacterProfessions(
@@ -134,10 +134,7 @@ describe('fetchCharacterProfessions — graceful handling', () => {
       fakeLogger,
     );
 
-    expect(result).not.toBeNull();
-    expect(result!.primary).toEqual([]);
-    expect(result!.secondary).toEqual([]);
-    expect(typeof result!.syncedAt).toBe('string');
+    expect(result).toBeNull();
   });
 
   it('returns null on 500 (signals orchestrator to leave prior value alone)', async () => {
@@ -176,7 +173,7 @@ describe('fetchCharacterProfessions — graceful handling', () => {
     expect(fakeLogger.warn).toHaveBeenCalled();
   });
 
-  it('treats missing primaries/secondaries arrays as empty', async () => {
+  it('returns null when 200 OK but parsed primary AND secondary are empty (no real data — manual entry preserved)', async () => {
     mockFetchOnce(200, {});
 
     const result = await fetchCharacterProfessions(
@@ -188,9 +185,22 @@ describe('fetchCharacterProfessions — graceful handling', () => {
       fakeLogger,
     );
 
-    expect(result).not.toBeNull();
-    expect(result!.primary).toEqual([]);
-    expect(result!.secondary).toEqual([]);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when 200 OK but explicit empty primaries+secondaries arrays', async () => {
+    mockFetchOnce(200, { primaries: [], secondaries: [] });
+
+    const result = await fetchCharacterProfessions(
+      'X',
+      'Y',
+      'us',
+      null,
+      't',
+      fakeLogger,
+    );
+
+    expect(result).toBeNull();
   });
 
   it('drops top-level specializations array (only nested tiers persisted)', async () => {
@@ -238,8 +248,8 @@ describe('fetchCharacterProfessions — Classic short-circuit', () => {
     },
   );
 
-  it('does NOT short-circuit for retail (apiNamespacePrefix=null)', async () => {
-    mockFetchOnce(200, { primaries: [], secondaries: [] });
+  it('does NOT short-circuit for retail (apiNamespacePrefix=null) — actually hits the API', async () => {
+    mockFetchOnce(200, RETAIL_PAYLOAD);
 
     const result = await fetchCharacterProfessions(
       'Thrall',
@@ -251,7 +261,6 @@ describe('fetchCharacterProfessions — Classic short-circuit', () => {
     );
 
     expect(result).not.toBeNull();
-    expect(result!.primary).toEqual([]);
-    expect(result!.secondary).toEqual([]);
+    expect(result!.primary.length).toBeGreaterThan(0);
   });
 });

--- a/api/src/plugins/wow-common/blizzard-professions.helpers.spec.ts
+++ b/api/src/plugins/wow-common/blizzard-professions.helpers.spec.ts
@@ -211,3 +211,47 @@ describe('fetchCharacterProfessions — graceful handling', () => {
     expect(result!.primary[0].tiers[0]).not.toHaveProperty('known_recipes');
   });
 });
+
+describe('fetchCharacterProfessions — Classic short-circuit', () => {
+  it.each([
+    ['classicann', 'Anniversary'],
+    ['classic1x', 'Classic 1x'],
+    ['classic', 'Classic'],
+    ['classicwrath', 'Wrath Classic'],
+  ])(
+    'returns null without making an HTTP request for %s namespace (Blizzard %s API does not expose /professions)',
+    async (prefix) => {
+      const fetchSpy = jest.fn();
+      global.fetch = fetchSpy as unknown as typeof fetch;
+
+      const result = await fetchCharacterProfessions(
+        'Roknua',
+        'Dreamscythe',
+        'us',
+        prefix,
+        'token-1',
+        fakeLogger,
+      );
+
+      expect(result).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    },
+  );
+
+  it('does NOT short-circuit for retail (apiNamespacePrefix=null)', async () => {
+    mockFetchOnce(200, { primaries: [], secondaries: [] });
+
+    const result = await fetchCharacterProfessions(
+      'Thrall',
+      'Area 52',
+      'us',
+      null,
+      'token-1',
+      fakeLogger,
+    );
+
+    expect(result).not.toBeNull();
+    expect(result!.primary).toEqual([]);
+    expect(result!.secondary).toEqual([]);
+  });
+});

--- a/api/src/plugins/wow-common/blizzard-professions.helpers.ts
+++ b/api/src/plugins/wow-common/blizzard-professions.helpers.ts
@@ -88,6 +88,11 @@ function parseProfessionsResponse(json: unknown): ExternalCharacterProfessions {
   };
 }
 
+/** True when the parsed response has no primary or secondary entries. */
+function hasNoEntries(p: ExternalCharacterProfessions): boolean {
+  return p.primary.length === 0 && p.secondary.length === 0;
+}
+
 /** Issue the request and translate HTTP states into the contract types. */
 async function requestProfessions(
   url: string,
@@ -96,26 +101,18 @@ async function requestProfessions(
   realmSlug: string,
   logger: Logger,
 ): Promise<ExternalCharacterProfessions | null> {
-  const res = await fetch(url, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
+  const res = await fetch(url, { headers: { Authorization: `Bearer ${token}` } });
   if (res.status === 404) {
-    logger.debug?.(
-      `Professions 404 for ${charName}-${realmSlug} — leaving prior value alone`,
-    );
+    logger.debug?.(`Professions 404 for ${charName}-${realmSlug} — leaving prior value alone`);
     return null;
   }
   if (!res.ok) {
-    logger.warn(
-      `Professions fetch failed for ${charName}-${realmSlug}: ${res.status}`,
-    );
+    logger.warn(`Professions fetch failed for ${charName}-${realmSlug}: ${res.status}`);
     return null;
   }
   const parsed = parseProfessionsResponse(await res.json());
-  if (parsed.primary.length === 0 && parsed.secondary.length === 0) {
-    logger.debug?.(
-      `Professions empty for ${charName}-${realmSlug} — leaving prior value alone`,
-    );
+  if (hasNoEntries(parsed)) {
+    logger.debug?.(`Professions empty for ${charName}-${realmSlug} — leaving prior value alone`);
     return null;
   }
   return parsed;

--- a/api/src/plugins/wow-common/blizzard-professions.helpers.ts
+++ b/api/src/plugins/wow-common/blizzard-professions.helpers.ts
@@ -1,0 +1,135 @@
+/**
+ * Profession fetching helpers for BlizzardService.
+ * Mirrors blizzard-equipment.helpers.ts (ROK-1130).
+ *
+ * Edge-case posture (architect §3):
+ *   404 → return `{ primary: [], secondary: [], syncedAt: now }`
+ *   non-OK status / network throw → return `null` (orchestrator leaves prior column alone)
+ */
+import type {
+  ExternalCharacterProfessions,
+  ExternalProfessionEntry,
+  ExternalProfessionTier,
+} from '../plugin-host/extension-types';
+import { buildCharacterParams } from './blizzard-character.helpers';
+
+type Logger = {
+  warn: (msg: string) => void;
+  log: (msg: string) => void;
+  debug?: (msg: string) => void;
+};
+
+interface RawProfessionTier {
+  tier?: { id?: number; name?: string };
+  skill_points?: number;
+  max_skill_points?: number;
+}
+
+interface RawProfessionEntry {
+  profession?: { id?: number; name?: string };
+  skill_points?: number;
+  max_skill_points?: number;
+  tiers?: RawProfessionTier[];
+}
+
+interface RawProfessionsResponse {
+  primaries?: RawProfessionEntry[];
+  secondaries?: RawProfessionEntry[];
+}
+
+/** Slugify a profession or tier name (lowercase + spaces → '-'). */
+function slugify(name: string): string {
+  return name.toLowerCase().replace(/\s+/g, '-');
+}
+
+/** Map a raw tier into the normalized shape (drops known_recipes). */
+function mapProfessionTier(raw: RawProfessionTier): ExternalProfessionTier {
+  return {
+    id: raw.tier?.id ?? 0,
+    name: raw.tier?.name ?? '',
+    skillLevel: raw.skill_points ?? 0,
+    maxSkillLevel: raw.max_skill_points ?? 0,
+  };
+}
+
+/** Map a raw entry (primary or secondary) into the normalized shape. */
+function mapProfessionEntry(raw: RawProfessionEntry): ExternalProfessionEntry {
+  const name = raw.profession?.name ?? '';
+  return {
+    id: raw.profession?.id ?? 0,
+    name,
+    slug: slugify(name),
+    skillLevel: raw.skill_points ?? 0,
+    maxSkillLevel: raw.max_skill_points ?? 0,
+    tiers: (raw.tiers ?? []).map(mapProfessionTier),
+  };
+}
+
+/** Parse the raw professions JSON into the normalized contract shape. */
+function parseProfessionsResponse(json: unknown): ExternalCharacterProfessions {
+  const raw = (json ?? {}) as RawProfessionsResponse;
+  return {
+    primary: (raw.primaries ?? []).map(mapProfessionEntry),
+    secondary: (raw.secondaries ?? []).map(mapProfessionEntry),
+    syncedAt: new Date().toISOString(),
+  };
+}
+
+/** Build the empty-arrays payload returned for graceful 404s. */
+function emptyProfessions(): ExternalCharacterProfessions {
+  return {
+    primary: [],
+    secondary: [],
+    syncedAt: new Date().toISOString(),
+  };
+}
+
+/** Issue the request and translate HTTP states into the contract types. */
+async function requestProfessions(
+  url: string,
+  token: string,
+  charName: string,
+  realmSlug: string,
+  logger: Logger,
+): Promise<ExternalCharacterProfessions | null> {
+  const res = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (res.status === 404) {
+    logger.debug?.(
+      `Professions 404 for ${charName}-${realmSlug} — empty payload`,
+    );
+    return emptyProfessions();
+  }
+  if (!res.ok) {
+    logger.warn(
+      `Professions fetch failed for ${charName}-${realmSlug}: ${res.status}`,
+    );
+    return null;
+  }
+  return parseProfessionsResponse(await res.json());
+}
+
+/** Fetch a WoW character's professions from the Blizzard API. */
+export async function fetchCharacterProfessions(
+  name: string,
+  realm: string,
+  region: string,
+  apiNamespacePrefix: string | null,
+  token: string,
+  logger: Logger,
+): Promise<ExternalCharacterProfessions | null> {
+  const { realmSlug, charName, namespace, baseUrl } = buildCharacterParams(
+    name,
+    realm,
+    region,
+    apiNamespacePrefix,
+  );
+  const url = `${baseUrl}/profile/wow/character/${realmSlug}/${charName}/professions?namespace=${namespace}&locale=en_US`;
+  try {
+    return await requestProfessions(url, token, charName, realmSlug, logger);
+  } catch (err) {
+    logger.warn(`Failed to fetch character professions: ${err}`);
+    return null;
+  }
+}

--- a/api/src/plugins/wow-common/blizzard-professions.helpers.ts
+++ b/api/src/plugins/wow-common/blizzard-professions.helpers.ts
@@ -3,8 +3,11 @@
  * Mirrors blizzard-equipment.helpers.ts (ROK-1130).
  *
  * Edge-case posture (architect §3):
- *   404 → return `{ primary: [], secondary: [], syncedAt: now }`
- *   non-OK status / network throw → return `null` (orchestrator leaves prior column alone)
+ *   Classic-stack namespace → short-circuit to `null` (Blizzard does not
+ *     expose `/professions` for any classic Profile API namespace; verified
+ *     2026-04-28 against profile-classicann-us / -classic1x-us / -classic-us).
+ *   404 (retail) → `{ primary: [], secondary: [], syncedAt: now }`
+ *   non-OK status / network throw → `null` (orchestrator leaves prior column alone)
  */
 import type {
   ExternalCharacterProfessions,
@@ -119,6 +122,12 @@ export async function fetchCharacterProfessions(
   token: string,
   logger: Logger,
 ): Promise<ExternalCharacterProfessions | null> {
+  if (apiNamespacePrefix !== null) {
+    logger.debug?.(
+      `Skipping professions fetch for ${name}-${realm} — Classic Profile API does not expose /professions`,
+    );
+    return null;
+  }
   const { realmSlug, charName, namespace, baseUrl } = buildCharacterParams(
     name,
     realm,

--- a/api/src/plugins/wow-common/blizzard-professions.helpers.ts
+++ b/api/src/plugins/wow-common/blizzard-professions.helpers.ts
@@ -2,12 +2,22 @@
  * Profession fetching helpers for BlizzardService.
  * Mirrors blizzard-equipment.helpers.ts (ROK-1130).
  *
- * Edge-case posture (architect §3):
- *   Classic-stack namespace → short-circuit to `null` (Blizzard does not
- *     expose `/professions` for any classic Profile API namespace; verified
- *     2026-04-28 against profile-classicann-us / -classic1x-us / -classic-us).
- *   404 (retail) → `{ primary: [], secondary: [], syncedAt: now }`
- *   non-OK status / network throw → `null` (orchestrator leaves prior column alone)
+ * Edge-case posture (architect §3 + operator directive):
+ *   The helper returns `null` whenever there is no actionable profession
+ *   data. The orchestrator's `if (professions !== null)` check is the only
+ *   write path, so a `null` return guarantees the existing column value
+ *   (e.g. a player's manual entry) is left untouched. Cases that produce
+ *   `null`:
+ *     • Classic-stack namespace (Blizzard Profile API does not expose
+ *       /professions for any classic flavor; verified 2026-04-28 against
+ *       profile-classicann-us / -classic1x-us / -classic-us).
+ *     • 404 from the endpoint.
+ *     • Non-OK status (5xx, timeout, network throw).
+ *     • 200 OK but the parsed response has zero primary AND zero
+ *       secondary entries — Blizzard reporting "no professions" is not
+ *       enough to clobber a manual entry.
+ *   Only a 200 OK with at least one actual primary or secondary entry
+ *   produces a non-null payload that the orchestrator writes to the DB.
  */
 import type {
   ExternalCharacterProfessions,
@@ -78,15 +88,6 @@ function parseProfessionsResponse(json: unknown): ExternalCharacterProfessions {
   };
 }
 
-/** Build the empty-arrays payload returned for graceful 404s. */
-function emptyProfessions(): ExternalCharacterProfessions {
-  return {
-    primary: [],
-    secondary: [],
-    syncedAt: new Date().toISOString(),
-  };
-}
-
 /** Issue the request and translate HTTP states into the contract types. */
 async function requestProfessions(
   url: string,
@@ -100,9 +101,9 @@ async function requestProfessions(
   });
   if (res.status === 404) {
     logger.debug?.(
-      `Professions 404 for ${charName}-${realmSlug} — empty payload`,
+      `Professions 404 for ${charName}-${realmSlug} — leaving prior value alone`,
     );
-    return emptyProfessions();
+    return null;
   }
   if (!res.ok) {
     logger.warn(
@@ -110,7 +111,14 @@ async function requestProfessions(
     );
     return null;
   }
-  return parseProfessionsResponse(await res.json());
+  const parsed = parseProfessionsResponse(await res.json());
+  if (parsed.primary.length === 0 && parsed.secondary.length === 0) {
+    logger.debug?.(
+      `Professions empty for ${charName}-${realmSlug} — leaving prior value alone`,
+    );
+    return null;
+  }
+  return parsed;
 }
 
 /** Fetch a WoW character's professions from the Blizzard API. */

--- a/api/src/plugins/wow-common/blizzard.service.ts
+++ b/api/src/plugins/wow-common/blizzard.service.ts
@@ -24,8 +24,10 @@ import {
 import { buildCharacterParams } from './blizzard-character.helpers';
 import * as profileH from './blizzard-profile.helpers';
 import * as equipH from './blizzard-equipment.helpers';
+import * as profH from './blizzard-professions.helpers';
 import * as specH from './blizzard-spec.helpers';
 import * as instH from './blizzard-instance.helpers';
+import type { ExternalCharacterProfessions } from '../plugin-host/extension-types';
 
 // Re-export types for backward compatibility
 export type {
@@ -107,6 +109,26 @@ export class BlizzardService {
   ): Promise<BlizzardCharacterEquipment | null> {
     const token = await this.getAccessToken(region);
     return equipH.fetchCharacterEquipment(
+      name,
+      realm,
+      region,
+      apiNamespacePrefix,
+      token,
+      this.logger,
+    );
+  }
+
+  /** Fetch character professions from the Blizzard API.
+   * @param apiNamespacePrefix - From the game row (null for retail)
+   */
+  async fetchCharacterProfessions(
+    name: string,
+    realm: string,
+    region: string,
+    apiNamespacePrefix: string | null = null,
+  ): Promise<ExternalCharacterProfessions | null> {
+    const token = await this.getAccessToken(region);
+    return profH.fetchCharacterProfessions(
       name,
       realm,
       region,

--- a/packages/contract/src/characters.schema.ts
+++ b/packages/contract/src/characters.schema.ts
@@ -67,6 +67,39 @@ export const CharacterEquipmentSchema = z.object({
 export type CharacterEquipmentDto = z.infer<typeof CharacterEquipmentSchema>;
 
 // ==========================================
+// Profession Types (Character Detail Page)
+// ==========================================
+
+export const ProfessionTierSchema = z.object({
+    id: z.number().int(),
+    name: z.string(),
+    skillLevel: z.number().int(),
+    maxSkillLevel: z.number().int(),
+});
+
+export type ProfessionTierDto = z.infer<typeof ProfessionTierSchema>;
+
+export const ProfessionEntrySchema = z.object({
+    id: z.number().int(),
+    name: z.string(),
+    /** Lowercased name with spaces replaced by '-' (e.g. 'tailoring', 'inscription') */
+    slug: z.string(),
+    skillLevel: z.number().int(),
+    maxSkillLevel: z.number().int(),
+    tiers: z.array(ProfessionTierSchema),
+});
+
+export type ProfessionEntryDto = z.infer<typeof ProfessionEntrySchema>;
+
+export const CharacterProfessionsSchema = z.object({
+    primary: z.array(ProfessionEntrySchema),
+    secondary: z.array(ProfessionEntrySchema),
+    syncedAt: z.string().datetime(),
+});
+
+export type CharacterProfessionsDto = z.infer<typeof CharacterProfessionsSchema>;
+
+// ==========================================
 // Character DTOs
 // ==========================================
 
@@ -99,6 +132,7 @@ export const CharacterSchema = z.object({
     gameVariant: z.string().max(30).nullable(),
     equipment: CharacterEquipmentSchema.nullable(),
     talents: z.unknown().nullable(),
+    professions: CharacterProfessionsSchema.nullable(),
     /** Cached enrichment data from third-party APIs (ROK-269) */
     enrichments: z.array(z.object({
         enricherKey: z.string(),

--- a/packages/contract/src/characters.schema.ts
+++ b/packages/contract/src/characters.schema.ts
@@ -188,6 +188,8 @@ export const UpdateCharacterSchema = z.object({
     itemLevel: z.number().int().positive().nullable().optional(),
     avatarUrl: z.string().url().nullable().optional(),
     displayOrder: z.number().int().optional(),
+    /** ROK-1130: manual profession entry (Classic players, retail overrides). */
+    professions: CharacterProfessionsSchema.nullable().optional(),
 });
 
 export type UpdateCharacterDto = z.infer<typeof UpdateCharacterSchema>;

--- a/packages/contract/src/signups.schema.ts
+++ b/packages/contract/src/signups.schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { CharacterProfessionsSchema } from './characters.schema.js';
 
 // ============================================================
 // Signup Schemas (FR-006 + ROK-131 Character Confirmation + ROK-137 Interactive Buttons)
@@ -45,6 +46,8 @@ export const SignupCharacterSchema = z.object({
     avatarUrl: z.string().nullable(),
     race: z.string().nullable().optional(),
     faction: z.enum(['alliance', 'horde']).nullable().optional(),
+    /** ROK-1130: profession data for the roster meta-row pills. */
+    professions: CharacterProfessionsSchema.nullable().optional(),
 });
 
 export type SignupCharacterDto = z.infer<typeof SignupCharacterSchema>;

--- a/scripts/smoke/character-detail.smoke.spec.ts
+++ b/scripts/smoke/character-detail.smoke.spec.ts
@@ -36,6 +36,19 @@ interface SeedCharacter {
     race: string | null;
     level: number | null;
     itemLevel: number | null;
+    professions?: {
+        primary: Array<{
+            name: string;
+            skillLevel: number;
+            maxSkillLevel: number;
+        }>;
+        secondary: Array<{
+            name: string;
+            skillLevel: number;
+            maxSkillLevel: number;
+        }>;
+        syncedAt: string;
+    } | null;
 }
 
 /**
@@ -55,6 +68,33 @@ async function findCharacterWithMetadata(
     };
 
     return data.find((c) => c.class && c.level) ?? null;
+}
+
+/**
+ * ROK-1130 — find a seeded WoW character whose `professions` JSONB is
+ * populated (non-null + has at least one primary). Used by the
+ * professions-panel smoke test below.
+ */
+async function findCharacterWithProfessions(
+    token: string,
+): Promise<SeedCharacter | null> {
+    const res = await fetch(`${API_BASE}/users/me/characters`, {
+        headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!res.ok) return null;
+
+    const { data } = (await res.json()) as {
+        data: Array<SeedCharacter>;
+    };
+
+    return (
+        data.find(
+            (c) =>
+                c.professions != null &&
+                c.professions.primary &&
+                c.professions.primary.length > 0,
+        ) ?? null
+    );
 }
 
 test.describe('Character detail page', () => {
@@ -157,6 +197,52 @@ test.describe('Character detail page', () => {
         // The back button contains "Back" text
         await expect(
             page.getByRole('button', { name: 'Back', exact: true }),
+        ).toBeVisible({ timeout: 5_000 });
+    });
+
+    /**
+     * ROK-1130 (AC #13) — Professions panel renders when a synced WoW
+     * character has a non-null `professions` blob. Runs on both desktop
+     * and mobile projects (inherits from playwright.config.ts).
+     */
+    test('renders professions panel for a synced WoW character', async ({
+        page,
+    }) => {
+        const token = getTokenFromStorageState();
+        test.skip(!token, 'No admin token in storage state');
+
+        const profChar = await findCharacterWithProfessions(token!);
+        test.skip(
+            !profChar,
+            'No seeded WoW character with non-null professions',
+        );
+
+        await page.goto(`/characters/${profChar!.id}`);
+
+        // Heading
+        await expect(
+            page.getByRole('heading', {
+                name: profChar!.name,
+                level: 1,
+            }),
+        ).toBeVisible({ timeout: 15_000 });
+
+        // Professions panel heading
+        await expect(
+            page.getByRole('heading', { name: 'Professions' }),
+        ).toBeVisible({ timeout: 10_000 });
+
+        // First primary profession name + its skill text render
+        const firstPrimary = profChar!.professions!.primary[0];
+        await expect(
+            page.getByText(firstPrimary.name, { exact: true }).first(),
+        ).toBeVisible({ timeout: 5_000 });
+        await expect(
+            page
+                .getByText(
+                    `${firstPrimary.skillLevel}/${firstPrimary.maxSkillLevel}`,
+                )
+                .first(),
         ).toBeVisible({ timeout: 5_000 });
     });
 });

--- a/web/src/components/characters/character-card-compact.tsx
+++ b/web/src/components/characters/character-card-compact.tsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom';
-import type { CharacterDto } from '@raid-ledger/contract';
+import type { CharacterDto, CharacterProfessionsDto } from '@raid-ledger/contract';
 import { getClassIconUrl } from '../../plugins/wow/lib/class-icons';
+import { ProfessionBadges } from '../../plugins/wow/components/ProfessionBadges';
 
 const FACTION_STYLES: Record<string, string> = {
     alliance: 'bg-blue-500/20 text-blue-400 border-blue-500/30',
@@ -35,6 +36,8 @@ interface CharacterCardCompactProps {
     role?: string | null;
     itemLevel?: number | null;
     isMain?: boolean;
+    /** ROK-1130: profession data threaded into the meta row. */
+    professions?: CharacterProfessionsDto | null;
     /** Visual size variant: 'default' for standard, 'sm' for compact/onboarding. */
     size?: 'default' | 'sm';
 }
@@ -52,6 +55,7 @@ interface ResolvedChar {
     level?: number | null; race?: string | null; charClass?: string | null;
     spec?: string | null; role?: string | null; itemLevel?: number | null;
     isMain?: boolean; variantLabel: string | null;
+    professions?: CharacterProfessionsDto | null;
 }
 
 function resolveCharProps(props: CharacterCardCompactProps): ResolvedChar {
@@ -64,6 +68,7 @@ function resolveCharProps(props: CharacterCardCompactProps): ResolvedChar {
         role: c?.effectiveRole ?? props.role, itemLevel: c?.itemLevel ?? props.itemLevel,
         isMain: c?.isMain ?? props.isMain,
         variantLabel: c?.gameVariant ? VARIANT_LABELS[c.gameVariant] : null,
+        professions: c?.professions ?? props.professions ?? null,
     };
 }
 
@@ -87,9 +92,10 @@ function NameRow({ charName, isMain, faction, variantLabel, textSize }: {
     );
 }
 
-function MetadataRow({ level, race, charClass, spec, role, itemLevel, textSize }: {
+function MetadataRow({ level, race, charClass, spec, role, itemLevel, professions, textSize }: {
     level?: number | null; race?: string | null; charClass?: string | null;
-    spec?: string | null; role?: string | null; itemLevel?: number | null; textSize: string;
+    spec?: string | null; role?: string | null; itemLevel?: number | null;
+    professions?: CharacterProfessionsDto | null; textSize: string;
 }) {
     return (
         <div className={`flex items-center gap-1.5 ${textSize} text-muted flex-wrap`}>
@@ -105,6 +111,7 @@ function MetadataRow({ level, race, charClass, spec, role, itemLevel, textSize }
             {spec && <span className="truncate max-w-[80px] sm:max-w-none">• {spec}</span>}
             {role && <span className={`px-1.5 py-0.5 rounded text-xs text-foreground flex-shrink-0 ${ROLE_COLORS[role] ?? 'bg-faint'}`}>{role.toUpperCase()}</span>}
             {itemLevel != null && itemLevel > 0 && <><span>•</span><span className="text-purple-400 whitespace-nowrap">{itemLevel} iLvl</span></>}
+            <ProfessionBadges professions={professions ?? null} separator="•" />
         </div>
     );
 }
@@ -120,7 +127,7 @@ export function CharacterCardCompact(props: CharacterCardCompactProps) {
             <CharacterAvatar avatarUrl={c.avatarUrl} charName={c.charName} size={isSm ? 'w-8 h-8' : 'w-10 h-10'} />
             <div className="min-w-0 overflow-hidden">
                 <NameRow charName={c.charName} isMain={c.isMain} faction={c.faction} variantLabel={c.variantLabel} textSize={isSm ? 'text-sm' : ''} />
-                <MetadataRow level={c.level} race={c.race} charClass={c.charClass} spec={c.spec} role={c.role} itemLevel={c.itemLevel} textSize={isSm ? 'text-xs' : 'text-sm'} />
+                <MetadataRow level={c.level} race={c.race} charClass={c.charClass} spec={c.spec} role={c.role} itemLevel={c.itemLevel} professions={c.professions} textSize={isSm ? 'text-xs' : 'text-sm'} />
             </div>
         </Link>
     );

--- a/web/src/components/roster/SelectableCharacterCard.test.tsx
+++ b/web/src/components/roster/SelectableCharacterCard.test.tsx
@@ -1,0 +1,244 @@
+/**
+ * Vitest — SelectableCharacterCard (ROK-1130).
+ *
+ * Covers AC #7 (pills render with data), AC #8 (pills omit when null/empty),
+ * and AC #9 (no DOM regression when professions === null).
+ *
+ * AC #9 — architect §8 / brief mandatory correction #4:
+ *   The original AC called for a byte-identical snapshot baseline.
+ *   Because SelectableCharacterCard.test.tsx didn't exist on `main`, a
+ *   snapshot baseline captured on the same branch as the code change is
+ *   trivially self-satisfying. Replaced with a positive DOM assertion:
+ *     - queryByRole('img', { name: /profession/i }) returns null
+ *     - meta-row child count is unchanged from a control case (a card
+ *       with `professions === null` should match the same card before
+ *       <ProfessionBadges> was added — i.e. no extra nodes / no leading
+ *       separator).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { CharacterDto } from '@raid-ledger/contract';
+import { SelectableCharacterCard } from './SelectableCharacterCard';
+
+vi.mock('../../plugins/wow/lib/profession-icons', () => ({
+    getProfessionIconUrl: (slug: string | null | undefined) => {
+        if (slug === 'tailoring') return 'https://render.example/tailoring.jpg';
+        if (slug === 'cooking') return 'https://render.example/cooking.jpg';
+        return null;
+    },
+    professionNameToSlug: (name: string) =>
+        name.toLowerCase().replace(/\s+/g, '-'),
+}));
+
+vi.mock('../../plugins/wow/lib/class-icons', () => ({
+    getClassIconUrl: () => 'https://render.example/class.jpg',
+}));
+
+function createMockCharacter(
+    overrides: Partial<CharacterDto> = {},
+): CharacterDto {
+    return {
+        id: '00000000-0000-0000-0000-000000000001',
+        userId: 1,
+        gameId: 1,
+        name: 'Profsync',
+        realm: 'Area 52',
+        class: 'Mage',
+        spec: 'Frost',
+        role: 'dps',
+        roleOverride: null,
+        effectiveRole: 'dps',
+        isMain: true,
+        itemLevel: 480,
+        externalId: null,
+        avatarUrl: null,
+        renderUrl: null,
+        level: 80,
+        race: 'Gnome',
+        faction: 'alliance',
+        lastSyncedAt: '2026-04-28T00:00:00.000Z',
+        profileUrl: null,
+        region: 'us',
+        gameVariant: 'retail',
+        equipment: null,
+        talents: null,
+        professions: null,
+        displayOrder: 0,
+        createdAt: '2026-04-28T00:00:00.000Z',
+        updatedAt: '2026-04-28T00:00:00.000Z',
+        ...overrides,
+    };
+}
+
+const POPULATED_PROFESSIONS = {
+    primary: [
+        {
+            id: 197,
+            name: 'Tailoring',
+            slug: 'tailoring',
+            skillLevel: 450,
+            maxSkillLevel: 450,
+            tiers: [],
+        },
+    ],
+    secondary: [
+        {
+            id: 185,
+            name: 'Cooking',
+            slug: 'cooking',
+            skillLevel: 150,
+            maxSkillLevel: 150,
+            tiers: [],
+        },
+    ],
+    syncedAt: '2026-04-28T00:00:00.000Z',
+};
+
+function renderCard(character: CharacterDto) {
+    return render(
+        <SelectableCharacterCard
+            character={character}
+            isSelected={false}
+            onSelect={() => undefined}
+            isMain={false}
+        />,
+    );
+}
+
+/** Find the meta row (`level/class/spec/iLvl`) for a rendered card. */
+function getMetaRow(container: HTMLElement): HTMLElement {
+    const span = container.querySelector(
+        '.flex.items-center.gap-2.text-sm.text-muted',
+    );
+    if (!span) throw new Error('meta row not found');
+    return span as HTMLElement;
+}
+
+describe('SelectableCharacterCard — profession pills present (AC #7)', () => {
+    it('renders one pill per profession (primary first, then secondary)', () => {
+        const char = createMockCharacter({ professions: POPULATED_PROFESSIONS });
+        renderCard(char);
+        // Primary pill
+        const tailoringImg = screen.getByRole('img', { name: /tailoring/i });
+        expect(tailoringImg.getAttribute('src')).toContain('tailoring.jpg');
+        // Secondary pill
+        const cookingImg = screen.getByRole('img', { name: /cooking/i });
+        expect(cookingImg.getAttribute('src')).toContain('cooking.jpg');
+    });
+
+    it('uses the {name} {skill}/{max} tooltip format', () => {
+        const char = createMockCharacter({ professions: POPULATED_PROFESSIONS });
+        renderCard(char);
+        // Tailoring 450/450 must appear as a `title` somewhere in the meta row
+        const titledTailoring =
+            document.querySelector('[title="Tailoring 450/450"]') ||
+            document.querySelector("[title='Tailoring 450/450']");
+        expect(titledTailoring).not.toBeNull();
+        const titledCooking =
+            document.querySelector('[title="Cooking 150/150"]');
+        expect(titledCooking).not.toBeNull();
+    });
+
+    it('falls back to text-only when a profession icon URL is unavailable', () => {
+        const unknownProfessions = {
+            primary: [
+                {
+                    id: 999,
+                    name: 'Mystery Craft',
+                    slug: 'mystery-craft',
+                    skillLevel: 25,
+                    maxSkillLevel: 100,
+                    tiers: [],
+                },
+            ],
+            secondary: [],
+            syncedAt: '2026-04-28T00:00:00.000Z',
+        };
+        const char = createMockCharacter({ professions: unknownProfessions });
+        renderCard(char);
+        expect(
+            screen.queryByRole('img', { name: /mystery craft/i }),
+        ).toBeNull();
+        // Tooltip + text still renders so the user sees the data
+        expect(
+            document.querySelector('[title="Mystery Craft 25/100"]'),
+        ).not.toBeNull();
+    });
+});
+
+describe('SelectableCharacterCard — profession pills omitted (AC #8 + AC #9)', () => {
+    it('renders no profession DOM when professions === null AND populated card DOES render pills (composite — fails until dev wires ProfessionBadges)', () => {
+        const nullChar = createMockCharacter({ professions: null });
+        const { unmount } = renderCard(nullChar);
+        // Negative assertion (AC #8): no profession imgs when null.
+        expect(
+            screen.queryByRole('img', { name: /tailoring/i }),
+        ).toBeNull();
+        unmount();
+
+        // Positive counterpart (AC #7) — without this, the negative assertion
+        // would trivially pass before any code is written. This forces the
+        // suite to FAIL before dev wires <ProfessionBadges>.
+        const populated = createMockCharacter({
+            professions: POPULATED_PROFESSIONS,
+        });
+        renderCard(populated);
+        expect(
+            screen.getByRole('img', { name: /tailoring/i }),
+        ).not.toBeNull();
+    });
+
+    it('renders no profession DOM when both arrays are empty AND populated case still works (composite)', () => {
+        const empty = {
+            primary: [],
+            secondary: [],
+            syncedAt: '2026-04-28T00:00:00.000Z',
+        };
+        const emptyChar = createMockCharacter({ professions: empty });
+        const { unmount } = renderCard(emptyChar);
+        expect(
+            screen.queryByRole('img', { name: /profession/i }),
+        ).toBeNull();
+        unmount();
+
+        // Same TDD-anchor: ensures the negative assertion isn't trivially
+        // satisfied by missing component — populated case must produce DOM.
+        const populated = createMockCharacter({
+            professions: POPULATED_PROFESSIONS,
+        });
+        renderCard(populated);
+        expect(
+            screen.getByRole('img', { name: /cooking/i }),
+        ).not.toBeNull();
+    });
+
+    it('null professions has the same meta-row child count as a baseline card without the professions field (AC #9, architect §8)', () => {
+        // Baseline: a card whose CharacterDto has `professions: null`.
+        // After dev adds <ProfessionBadges>, the null branch must render
+        // NOTHING — no fragment, no <></>, no leading separator. We assert
+        // by counting child element nodes in the meta row.
+        const baseline = createMockCharacter({ professions: null });
+        const { container: baselineContainer } = renderCard(baseline);
+        const baselineMetaCount = getMetaRow(
+            baselineContainer,
+        ).childElementCount;
+
+        // Re-render: same character, same null professions. Must produce the
+        // exact same number of child nodes (idempotent — null branch is no-op).
+        const repeat = createMockCharacter({ professions: null });
+        const { container: repeatContainer } = renderCard(repeat);
+        const repeatMetaCount = getMetaRow(repeatContainer).childElementCount;
+        expect(repeatMetaCount).toBe(baselineMetaCount);
+
+        // Sanity: a populated card SHOULD have additional nodes (proves the
+        // baseline isn't trivially equal because both rendered nothing).
+        const populated = createMockCharacter({
+            professions: POPULATED_PROFESSIONS,
+        });
+        const { container: populatedContainer } = renderCard(populated);
+        const populatedMetaCount = getMetaRow(
+            populatedContainer,
+        ).childElementCount;
+        expect(populatedMetaCount).toBeGreaterThan(baselineMetaCount);
+    });
+});

--- a/web/src/components/roster/SelectableCharacterCard.tsx
+++ b/web/src/components/roster/SelectableCharacterCard.tsx
@@ -1,11 +1,6 @@
-import { Fragment } from 'react';
-import type {
-    CharacterDto,
-    CharacterProfessionsDto,
-    ProfessionEntryDto,
-} from '@raid-ledger/contract';
+import type { CharacterDto } from '@raid-ledger/contract';
 import { getClassIconUrl } from '../../plugins/wow/lib/class-icons';
-import { getProfessionIconUrl } from '../../plugins/wow/lib/profession-icons';
+import { ProfessionBadges } from '../../plugins/wow/components/ProfessionBadges';
 
 /**
  * ROK-461: Selectable character card for admin assignment flow.
@@ -69,36 +64,6 @@ function CharacterInfo({ character, isMain }: { character: CharacterDto; isMain?
                 <ProfessionBadges professions={character.professions} />
             </div>
         </div>
-    );
-}
-
-function ProfessionBadges({ professions }: { professions: CharacterProfessionsDto | null }) {
-    if (!professions) return null;
-    const all = [...professions.primary, ...professions.secondary];
-    if (all.length === 0) return null;
-    return (
-        <>
-            {all.map((entry) => (
-                <Fragment key={entry.id}>
-                    <span>·</span>
-                    <ProfessionPill entry={entry} />
-                </Fragment>
-            ))}
-        </>
-    );
-}
-
-function ProfessionPill({ entry }: { entry: ProfessionEntryDto }) {
-    const iconUrl = getProfessionIconUrl(entry.slug);
-    const title = `${entry.name} ${entry.skillLevel}/${entry.maxSkillLevel}`;
-    if (!iconUrl) {
-        return <span title={title}>{entry.name} {entry.skillLevel}</span>;
-    }
-    return (
-        <span className="inline-flex items-center gap-1" title={title}>
-            <img src={iconUrl} alt={entry.name} className="w-4 h-4" />
-            {entry.skillLevel}
-        </span>
     );
 }
 

--- a/web/src/components/roster/SelectableCharacterCard.tsx
+++ b/web/src/components/roster/SelectableCharacterCard.tsx
@@ -1,5 +1,11 @@
-import type { CharacterDto } from '@raid-ledger/contract';
+import { Fragment } from 'react';
+import type {
+    CharacterDto,
+    CharacterProfessionsDto,
+    ProfessionEntryDto,
+} from '@raid-ledger/contract';
 import { getClassIconUrl } from '../../plugins/wow/lib/class-icons';
+import { getProfessionIconUrl } from '../../plugins/wow/lib/profession-icons';
 
 /**
  * ROK-461: Selectable character card for admin assignment flow.
@@ -60,8 +66,39 @@ function CharacterInfo({ character, isMain }: { character: CharacterDto; isMain?
                 {character.itemLevel && (
                     <><span>·</span><span className="text-purple-400">{character.itemLevel} iLvl</span></>
                 )}
+                <ProfessionBadges professions={character.professions} />
             </div>
         </div>
+    );
+}
+
+function ProfessionBadges({ professions }: { professions: CharacterProfessionsDto | null }) {
+    if (!professions) return null;
+    const all = [...professions.primary, ...professions.secondary];
+    if (all.length === 0) return null;
+    return (
+        <>
+            {all.map((entry) => (
+                <Fragment key={entry.id}>
+                    <span>·</span>
+                    <ProfessionPill entry={entry} />
+                </Fragment>
+            ))}
+        </>
+    );
+}
+
+function ProfessionPill({ entry }: { entry: ProfessionEntryDto }) {
+    const iconUrl = getProfessionIconUrl(entry.slug);
+    const title = `${entry.name} ${entry.skillLevel}/${entry.maxSkillLevel}`;
+    if (!iconUrl) {
+        return <span title={title}>{entry.name} {entry.skillLevel}</span>;
+    }
+    return (
+        <span className="inline-flex items-center gap-1" title={title}>
+            <img src={iconUrl} alt={entry.name} className="w-4 h-4" />
+            {entry.skillLevel}
+        </span>
     );
 }
 

--- a/web/src/pages/character-detail-page.tsx
+++ b/web/src/pages/character-detail-page.tsx
@@ -165,7 +165,7 @@ function CharacterHeader({ character, isOwner, isArmoryImported }: { character: 
 function CharacterEquipmentSection({ character, isArmoryImported }: { character: CharacterDto; isArmoryImported: boolean }) {
     return (
         <PluginSlot name="character-detail:sections"
-            context={{ equipment: character.equipment, talents: character.talents, gameVariant: character.gameVariant, renderUrl: character.renderUrl, isArmoryImported, characterClass: character.class ?? null, enrichments: character.enrichments ?? [] }}
+            context={{ equipment: character.equipment, talents: character.talents, professions: character.professions, gameVariant: character.gameVariant, renderUrl: character.renderUrl, isArmoryImported, characterClass: character.class ?? null, enrichments: character.enrichments ?? [] }}
             fallback={character.equipment?.items.length ? null : (
                 <div className="bg-panel border border-edge rounded-lg p-6">
                     <h2 className="text-lg font-semibold text-foreground mb-4">Equipment</h2>

--- a/web/src/pages/character-detail-page.tsx
+++ b/web/src/pages/character-detail-page.tsx
@@ -165,7 +165,7 @@ function CharacterHeader({ character, isOwner, isArmoryImported }: { character: 
 function CharacterEquipmentSection({ character, isArmoryImported, isOwner }: { character: CharacterDto; isArmoryImported: boolean; isOwner: boolean }) {
     return (
         <PluginSlot name="character-detail:sections"
-            context={{ equipment: character.equipment, talents: character.talents, professions: character.professions, gameVariant: character.gameVariant, renderUrl: character.renderUrl, isArmoryImported, characterClass: character.class ?? null, enrichments: character.enrichments ?? [], isOwner, characterId: character.id }}
+            context={{ equipment: character.equipment, talents: character.talents, professions: character.professions, gameVariant: character.gameVariant, renderUrl: character.renderUrl, isArmoryImported, characterClass: character.class ?? null, enrichments: character.enrichments ?? [], isOwner, characterId: character.id, gameId: character.gameId }}
             fallback={character.equipment?.items.length ? null : (
                 <div className="bg-panel border border-edge rounded-lg p-6">
                     <h2 className="text-lg font-semibold text-foreground mb-4">Equipment</h2>

--- a/web/src/pages/character-detail-page.tsx
+++ b/web/src/pages/character-detail-page.tsx
@@ -162,10 +162,10 @@ function CharacterHeader({ character, isOwner, isArmoryImported }: { character: 
     );
 }
 
-function CharacterEquipmentSection({ character, isArmoryImported }: { character: CharacterDto; isArmoryImported: boolean }) {
+function CharacterEquipmentSection({ character, isArmoryImported, isOwner }: { character: CharacterDto; isArmoryImported: boolean; isOwner: boolean }) {
     return (
         <PluginSlot name="character-detail:sections"
-            context={{ equipment: character.equipment, talents: character.talents, professions: character.professions, gameVariant: character.gameVariant, renderUrl: character.renderUrl, isArmoryImported, characterClass: character.class ?? null, enrichments: character.enrichments ?? [] }}
+            context={{ equipment: character.equipment, talents: character.talents, professions: character.professions, gameVariant: character.gameVariant, renderUrl: character.renderUrl, isArmoryImported, characterClass: character.class ?? null, enrichments: character.enrichments ?? [], isOwner, characterId: character.id }}
             fallback={character.equipment?.items.length ? null : (
                 <div className="bg-panel border border-edge rounded-lg p-6">
                     <h2 className="text-lg font-semibold text-foreground mb-4">Equipment</h2>
@@ -193,7 +193,7 @@ export function CharacterDetailPage() {
                 <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" /></svg> Back
             </button>
             <CharacterHeader character={character} isOwner={isOwner} isArmoryImported={isArmoryImported} />
-            <CharacterEquipmentSection character={character} isArmoryImported={isArmoryImported} />
+            <CharacterEquipmentSection character={character} isArmoryImported={isArmoryImported} isOwner={isOwner} />
         </div>
     );
 }

--- a/web/src/pages/event-detail/EventDetailRoster.tsx
+++ b/web/src/pages/event-detail/EventDetailRoster.tsx
@@ -131,7 +131,8 @@ function ConfirmedGroup({ signups, event }: { signups: SignupItem[]; event: Even
                         {s.character && (
                             <CharacterCardCompact id={s.character.id} name={s.character.name} avatarUrl={s.character.avatarUrl}
                                 faction={s.character.faction} level={s.character.level} race={s.character.race}
-                                className={s.character.class} spec={s.character.spec} role={s.character.role} itemLevel={s.character.itemLevel} />
+                                className={s.character.class} spec={s.character.spec} role={s.character.role} itemLevel={s.character.itemLevel}
+                                professions={s.character.professions} />
                         )}
                     </div>
                 ))}

--- a/web/src/pages/event-detail/EventDetailRoster.tsx
+++ b/web/src/pages/event-detail/EventDetailRoster.tsx
@@ -36,6 +36,8 @@ interface SignupItem {
         role: string | null;
         itemLevel: number | null;
         isMain?: boolean;
+        /** ROK-1130 — for the inline ProfessionBadges meta pills. */
+        professions?: import('@raid-ledger/contract').CharacterProfessionsDto | null;
     } | null;
 }
 

--- a/web/src/plugins/wow/components/CharacterProfessionsPanel.test.tsx
+++ b/web/src/plugins/wow/components/CharacterProfessionsPanel.test.tsx
@@ -1,0 +1,157 @@
+/**
+ * Vitest — CharacterProfessionsPanel (ROK-1130).
+ *
+ * Covers AC #5 (renders with data) and AC #6 (empty/null states).
+ * Also covers the icon-fallback case — when `getProfessionIconUrl`
+ * returns null the component should render text only without a broken
+ * `<img>`.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { CharacterProfessionsDto } from '@raid-ledger/contract';
+import { CharacterProfessionsPanel } from './CharacterProfessionsPanel';
+
+vi.mock('../lib/profession-icons', () => ({
+    getProfessionIconUrl: (slug: string | null | undefined) => {
+        if (slug === 'tailoring') return 'https://render.example/tailoring.jpg';
+        if (slug === 'cooking') return 'https://render.example/cooking.jpg';
+        return null;
+    },
+    professionNameToSlug: (name: string) =>
+        name.toLowerCase().replace(/\s+/g, '-'),
+}));
+
+const TAILORING_WITH_TIER: CharacterProfessionsDto = {
+    primary: [
+        {
+            id: 197,
+            name: 'Tailoring',
+            slug: 'tailoring',
+            skillLevel: 450,
+            maxSkillLevel: 450,
+            tiers: [
+                {
+                    id: 2823,
+                    name: 'Dragon Isles Tailoring',
+                    skillLevel: 100,
+                    maxSkillLevel: 100,
+                },
+            ],
+        },
+    ],
+    secondary: [
+        {
+            id: 185,
+            name: 'Cooking',
+            slug: 'cooking',
+            skillLevel: 150,
+            maxSkillLevel: 150,
+            tiers: [],
+        },
+    ],
+    syncedAt: '2026-04-28T00:00:00.000Z',
+};
+
+describe('CharacterProfessionsPanel — empty / null states (AC #6)', () => {
+    it('renders the never-synced empty hint when professions === null and not armory-imported', () => {
+        render(
+            <CharacterProfessionsPanel
+                professions={null}
+                isArmoryImported={false}
+            />,
+        );
+        expect(
+            screen.getByRole('heading', { name: /professions/i }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(/armory|import|sync/i),
+        ).toBeInTheDocument();
+    });
+
+    it('renders an empty hint when professions === null and armory-imported (different copy)', () => {
+        render(
+            <CharacterProfessionsPanel
+                professions={null}
+                isArmoryImported={true}
+            />,
+        );
+        expect(
+            screen.getByRole('heading', { name: /professions/i }),
+        ).toBeInTheDocument();
+    });
+
+    it('renders "no professions" copy when both arrays are empty', () => {
+        const empty: CharacterProfessionsDto = {
+            primary: [],
+            secondary: [],
+            syncedAt: '2026-04-28T00:00:00.000Z',
+        };
+        render(
+            <CharacterProfessionsPanel
+                professions={empty}
+                isArmoryImported={true}
+            />,
+        );
+        expect(
+            screen.getByRole('heading', { name: /professions/i }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByText(/no professions/i),
+        ).toBeInTheDocument();
+    });
+});
+
+describe('CharacterProfessionsPanel — populated state (AC #5)', () => {
+    it('renders primary, secondary, tiers, and skill numbers', () => {
+        render(
+            <CharacterProfessionsPanel
+                professions={TAILORING_WITH_TIER}
+                isArmoryImported={true}
+            />,
+        );
+
+        // Primary profession name + skill text
+        expect(screen.getByText('Tailoring')).toBeInTheDocument();
+        expect(screen.getByText(/450\s*\/\s*450/)).toBeInTheDocument();
+
+        // Secondary profession name + skill text
+        expect(screen.getByText('Cooking')).toBeInTheDocument();
+        expect(screen.getByText(/150\s*\/\s*150/)).toBeInTheDocument();
+
+        // Tier entry
+        expect(screen.getByText('Dragon Isles Tailoring')).toBeInTheDocument();
+        expect(screen.getByText(/100\s*\/\s*100/)).toBeInTheDocument();
+
+        // Profession icons rendered (one per profession with a known slug)
+        const tailoringImg = screen.getByAltText(/tailoring/i);
+        expect(tailoringImg.getAttribute('src')).toContain('tailoring.jpg');
+    });
+
+    it('falls back to text-only when getProfessionIconUrl returns null', () => {
+        const unknown: CharacterProfessionsDto = {
+            primary: [
+                {
+                    id: 999,
+                    name: 'Mystery Craft',
+                    slug: 'mystery-craft',
+                    skillLevel: 25,
+                    maxSkillLevel: 100,
+                    tiers: [],
+                },
+            ],
+            secondary: [],
+            syncedAt: '2026-04-28T00:00:00.000Z',
+        };
+        render(
+            <CharacterProfessionsPanel
+                professions={unknown}
+                isArmoryImported={true}
+            />,
+        );
+        expect(screen.getByText('Mystery Craft')).toBeInTheDocument();
+        // No <img> should render with the unknown slug as alt text.
+        expect(
+            screen.queryByRole('img', { name: /mystery craft/i }),
+        ).toBeNull();
+    });
+});

--- a/web/src/plugins/wow/components/CharacterProfessionsPanel.test.tsx
+++ b/web/src/plugins/wow/components/CharacterProfessionsPanel.test.tsx
@@ -1,10 +1,11 @@
 /**
  * Vitest — CharacterProfessionsPanel (ROK-1130).
  *
- * Covers AC #5 (renders with data) and AC #6 (empty/null states).
- * Also covers the icon-fallback case — when `getProfessionIconUrl`
- * returns null the component should render text only without a broken
- * `<img>`.
+ * Architect §3 + operator directive: panel renders nothing when professions
+ * are null OR both primary/secondary arrays are empty. Empty-state copy was
+ * removed because the Blizzard Classic Profile API does not expose
+ * /professions for any classic namespace, so empty data is the common case
+ * and a placeholder card adds clutter without information.
  */
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
@@ -52,63 +53,34 @@ const TAILORING_WITH_TIER: CharacterProfessionsDto = {
     syncedAt: '2026-04-28T00:00:00.000Z',
 };
 
-describe('CharacterProfessionsPanel — empty / null states (AC #6)', () => {
-    it('renders the never-synced empty hint when professions === null and not armory-imported', () => {
-        render(
-            <CharacterProfessionsPanel
-                professions={null}
-                isArmoryImported={false}
-            />,
+describe('CharacterProfessionsPanel — short-circuit hide (AC #6, operator directive)', () => {
+    it('renders nothing when professions === null', () => {
+        const { container } = render(
+            <CharacterProfessionsPanel professions={null} />,
         );
-        expect(
-            screen.getByRole('heading', { name: /professions/i }),
-        ).toBeInTheDocument();
-        expect(
-            screen.getByText(/armory|import|sync/i),
-        ).toBeInTheDocument();
+        expect(container).toBeEmptyDOMElement();
     });
 
-    it('renders an empty hint when professions === null and armory-imported (different copy)', () => {
-        render(
-            <CharacterProfessionsPanel
-                professions={null}
-                isArmoryImported={true}
-            />,
-        );
-        expect(
-            screen.getByRole('heading', { name: /professions/i }),
-        ).toBeInTheDocument();
-    });
-
-    it('renders "no professions" copy when both arrays are empty', () => {
+    it('renders nothing when both primary and secondary are empty', () => {
         const empty: CharacterProfessionsDto = {
             primary: [],
             secondary: [],
             syncedAt: '2026-04-28T00:00:00.000Z',
         };
-        render(
-            <CharacterProfessionsPanel
-                professions={empty}
-                isArmoryImported={true}
-            />,
+        const { container } = render(
+            <CharacterProfessionsPanel professions={empty} />,
         );
-        expect(
-            screen.getByRole('heading', { name: /professions/i }),
-        ).toBeInTheDocument();
-        expect(
-            screen.getByText(/no professions/i),
-        ).toBeInTheDocument();
+        expect(container).toBeEmptyDOMElement();
     });
 });
 
 describe('CharacterProfessionsPanel — populated state (AC #5)', () => {
     it('renders primary, secondary, tiers, and skill numbers', () => {
-        render(
-            <CharacterProfessionsPanel
-                professions={TAILORING_WITH_TIER}
-                isArmoryImported={true}
-            />,
-        );
+        render(<CharacterProfessionsPanel professions={TAILORING_WITH_TIER} />);
+
+        expect(
+            screen.getByRole('heading', { name: /professions/i }),
+        ).toBeInTheDocument();
 
         // Primary profession name + skill text
         expect(screen.getByText('Tailoring')).toBeInTheDocument();
@@ -142,12 +114,7 @@ describe('CharacterProfessionsPanel — populated state (AC #5)', () => {
             secondary: [],
             syncedAt: '2026-04-28T00:00:00.000Z',
         };
-        render(
-            <CharacterProfessionsPanel
-                professions={unknown}
-                isArmoryImported={true}
-            />,
-        );
+        render(<CharacterProfessionsPanel professions={unknown} />);
         expect(screen.getByText('Mystery Craft')).toBeInTheDocument();
         // No <img> should render with the unknown slug as alt text.
         expect(

--- a/web/src/plugins/wow/components/CharacterProfessionsPanel.test.tsx
+++ b/web/src/plugins/wow/components/CharacterProfessionsPanel.test.tsx
@@ -1,11 +1,11 @@
 /**
  * Vitest — CharacterProfessionsPanel (ROK-1130).
  *
- * Architect §3 + operator directive: panel renders nothing when professions
- * are null OR both primary/secondary arrays are empty. Empty-state copy was
- * removed because the Blizzard Classic Profile API does not expose
- * /professions for any classic namespace, so empty data is the common case
- * and a placeholder card adds clutter without information.
+ * Visibility rules:
+ *   • non-owner + no data  → render nothing
+ *   • non-owner + has data → render the panel (read-only)
+ *   • owner    + no data   → render an "Add Professions" CTA card
+ *   • owner    + has data  → render the panel + an "Edit" affordance
  */
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
@@ -22,103 +22,83 @@ vi.mock('../lib/profession-icons', () => ({
         name.toLowerCase().replace(/\s+/g, '-'),
 }));
 
+vi.mock('./EditProfessionsModal', () => ({
+    EditProfessionsModal: ({ isOpen }: { isOpen: boolean }) =>
+        isOpen ? <div data-testid="edit-modal" /> : null,
+}));
+
 const TAILORING_WITH_TIER: CharacterProfessionsDto = {
     primary: [
-        {
-            id: 197,
-            name: 'Tailoring',
-            slug: 'tailoring',
-            skillLevel: 450,
-            maxSkillLevel: 450,
-            tiers: [
-                {
-                    id: 2823,
-                    name: 'Dragon Isles Tailoring',
-                    skillLevel: 100,
-                    maxSkillLevel: 100,
-                },
-            ],
-        },
+        { id: 197, name: 'Tailoring', slug: 'tailoring', skillLevel: 450, maxSkillLevel: 450, tiers: [{ id: 2823, name: 'Dragon Isles Tailoring', skillLevel: 100, maxSkillLevel: 100 }] },
     ],
     secondary: [
-        {
-            id: 185,
-            name: 'Cooking',
-            slug: 'cooking',
-            skillLevel: 150,
-            maxSkillLevel: 150,
-            tiers: [],
-        },
+        { id: 185, name: 'Cooking', slug: 'cooking', skillLevel: 150, maxSkillLevel: 150, tiers: [] },
     ],
     syncedAt: '2026-04-28T00:00:00.000Z',
 };
 
-describe('CharacterProfessionsPanel — short-circuit hide (AC #6, operator directive)', () => {
-    it('renders nothing when professions === null', () => {
+const EMPTY_PROFESSIONS: CharacterProfessionsDto = {
+    primary: [],
+    secondary: [],
+    syncedAt: '2026-04-28T00:00:00.000Z',
+};
+
+describe('CharacterProfessionsPanel — visibility short-circuit', () => {
+    it('renders nothing when professions === null and viewer is NOT the owner', () => {
         const { container } = render(
-            <CharacterProfessionsPanel professions={null} />,
+            <CharacterProfessionsPanel professions={null} isOwner={false} characterId="c1" />,
         );
         expect(container).toBeEmptyDOMElement();
     });
 
-    it('renders nothing when both primary and secondary are empty', () => {
-        const empty: CharacterProfessionsDto = {
-            primary: [],
-            secondary: [],
-            syncedAt: '2026-04-28T00:00:00.000Z',
-        };
+    it('renders nothing when both arrays are empty and viewer is NOT the owner', () => {
         const { container } = render(
-            <CharacterProfessionsPanel professions={empty} />,
+            <CharacterProfessionsPanel professions={EMPTY_PROFESSIONS} isOwner={false} characterId="c1" />,
         );
         expect(container).toBeEmptyDOMElement();
     });
 });
 
-describe('CharacterProfessionsPanel — populated state (AC #5)', () => {
-    it('renders primary, secondary, tiers, and skill numbers', () => {
-        render(<CharacterProfessionsPanel professions={TAILORING_WITH_TIER} />);
+describe('CharacterProfessionsPanel — owner CTA when no data', () => {
+    it('renders an "Add Professions" CTA when owner has no data', () => {
+        render(<CharacterProfessionsPanel professions={null} isOwner characterId="c1" />);
+        expect(screen.getByRole('heading', { name: /professions/i })).toBeInTheDocument();
+        expect(screen.getByRole('button', { name: /add professions/i })).toBeInTheDocument();
+    });
 
-        expect(
-            screen.getByRole('heading', { name: /professions/i }),
-        ).toBeInTheDocument();
+    it('renders the CTA when owner has empty arrays (sync-with-no-data path)', () => {
+        render(<CharacterProfessionsPanel professions={EMPTY_PROFESSIONS} isOwner characterId="c1" />);
+        expect(screen.getByRole('button', { name: /add professions/i })).toBeInTheDocument();
+    });
+});
 
-        // Primary profession name + skill text
+describe('CharacterProfessionsPanel — populated state', () => {
+    it('renders primary, secondary, tiers, and skill numbers (non-owner)', () => {
+        render(<CharacterProfessionsPanel professions={TAILORING_WITH_TIER} isOwner={false} characterId="c1" />);
+        expect(screen.getByRole('heading', { name: /professions/i })).toBeInTheDocument();
         expect(screen.getByText('Tailoring')).toBeInTheDocument();
         expect(screen.getByText(/450\s*\/\s*450/)).toBeInTheDocument();
-
-        // Secondary profession name + skill text
         expect(screen.getByText('Cooking')).toBeInTheDocument();
         expect(screen.getByText(/150\s*\/\s*150/)).toBeInTheDocument();
-
-        // Tier entry
         expect(screen.getByText('Dragon Isles Tailoring')).toBeInTheDocument();
         expect(screen.getByText(/100\s*\/\s*100/)).toBeInTheDocument();
+        // No edit affordance for non-owners
+        expect(screen.queryByRole('button', { name: /^edit$/i })).toBeNull();
+    });
 
-        // Profession icons rendered (one per profession with a known slug)
-        const tailoringImg = screen.getByAltText(/tailoring/i);
-        expect(tailoringImg.getAttribute('src')).toContain('tailoring.jpg');
+    it('renders an Edit affordance for owners with data', () => {
+        render(<CharacterProfessionsPanel professions={TAILORING_WITH_TIER} isOwner characterId="c1" />);
+        expect(screen.getByRole('button', { name: /^edit$/i })).toBeInTheDocument();
     });
 
     it('falls back to text-only when getProfessionIconUrl returns null', () => {
         const unknown: CharacterProfessionsDto = {
-            primary: [
-                {
-                    id: 999,
-                    name: 'Mystery Craft',
-                    slug: 'mystery-craft',
-                    skillLevel: 25,
-                    maxSkillLevel: 100,
-                    tiers: [],
-                },
-            ],
+            primary: [{ id: 999, name: 'Mystery Craft', slug: 'mystery-craft', skillLevel: 25, maxSkillLevel: 100, tiers: [] }],
             secondary: [],
             syncedAt: '2026-04-28T00:00:00.000Z',
         };
-        render(<CharacterProfessionsPanel professions={unknown} />);
+        render(<CharacterProfessionsPanel professions={unknown} isOwner={false} characterId="c1" />);
         expect(screen.getByText('Mystery Craft')).toBeInTheDocument();
-        // No <img> should render with the unknown slug as alt text.
-        expect(
-            screen.queryByRole('img', { name: /mystery craft/i }),
-        ).toBeNull();
+        expect(screen.queryByRole('img', { name: /mystery craft/i })).toBeNull();
     });
 });

--- a/web/src/plugins/wow/components/CharacterProfessionsPanel.tsx
+++ b/web/src/plugins/wow/components/CharacterProfessionsPanel.tsx
@@ -1,48 +1,99 @@
+import { useState } from 'react';
 import type {
     CharacterProfessionsDto,
     ProfessionEntryDto,
     ProfessionTierDto,
 } from '@raid-ledger/contract';
 import { getProfessionIconUrl } from '../lib/profession-icons';
+import { EditProfessionsModal } from './EditProfessionsModal';
 
 interface CharacterProfessionsPanelProps {
     professions: CharacterProfessionsDto | null;
+    isOwner: boolean;
+    characterId: string;
 }
 
-export function CharacterProfessionsPanel({ professions }: CharacterProfessionsPanelProps) {
-    if (
-        professions === null ||
-        (professions.primary.length === 0 && professions.secondary.length === 0)
-    ) {
-        return null;
-    }
+export function CharacterProfessionsPanel({
+    professions, isOwner, characterId,
+}: CharacterProfessionsPanelProps) {
+    const [isEditing, setIsEditing] = useState(false);
+    const hasData = !!(
+        professions &&
+        (professions.primary.length > 0 || professions.secondary.length > 0)
+    );
+
+    if (!hasData && !isOwner) return null;
+
     return (
-        <div className="bg-panel border border-edge rounded-lg p-6">
-            <h2 className="text-lg font-semibold text-foreground mb-4">Professions</h2>
-            <div className="space-y-6">
-                {professions.primary.length > 0 && (
-                    <ProfessionGroup heading="Primary" entries={professions.primary} />
-                )}
-                {professions.secondary.length > 0 && (
-                    <ProfessionGroup heading="Secondary" entries={professions.secondary} />
+        <>
+            <div className="bg-panel border border-edge rounded-lg p-6">
+                <PanelHeader showEdit={isOwner && hasData} onEdit={() => setIsEditing(true)} />
+                {hasData ? (
+                    <ProfessionsBody professions={professions!} />
+                ) : (
+                    <AddProfessionsCta onAdd={() => setIsEditing(true)} />
                 )}
             </div>
+            {isOwner && (
+                <EditProfessionsModal
+                    isOpen={isEditing}
+                    onClose={() => setIsEditing(false)}
+                    characterId={characterId}
+                    initial={professions}
+                />
+            )}
+        </>
+    );
+}
+
+function PanelHeader({ showEdit, onEdit }: { showEdit: boolean; onEdit: () => void }) {
+    return (
+        <div className="flex items-center justify-between mb-4">
+            <h2 className="text-lg font-semibold text-foreground">Professions</h2>
+            {showEdit && (
+                <button type="button" onClick={onEdit}
+                    className="text-sm text-indigo-400 hover:text-indigo-300">
+                    Edit
+                </button>
+            )}
+        </div>
+    );
+}
+
+function ProfessionsBody({ professions }: { professions: CharacterProfessionsDto }) {
+    return (
+        <div className="space-y-6">
+            {professions.primary.length > 0 && (
+                <ProfessionGroup heading="Primary" entries={professions.primary} />
+            )}
+            {professions.secondary.length > 0 && (
+                <ProfessionGroup heading="Secondary" entries={professions.secondary} />
+            )}
+        </div>
+    );
+}
+
+function AddProfessionsCta({ onAdd }: { onAdd: () => void }) {
+    return (
+        <div className="text-center py-6 text-muted">
+            <p className="text-sm mb-3">No profession data yet.</p>
+            <button type="button" onClick={onAdd}
+                className="px-4 py-2 bg-indigo-600 hover:bg-indigo-500 text-foreground font-medium rounded-lg transition-colors">
+                Add Professions
+            </button>
         </div>
     );
 }
 
 function ProfessionGroup({
-    heading,
-    entries,
+    heading, entries,
 }: {
     heading: string;
     entries: ProfessionEntryDto[];
 }) {
     return (
         <section>
-            <h3 className="text-sm font-semibold uppercase tracking-wide text-muted mb-2">
-                {heading}
-            </h3>
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-muted mb-2">{heading}</h3>
             <ul className="space-y-3">
                 {entries.map((entry) => (
                     <li key={entry.id}>
@@ -78,9 +129,7 @@ function ProfessionTierList({ tiers }: { tiers: ProfessionTierDto[] }) {
             {tiers.map((tier) => (
                 <li key={tier.id} className="flex items-center gap-2">
                     <span>{tier.name}</span>
-                    <span>
-                        {tier.skillLevel}/{tier.maxSkillLevel}
-                    </span>
+                    <span>{tier.skillLevel}/{tier.maxSkillLevel}</span>
                 </li>
             ))}
         </ul>

--- a/web/src/plugins/wow/components/CharacterProfessionsPanel.tsx
+++ b/web/src/plugins/wow/components/CharacterProfessionsPanel.tsx
@@ -1,0 +1,128 @@
+import type {
+    CharacterProfessionsDto,
+    ProfessionEntryDto,
+    ProfessionTierDto,
+} from '@raid-ledger/contract';
+import { getProfessionIconUrl } from '../lib/profession-icons';
+
+interface CharacterProfessionsPanelProps {
+    professions: CharacterProfessionsDto | null;
+    isArmoryImported: boolean;
+}
+
+export function CharacterProfessionsPanel({
+    professions,
+    isArmoryImported,
+}: CharacterProfessionsPanelProps) {
+    return (
+        <div className="bg-panel border border-edge rounded-lg p-6">
+            <h2 className="text-lg font-semibold text-foreground mb-4">Professions</h2>
+            <ProfessionsBody professions={professions} isArmoryImported={isArmoryImported} />
+        </div>
+    );
+}
+
+function ProfessionsBody({
+    professions,
+    isArmoryImported,
+}: CharacterProfessionsPanelProps) {
+    if (professions === null) {
+        return <ProfessionsEmpty isArmoryImported={isArmoryImported} reason="never-synced" />;
+    }
+    if (professions.primary.length === 0 && professions.secondary.length === 0) {
+        return <ProfessionsEmpty isArmoryImported={isArmoryImported} reason="no-data" />;
+    }
+    return (
+        <div className="space-y-6">
+            {professions.primary.length > 0 && (
+                <ProfessionGroup heading="Primary" entries={professions.primary} />
+            )}
+            {professions.secondary.length > 0 && (
+                <ProfessionGroup heading="Secondary" entries={professions.secondary} />
+            )}
+        </div>
+    );
+}
+
+function ProfessionGroup({
+    heading,
+    entries,
+}: {
+    heading: string;
+    entries: ProfessionEntryDto[];
+}) {
+    return (
+        <section>
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-muted mb-2">
+                {heading}
+            </h3>
+            <ul className="space-y-3">
+                {entries.map((entry) => (
+                    <li key={entry.id}>
+                        <ProfessionRow entry={entry} />
+                    </li>
+                ))}
+            </ul>
+        </section>
+    );
+}
+
+function ProfessionRow({ entry }: { entry: ProfessionEntryDto }) {
+    const iconUrl = getProfessionIconUrl(entry.slug);
+    return (
+        <div>
+            <div className="flex items-center gap-2 text-foreground">
+                {iconUrl && (
+                    <img src={iconUrl} alt={entry.name} className="w-6 h-6 rounded-sm" />
+                )}
+                <span className="font-medium">{entry.name}</span>
+                <span className="text-sm text-muted">
+                    {entry.skillLevel}/{entry.maxSkillLevel}
+                </span>
+            </div>
+            {entry.tiers.length > 0 && <ProfessionTierList tiers={entry.tiers} />}
+        </div>
+    );
+}
+
+function ProfessionTierList({ tiers }: { tiers: ProfessionTierDto[] }) {
+    return (
+        <ul className="mt-2 ml-8 space-y-1 text-sm text-muted">
+            {tiers.map((tier) => (
+                <li key={tier.id} className="flex items-center gap-2">
+                    <span>{tier.name}</span>
+                    <span>
+                        {tier.skillLevel}/{tier.maxSkillLevel}
+                    </span>
+                </li>
+            ))}
+        </ul>
+    );
+}
+
+function ProfessionsEmpty({
+    isArmoryImported,
+    reason,
+}: {
+    isArmoryImported: boolean;
+    reason: 'never-synced' | 'no-data';
+}) {
+    return (
+        <div className="text-center py-8 text-muted">
+            <p className="text-lg">{reason === 'no-data' ? 'No professions' : 'No profession data'}</p>
+            <p className="text-sm mt-1">{getEmptyHint(isArmoryImported, reason)}</p>
+        </div>
+    );
+}
+
+function getEmptyHint(
+    isArmoryImported: boolean,
+    reason: 'never-synced' | 'no-data',
+): string {
+    if (reason === 'no-data') {
+        return 'This character has no primary or secondary professions.';
+    }
+    return isArmoryImported
+        ? 'No profession data. Try refreshing.'
+        : 'Profession data is only available for characters imported from the Blizzard Armory.';
+}

--- a/web/src/plugins/wow/components/CharacterProfessionsPanel.tsx
+++ b/web/src/plugins/wow/components/CharacterProfessionsPanel.tsx
@@ -14,35 +14,26 @@ interface CharacterProfessionsPanelProps {
     gameId: number;
 }
 
+function hasProfessionData(professions: CharacterProfessionsDto | null): professions is CharacterProfessionsDto {
+    return !!professions && (professions.primary.length > 0 || professions.secondary.length > 0);
+}
+
 export function CharacterProfessionsPanel({
     professions, isOwner, characterId, gameId,
 }: CharacterProfessionsPanelProps) {
     const [isEditing, setIsEditing] = useState(false);
-    const hasData = !!(
-        professions &&
-        (professions.primary.length > 0 || professions.secondary.length > 0)
-    );
-
+    const hasData = hasProfessionData(professions);
     if (!hasData && !isOwner) return null;
-
+    const openEdit = () => setIsEditing(true);
     return (
         <>
             <div className="bg-panel border border-edge rounded-lg p-6">
-                <PanelHeader showEdit={isOwner && hasData} onEdit={() => setIsEditing(true)} />
-                {hasData ? (
-                    <ProfessionsBody professions={professions!} />
-                ) : (
-                    <AddProfessionsCta onAdd={() => setIsEditing(true)} />
-                )}
+                <PanelHeader showEdit={isOwner && hasData} onEdit={openEdit} />
+                {hasData ? <ProfessionsBody professions={professions} /> : <AddProfessionsCta onAdd={openEdit} />}
             </div>
             {isOwner && (
-                <EditProfessionsModal
-                    isOpen={isEditing}
-                    onClose={() => setIsEditing(false)}
-                    characterId={characterId}
-                    gameId={gameId}
-                    initial={professions}
-                />
+                <EditProfessionsModal isOpen={isEditing} onClose={() => setIsEditing(false)}
+                    characterId={characterId} gameId={gameId} initial={professions} />
             )}
         </>
     );

--- a/web/src/plugins/wow/components/CharacterProfessionsPanel.tsx
+++ b/web/src/plugins/wow/components/CharacterProfessionsPanel.tsx
@@ -7,39 +7,26 @@ import { getProfessionIconUrl } from '../lib/profession-icons';
 
 interface CharacterProfessionsPanelProps {
     professions: CharacterProfessionsDto | null;
-    isArmoryImported: boolean;
 }
 
-export function CharacterProfessionsPanel({
-    professions,
-    isArmoryImported,
-}: CharacterProfessionsPanelProps) {
+export function CharacterProfessionsPanel({ professions }: CharacterProfessionsPanelProps) {
+    if (
+        professions === null ||
+        (professions.primary.length === 0 && professions.secondary.length === 0)
+    ) {
+        return null;
+    }
     return (
         <div className="bg-panel border border-edge rounded-lg p-6">
             <h2 className="text-lg font-semibold text-foreground mb-4">Professions</h2>
-            <ProfessionsBody professions={professions} isArmoryImported={isArmoryImported} />
-        </div>
-    );
-}
-
-function ProfessionsBody({
-    professions,
-    isArmoryImported,
-}: CharacterProfessionsPanelProps) {
-    if (professions === null) {
-        return <ProfessionsEmpty isArmoryImported={isArmoryImported} reason="never-synced" />;
-    }
-    if (professions.primary.length === 0 && professions.secondary.length === 0) {
-        return <ProfessionsEmpty isArmoryImported={isArmoryImported} reason="no-data" />;
-    }
-    return (
-        <div className="space-y-6">
-            {professions.primary.length > 0 && (
-                <ProfessionGroup heading="Primary" entries={professions.primary} />
-            )}
-            {professions.secondary.length > 0 && (
-                <ProfessionGroup heading="Secondary" entries={professions.secondary} />
-            )}
+            <div className="space-y-6">
+                {professions.primary.length > 0 && (
+                    <ProfessionGroup heading="Primary" entries={professions.primary} />
+                )}
+                {professions.secondary.length > 0 && (
+                    <ProfessionGroup heading="Secondary" entries={professions.secondary} />
+                )}
+            </div>
         </div>
     );
 }
@@ -98,31 +85,4 @@ function ProfessionTierList({ tiers }: { tiers: ProfessionTierDto[] }) {
             ))}
         </ul>
     );
-}
-
-function ProfessionsEmpty({
-    isArmoryImported,
-    reason,
-}: {
-    isArmoryImported: boolean;
-    reason: 'never-synced' | 'no-data';
-}) {
-    return (
-        <div className="text-center py-8 text-muted">
-            <p className="text-lg">{reason === 'no-data' ? 'No professions' : 'No profession data'}</p>
-            <p className="text-sm mt-1">{getEmptyHint(isArmoryImported, reason)}</p>
-        </div>
-    );
-}
-
-function getEmptyHint(
-    isArmoryImported: boolean,
-    reason: 'never-synced' | 'no-data',
-): string {
-    if (reason === 'no-data') {
-        return 'This character has no primary or secondary professions.';
-    }
-    return isArmoryImported
-        ? 'No profession data. Try refreshing.'
-        : 'Profession data is only available for characters imported from the Blizzard Armory.';
 }

--- a/web/src/plugins/wow/components/CharacterProfessionsPanel.tsx
+++ b/web/src/plugins/wow/components/CharacterProfessionsPanel.tsx
@@ -11,10 +11,11 @@ interface CharacterProfessionsPanelProps {
     professions: CharacterProfessionsDto | null;
     isOwner: boolean;
     characterId: string;
+    gameId: number;
 }
 
 export function CharacterProfessionsPanel({
-    professions, isOwner, characterId,
+    professions, isOwner, characterId, gameId,
 }: CharacterProfessionsPanelProps) {
     const [isEditing, setIsEditing] = useState(false);
     const hasData = !!(
@@ -39,6 +40,7 @@ export function CharacterProfessionsPanel({
                     isOpen={isEditing}
                     onClose={() => setIsEditing(false)}
                     characterId={characterId}
+                    gameId={gameId}
                     initial={professions}
                 />
             )}

--- a/web/src/plugins/wow/components/EditProfessionsModal.tsx
+++ b/web/src/plugins/wow/components/EditProfessionsModal.tsx
@@ -1,0 +1,176 @@
+import { useState } from 'react';
+import type {
+    CharacterProfessionsDto,
+    ProfessionEntryDto,
+} from '@raid-ledger/contract';
+import { Modal } from '../../../components/ui/modal';
+import { useUpdateCharacter } from '../../../hooks/use-character-mutations';
+import { professionNameToSlug } from '../lib/profession-icons';
+
+interface EditProfessionsModalProps {
+    isOpen: boolean;
+    onClose: () => void;
+    characterId: string;
+    initial: CharacterProfessionsDto | null;
+}
+
+/** Knownretail profession names — used as `<datalist>` suggestions; free-text still allowed. */
+const PROFESSION_SUGGESTIONS = [
+    'Alchemy', 'Blacksmithing', 'Enchanting', 'Engineering', 'Herbalism',
+    'Inscription', 'Jewelcrafting', 'Leatherworking', 'Mining', 'Skinning',
+    'Tailoring', 'Cooking', 'Fishing', 'First Aid', 'Archaeology',
+];
+
+interface DraftEntry {
+    name: string;
+    skillLevel: number;
+    maxSkillLevel: number;
+}
+
+function emptyEntry(): DraftEntry {
+    return { name: '', skillLevel: 0, maxSkillLevel: 0 };
+}
+
+function entriesToDraft(entries: ProfessionEntryDto[]): DraftEntry[] {
+    return entries.map((e) => ({
+        name: e.name,
+        skillLevel: e.skillLevel,
+        maxSkillLevel: e.maxSkillLevel,
+    }));
+}
+
+function draftToEntries(drafts: DraftEntry[]): ProfessionEntryDto[] {
+    return drafts
+        .filter((d) => d.name.trim().length > 0)
+        .map((d, idx) => ({
+            id: idx + 1,
+            name: d.name.trim(),
+            slug: professionNameToSlug(d.name.trim()),
+            skillLevel: Number(d.skillLevel) || 0,
+            maxSkillLevel: Number(d.maxSkillLevel) || 0,
+            tiers: [],
+        }));
+}
+
+export function EditProfessionsModal({
+    isOpen, onClose, characterId, initial,
+}: EditProfessionsModalProps) {
+    const [primary, setPrimary] = useState<DraftEntry[]>(
+        () => entriesToDraft(initial?.primary ?? []),
+    );
+    const [secondary, setSecondary] = useState<DraftEntry[]>(
+        () => entriesToDraft(initial?.secondary ?? []),
+    );
+    const update = useUpdateCharacter();
+
+    function handleSave() {
+        const primaryEntries = draftToEntries(primary);
+        const secondaryEntries = draftToEntries(secondary);
+        const professions =
+            primaryEntries.length === 0 && secondaryEntries.length === 0
+                ? null
+                : {
+                    primary: primaryEntries,
+                    secondary: secondaryEntries,
+                    syncedAt: new Date().toISOString(),
+                };
+        update.mutate(
+            { id: characterId, dto: { professions } },
+            { onSuccess: onClose },
+        );
+    }
+
+    return (
+        <Modal isOpen={isOpen} onClose={onClose} title="Edit Professions">
+            <div className="space-y-6">
+                <ProfessionSection
+                    heading="Primary"
+                    drafts={primary}
+                    onChange={setPrimary}
+                    maxEntries={2}
+                />
+                <ProfessionSection
+                    heading="Secondary"
+                    drafts={secondary}
+                    onChange={setSecondary}
+                    maxEntries={5}
+                />
+                <ModalActions
+                    onCancel={onClose}
+                    onSave={handleSave}
+                    isPending={update.isPending}
+                />
+            </div>
+            <datalist id="profession-name-options">
+                {PROFESSION_SUGGESTIONS.map((n) => <option key={n} value={n} />)}
+            </datalist>
+        </Modal>
+    );
+}
+
+function ProfessionSection({
+    heading, drafts, onChange, maxEntries,
+}: {
+    heading: string;
+    drafts: DraftEntry[];
+    onChange: (next: DraftEntry[]) => void;
+    maxEntries: number;
+}) {
+    return (
+        <section>
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-muted mb-2">{heading}</h3>
+            <div className="space-y-2">
+                {drafts.map((d, idx) => (
+                    <ProfessionRowEditor key={idx} draft={d}
+                        onChange={(next) => onChange(drafts.map((x, i) => i === idx ? next : x))}
+                        onRemove={() => onChange(drafts.filter((_, i) => i !== idx))} />
+                ))}
+                {drafts.length < maxEntries && (
+                    <button type="button" onClick={() => onChange([...drafts, emptyEntry()])}
+                        className="text-sm text-indigo-400 hover:text-indigo-300">
+                        + Add {heading.toLowerCase()}
+                    </button>
+                )}
+            </div>
+        </section>
+    );
+}
+
+function ProfessionRowEditor({
+    draft, onChange, onRemove,
+}: {
+    draft: DraftEntry;
+    onChange: (next: DraftEntry) => void;
+    onRemove: () => void;
+}) {
+    return (
+        <div className="flex items-center gap-2">
+            <input type="text" list="profession-name-options" value={draft.name} placeholder="Profession name"
+                onChange={(e) => onChange({ ...draft, name: e.target.value })}
+                className="flex-1 bg-overlay border border-edge rounded-md px-2 py-1 text-foreground" />
+            <input type="number" min="0" max="2000" value={draft.skillLevel} aria-label="Skill"
+                onChange={(e) => onChange({ ...draft, skillLevel: Number(e.target.value) })}
+                className="w-20 bg-overlay border border-edge rounded-md px-2 py-1 text-foreground" />
+            <span className="text-muted">/</span>
+            <input type="number" min="0" max="2000" value={draft.maxSkillLevel} aria-label="Max skill"
+                onChange={(e) => onChange({ ...draft, maxSkillLevel: Number(e.target.value) })}
+                className="w-20 bg-overlay border border-edge rounded-md px-2 py-1 text-foreground" />
+            <button type="button" onClick={onRemove} aria-label="Remove profession"
+                className="text-muted hover:text-red-400">✕</button>
+        </div>
+    );
+}
+
+function ModalActions({ onCancel, onSave, isPending }: {
+    onCancel: () => void; onSave: () => void; isPending: boolean;
+}) {
+    return (
+        <div className="flex justify-end gap-3 pt-2">
+            <button type="button" onClick={onCancel} className="px-4 py-2 text-secondary hover:text-foreground transition-colors">Cancel</button>
+            <button type="button" onClick={onSave} disabled={isPending}
+                className="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 disabled:bg-overlay disabled:text-muted text-foreground font-medium rounded-lg transition-colors">
+                {isPending ? 'Saving...' : 'Save'}
+            </button>
+        </div>
+    );
+}

--- a/web/src/plugins/wow/components/EditProfessionsModal.tsx
+++ b/web/src/plugins/wow/components/EditProfessionsModal.tsx
@@ -5,16 +5,19 @@ import type {
 } from '@raid-ledger/contract';
 import { Modal } from '../../../components/ui/modal';
 import { useUpdateCharacter } from '../../../hooks/use-character-mutations';
+import { useGameRegistry } from '../../../hooks/use-game-registry';
 import { professionNameToSlug } from '../lib/profession-icons';
+import { getMaxProfessionSkill } from '../lib/profession-max-skill';
 
 interface EditProfessionsModalProps {
     isOpen: boolean;
     onClose: () => void;
     characterId: string;
+    gameId: number;
     initial: CharacterProfessionsDto | null;
 }
 
-/** Knownretail profession names — used as `<datalist>` suggestions; free-text still allowed. */
+/** Known retail profession names — used as `<datalist>` suggestions; free-text still allowed. */
 const PROFESSION_SUGGESTIONS = [
     'Alchemy', 'Blacksmithing', 'Enchanting', 'Engineering', 'Herbalism',
     'Inscription', 'Jewelcrafting', 'Leatherworking', 'Mining', 'Skinning',
@@ -24,37 +27,43 @@ const PROFESSION_SUGGESTIONS = [
 interface DraftEntry {
     name: string;
     skillLevel: number;
-    maxSkillLevel: number;
 }
 
 function emptyEntry(): DraftEntry {
-    return { name: '', skillLevel: 0, maxSkillLevel: 0 };
+    return { name: '', skillLevel: 0 };
 }
 
 function entriesToDraft(entries: ProfessionEntryDto[]): DraftEntry[] {
-    return entries.map((e) => ({
-        name: e.name,
-        skillLevel: e.skillLevel,
-        maxSkillLevel: e.maxSkillLevel,
-    }));
+    return entries.map((e) => ({ name: e.name, skillLevel: e.skillLevel }));
 }
 
-function draftToEntries(drafts: DraftEntry[]): ProfessionEntryDto[] {
+function draftToEntries(drafts: DraftEntry[], maxSkill: number): ProfessionEntryDto[] {
     return drafts
         .filter((d) => d.name.trim().length > 0)
         .map((d, idx) => ({
             id: idx + 1,
             name: d.name.trim(),
             slug: professionNameToSlug(d.name.trim()),
-            skillLevel: Number(d.skillLevel) || 0,
-            maxSkillLevel: Number(d.maxSkillLevel) || 0,
+            skillLevel: clampSkill(d.skillLevel, maxSkill),
+            maxSkillLevel: maxSkill,
             tiers: [],
         }));
 }
 
+function clampSkill(value: number, max: number): number {
+    const n = Number(value) || 0;
+    if (n < 0) return 0;
+    if (n > max) return max;
+    return n;
+}
+
 export function EditProfessionsModal({
-    isOpen, onClose, characterId, initial,
+    isOpen, onClose, characterId, gameId, initial,
 }: EditProfessionsModalProps) {
+    const { games } = useGameRegistry();
+    const game = games.find((g) => g.id === gameId);
+    const maxSkill = getMaxProfessionSkill(game?.slug);
+
     const [primary, setPrimary] = useState<DraftEntry[]>(
         () => entriesToDraft(initial?.primary ?? []),
     );
@@ -64,8 +73,8 @@ export function EditProfessionsModal({
     const update = useUpdateCharacter();
 
     function handleSave() {
-        const primaryEntries = draftToEntries(primary);
-        const secondaryEntries = draftToEntries(secondary);
+        const primaryEntries = draftToEntries(primary, maxSkill);
+        const secondaryEntries = draftToEntries(secondary, maxSkill);
         const professions =
             primaryEntries.length === 0 && secondaryEntries.length === 0
                 ? null
@@ -83,17 +92,22 @@ export function EditProfessionsModal({
     return (
         <Modal isOpen={isOpen} onClose={onClose} title="Edit Professions">
             <div className="space-y-6">
+                <p className="text-xs text-muted">
+                    Skill cap for this game variant: <span className="font-mono">{maxSkill}</span>
+                </p>
                 <ProfessionSection
                     heading="Primary"
                     drafts={primary}
                     onChange={setPrimary}
                     maxEntries={2}
+                    maxSkill={maxSkill}
                 />
                 <ProfessionSection
                     heading="Secondary"
                     drafts={secondary}
                     onChange={setSecondary}
                     maxEntries={5}
+                    maxSkill={maxSkill}
                 />
                 <ModalActions
                     onCancel={onClose}
@@ -109,19 +123,20 @@ export function EditProfessionsModal({
 }
 
 function ProfessionSection({
-    heading, drafts, onChange, maxEntries,
+    heading, drafts, onChange, maxEntries, maxSkill,
 }: {
     heading: string;
     drafts: DraftEntry[];
     onChange: (next: DraftEntry[]) => void;
     maxEntries: number;
+    maxSkill: number;
 }) {
     return (
         <section>
             <h3 className="text-sm font-semibold uppercase tracking-wide text-muted mb-2">{heading}</h3>
             <div className="space-y-2">
                 {drafts.map((d, idx) => (
-                    <ProfessionRowEditor key={idx} draft={d}
+                    <ProfessionRowEditor key={idx} draft={d} maxSkill={maxSkill}
                         onChange={(next) => onChange(drafts.map((x, i) => i === idx ? next : x))}
                         onRemove={() => onChange(drafts.filter((_, i) => i !== idx))} />
                 ))}
@@ -137,24 +152,23 @@ function ProfessionSection({
 }
 
 function ProfessionRowEditor({
-    draft, onChange, onRemove,
+    draft, onChange, onRemove, maxSkill,
 }: {
     draft: DraftEntry;
     onChange: (next: DraftEntry) => void;
     onRemove: () => void;
+    maxSkill: number;
 }) {
     return (
         <div className="flex items-center gap-2">
             <input type="text" list="profession-name-options" value={draft.name} placeholder="Profession name"
                 onChange={(e) => onChange({ ...draft, name: e.target.value })}
                 className="flex-1 bg-overlay border border-edge rounded-md px-2 py-1 text-foreground" />
-            <input type="number" min="0" max="2000" value={draft.skillLevel} aria-label="Skill"
+            <input type="number" min="0" max={maxSkill} value={draft.skillLevel} aria-label="Skill"
                 onChange={(e) => onChange({ ...draft, skillLevel: Number(e.target.value) })}
                 className="w-20 bg-overlay border border-edge rounded-md px-2 py-1 text-foreground" />
             <span className="text-muted">/</span>
-            <input type="number" min="0" max="2000" value={draft.maxSkillLevel} aria-label="Max skill"
-                onChange={(e) => onChange({ ...draft, maxSkillLevel: Number(e.target.value) })}
-                className="w-20 bg-overlay border border-edge rounded-md px-2 py-1 text-foreground" />
+            <span className="w-16 text-center text-muted font-mono" aria-label="Max skill">{maxSkill}</span>
             <button type="button" onClick={onRemove} aria-label="Remove profession"
                 className="text-muted hover:text-red-400">✕</button>
         </div>

--- a/web/src/plugins/wow/components/EditProfessionsModal.tsx
+++ b/web/src/plugins/wow/components/EditProfessionsModal.tsx
@@ -10,6 +10,7 @@ import { professionNameToSlug } from '../lib/profession-icons';
 import { getMaxProfessionSkill } from '../lib/profession-max-skill';
 import {
     getProfessionOptions,
+    getMaxEntriesForCategory,
     type ProfessionCategory,
 } from '../lib/profession-categories';
 
@@ -59,7 +60,8 @@ export function EditProfessionsModal({
 }: EditProfessionsModalProps) {
     const { games } = useGameRegistry();
     const game = games.find((g) => g.id === gameId);
-    const maxSkill = getMaxProfessionSkill(game?.slug);
+    const gameSlug = game?.slug ?? null;
+    const maxSkill = getMaxProfessionSkill(gameSlug);
 
     const [primary, setPrimary] = useState<DraftEntry[]>(
         () => entriesToDraft(initial?.primary ?? []),
@@ -97,8 +99,9 @@ export function EditProfessionsModal({
                     category="primary"
                     drafts={primary}
                     onChange={setPrimary}
-                    maxEntries={2}
+                    maxEntries={getMaxEntriesForCategory('primary', gameSlug)}
                     maxSkill={maxSkill}
+                    gameSlug={gameSlug}
                     siblingNames={primary.map((d) => d.name)}
                 />
                 <ProfessionSection
@@ -106,8 +109,9 @@ export function EditProfessionsModal({
                     category="secondary"
                     drafts={secondary}
                     onChange={setSecondary}
-                    maxEntries={4}
+                    maxEntries={getMaxEntriesForCategory('secondary', gameSlug)}
                     maxSkill={maxSkill}
+                    gameSlug={gameSlug}
                     siblingNames={secondary.map((d) => d.name)}
                 />
                 <ModalActions
@@ -121,7 +125,7 @@ export function EditProfessionsModal({
 }
 
 function ProfessionSection({
-    heading, category, drafts, onChange, maxEntries, maxSkill, siblingNames,
+    heading, category, drafts, onChange, maxEntries, maxSkill, gameSlug, siblingNames,
 }: {
     heading: string;
     category: ProfessionCategory;
@@ -129,9 +133,10 @@ function ProfessionSection({
     onChange: (next: DraftEntry[]) => void;
     maxEntries: number;
     maxSkill: number;
+    gameSlug: string | null;
     siblingNames: string[];
 }) {
-    const allOptions = getProfessionOptions(category);
+    const allOptions = getProfessionOptions(category, gameSlug);
     return (
         <section>
             <h3 className="text-sm font-semibold uppercase tracking-wide text-muted mb-2">{heading}</h3>

--- a/web/src/plugins/wow/components/EditProfessionsModal.tsx
+++ b/web/src/plugins/wow/components/EditProfessionsModal.tsx
@@ -64,70 +64,65 @@ function draftToEntries(drafts: DraftEntry[], maxSkill: number): ProfessionEntry
         }));
 }
 
-export function EditProfessionsModal({
-    isOpen, onClose, characterId, gameId, initial,
-}: EditProfessionsModalProps) {
-    const { games } = useGameRegistry();
-    const game = games.find((g) => g.id === gameId);
-    const gameSlug = game?.slug ?? null;
-    const maxSkill = getMaxProfessionSkill(gameSlug);
+function buildProfessionsPayload(
+    primary: DraftEntry[],
+    secondary: DraftEntry[],
+    maxSkill: number,
+): CharacterProfessionsDto | null {
+    const primaryEntries = draftToEntries(primary, maxSkill);
+    const secondaryEntries = draftToEntries(secondary, maxSkill);
+    if (primaryEntries.length === 0 && secondaryEntries.length === 0) return null;
+    return {
+        primary: primaryEntries,
+        secondary: secondaryEntries,
+        syncedAt: new Date().toISOString(),
+    };
+}
 
+function useEditProfessionsState(
+    gameId: number,
+    initial: CharacterProfessionsDto | null,
+) {
+    const { games } = useGameRegistry();
+    const gameSlug = games.find((g) => g.id === gameId)?.slug ?? null;
+    const maxSkill = getMaxProfessionSkill(gameSlug);
     const [primary, setPrimary] = useState<DraftEntry[]>(
         () => entriesToDraft(initial?.primary ?? []),
     );
     const [secondary, setSecondary] = useState<DraftEntry[]>(
         () => entriesToDraft(initial?.secondary ?? []),
     );
+    return { gameSlug, maxSkill, primary, setPrimary, secondary, setSecondary };
+}
+
+export function EditProfessionsModal({
+    isOpen, onClose, characterId, gameId, initial,
+}: EditProfessionsModalProps) {
+    const s = useEditProfessionsState(gameId, initial);
     const update = useUpdateCharacter();
 
-    function handleSave() {
-        const primaryEntries = draftToEntries(primary, maxSkill);
-        const secondaryEntries = draftToEntries(secondary, maxSkill);
-        const professions =
-            primaryEntries.length === 0 && secondaryEntries.length === 0
-                ? null
-                : {
-                    primary: primaryEntries,
-                    secondary: secondaryEntries,
-                    syncedAt: new Date().toISOString(),
-                };
-        update.mutate(
-            { id: characterId, dto: { professions } },
-            { onSuccess: onClose },
-        );
-    }
+    const handleSave = () => update.mutate(
+        { id: characterId, dto: { professions: buildProfessionsPayload(s.primary, s.secondary, s.maxSkill) } },
+        { onSuccess: onClose },
+    );
 
     return (
         <Modal isOpen={isOpen} onClose={onClose} title="Edit Professions">
             <div className="space-y-6">
                 <p className="text-xs text-muted">
-                    Skill cap for this game variant: <span className="font-mono">{maxSkill}</span>
+                    Skill cap for this game variant: <span className="font-mono">{s.maxSkill}</span>
                 </p>
-                <ProfessionSection
-                    heading="Primary"
-                    category="primary"
-                    drafts={primary}
-                    onChange={setPrimary}
-                    maxEntries={getMaxEntriesForCategory('primary', gameSlug)}
-                    maxSkill={maxSkill}
-                    gameSlug={gameSlug}
-                    siblingNames={primary.map((d) => d.name)}
-                />
-                <ProfessionSection
-                    heading="Secondary"
-                    category="secondary"
-                    drafts={secondary}
-                    onChange={setSecondary}
-                    maxEntries={getMaxEntriesForCategory('secondary', gameSlug)}
-                    maxSkill={maxSkill}
-                    gameSlug={gameSlug}
-                    siblingNames={secondary.map((d) => d.name)}
-                />
-                <ModalActions
-                    onCancel={onClose}
-                    onSave={handleSave}
-                    isPending={update.isPending}
-                />
+                <ProfessionSection heading="Primary" category="primary"
+                    drafts={s.primary} onChange={s.setPrimary}
+                    maxEntries={getMaxEntriesForCategory('primary', s.gameSlug)}
+                    maxSkill={s.maxSkill} gameSlug={s.gameSlug}
+                    siblingNames={s.primary.map((d) => d.name)} />
+                <ProfessionSection heading="Secondary" category="secondary"
+                    drafts={s.secondary} onChange={s.setSecondary}
+                    maxEntries={getMaxEntriesForCategory('secondary', s.gameSlug)}
+                    maxSkill={s.maxSkill} gameSlug={s.gameSlug}
+                    siblingNames={s.secondary.map((d) => d.name)} />
+                <ModalActions onCancel={onClose} onSave={handleSave} isPending={update.isPending} />
             </div>
         </Modal>
     );

--- a/web/src/plugins/wow/components/EditProfessionsModal.tsx
+++ b/web/src/plugins/wow/components/EditProfessionsModal.tsx
@@ -22,22 +22,31 @@ interface EditProfessionsModalProps {
     initial: CharacterProfessionsDto | null;
 }
 
+/**
+ * Skill level is held as a string while editing so the user can fully
+ * clear the field — number-typed controlled inputs can't be backspaced
+ * past 0 because empty input would round-trip through `Number('')` → 0
+ * and re-render as "0", trapping a leading zero.
+ */
 interface DraftEntry {
     name: string;
-    skillLevel: number;
+    skillLevel: string;
 }
 
 function emptyEntry(): DraftEntry {
-    return { name: '', skillLevel: 0 };
+    return { name: '', skillLevel: '' };
 }
 
 function entriesToDraft(entries: ProfessionEntryDto[]): DraftEntry[] {
-    return entries.map((e) => ({ name: e.name, skillLevel: e.skillLevel }));
+    return entries.map((e) => ({
+        name: e.name,
+        skillLevel: e.skillLevel === 0 ? '' : String(e.skillLevel),
+    }));
 }
 
-function clampSkill(value: number, max: number): number {
-    const n = Number(value) || 0;
-    if (n < 0) return 0;
+function clampSkill(value: string, max: number): number {
+    const n = Number.parseInt(value, 10);
+    if (Number.isNaN(n) || n < 0) return 0;
     if (n > max) return max;
     return n;
 }
@@ -192,8 +201,9 @@ function ProfessionRowEditor({
                     <option key={name} value={name}>{name}</option>
                 ))}
             </select>
-            <input type="number" min="0" max={maxSkill} value={draft.skillLevel} aria-label="Skill"
-                onChange={(e) => onChange({ ...draft, skillLevel: Number(e.target.value) })}
+            <input type="number" inputMode="numeric" min="0" max={maxSkill} value={draft.skillLevel}
+                aria-label="Skill" placeholder="0"
+                onChange={(e) => onChange({ ...draft, skillLevel: e.target.value })}
                 className="w-20 bg-overlay border border-edge rounded-md px-2 py-1 text-foreground" />
             <span className="text-muted">/</span>
             <span className="w-16 text-center text-muted font-mono" aria-label="Max skill">{maxSkill}</span>

--- a/web/src/plugins/wow/components/EditProfessionsModal.tsx
+++ b/web/src/plugins/wow/components/EditProfessionsModal.tsx
@@ -8,6 +8,10 @@ import { useUpdateCharacter } from '../../../hooks/use-character-mutations';
 import { useGameRegistry } from '../../../hooks/use-game-registry';
 import { professionNameToSlug } from '../lib/profession-icons';
 import { getMaxProfessionSkill } from '../lib/profession-max-skill';
+import {
+    getProfessionOptions,
+    type ProfessionCategory,
+} from '../lib/profession-categories';
 
 interface EditProfessionsModalProps {
     isOpen: boolean;
@@ -16,13 +20,6 @@ interface EditProfessionsModalProps {
     gameId: number;
     initial: CharacterProfessionsDto | null;
 }
-
-/** Known retail profession names — used as `<datalist>` suggestions; free-text still allowed. */
-const PROFESSION_SUGGESTIONS = [
-    'Alchemy', 'Blacksmithing', 'Enchanting', 'Engineering', 'Herbalism',
-    'Inscription', 'Jewelcrafting', 'Leatherworking', 'Mining', 'Skinning',
-    'Tailoring', 'Cooking', 'Fishing', 'First Aid', 'Archaeology',
-];
 
 interface DraftEntry {
     name: string;
@@ -37,6 +34,13 @@ function entriesToDraft(entries: ProfessionEntryDto[]): DraftEntry[] {
     return entries.map((e) => ({ name: e.name, skillLevel: e.skillLevel }));
 }
 
+function clampSkill(value: number, max: number): number {
+    const n = Number(value) || 0;
+    if (n < 0) return 0;
+    if (n > max) return max;
+    return n;
+}
+
 function draftToEntries(drafts: DraftEntry[], maxSkill: number): ProfessionEntryDto[] {
     return drafts
         .filter((d) => d.name.trim().length > 0)
@@ -48,13 +52,6 @@ function draftToEntries(drafts: DraftEntry[], maxSkill: number): ProfessionEntry
             maxSkillLevel: maxSkill,
             tiers: [],
         }));
-}
-
-function clampSkill(value: number, max: number): number {
-    const n = Number(value) || 0;
-    if (n < 0) return 0;
-    if (n > max) return max;
-    return n;
 }
 
 export function EditProfessionsModal({
@@ -97,17 +94,21 @@ export function EditProfessionsModal({
                 </p>
                 <ProfessionSection
                     heading="Primary"
+                    category="primary"
                     drafts={primary}
                     onChange={setPrimary}
                     maxEntries={2}
                     maxSkill={maxSkill}
+                    siblingNames={primary.map((d) => d.name)}
                 />
                 <ProfessionSection
                     heading="Secondary"
+                    category="secondary"
                     drafts={secondary}
                     onChange={setSecondary}
-                    maxEntries={5}
+                    maxEntries={4}
                     maxSkill={maxSkill}
+                    siblingNames={secondary.map((d) => d.name)}
                 />
                 <ModalActions
                     onCancel={onClose}
@@ -115,30 +116,35 @@ export function EditProfessionsModal({
                     isPending={update.isPending}
                 />
             </div>
-            <datalist id="profession-name-options">
-                {PROFESSION_SUGGESTIONS.map((n) => <option key={n} value={n} />)}
-            </datalist>
         </Modal>
     );
 }
 
 function ProfessionSection({
-    heading, drafts, onChange, maxEntries, maxSkill,
+    heading, category, drafts, onChange, maxEntries, maxSkill, siblingNames,
 }: {
     heading: string;
+    category: ProfessionCategory;
     drafts: DraftEntry[];
     onChange: (next: DraftEntry[]) => void;
     maxEntries: number;
     maxSkill: number;
+    siblingNames: string[];
 }) {
+    const allOptions = getProfessionOptions(category);
     return (
         <section>
             <h3 className="text-sm font-semibold uppercase tracking-wide text-muted mb-2">{heading}</h3>
             <div className="space-y-2">
                 {drafts.map((d, idx) => (
-                    <ProfessionRowEditor key={idx} draft={d} maxSkill={maxSkill}
+                    <ProfessionRowEditor
+                        key={idx}
+                        draft={d}
+                        maxSkill={maxSkill}
+                        availableOptions={availableFor(allOptions, siblingNames, d.name)}
                         onChange={(next) => onChange(drafts.map((x, i) => i === idx ? next : x))}
-                        onRemove={() => onChange(drafts.filter((_, i) => i !== idx))} />
+                        onRemove={() => onChange(drafts.filter((_, i) => i !== idx))}
+                    />
                 ))}
                 {drafts.length < maxEntries && (
                     <button type="button" onClick={() => onChange([...drafts, emptyEntry()])}
@@ -151,19 +157,36 @@ function ProfessionSection({
     );
 }
 
+/** Hide options already chosen by sibling rows so the user can't pick the same profession twice. */
+function availableFor(
+    all: readonly string[],
+    siblingNames: string[],
+    selfName: string,
+): readonly string[] {
+    const taken = new Set(siblingNames.filter((n) => n && n !== selfName));
+    return all.filter((opt) => !taken.has(opt));
+}
+
 function ProfessionRowEditor({
-    draft, onChange, onRemove, maxSkill,
+    draft, onChange, onRemove, maxSkill, availableOptions,
 }: {
     draft: DraftEntry;
     onChange: (next: DraftEntry) => void;
     onRemove: () => void;
     maxSkill: number;
+    availableOptions: readonly string[];
 }) {
     return (
         <div className="flex items-center gap-2">
-            <input type="text" list="profession-name-options" value={draft.name} placeholder="Profession name"
+            <select value={draft.name}
                 onChange={(e) => onChange({ ...draft, name: e.target.value })}
-                className="flex-1 bg-overlay border border-edge rounded-md px-2 py-1 text-foreground" />
+                aria-label="Profession"
+                className="flex-1 bg-overlay border border-edge rounded-md px-2 py-1 text-foreground">
+                <option value="">Select profession…</option>
+                {availableOptions.map((name) => (
+                    <option key={name} value={name}>{name}</option>
+                ))}
+            </select>
             <input type="number" min="0" max={maxSkill} value={draft.skillLevel} aria-label="Skill"
                 onChange={(e) => onChange({ ...draft, skillLevel: Number(e.target.value) })}
                 className="w-20 bg-overlay border border-edge rounded-md px-2 py-1 text-foreground" />

--- a/web/src/plugins/wow/components/ProfessionBadges.tsx
+++ b/web/src/plugins/wow/components/ProfessionBadges.tsx
@@ -1,0 +1,52 @@
+import { Fragment } from 'react';
+import type {
+    CharacterProfessionsDto,
+    ProfessionEntryDto,
+} from '@raid-ledger/contract';
+import { getProfessionIconUrl } from '../lib/profession-icons';
+
+/**
+ * Inline pills showing one badge per profession (primary first, then
+ * secondary). Returns `null` when professions is null or both arrays
+ * are empty so the parent meta row is byte-identical to a baseline
+ * card without the field (see architect §8 in ROK-1130).
+ *
+ * Pre-baked icon URLs come from `profession-icons.ts`. When the slug
+ * isn't in the map, the pill falls back to text-only (`{name} {skill}`).
+ */
+export function ProfessionBadges({
+    professions,
+    separator = '·',
+}: {
+    professions: CharacterProfessionsDto | null | undefined;
+    /** Visual separator between pills; defaults to a middle dot to match meta rows. */
+    separator?: string;
+}) {
+    if (!professions) return null;
+    const all = [...professions.primary, ...professions.secondary];
+    if (all.length === 0) return null;
+    return (
+        <>
+            {all.map((entry) => (
+                <Fragment key={entry.id}>
+                    <span>{separator}</span>
+                    <ProfessionPill entry={entry} />
+                </Fragment>
+            ))}
+        </>
+    );
+}
+
+function ProfessionPill({ entry }: { entry: ProfessionEntryDto }) {
+    const iconUrl = getProfessionIconUrl(entry.slug);
+    const title = `${entry.name} ${entry.skillLevel}/${entry.maxSkillLevel}`;
+    if (!iconUrl) {
+        return <span title={title}>{entry.name} {entry.skillLevel}</span>;
+    }
+    return (
+        <span className="inline-flex items-center gap-1" title={title}>
+            <img src={iconUrl} alt={entry.name} className="w-4 h-4" />
+            {entry.skillLevel}
+        </span>
+    );
+}

--- a/web/src/plugins/wow/lib/profession-categories.ts
+++ b/web/src/plugins/wow/lib/profession-categories.ts
@@ -1,36 +1,60 @@
 /**
- * Canonical primary / secondary profession lists for WoW.
+ * Canonical primary / secondary profession lists for WoW, with
+ * per-era availability filtering.
  *
- * The category (primary vs secondary) is fixed across game variants —
- * Cooking is always secondary, Tailoring is always primary, etc. Some
- * professions are gated by expansion availability (Inscription was added
- * in Wrath, Jewelcrafting in BC, Archaeology in Cataclysm) but their
- * category never changes once introduced.
+ * Category (primary vs secondary) is fixed across game variants —
+ * Cooking is always secondary, Tailoring is always primary, etc. But
+ * availability varies by era:
+ *   • Jewelcrafting was added in The Burning Crusade
+ *   • Inscription was added in Wrath of the Lich King
+ *   • Archaeology was added in Cataclysm
+ *   • First Aid was removed from retail in Battle for Azeroth (still
+ *     in every Classic flavor)
  */
 
-export const PRIMARY_PROFESSIONS = [
-    'Alchemy',
-    'Blacksmithing',
-    'Enchanting',
-    'Engineering',
-    'Herbalism',
-    'Inscription',
-    'Jewelcrafting',
-    'Leatherworking',
-    'Mining',
-    'Skinning',
-    'Tailoring',
-] as const;
-
-export const SECONDARY_PROFESSIONS = [
-    'Cooking',
-    'Fishing',
-    'First Aid',
-    'Archaeology',
-] as const;
+import type { WowEra } from './wow-era';
+import { getWowEra } from './wow-era';
 
 export type ProfessionCategory = 'primary' | 'secondary';
 
-export function getProfessionOptions(category: ProfessionCategory): readonly string[] {
-    return category === 'primary' ? PRIMARY_PROFESSIONS : SECONDARY_PROFESSIONS;
+const VANILLA_PRIMARY = [
+    'Alchemy', 'Blacksmithing', 'Enchanting', 'Engineering',
+    'Herbalism', 'Leatherworking', 'Mining', 'Skinning', 'Tailoring',
+] as const;
+
+const PRIMARY_BY_ERA: Record<WowEra, readonly string[]> = {
+    vanilla: VANILLA_PRIMARY,
+    bc: [...VANILLA_PRIMARY, 'Jewelcrafting'],
+    wrath: [...VANILLA_PRIMARY, 'Jewelcrafting', 'Inscription'],
+    cataclysm: [...VANILLA_PRIMARY, 'Jewelcrafting', 'Inscription'],
+    mop: [...VANILLA_PRIMARY, 'Jewelcrafting', 'Inscription'],
+    retail: [...VANILLA_PRIMARY, 'Jewelcrafting', 'Inscription'],
+};
+
+const SECONDARY_BY_ERA: Record<WowEra, readonly string[]> = {
+    vanilla: ['Cooking', 'Fishing', 'First Aid'],
+    bc: ['Cooking', 'Fishing', 'First Aid'],
+    wrath: ['Cooking', 'Fishing', 'First Aid'],
+    cataclysm: ['Cooking', 'Fishing', 'First Aid', 'Archaeology'],
+    mop: ['Cooking', 'Fishing', 'First Aid', 'Archaeology'],
+    // Retail removed First Aid in Battle for Azeroth.
+    retail: ['Cooking', 'Fishing', 'Archaeology'],
+};
+
+/** Available profession options for the given category in the given game variant. */
+export function getProfessionOptions(
+    category: ProfessionCategory,
+    gameSlug: string | null | undefined,
+): readonly string[] {
+    const era = getWowEra(gameSlug);
+    return category === 'primary' ? PRIMARY_BY_ERA[era] : SECONDARY_BY_ERA[era];
+}
+
+/** How many entries the given category supports (primary always 2, secondary varies). */
+export function getMaxEntriesForCategory(
+    category: ProfessionCategory,
+    gameSlug: string | null | undefined,
+): number {
+    if (category === 'primary') return 2;
+    return getProfessionOptions('secondary', gameSlug).length;
 }

--- a/web/src/plugins/wow/lib/profession-categories.ts
+++ b/web/src/plugins/wow/lib/profession-categories.ts
@@ -1,0 +1,36 @@
+/**
+ * Canonical primary / secondary profession lists for WoW.
+ *
+ * The category (primary vs secondary) is fixed across game variants —
+ * Cooking is always secondary, Tailoring is always primary, etc. Some
+ * professions are gated by expansion availability (Inscription was added
+ * in Wrath, Jewelcrafting in BC, Archaeology in Cataclysm) but their
+ * category never changes once introduced.
+ */
+
+export const PRIMARY_PROFESSIONS = [
+    'Alchemy',
+    'Blacksmithing',
+    'Enchanting',
+    'Engineering',
+    'Herbalism',
+    'Inscription',
+    'Jewelcrafting',
+    'Leatherworking',
+    'Mining',
+    'Skinning',
+    'Tailoring',
+] as const;
+
+export const SECONDARY_PROFESSIONS = [
+    'Cooking',
+    'Fishing',
+    'First Aid',
+    'Archaeology',
+] as const;
+
+export type ProfessionCategory = 'primary' | 'secondary';
+
+export function getProfessionOptions(category: ProfessionCategory): readonly string[] {
+    return category === 'primary' ? PRIMARY_PROFESSIONS : SECONDARY_PROFESSIONS;
+}

--- a/web/src/plugins/wow/lib/profession-icons.ts
+++ b/web/src/plugins/wow/lib/profession-icons.ts
@@ -1,0 +1,58 @@
+/**
+ * WoW profession icon URLs from Blizzard CDN.
+ *
+ * Used in web UI to show profession icons next to a character's profession entries
+ * (detail page panel + roster character card pills).
+ *
+ * Keys are profession slugs derived from the Blizzard API profession name:
+ *   slug = name.toLowerCase().replace(/\s+/g, '-')
+ *
+ * Map was harvested once from Blizzard's media API
+ * (`/data/wow/profession/index` + `/data/wow/media/profession/{id}`)
+ * and is intentionally static — no runtime fetch.
+ */
+
+const WOW_PROFESSION_ICONS: Record<string, string> = {
+  'abominable-stitching': 'https://render.worldofwarcraft.com/us/icons/56/sanctum_features_buildabom.jpg',
+  alchemy: 'https://render.worldofwarcraft.com/us/icons/56/ui_profession_alchemy.jpg',
+  'alchemy-research': 'https://render.worldofwarcraft.com/us/icons/56/inv_misc_cauldron_shadow.jpg',
+  'arcana-manipulation': 'https://render.worldofwarcraft.com/us/icons/56/ability_socererking_arcanemines.jpg',
+  archaeology: 'https://render.worldofwarcraft.com/us/icons/56/trade_archaeology.jpg',
+  'ascension-crafting': 'https://render.worldofwarcraft.com/us/icons/56/inv_mace_1h_bastionquest_b_01.jpg',
+  blacksmithing: 'https://render.worldofwarcraft.com/us/icons/56/ui_profession_blacksmithing.jpg',
+  cooking: 'https://render.worldofwarcraft.com/us/icons/56/ui_profession_cooking.jpg',
+  'dye-crafting': 'https://render.worldofwarcraft.com/us/icons/56/housing-dye-bonewhite.jpg',
+  enchanting: 'https://render.worldofwarcraft.com/us/icons/56/ui_profession_enchanting.jpg',
+  engineering: 'https://render.worldofwarcraft.com/us/icons/56/ui_profession_engineering.jpg',
+  fishing: 'https://render.worldofwarcraft.com/us/icons/56/ui_profession_fishing.jpg',
+  herbalism: 'https://render.worldofwarcraft.com/us/icons/56/ui_profession_herbalism.jpg',
+  inscription: 'https://render.worldofwarcraft.com/us/icons/56/ui_profession_inscription.jpg',
+  jewelcrafting: 'https://render.worldofwarcraft.com/us/icons/56/ui_profession_jewelcrafting.jpg',
+  leatherworking: 'https://render.worldofwarcraft.com/us/icons/56/ui_profession_leatherworking.jpg',
+  mining: 'https://render.worldofwarcraft.com/us/icons/56/ui_profession_mining.jpg',
+  'protoform-synthesis': 'https://render.worldofwarcraft.com/us/icons/56/inv_progenitor_protoformsynthesis.jpg',
+  'shipment-prototype': 'https://render.worldofwarcraft.com/us/icons/56/inv_mechagon_junkyardtinkeringcrafting.jpg',
+  skinning: 'https://render.worldofwarcraft.com/us/icons/56/ui_profession_skinning.jpg',
+  'soul-cyphering': 'https://render.worldofwarcraft.com/us/icons/56/sha_spell_warlock_demonsoul.jpg',
+  'stygia-crafting': 'https://render.worldofwarcraft.com/us/icons/56/inv_blacksmithing_815_khazgorianhammer.jpg',
+  'supply-shipments': 'https://render.worldofwarcraft.com/us/icons/56/inv_legion_cache_dreamweavers.jpg',
+  tailoring: 'https://render.worldofwarcraft.com/us/icons/56/ui_profession_tailoring.jpg',
+  'tuskarr-fishing-gear': 'https://render.worldofwarcraft.com/us/icons/56/inv_10_dungeonjewelry_tuskarr_trinket_1_color4.jpg',
+};
+
+/**
+ * Look up a profession icon URL by slug.
+ * Returns null if the slug isn't in the map (UI should fall back to text-only).
+ */
+export function getProfessionIconUrl(slug: string | null | undefined): string | null {
+  if (!slug) return null;
+  return WOW_PROFESSION_ICONS[slug] ?? null;
+}
+
+/**
+ * Convert a profession name (e.g. from the contract DTO) to its canonical slug.
+ * Mirrors the slug derivation used by the backend parser.
+ */
+export function professionNameToSlug(name: string): string {
+  return name.toLowerCase().replace(/\s+/g, '-');
+}

--- a/web/src/plugins/wow/lib/profession-max-skill.ts
+++ b/web/src/plugins/wow/lib/profession-max-skill.ts
@@ -1,33 +1,26 @@
 /**
- * WoW profession max skill cap by game variant.
+ * WoW profession max skill cap by era.
  *
- * The `apiNamespacePrefix` alone is ambiguous (the `classic` prefix covers
- * both BC Classic at 375 and Wrath Classic at 450), so we key the lookup off
- * the games table slug. Retail variants and unmapped slugs default to 100,
- * which matches the per-expansion tier cap Blizzard returns on retail.
+ * Era is derived from the game slug via `getWowEra` so the lookup is
+ * consistent with profession availability filtering.
  */
 
-const BY_SLUG: Record<string, number> = {
-  // Vanilla / Era / Anniversary 1x
-  'world-of-warcraft-classic': 300,
-  // Burning Crusade era
-  'world-of-warcraft-burning-crusade-classic': 375,
-  'world-of-warcraft-burning-crusade-classic-anniversary-edition': 375,
-  // Wrath of the Lich King era
-  'world-of-warcraft-wrath-of-the-lich-king-classic': 450,
-  // Cataclysm era
-  'world-of-warcraft-cataclysm-classic': 525,
-  // Mists of Pandaria era
-  'world-of-warcraft-mists-of-pandaria-classic': 600,
-  // Season of Discovery rides Vanilla 1x's cap
-  'world-of-warcraft-classic-season-of-discovery': 300,
+import type { WowEra } from './wow-era';
+import { getWowEra } from './wow-era';
+
+const MAX_BY_ERA: Record<WowEra, number> = {
+    vanilla: 300,
+    bc: 375,
+    wrath: 450,
+    cataclysm: 525,
+    mop: 600,
+    // Retail uses a per-expansion tier system where each expansion's
+    // tier caps at 100. The parent profession aggregates higher in the
+    // legacy API but the editable manual cap surfaces 100 by default.
+    retail: 100,
 };
 
-/**
- * Derive the max skill cap for a profession in the given game.
- * Retail variants and unrecognised slugs return 100 (current per-expansion tier).
- */
+/** Derive the max skill cap for a profession in the given game. */
 export function getMaxProfessionSkill(gameSlug: string | null | undefined): number {
-  if (!gameSlug) return 100;
-  return BY_SLUG[gameSlug] ?? 100;
+    return MAX_BY_ERA[getWowEra(gameSlug)];
 }

--- a/web/src/plugins/wow/lib/profession-max-skill.ts
+++ b/web/src/plugins/wow/lib/profession-max-skill.ts
@@ -1,0 +1,33 @@
+/**
+ * WoW profession max skill cap by game variant.
+ *
+ * The `apiNamespacePrefix` alone is ambiguous (the `classic` prefix covers
+ * both BC Classic at 375 and Wrath Classic at 450), so we key the lookup off
+ * the games table slug. Retail variants and unmapped slugs default to 100,
+ * which matches the per-expansion tier cap Blizzard returns on retail.
+ */
+
+const BY_SLUG: Record<string, number> = {
+  // Vanilla / Era / Anniversary 1x
+  'world-of-warcraft-classic': 300,
+  // Burning Crusade era
+  'world-of-warcraft-burning-crusade-classic': 375,
+  'world-of-warcraft-burning-crusade-classic-anniversary-edition': 375,
+  // Wrath of the Lich King era
+  'world-of-warcraft-wrath-of-the-lich-king-classic': 450,
+  // Cataclysm era
+  'world-of-warcraft-cataclysm-classic': 525,
+  // Mists of Pandaria era
+  'world-of-warcraft-mists-of-pandaria-classic': 600,
+  // Season of Discovery rides Vanilla 1x's cap
+  'world-of-warcraft-classic-season-of-discovery': 300,
+};
+
+/**
+ * Derive the max skill cap for a profession in the given game.
+ * Retail variants and unrecognised slugs return 100 (current per-expansion tier).
+ */
+export function getMaxProfessionSkill(gameSlug: string | null | undefined): number {
+  if (!gameSlug) return 100;
+  return BY_SLUG[gameSlug] ?? 100;
+}

--- a/web/src/plugins/wow/lib/wow-era.ts
+++ b/web/src/plugins/wow/lib/wow-era.ts
@@ -1,0 +1,30 @@
+/**
+ * Map a game slug to a WoW era so other libs (max-skill, profession
+ * availability) can derive variant-specific behavior from a single source.
+ *
+ * Anything we don't recognise falls back to `retail` since most modern
+ * variants share the live WoW Profile API namespace and the same caps.
+ */
+
+export type WowEra =
+    | 'vanilla'
+    | 'bc'
+    | 'wrath'
+    | 'cataclysm'
+    | 'mop'
+    | 'retail';
+
+const ERA_BY_SLUG: Record<string, WowEra> = {
+    'world-of-warcraft-classic': 'vanilla',
+    'world-of-warcraft-classic-season-of-discovery': 'vanilla',
+    'world-of-warcraft-burning-crusade-classic': 'bc',
+    'world-of-warcraft-burning-crusade-classic-anniversary-edition': 'bc',
+    'world-of-warcraft-wrath-of-the-lich-king-classic': 'wrath',
+    'world-of-warcraft-cataclysm-classic': 'cataclysm',
+    'world-of-warcraft-mists-of-pandaria-classic': 'mop',
+};
+
+export function getWowEra(gameSlug: string | null | undefined): WowEra {
+    if (!gameSlug) return 'retail';
+    return ERA_BY_SLUG[gameSlug] ?? 'retail';
+}

--- a/web/src/plugins/wow/slots/character-detail-sections.tsx
+++ b/web/src/plugins/wow/slots/character-detail-sections.tsx
@@ -73,7 +73,7 @@ export function CharacterDetailSections({
             )}
             <TalentSection talents={talents} isArmoryImported={isArmoryImported}
                 characterClass={characterClass} gameVariant={gameVariant} />
-            <CharacterProfessionsPanel professions={professions} isArmoryImported={isArmoryImported} />
+            <CharacterProfessionsPanel professions={professions} />
         </>
     );
 }

--- a/web/src/plugins/wow/slots/character-detail-sections.tsx
+++ b/web/src/plugins/wow/slots/character-detail-sections.tsx
@@ -6,14 +6,20 @@ import { useState } from 'react';
 import { useWowheadTooltips } from '../hooks/use-wowhead-tooltips';
 import { ItemDetailModal } from '../components/item-detail-modal';
 import { TalentDisplay } from '../components/talent-display';
+import { CharacterProfessionsPanel } from '../components/CharacterProfessionsPanel';
 import { EquipmentGrid } from './equipment-grid';
 import { buildOrderedItems } from './equipment-constants';
-import type { CharacterEquipmentDto, EquipmentItemDto } from '@raid-ledger/contract';
+import type {
+    CharacterEquipmentDto,
+    CharacterProfessionsDto,
+    EquipmentItemDto,
+} from '@raid-ledger/contract';
 
 /** Props passed via PluginSlot context from character-detail-page */
 interface CharacterDetailSectionsProps {
     equipment: CharacterEquipmentDto | null;
     talents: unknown;
+    professions: CharacterProfessionsDto | null;
     gameVariant: string | null;
     renderUrl: string | null;
     isArmoryImported: boolean;
@@ -52,7 +58,7 @@ function EquipmentWithItems({ equipment, gameVariant, renderUrl, isArmoryImporte
 
 /** Main character detail sections component */
 export function CharacterDetailSections({
-    equipment, talents, gameVariant,
+    equipment, talents, professions, gameVariant,
     renderUrl, isArmoryImported, characterClass,
 }: CharacterDetailSectionsProps) {
     useWowheadTooltips(equipment ? [equipment] : []);
@@ -67,6 +73,7 @@ export function CharacterDetailSections({
             )}
             <TalentSection talents={talents} isArmoryImported={isArmoryImported}
                 characterClass={characterClass} gameVariant={gameVariant} />
+            <CharacterProfessionsPanel professions={professions} isArmoryImported={isArmoryImported} />
         </>
     );
 }

--- a/web/src/plugins/wow/slots/character-detail-sections.tsx
+++ b/web/src/plugins/wow/slots/character-detail-sections.tsx
@@ -24,6 +24,8 @@ interface CharacterDetailSectionsProps {
     renderUrl: string | null;
     isArmoryImported: boolean;
     characterClass: string | null;
+    isOwner: boolean;
+    characterId: string;
 }
 
 /** Equipment panel with items and item detail modal */
@@ -60,6 +62,7 @@ function EquipmentWithItems({ equipment, gameVariant, renderUrl, isArmoryImporte
 export function CharacterDetailSections({
     equipment, talents, professions, gameVariant,
     renderUrl, isArmoryImported, characterClass,
+    isOwner, characterId,
 }: CharacterDetailSectionsProps) {
     useWowheadTooltips(equipment ? [equipment] : []);
 
@@ -73,7 +76,8 @@ export function CharacterDetailSections({
             )}
             <TalentSection talents={talents} isArmoryImported={isArmoryImported}
                 characterClass={characterClass} gameVariant={gameVariant} />
-            <CharacterProfessionsPanel professions={professions} />
+            <CharacterProfessionsPanel professions={professions}
+                isOwner={isOwner} characterId={characterId} />
         </>
     );
 }

--- a/web/src/plugins/wow/slots/character-detail-sections.tsx
+++ b/web/src/plugins/wow/slots/character-detail-sections.tsx
@@ -26,6 +26,7 @@ interface CharacterDetailSectionsProps {
     characterClass: string | null;
     isOwner: boolean;
     characterId: string;
+    gameId: number;
 }
 
 /** Equipment panel with items and item detail modal */
@@ -62,7 +63,7 @@ function EquipmentWithItems({ equipment, gameVariant, renderUrl, isArmoryImporte
 export function CharacterDetailSections({
     equipment, talents, professions, gameVariant,
     renderUrl, isArmoryImported, characterClass,
-    isOwner, characterId,
+    isOwner, characterId, gameId,
 }: CharacterDetailSectionsProps) {
     useWowheadTooltips(equipment ? [equipment] : []);
 
@@ -77,7 +78,7 @@ export function CharacterDetailSections({
             <TalentSection talents={talents} isArmoryImported={isArmoryImported}
                 characterClass={characterClass} gameVariant={gameVariant} />
             <CharacterProfessionsPanel professions={professions}
-                isOwner={isOwner} characterId={characterId} />
+                isOwner={isOwner} characterId={characterId} gameId={gameId} />
         </>
     );
 }


### PR DESCRIPTION
## Summary

- Adds the `professions` JSONB column to `characters` (migration `0132_equal_mandarin.sql`) and a normalized `CharacterProfessionsDto` to the contract.
- Wires the Blizzard `/professions` endpoint into the WoW sync chain (helper → service → adapter → orchestrator) with strict null semantics: sync **never zero-outs manual entries** — only a 200 with real data overwrites; Classic / 404 / 5xx / empty all leave the prior value intact (architect §3 + operator directive).
- Detail page renders a `CharacterProfessionsPanel` with per-era owner CTA / read-only / edit affordances. Roster surfaces (admin assignment + event attendees + onboarding via shared `CharacterCardCompact`) get inline icon pills.
- New `EditProfessionsModal` lets owners enter professions manually — required for Classic players because Blizzard's Classic Profile API doesn't expose `/professions` (verified directly during this build). Picker is era-aware (`profession-categories.ts`) and the skill cap is variant-derived (`profession-max-skill.ts`).
- Seed-testing extended: `buildSeedProfessions(charClass, gameSlug)` populates each WoW seed character with a realistic blob (per-class map, retail gets 1 nested tier, classic gets `tiers: []`, non-WoW returns null).

## Linear

ROK-1130

## Test plan

- [x] `validate-ci.sh --full` passes (build + ts + lint + unit/coverage + integration + migration validation against a real Postgres container)
- [x] Migration validation: `0132_equal_mandarin.sql` is a single `ALTER TABLE characters ADD COLUMN professions jsonb;`. Journal monotonic (idx 132, ts 1777593700000). Co-exists with `0131_pg_stat_statements_extension` from main.
- [x] 13 helper unit tests + 6 adapter tests + 20 character integration tests pass (including architect-required 5xx-prior-value-preserved guard)
- [x] 7 Vitest cases for `CharacterProfessionsPanel` cover all four visibility quadrants
- [x] 6 Vitest cases for `SelectableCharacterCard` cover pill render / omit / no-DOM-diff (architect §8 positive assertion)
- [x] Playwright (desktop + mobile): 499 passed, 185 skipped (data prereq), 0 failed
- [x] Manual end-to-end on real Roknua row: helper short-circuited on Classic → orchestrator did not include `professions` in the update set → DB row byte-identical pre/post `syncAllCharacters()` simulation

## Notes

- Migration `0131` was claimed by ROK-1156 (#672, pg_stat_statements) during this build's life; rebased and re-numbered to `0132`.
- Spec reconciled in `planning-artifacts/specs/ROK-1130.md` — see "As-built reconciliation" for 9 mid-build operator-feedback additions (Classic short-circuit verified empirically, hide-when-empty visibility matrix, manual entry, era + category-aware picker, derived max skill, pills on every read-only card, never-zero-out tightening, string-state skill input, seed data per-class map).
- 12 non-blocking follow-ups flagged in `planning-artifacts/review-ROK-1130.md` (component-level Vitest for `EditProfessionsModal`/`ProfessionBadges`/`character-card-compact`, era-lib unit tests, file-size tech-debt for `blizzard.service.ts` + `seed-testing.ts` + `characters-import.helpers.ts`, slug-map consolidation, missing `first-aid` icon, two stale doc strings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)