### PR TITLE
chore: batch 2026-04-29 (ROK-1166 + ROK-1163 + ROK-1183)

### DIFF
--- a/api/scripts/seed-testing-availability.helpers.ts
+++ b/api/scripts/seed-testing-availability.helpers.ts
@@ -1,0 +1,216 @@
+import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from '../src/drizzle/schema';
+import { FAKE_GAMERS } from './seed-testing-users.helpers';
+
+type Db = PostgresJsDatabase<typeof schema>;
+type User = typeof schema.users.$inferSelect;
+
+function roundToHour(date: Date): Date {
+  const rounded = new Date(date);
+  rounded.setMinutes(0, 0, 0);
+  return rounded;
+}
+
+function hoursFromNow(baseHour: Date, hours: number): Date {
+  return new Date(baseHour.getTime() + hours * 60 * 60 * 1000);
+}
+
+function daysFromNow(baseHour: Date, days: number): Date {
+  return new Date(baseHour.getTime() + days * 24 * 60 * 60 * 1000);
+}
+
+export async function seedAvailability(
+  db: Db,
+  createdUsers: User[],
+): Promise<void> {
+  console.log('\n⏰ Creating unavailability periods...\n');
+
+  const baseHour = roundToHour(new Date());
+  const h = (hours: number) => hoursFromNow(baseHour, hours);
+  const d = (days: number) => daysFromNow(baseHour, days);
+
+  // Define availability/unavailability for heatmap testing.
+  // Need to overlap with event times for visibility.
+  const availabilityData = [
+    // Available slots (will show green on heatmap)
+    {
+      username: 'ShadowMage',
+      start: h(-2),
+      end: h(4),
+      status: 'available' as const,
+    },
+    {
+      username: 'DragonSlayer99',
+      start: h(-1),
+      end: h(6),
+      status: 'available' as const,
+    },
+    {
+      username: 'HealzForDayz',
+      start: h(0),
+      end: h(3),
+      status: 'available' as const,
+    },
+    {
+      username: 'TankMaster',
+      start: h(-3),
+      end: h(5),
+      status: 'available' as const,
+    },
+    {
+      username: 'ProRaider',
+      start: h(1),
+      end: h(8),
+      status: 'available' as const,
+    },
+
+    // Blocked slots (will show gray/locked on heatmap)
+    {
+      username: 'HealzForDayz',
+      start: h(3),
+      end: h(6),
+      status: 'blocked' as const,
+    },
+    {
+      username: 'CasualCarl',
+      start: h(-1),
+      end: h(2),
+      status: 'blocked' as const,
+    },
+    {
+      username: 'NightOwlGamer',
+      start: h(0),
+      end: h(4),
+      status: 'blocked' as const,
+    },
+
+    // Future unavailability
+    {
+      username: 'DragonSlayer99',
+      start: d(2),
+      end: d(4),
+      status: 'blocked' as const,
+    },
+    {
+      username: 'TankMaster',
+      start: d(5),
+      end: d(7),
+      status: 'blocked' as const,
+    },
+  ];
+
+  for (const avail of availabilityData) {
+    const user = createdUsers.find((u) => u.username === avail.username);
+    if (!user) continue;
+
+    try {
+      await db.insert(schema.availability).values({
+        userId: user.id,
+        timeRange: [avail.start, avail.end],
+        status: avail.status,
+      });
+      const icon = avail.status === 'available' ? '✅' : '❌';
+      console.log(
+        `  ${icon} ${user.username}: ${avail.status} (${avail.start.toLocaleTimeString()} - ${avail.end.toLocaleTimeString()})`,
+      );
+    } catch {
+      console.log(
+        `  ⏭️  Skipped availability for ${user.username} (may exist)`,
+      );
+    }
+  }
+}
+
+// dayOfWeek: 0=Mon, 1=Tue, 2=Wed, 3=Thu, 4=Fri, 5=Sat, 6=Sun
+function expandHours(
+  username: string,
+  dayOfWeek: number,
+  startHour: number,
+  endHour: number,
+) {
+  const slots: { username: string; dayOfWeek: number; startHour: number }[] =
+    [];
+  if (endHour > startHour) {
+    for (let h = startHour; h < endHour; h++)
+      slots.push({ username, dayOfWeek, startHour: h });
+  } else {
+    // wraps past midnight — same day gets startHour..23, next day gets 0..endHour
+    for (let h = startHour; h < 24; h++)
+      slots.push({ username, dayOfWeek, startHour: h });
+    const nextDay = (dayOfWeek + 1) % 7;
+    for (let h = 0; h < endHour; h++)
+      slots.push({ username, dayOfWeek: nextDay, startHour: h });
+  }
+  return slots;
+}
+
+function expandDays(
+  username: string,
+  days: number[],
+  startHour: number,
+  endHour: number,
+) {
+  return days.flatMap((d) => expandHours(username, d, startHour, endHour));
+}
+
+const weekdays = [0, 1, 2, 3, 4]; // Mon-Fri
+const weekends = [5, 6]; // Sat, Sun
+const allDays = [0, 1, 2, 3, 4, 5, 6];
+
+const gameTimeSlots = [
+  // ShadowMage — Raid leader, wide availability
+  ...expandDays('ShadowMage', weekdays, 18, 23),
+  ...expandDays('ShadowMage', weekends, 10, 23),
+  // TankMaster — Weekday evenings + full weekends
+  ...expandDays('TankMaster', weekdays, 19, 22),
+  ...expandDays('TankMaster', weekends, 8, 23),
+  // HealzForDayz — Late nights + weekend afternoons
+  ...expandDays('HealzForDayz', weekdays, 21, 1), // wraps to next day 0
+  ...expandDays('HealzForDayz', weekends, 13, 20),
+  // DragonSlayer99 — Early evenings weekdays, scattered weekend
+  ...expandDays('DragonSlayer99', weekdays, 17, 21),
+  ...expandHours('DragonSlayer99', 5, 10, 14), // Sat 10-14
+  ...expandHours('DragonSlayer99', 6, 16, 20), // Sun 16-20
+  // LootGoblin — Night owl, daily 22-03
+  ...expandDays('LootGoblin', allDays, 22, 3),
+  // NightOwlGamer — Night owl variant
+  ...expandDays('NightOwlGamer', weekdays, 23, 4),
+  ...expandDays('NightOwlGamer', weekends, 21, 4),
+  // CasualCarl — Light schedule
+  ...expandHours('CasualCarl', 2, 18, 22), // Wed 18-22
+  ...expandHours('CasualCarl', 4, 19, 23), // Fri 19-23
+  ...expandHours('CasualCarl', 5, 12, 18), // Sat 12-18
+  // ProRaider — Hardcore, big blocks
+  ...expandDays('ProRaider', [0, 1, 2, 3], 17, 23), // Mon-Thu 17-23
+  ...expandDays('ProRaider', [4, 5], 15, 2), // Fri-Sat 15-02
+  ...expandHours('ProRaider', 6, 12, 22), // Sun 12-22
+];
+
+export async function seedGameTimeSlots(
+  db: Db,
+  createdUsers: User[],
+): Promise<void> {
+  console.log('\n🕹️  Seeding game time templates...\n');
+
+  const gameTimeValues = gameTimeSlots
+    .map((slot) => {
+      const user = createdUsers.find((u) => u.username === slot.username);
+      if (!user) return null;
+      return {
+        userId: user.id,
+        dayOfWeek: slot.dayOfWeek,
+        startHour: slot.startHour,
+      };
+    })
+    .filter((v): v is NonNullable<typeof v> => v !== null);
+
+  if (gameTimeValues.length > 0) {
+    await db
+      .insert(schema.gameTimeTemplates)
+      .values(gameTimeValues)
+      .onConflictDoNothing();
+    console.log(
+      `  ✅ Seeded ${gameTimeValues.length} game time slots across ${FAKE_GAMERS.length} users`,
+    );
+  }
+}

--- a/api/scripts/seed-testing-events.helpers.ts
+++ b/api/scripts/seed-testing-events.helpers.ts
@@ -1,0 +1,50 @@
+import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { eq } from 'drizzle-orm';
+import * as schema from '../src/drizzle/schema';
+
+type Db = PostgresJsDatabase<typeof schema>;
+type User = typeof schema.users.$inferSelect;
+
+export async function seedEventSignups(
+  db: Db,
+  createdUsers: User[],
+): Promise<void> {
+  console.log('\n📝 Creating event signups with character links...\n');
+
+  const allEvents = await db.select().from(schema.events);
+  // Pre-fetch all characters for our seed users
+  const allCharacters = await db.select().from(schema.characters);
+
+  for (const event of allEvents) {
+    // Sign up 3-5 random users for each event
+    const numSignups = Math.floor(Math.random() * 3) + 3;
+    const shuffledUsers = [...createdUsers].sort(() => Math.random() - 0.5);
+    const selectedUsers = shuffledUsers.slice(0, numSignups);
+
+    for (const user of selectedUsers) {
+      const existingSignup = await db
+        .select()
+        .from(schema.eventSignups)
+        .where(eq(schema.eventSignups.eventId, event.id))
+        .then((rows) => rows.find((r) => r.userId === user.id));
+
+      if (!existingSignup) {
+        // Find user's character for this event's game
+        const userChar = event.gameId
+          ? allCharacters.find(
+              (c) => c.userId === user.id && c.gameId === event.gameId,
+            )
+          : undefined;
+
+        await db.insert(schema.eventSignups).values({
+          eventId: event.id,
+          userId: user.id,
+          characterId: userChar?.id ?? null,
+          confirmationStatus: userChar ? 'confirmed' : 'pending',
+        });
+        const charInfo = userChar ? ` [${userChar.name}]` : '';
+        console.log(`  ✅ ${user.username}${charInfo} → ${event.title}`);
+      }
+    }
+  }
+}

--- a/api/scripts/seed-testing-theme.helpers.ts
+++ b/api/scripts/seed-testing-theme.helpers.ts
@@ -1,0 +1,66 @@
+import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { eq } from 'drizzle-orm';
+import * as schema from '../src/drizzle/schema';
+
+type Db = PostgresJsDatabase<typeof schema>;
+type User = typeof schema.users.$inferSelect;
+
+const themeAssignments: Record<string, string> = {
+  ShadowMage: 'default-dark',
+  TankMaster: 'default-light',
+  HealzForDayz: 'auto',
+  DragonSlayer99: 'default-light',
+  CasualCarl: 'default-dark',
+  NightOwlGamer: 'auto',
+  ProRaider: 'auto',
+  LootGoblin: 'auto',
+};
+
+export async function seedThemePreferences(
+  db: Db,
+  createdUsers: User[],
+): Promise<void> {
+  console.log('\n🎨 Setting theme preferences...\n');
+
+  for (const [username, theme] of Object.entries(themeAssignments)) {
+    const user = createdUsers.find((u) => u.username === username);
+    if (!user) continue;
+
+    try {
+      await db
+        .insert(schema.userPreferences)
+        .values({
+          userId: user.id,
+          key: 'theme',
+          value: theme,
+        })
+        .onConflictDoNothing();
+      console.log(`  🎨 ${username} → ${theme}`);
+    } catch {
+      console.log(`  ⏭️  Skipped theme for ${username} (may exist)`);
+    }
+  }
+
+  const adminUser = await db
+    .select()
+    .from(schema.users)
+    .where(eq(schema.users.role, 'admin'))
+    .limit(1)
+    .then((rows) => rows[0]);
+
+  if (adminUser) {
+    try {
+      await db
+        .insert(schema.userPreferences)
+        .values({
+          userId: adminUser.id,
+          key: 'theme',
+          value: 'auto',
+        })
+        .onConflictDoNothing();
+      console.log(`  🎨 ${adminUser.username} (admin) → auto`);
+    } catch {
+      console.log(`  ⏭️  Skipped theme for admin (may exist)`);
+    }
+  }
+}

--- a/api/scripts/seed-testing-users.helpers.ts
+++ b/api/scripts/seed-testing-users.helpers.ts
@@ -1,0 +1,278 @@
+import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { eq } from 'drizzle-orm';
+import * as schema from '../src/drizzle/schema';
+import { buildSeedProfessions } from './seed-testing.helpers';
+
+type Db = PostgresJsDatabase<typeof schema>;
+type User = typeof schema.users.$inferSelect;
+
+// Fake gamer data (ROK-194: Added Discord avatars for fallback testing)
+export const FAKE_GAMERS = [
+  { username: 'ShadowMage', avatar: 'a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6' },
+  { username: 'DragonSlayer99', avatar: 'b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7' },
+  { username: 'HealzForDayz', avatar: 'c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8' },
+  { username: 'TankMaster', avatar: 'd4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9' },
+  { username: 'NightOwlGamer', avatar: 'e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0' },
+  { username: 'CasualCarl', avatar: 'f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1' },
+  { username: 'ProRaider', avatar: 'g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2' },
+  { username: 'LootGoblin', avatar: 'h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3' },
+];
+
+/**
+ * Get the Blizzard CDN URL for a WoW class icon.
+ * Uses the official render CDN which hosts class icons at 56x56.
+ */
+export function getClassIconUrl(wowClass: string): string {
+  return `https://render.worldofwarcraft.com/icons/56/classicon_${wowClass.toLowerCase()}.jpg`;
+}
+
+export async function seedUsers(db: Db): Promise<User[]> {
+  console.log('👥 Creating fake gamers...\n');
+
+  const createdUsers: User[] = [];
+
+  for (const gamer of FAKE_GAMERS) {
+    let user = await db
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.username, gamer.username))
+      .limit(1)
+      .then((rows) => rows[0]);
+
+    if (!user) {
+      const [newUser] = await db
+        .insert(schema.users)
+        .values({
+          username: gamer.username,
+          avatar: gamer.avatar,
+          role: 'member',
+        })
+        .returning();
+      user = newUser;
+      console.log(`  ✅ Created user: ${gamer.username}`);
+    } else {
+      console.log(`  ⏭️  Skipped: ${gamer.username} (exists)`);
+    }
+
+    createdUsers.push(user);
+  }
+
+  return createdUsers;
+}
+
+const charactersToCreate = [
+  // WoW Retail characters
+  {
+    username: 'ShadowMage',
+    gameSlug: 'world-of-warcraft',
+    charName: 'Shadowmage',
+    class: 'Mage',
+    spec: 'Arcane',
+    role: 'dps' as const,
+    wowClass: 'mage',
+  },
+  {
+    username: 'DragonSlayer99',
+    gameSlug: 'world-of-warcraft',
+    charName: 'Dragonslayer',
+    class: 'Rogue',
+    spec: 'Assassination',
+    role: 'dps' as const,
+    wowClass: 'rogue',
+  },
+  {
+    username: 'HealzForDayz',
+    gameSlug: 'world-of-warcraft',
+    charName: 'Healzfordays',
+    class: 'Priest',
+    spec: 'Holy',
+    role: 'healer' as const,
+    wowClass: 'priest',
+  },
+  {
+    username: 'TankMaster',
+    gameSlug: 'world-of-warcraft',
+    charName: 'Tankmaster',
+    class: 'Warrior',
+    spec: 'Protection',
+    role: 'tank' as const,
+    wowClass: 'warrior',
+  },
+  {
+    username: 'ProRaider',
+    gameSlug: 'world-of-warcraft',
+    charName: 'Deathbringer',
+    class: 'Death Knight',
+    spec: 'Unholy',
+    role: 'dps' as const,
+    wowClass: 'deathknight',
+  },
+  {
+    username: 'NightOwlGamer',
+    gameSlug: 'world-of-warcraft',
+    charName: 'Moonweaver',
+    class: 'Druid',
+    spec: 'Restoration',
+    role: 'healer' as const,
+    wowClass: 'druid',
+  },
+  {
+    username: 'LootGoblin',
+    gameSlug: 'world-of-warcraft',
+    charName: 'Felstrike',
+    class: 'Warlock',
+    spec: 'Destruction',
+    role: 'dps' as const,
+    wowClass: 'warlock',
+  },
+  {
+    username: 'CasualCarl',
+    gameSlug: 'world-of-warcraft',
+    charName: 'Shieldwall',
+    class: 'Paladin',
+    spec: 'Protection',
+    role: 'tank' as const,
+    wowClass: 'paladin',
+  },
+  // WoW Classic characters
+  {
+    username: 'ShadowMage',
+    gameSlug: 'world-of-warcraft-classic',
+    charName: 'Frostbolt',
+    class: 'Mage',
+    spec: 'Frost',
+    role: 'dps' as const,
+    wowClass: 'mage',
+  },
+  {
+    username: 'TankMaster',
+    gameSlug: 'world-of-warcraft-classic',
+    charName: 'Ironfist',
+    class: 'Warrior',
+    spec: 'Protection',
+    role: 'tank' as const,
+    wowClass: 'warrior',
+  },
+  {
+    username: 'HealzForDayz',
+    gameSlug: 'world-of-warcraft-classic',
+    charName: 'Lightbringer',
+    class: 'Priest',
+    spec: 'Holy',
+    role: 'healer' as const,
+    wowClass: 'priest',
+  },
+  {
+    username: 'ProRaider',
+    gameSlug: 'world-of-warcraft-classic',
+    charName: 'Backstab',
+    class: 'Rogue',
+    spec: 'Combat',
+    role: 'dps' as const,
+    wowClass: 'rogue',
+  },
+  // Valheim characters
+  {
+    username: 'ShadowMage',
+    gameSlug: 'valheim',
+    charName: 'Windwalker',
+    class: 'Monk',
+    spec: 'Windwalker',
+    role: 'dps' as const,
+    wowClass: 'monk',
+  },
+  {
+    username: 'TankMaster',
+    gameSlug: 'valheim',
+    charName: 'Earthguard',
+    class: 'Shaman',
+    spec: 'Restoration',
+    role: 'healer' as const,
+    wowClass: 'shaman',
+  },
+  {
+    username: 'ProRaider',
+    gameSlug: 'valheim',
+    charName: 'Hawkeye',
+    class: 'Hunter',
+    spec: 'Marksmanship',
+    role: 'dps' as const,
+    wowClass: 'hunter',
+  },
+  // FFXIV characters
+  {
+    username: 'NightOwlGamer',
+    gameSlug: 'final-fantasy-xiv-online',
+    charName: 'Voidcaller',
+    class: 'Evoker',
+    spec: 'Preservation',
+    role: 'healer' as const,
+    wowClass: 'evoker',
+  },
+  {
+    username: 'LootGoblin',
+    gameSlug: 'final-fantasy-xiv-online',
+    charName: 'Demonbane',
+    class: 'Demon Hunter',
+    spec: 'Havoc',
+    role: 'dps' as const,
+    wowClass: 'demonhunter',
+  },
+];
+
+export async function seedCharacters(
+  db: Db,
+  createdUsers: User[],
+): Promise<void> {
+  console.log('\n🎭 Creating characters with WoW class icons...\n');
+
+  const registryGames = await db.select().from(schema.games);
+
+  if (registryGames.length === 0) {
+    console.log('  ⚠️  No games found - skipping character creation');
+    return;
+  }
+
+  const gameBySlug: Record<string, (typeof registryGames)[number]> = {};
+  for (const g of registryGames) gameBySlug[g.slug] = g;
+
+  // Track which users already have a main — only first character per player is main
+  const usersWithMain = new Set<string>();
+
+  for (const charData of charactersToCreate) {
+    const user = createdUsers.find((u) => u.username === charData.username);
+    const game = gameBySlug[charData.gameSlug];
+
+    if (!user || !game) continue;
+
+    const existing = await db
+      .select()
+      .from(schema.characters)
+      .where(eq(schema.characters.userId, user.id))
+      .then((rows) => rows.find((c) => c.gameId === game.id));
+
+    if (!existing) {
+      const isMain = !usersWithMain.has(charData.username);
+      usersWithMain.add(charData.username);
+
+      await db.insert(schema.characters).values({
+        userId: user.id,
+        gameId: game.id,
+        name: charData.charName,
+        class: charData.class,
+        spec: charData.spec,
+        role: charData.role,
+        isMain,
+        avatarUrl: getClassIconUrl(charData.wowClass),
+        displayOrder: isMain ? 0 : 1,
+        professions: buildSeedProfessions(charData.class, charData.gameSlug),
+      });
+      const tag = isMain ? 'MAIN' : 'ALT';
+      console.log(
+        `  ✅ Created ${charData.charName} [${charData.class}/${charData.spec}] (${game.name}) [${tag}]`,
+      );
+    } else {
+      console.log(`  ⏭️  Skipped: ${charData.charName} (exists)`);
+    }
+  }
+}

--- a/api/scripts/seed-testing-users.helpers.ts
+++ b/api/scripts/seed-testing-users.helpers.ts
@@ -60,165 +60,56 @@ export async function seedUsers(db: Db): Promise<User[]> {
   return createdUsers;
 }
 
-const charactersToCreate = [
-  // WoW Retail characters
-  {
-    username: 'ShadowMage',
-    gameSlug: 'world-of-warcraft',
-    charName: 'Shadowmage',
-    class: 'Mage',
-    spec: 'Arcane',
-    role: 'dps' as const,
-    wowClass: 'mage',
-  },
-  {
-    username: 'DragonSlayer99',
-    gameSlug: 'world-of-warcraft',
-    charName: 'Dragonslayer',
-    class: 'Rogue',
-    spec: 'Assassination',
-    role: 'dps' as const,
-    wowClass: 'rogue',
-  },
-  {
-    username: 'HealzForDayz',
-    gameSlug: 'world-of-warcraft',
-    charName: 'Healzfordays',
-    class: 'Priest',
-    spec: 'Holy',
-    role: 'healer' as const,
-    wowClass: 'priest',
-  },
-  {
-    username: 'TankMaster',
-    gameSlug: 'world-of-warcraft',
-    charName: 'Tankmaster',
-    class: 'Warrior',
-    spec: 'Protection',
-    role: 'tank' as const,
-    wowClass: 'warrior',
-  },
-  {
-    username: 'ProRaider',
-    gameSlug: 'world-of-warcraft',
-    charName: 'Deathbringer',
-    class: 'Death Knight',
-    spec: 'Unholy',
-    role: 'dps' as const,
-    wowClass: 'deathknight',
-  },
-  {
-    username: 'NightOwlGamer',
-    gameSlug: 'world-of-warcraft',
-    charName: 'Moonweaver',
-    class: 'Druid',
-    spec: 'Restoration',
-    role: 'healer' as const,
-    wowClass: 'druid',
-  },
-  {
-    username: 'LootGoblin',
-    gameSlug: 'world-of-warcraft',
-    charName: 'Felstrike',
-    class: 'Warlock',
-    spec: 'Destruction',
-    role: 'dps' as const,
-    wowClass: 'warlock',
-  },
-  {
-    username: 'CasualCarl',
-    gameSlug: 'world-of-warcraft',
-    charName: 'Shieldwall',
-    class: 'Paladin',
-    spec: 'Protection',
-    role: 'tank' as const,
-    wowClass: 'paladin',
-  },
-  // WoW Classic characters
-  {
-    username: 'ShadowMage',
-    gameSlug: 'world-of-warcraft-classic',
-    charName: 'Frostbolt',
-    class: 'Mage',
-    spec: 'Frost',
-    role: 'dps' as const,
-    wowClass: 'mage',
-  },
-  {
-    username: 'TankMaster',
-    gameSlug: 'world-of-warcraft-classic',
-    charName: 'Ironfist',
-    class: 'Warrior',
-    spec: 'Protection',
-    role: 'tank' as const,
-    wowClass: 'warrior',
-  },
-  {
-    username: 'HealzForDayz',
-    gameSlug: 'world-of-warcraft-classic',
-    charName: 'Lightbringer',
-    class: 'Priest',
-    spec: 'Holy',
-    role: 'healer' as const,
-    wowClass: 'priest',
-  },
-  {
-    username: 'ProRaider',
-    gameSlug: 'world-of-warcraft-classic',
-    charName: 'Backstab',
-    class: 'Rogue',
-    spec: 'Combat',
-    role: 'dps' as const,
-    wowClass: 'rogue',
-  },
-  // Valheim characters
-  {
-    username: 'ShadowMage',
-    gameSlug: 'valheim',
-    charName: 'Windwalker',
-    class: 'Monk',
-    spec: 'Windwalker',
-    role: 'dps' as const,
-    wowClass: 'monk',
-  },
-  {
-    username: 'TankMaster',
-    gameSlug: 'valheim',
-    charName: 'Earthguard',
-    class: 'Shaman',
-    spec: 'Restoration',
-    role: 'healer' as const,
-    wowClass: 'shaman',
-  },
-  {
-    username: 'ProRaider',
-    gameSlug: 'valheim',
-    charName: 'Hawkeye',
-    class: 'Hunter',
-    spec: 'Marksmanship',
-    role: 'dps' as const,
-    wowClass: 'hunter',
-  },
-  // FFXIV characters
-  {
-    username: 'NightOwlGamer',
-    gameSlug: 'final-fantasy-xiv-online',
-    charName: 'Voidcaller',
-    class: 'Evoker',
-    spec: 'Preservation',
-    role: 'healer' as const,
-    wowClass: 'evoker',
-  },
-  {
-    username: 'LootGoblin',
-    gameSlug: 'final-fantasy-xiv-online',
-    charName: 'Demonbane',
-    class: 'Demon Hunter',
-    spec: 'Havoc',
-    role: 'dps' as const,
-    wowClass: 'demonhunter',
-  },
+type Role = 'dps' | 'tank' | 'healer';
+type CharSeed = {
+  username: string;
+  gameSlug: string;
+  charName: string;
+  class: string;
+  spec: string;
+  role: Role;
+  wowClass: string;
+};
+
+// [username, gameSlug, charName, class, spec, role, wowClass]
+type CharRow = [string, string, string, string, string, Role, string];
+
+// prettier-ignore
+const CHAR_ROWS: readonly CharRow[] = [
+  // WoW Retail
+  ['ShadowMage',     'world-of-warcraft', 'Shadowmage',   'Mage',         'Arcane',        'dps',    'mage'],
+  ['DragonSlayer99', 'world-of-warcraft', 'Dragonslayer', 'Rogue',        'Assassination', 'dps',    'rogue'],
+  ['HealzForDayz',   'world-of-warcraft', 'Healzfordays', 'Priest',       'Holy',          'healer', 'priest'],
+  ['TankMaster',     'world-of-warcraft', 'Tankmaster',   'Warrior',      'Protection',    'tank',   'warrior'],
+  ['ProRaider',      'world-of-warcraft', 'Deathbringer', 'Death Knight', 'Unholy',        'dps',    'deathknight'],
+  ['NightOwlGamer',  'world-of-warcraft', 'Moonweaver',   'Druid',        'Restoration',   'healer', 'druid'],
+  ['LootGoblin',     'world-of-warcraft', 'Felstrike',    'Warlock',      'Destruction',   'dps',    'warlock'],
+  ['CasualCarl',     'world-of-warcraft', 'Shieldwall',   'Paladin',      'Protection',    'tank',   'paladin'],
+  // WoW Classic
+  ['ShadowMage',   'world-of-warcraft-classic', 'Frostbolt',    'Mage',    'Frost',      'dps',    'mage'],
+  ['TankMaster',   'world-of-warcraft-classic', 'Ironfist',     'Warrior', 'Protection', 'tank',   'warrior'],
+  ['HealzForDayz', 'world-of-warcraft-classic', 'Lightbringer', 'Priest',  'Holy',       'healer', 'priest'],
+  ['ProRaider',    'world-of-warcraft-classic', 'Backstab',     'Rogue',   'Combat',     'dps',    'rogue'],
+  // Valheim
+  ['ShadowMage', 'valheim', 'Windwalker', 'Monk',   'Windwalker',   'dps',    'monk'],
+  ['TankMaster', 'valheim', 'Earthguard', 'Shaman', 'Restoration',  'healer', 'shaman'],
+  ['ProRaider',  'valheim', 'Hawkeye',    'Hunter', 'Marksmanship', 'dps',    'hunter'],
+  // FFXIV
+  ['NightOwlGamer', 'final-fantasy-xiv-online', 'Voidcaller', 'Evoker',       'Preservation', 'healer', 'evoker'],
+  ['LootGoblin',    'final-fantasy-xiv-online', 'Demonbane',  'Demon Hunter', 'Havoc',        'dps',    'demonhunter'],
 ];
+
+const charactersToCreate: CharSeed[] = CHAR_ROWS.map(
+  ([username, gameSlug, charName, cls, spec, role, wowClass]) => ({
+    username,
+    gameSlug,
+    charName,
+    class: cls,
+    spec,
+    role,
+    wowClass,
+  }),
+);
 
 export async function seedCharacters(
   db: Db,

--- a/api/scripts/seed-testing.ts
+++ b/api/scripts/seed-testing.ts
@@ -9,12 +9,12 @@ import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { eq } from 'drizzle-orm';
 import * as schema from '../src/drizzle/schema';
 import * as dotenv from 'dotenv';
-import {
-  FAKE_GAMERS,
-  seedUsers,
-  seedCharacters,
-} from './seed-testing-users.helpers';
+import { seedUsers, seedCharacters } from './seed-testing-users.helpers';
 import { seedThemePreferences } from './seed-testing-theme.helpers';
+import {
+  seedAvailability,
+  seedGameTimeSlots,
+} from './seed-testing-availability.helpers';
 
 dotenv.config();
 
@@ -88,211 +88,11 @@ async function bootstrap() {
     // =====================
     // Create Unavailability
     // =====================
-    console.log('\n⏰ Creating unavailability periods...\n');
-
-    const now = new Date();
-    const roundToHour = (date: Date): Date => {
-      const rounded = new Date(date);
-      rounded.setMinutes(0, 0, 0);
-      return rounded;
-    };
-    const baseHour = roundToHour(now);
-
-    // Helper functions
-    const hoursFromNow = (hours: number) =>
-      new Date(baseHour.getTime() + hours * 60 * 60 * 1000);
-    const daysFromNow = (days: number) =>
-      new Date(baseHour.getTime() + days * 24 * 60 * 60 * 1000);
-
-    // Define availability/unavailability for heatmap testing
-    // Need to overlap with event times for visibility
-    const availabilityData = [
-      // Available slots (will show green on heatmap)
-      {
-        username: 'ShadowMage',
-        start: hoursFromNow(-2),
-        end: hoursFromNow(4),
-        status: 'available' as const,
-      },
-      {
-        username: 'DragonSlayer99',
-        start: hoursFromNow(-1),
-        end: hoursFromNow(6),
-        status: 'available' as const,
-      },
-      {
-        username: 'HealzForDayz',
-        start: hoursFromNow(0),
-        end: hoursFromNow(3),
-        status: 'available' as const,
-      },
-      {
-        username: 'TankMaster',
-        start: hoursFromNow(-3),
-        end: hoursFromNow(5),
-        status: 'available' as const,
-      },
-      {
-        username: 'ProRaider',
-        start: hoursFromNow(1),
-        end: hoursFromNow(8),
-        status: 'available' as const,
-      },
-
-      // Blocked slots (will show gray/locked on heatmap)
-      {
-        username: 'HealzForDayz',
-        start: hoursFromNow(3),
-        end: hoursFromNow(6),
-        status: 'blocked' as const,
-      },
-      {
-        username: 'CasualCarl',
-        start: hoursFromNow(-1),
-        end: hoursFromNow(2),
-        status: 'blocked' as const,
-      },
-      {
-        username: 'NightOwlGamer',
-        start: hoursFromNow(0),
-        end: hoursFromNow(4),
-        status: 'blocked' as const,
-      },
-
-      // Future unavailability
-      {
-        username: 'DragonSlayer99',
-        start: daysFromNow(2),
-        end: daysFromNow(4),
-        status: 'blocked' as const,
-      },
-      {
-        username: 'TankMaster',
-        start: daysFromNow(5),
-        end: daysFromNow(7),
-        status: 'blocked' as const,
-      },
-    ];
-
-    for (const avail of availabilityData) {
-      const user = createdUsers.find((u) => u.username === avail.username);
-      if (!user) continue;
-
-      // Create availability record
-      try {
-        await db.insert(schema.availability).values({
-          userId: user.id,
-          timeRange: [avail.start, avail.end],
-          status: avail.status,
-        });
-        const icon = avail.status === 'available' ? '✅' : '❌';
-        console.log(
-          `  ${icon} ${user.username}: ${avail.status} (${avail.start.toLocaleTimeString()} - ${avail.end.toLocaleTimeString()})`,
-        );
-      } catch {
-        console.log(
-          `  ⏭️  Skipped availability for ${user.username} (may exist)`,
-        );
-      }
-    }
+    await seedAvailability(db, createdUsers);
 
     await seedThemePreferences(db, createdUsers);
 
-    // =====================
-    // Seed Game Time Templates (ROK-227)
-    // =====================
-    console.log('\n🕹️  Seeding game time templates...\n');
-
-    // dayOfWeek: 0=Mon, 1=Tue, 2=Wed, 3=Thu, 4=Fri, 5=Sat, 6=Sun
-    function expandHours(
-      username: string,
-      dayOfWeek: number,
-      startHour: number,
-      endHour: number,
-    ) {
-      const slots: {
-        username: string;
-        dayOfWeek: number;
-        startHour: number;
-      }[] = [];
-      if (endHour > startHour) {
-        for (let h = startHour; h < endHour; h++)
-          slots.push({ username, dayOfWeek, startHour: h });
-      } else {
-        // wraps past midnight — same day gets startHour..23, next day gets 0..endHour
-        for (let h = startHour; h < 24; h++)
-          slots.push({ username, dayOfWeek, startHour: h });
-        const nextDay = (dayOfWeek + 1) % 7;
-        for (let h = 0; h < endHour; h++)
-          slots.push({ username, dayOfWeek: nextDay, startHour: h });
-      }
-      return slots;
-    }
-
-    function expandDays(
-      username: string,
-      days: number[],
-      startHour: number,
-      endHour: number,
-    ) {
-      return days.flatMap((d) => expandHours(username, d, startHour, endHour));
-    }
-
-    const weekdays = [0, 1, 2, 3, 4]; // Mon-Fri
-    const weekends = [5, 6]; // Sat, Sun
-    const allDays = [0, 1, 2, 3, 4, 5, 6];
-
-    const gameTimeSlots = [
-      // ShadowMage — Raid leader, wide availability
-      ...expandDays('ShadowMage', weekdays, 18, 23),
-      ...expandDays('ShadowMage', weekends, 10, 23),
-      // TankMaster — Weekday evenings + full weekends
-      ...expandDays('TankMaster', weekdays, 19, 22),
-      ...expandDays('TankMaster', weekends, 8, 23),
-      // HealzForDayz — Late nights + weekend afternoons
-      ...expandDays('HealzForDayz', weekdays, 21, 1), // wraps to next day 0
-      ...expandDays('HealzForDayz', weekends, 13, 20),
-      // DragonSlayer99 — Early evenings weekdays, scattered weekend
-      ...expandDays('DragonSlayer99', weekdays, 17, 21),
-      ...expandHours('DragonSlayer99', 5, 10, 14), // Sat 10-14
-      ...expandHours('DragonSlayer99', 6, 16, 20), // Sun 16-20
-      // LootGoblin — Night owl, daily 22-03
-      ...expandDays('LootGoblin', allDays, 22, 3),
-      // NightOwlGamer — Night owl variant
-      ...expandDays('NightOwlGamer', weekdays, 23, 4),
-      ...expandDays('NightOwlGamer', weekends, 21, 4),
-      // CasualCarl — Light schedule
-      ...expandHours('CasualCarl', 2, 18, 22), // Wed 18-22
-      ...expandHours('CasualCarl', 4, 19, 23), // Fri 19-23
-      ...expandHours('CasualCarl', 5, 12, 18), // Sat 12-18
-      // ProRaider — Hardcore, big blocks
-      ...expandDays('ProRaider', [0, 1, 2, 3], 17, 23), // Mon-Thu 17-23
-      ...expandDays('ProRaider', [4, 5], 15, 2), // Fri-Sat 15-02
-      ...expandHours('ProRaider', 6, 12, 22), // Sun 12-22
-    ];
-
-    // Map usernames to user IDs
-    const gameTimeValues = gameTimeSlots
-      .map((slot) => {
-        const user = createdUsers.find((u) => u.username === slot.username);
-        if (!user) return null;
-        return {
-          userId: user.id,
-          dayOfWeek: slot.dayOfWeek,
-          startHour: slot.startHour,
-        };
-      })
-      .filter((v): v is NonNullable<typeof v> => v !== null);
-
-    if (gameTimeValues.length > 0) {
-      await db
-        .insert(schema.gameTimeTemplates)
-        .values(gameTimeValues)
-        .onConflictDoNothing();
-      console.log(
-        `  ✅ Seeded ${gameTimeValues.length} game time slots across ${FAKE_GAMERS.length} users`,
-      );
-    }
+    await seedGameTimeSlots(db, createdUsers);
 
     console.log('\n🎉 Testing data seed complete!');
     console.log('\n📍 View events at: http://localhost:80/events');

--- a/api/scripts/seed-testing.ts
+++ b/api/scripts/seed-testing.ts
@@ -6,10 +6,10 @@ import {
   DrizzleAsyncProvider,
 } from '../src/drizzle/drizzle.module';
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
-import { eq } from 'drizzle-orm';
 import * as schema from '../src/drizzle/schema';
 import * as dotenv from 'dotenv';
 import { seedUsers, seedCharacters } from './seed-testing-users.helpers';
+import { seedEventSignups } from './seed-testing-events.helpers';
 import { seedThemePreferences } from './seed-testing-theme.helpers';
 import {
   seedAvailability,
@@ -40,58 +40,9 @@ async function bootstrap() {
   try {
     const createdUsers = await seedUsers(db);
     await seedCharacters(db, createdUsers);
-
-    // =====================
-    // Create Event Signups (linked to characters)
-    // =====================
-    console.log('\n📝 Creating event signups with character links...\n');
-
-    const allEvents = await db.select().from(schema.events);
-
-    // Pre-fetch all characters for our seed users
-    const allCharacters = await db.select().from(schema.characters);
-
-    for (const event of allEvents) {
-      // Sign up 3-5 random users for each event
-      const numSignups = Math.floor(Math.random() * 3) + 3;
-      const shuffledUsers = [...createdUsers].sort(() => Math.random() - 0.5);
-      const selectedUsers = shuffledUsers.slice(0, numSignups);
-
-      for (const user of selectedUsers) {
-        // Check if signup exists
-        const existingSignup = await db
-          .select()
-          .from(schema.eventSignups)
-          .where(eq(schema.eventSignups.eventId, event.id))
-          .then((rows) => rows.find((r) => r.userId === user.id));
-
-        if (!existingSignup) {
-          // Find user's character for this event's game
-          const userChar = event.gameId
-            ? allCharacters.find(
-                (c) => c.userId === user.id && c.gameId === event.gameId,
-              )
-            : undefined;
-
-          await db.insert(schema.eventSignups).values({
-            eventId: event.id,
-            userId: user.id,
-            characterId: userChar?.id ?? null,
-            confirmationStatus: userChar ? 'confirmed' : 'pending',
-          });
-          const charInfo = userChar ? ` [${userChar.name}]` : '';
-          console.log(`  ✅ ${user.username}${charInfo} → ${event.title}`);
-        }
-      }
-    }
-
-    // =====================
-    // Create Unavailability
-    // =====================
+    await seedEventSignups(db, createdUsers);
     await seedAvailability(db, createdUsers);
-
     await seedThemePreferences(db, createdUsers);
-
     await seedGameTimeSlots(db, createdUsers);
 
     console.log('\n🎉 Testing data seed complete!');
@@ -107,4 +58,4 @@ async function bootstrap() {
   process.exit(0);
 }
 
-bootstrap();
+void bootstrap();

--- a/api/scripts/seed-testing.ts
+++ b/api/scripts/seed-testing.ts
@@ -1,12 +1,19 @@
 import { NestFactory } from '@nestjs/core';
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
-import { DrizzleModule, DrizzleAsyncProvider } from '../src/drizzle/drizzle.module';
+import {
+  DrizzleModule,
+  DrizzleAsyncProvider,
+} from '../src/drizzle/drizzle.module';
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { eq } from 'drizzle-orm';
 import * as schema from '../src/drizzle/schema';
 import * as dotenv from 'dotenv';
-import { buildSeedProfessions } from './seed-testing.helpers';
+import {
+  FAKE_GAMERS,
+  seedUsers,
+  seedCharacters,
+} from './seed-testing-users.helpers';
 
 dotenv.config();
 
@@ -16,412 +23,344 @@ dotenv.config();
  */
 
 @Module({
-    imports: [
-        ConfigModule.forRoot({ isGlobal: true, envFilePath: '.env' }),
-        DrizzleModule,
-    ],
+  imports: [
+    ConfigModule.forRoot({ isGlobal: true, envFilePath: '.env' }),
+    DrizzleModule,
+  ],
 })
-class SeedTestingModule { }
-
-// Fake gamer data (ROK-194: Added Discord avatars for fallback testing)
-const FAKE_GAMERS = [
-    { username: 'ShadowMage', avatar: 'a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6' },
-    { username: 'DragonSlayer99', avatar: 'b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7' },
-    { username: 'HealzForDayz', avatar: 'c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8' },
-    { username: 'TankMaster', avatar: 'd4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9' },
-    { username: 'NightOwlGamer', avatar: 'e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0' },
-    { username: 'CasualCarl', avatar: 'f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1' },
-    { username: 'ProRaider', avatar: 'g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2' },
-    { username: 'LootGoblin', avatar: 'h8i9j0k1l2m3n4o5p6q7r8s9t0u1v2w3' },
-];
-
-/**
- * Get the Blizzard CDN URL for a WoW class icon.
- * Uses the official render CDN which hosts class icons at 56x56.
- */
-function getClassIconUrl(wowClass: string): string {
-    return `https://render.worldofwarcraft.com/icons/56/classicon_${wowClass.toLowerCase()}.jpg`;
-}
+class SeedTestingModule {}
 
 async function bootstrap() {
-    console.log('🌱 Seeding test users, signups, and availability...\n');
+  console.log('🌱 Seeding test users, signups, and availability...\n');
 
-    const app = await NestFactory.createApplicationContext(SeedTestingModule);
-    const db = app.get<PostgresJsDatabase<typeof schema>>(DrizzleAsyncProvider);
+  const app = await NestFactory.createApplicationContext(SeedTestingModule);
+  const db = app.get<PostgresJsDatabase<typeof schema>>(DrizzleAsyncProvider);
 
-    try {
-        // =====================
-        // Create Fake Users
-        // =====================
-        console.log('👥 Creating fake gamers...\n');
+  try {
+    const createdUsers = await seedUsers(db);
+    await seedCharacters(db, createdUsers);
 
-        const createdUsers: (typeof schema.users.$inferSelect)[] = [];
+    // =====================
+    // Create Event Signups (linked to characters)
+    // =====================
+    console.log('\n📝 Creating event signups with character links...\n');
 
-        for (const gamer of FAKE_GAMERS) {
-            let user = await db
-                .select()
-                .from(schema.users)
-                .where(eq(schema.users.username, gamer.username))
-                .limit(1)
-                .then((rows) => rows[0]);
+    const allEvents = await db.select().from(schema.events);
 
-            if (!user) {
-                const [newUser] = await db
-                    .insert(schema.users)
-                    .values({
-                        username: gamer.username,
-                        avatar: gamer.avatar,
-                        role: 'member',
-                    })
-                    .returning();
-                user = newUser;
-                console.log(`  ✅ Created user: ${gamer.username}`);
-            } else {
-                console.log(`  ⏭️  Skipped: ${gamer.username} (exists)`);
-            }
+    // Pre-fetch all characters for our seed users
+    const allCharacters = await db.select().from(schema.characters);
 
-            createdUsers.push(user);
+    for (const event of allEvents) {
+      // Sign up 3-5 random users for each event
+      const numSignups = Math.floor(Math.random() * 3) + 3;
+      const shuffledUsers = [...createdUsers].sort(() => Math.random() - 0.5);
+      const selectedUsers = shuffledUsers.slice(0, numSignups);
+
+      for (const user of selectedUsers) {
+        // Check if signup exists
+        const existingSignup = await db
+          .select()
+          .from(schema.eventSignups)
+          .where(eq(schema.eventSignups.eventId, event.id))
+          .then((rows) => rows.find((r) => r.userId === user.id));
+
+        if (!existingSignup) {
+          // Find user's character for this event's game
+          const userChar = event.gameId
+            ? allCharacters.find(
+                (c) => c.userId === user.id && c.gameId === event.gameId,
+              )
+            : undefined;
+
+          await db.insert(schema.eventSignups).values({
+            eventId: event.id,
+            userId: user.id,
+            characterId: userChar?.id ?? null,
+            confirmationStatus: userChar ? 'confirmed' : 'pending',
+          });
+          const charInfo = userChar ? ` [${userChar.name}]` : '';
+          console.log(`  ✅ ${user.username}${charInfo} → ${event.title}`);
         }
-
-        // =====================
-        // Create Characters with WoW Class Icons (ROK-194)
-        // =====================
-        console.log('\n🎭 Creating characters with WoW class icons...\n');
-
-        // Get games by slug for character creation
-        const registryGames = await db.select().from(schema.games);
-
-        if (registryGames.length > 0) {
-            // Characters with WoW class/role assignments and Blizzard CDN class icons
-            const charactersToCreate = [
-                // WoW Retail characters
-                { username: 'ShadowMage', gameSlug: 'world-of-warcraft', charName: 'Shadowmage', class: 'Mage', spec: 'Arcane', role: 'dps' as const, wowClass: 'mage' },
-                { username: 'DragonSlayer99', gameSlug: 'world-of-warcraft', charName: 'Dragonslayer', class: 'Rogue', spec: 'Assassination', role: 'dps' as const, wowClass: 'rogue' },
-                { username: 'HealzForDayz', gameSlug: 'world-of-warcraft', charName: 'Healzfordays', class: 'Priest', spec: 'Holy', role: 'healer' as const, wowClass: 'priest' },
-                { username: 'TankMaster', gameSlug: 'world-of-warcraft', charName: 'Tankmaster', class: 'Warrior', spec: 'Protection', role: 'tank' as const, wowClass: 'warrior' },
-                { username: 'ProRaider', gameSlug: 'world-of-warcraft', charName: 'Deathbringer', class: 'Death Knight', spec: 'Unholy', role: 'dps' as const, wowClass: 'deathknight' },
-                { username: 'NightOwlGamer', gameSlug: 'world-of-warcraft', charName: 'Moonweaver', class: 'Druid', spec: 'Restoration', role: 'healer' as const, wowClass: 'druid' },
-                { username: 'LootGoblin', gameSlug: 'world-of-warcraft', charName: 'Felstrike', class: 'Warlock', spec: 'Destruction', role: 'dps' as const, wowClass: 'warlock' },
-                { username: 'CasualCarl', gameSlug: 'world-of-warcraft', charName: 'Shieldwall', class: 'Paladin', spec: 'Protection', role: 'tank' as const, wowClass: 'paladin' },
-                // WoW Classic characters
-                { username: 'ShadowMage', gameSlug: 'world-of-warcraft-classic', charName: 'Frostbolt', class: 'Mage', spec: 'Frost', role: 'dps' as const, wowClass: 'mage' },
-                { username: 'TankMaster', gameSlug: 'world-of-warcraft-classic', charName: 'Ironfist', class: 'Warrior', spec: 'Protection', role: 'tank' as const, wowClass: 'warrior' },
-                { username: 'HealzForDayz', gameSlug: 'world-of-warcraft-classic', charName: 'Lightbringer', class: 'Priest', spec: 'Holy', role: 'healer' as const, wowClass: 'priest' },
-                { username: 'ProRaider', gameSlug: 'world-of-warcraft-classic', charName: 'Backstab', class: 'Rogue', spec: 'Combat', role: 'dps' as const, wowClass: 'rogue' },
-                // Valheim characters
-                { username: 'ShadowMage', gameSlug: 'valheim', charName: 'Windwalker', class: 'Monk', spec: 'Windwalker', role: 'dps' as const, wowClass: 'monk' },
-                { username: 'TankMaster', gameSlug: 'valheim', charName: 'Earthguard', class: 'Shaman', spec: 'Restoration', role: 'healer' as const, wowClass: 'shaman' },
-                { username: 'ProRaider', gameSlug: 'valheim', charName: 'Hawkeye', class: 'Hunter', spec: 'Marksmanship', role: 'dps' as const, wowClass: 'hunter' },
-                // FFXIV characters
-                { username: 'NightOwlGamer', gameSlug: 'final-fantasy-xiv-online', charName: 'Voidcaller', class: 'Evoker', spec: 'Preservation', role: 'healer' as const, wowClass: 'evoker' },
-                { username: 'LootGoblin', gameSlug: 'final-fantasy-xiv-online', charName: 'Demonbane', class: 'Demon Hunter', spec: 'Havoc', role: 'dps' as const, wowClass: 'demonhunter' },
-            ];
-
-            // Build slug → game map for lookups
-            const gameBySlug: Record<string, typeof registryGames[number]> = {};
-            for (const g of registryGames) gameBySlug[g.slug] = g;
-
-            // Track which users already have a main — only first character per player is main
-            const usersWithMain = new Set<string>();
-
-            for (const charData of charactersToCreate) {
-                const user = createdUsers.find((u) => u.username === charData.username);
-                const game = gameBySlug[charData.gameSlug];
-
-                if (!user || !game) continue;
-
-                // Check if character already exists
-                const existing = await db
-                    .select()
-                    .from(schema.characters)
-                    .where(eq(schema.characters.userId, user.id))
-                    .then((rows) => rows.find((c) => c.gameId === game.id));
-
-                if (!existing) {
-                    const isMain = !usersWithMain.has(charData.username);
-                    usersWithMain.add(charData.username);
-
-                    await db.insert(schema.characters).values({
-                        userId: user.id,
-                        gameId: game.id,
-                        name: charData.charName,
-                        class: charData.class,
-                        spec: charData.spec,
-                        role: charData.role,
-                        isMain,
-                        avatarUrl: getClassIconUrl(charData.wowClass),
-                        displayOrder: isMain ? 0 : 1,
-                        professions: buildSeedProfessions(charData.class, charData.gameSlug),
-                    });
-                    const tag = isMain ? 'MAIN' : 'ALT';
-                    console.log(`  ✅ Created ${charData.charName} [${charData.class}/${charData.spec}] (${game.name}) [${tag}]`);
-                } else {
-                    console.log(`  ⏭️  Skipped: ${charData.charName} (exists)`);
-                }
-            }
-        } else {
-            console.log('  ⚠️  No games found - skipping character creation');
-        }
-
-        // =====================
-        // Create Event Signups (linked to characters)
-        // =====================
-        console.log('\n📝 Creating event signups with character links...\n');
-
-        const allEvents = await db.select().from(schema.events);
-
-        // Pre-fetch all characters for our seed users
-        const allCharacters = await db.select().from(schema.characters);
-
-        for (const event of allEvents) {
-            // Sign up 3-5 random users for each event
-            const numSignups = Math.floor(Math.random() * 3) + 3;
-            const shuffledUsers = [...createdUsers].sort(() => Math.random() - 0.5);
-            const selectedUsers = shuffledUsers.slice(0, numSignups);
-
-            for (const user of selectedUsers) {
-                // Check if signup exists
-                const existingSignup = await db
-                    .select()
-                    .from(schema.eventSignups)
-                    .where(eq(schema.eventSignups.eventId, event.id))
-                    .then((rows) => rows.find((r) => r.userId === user.id));
-
-                if (!existingSignup) {
-                    // Find user's character for this event's game
-                    const userChar = event.gameId
-                        ? allCharacters.find(
-                            (c) => c.userId === user.id && c.gameId === event.gameId,
-                        )
-                        : undefined;
-
-                    await db.insert(schema.eventSignups).values({
-                        eventId: event.id,
-                        userId: user.id,
-                        characterId: userChar?.id ?? null,
-                        confirmationStatus: userChar ? 'confirmed' : 'pending',
-                    });
-                    const charInfo = userChar ? ` [${userChar.name}]` : '';
-                    console.log(`  ✅ ${user.username}${charInfo} → ${event.title}`);
-                }
-            }
-        }
-
-        // =====================
-        // Create Unavailability
-        // =====================
-        console.log('\n⏰ Creating unavailability periods...\n');
-
-        const now = new Date();
-        const roundToHour = (date: Date): Date => {
-            const rounded = new Date(date);
-            rounded.setMinutes(0, 0, 0);
-            return rounded;
-        };
-        const baseHour = roundToHour(now);
-
-        // Helper functions
-        const hoursFromNow = (hours: number) => new Date(baseHour.getTime() + hours * 60 * 60 * 1000);
-        const daysFromNow = (days: number) => new Date(baseHour.getTime() + days * 24 * 60 * 60 * 1000);
-
-        // Define availability/unavailability for heatmap testing
-        // Need to overlap with event times for visibility
-        const availabilityData = [
-            // Available slots (will show green on heatmap)
-            { username: 'ShadowMage', start: hoursFromNow(-2), end: hoursFromNow(4), status: 'available' as const },
-            { username: 'DragonSlayer99', start: hoursFromNow(-1), end: hoursFromNow(6), status: 'available' as const },
-            { username: 'HealzForDayz', start: hoursFromNow(0), end: hoursFromNow(3), status: 'available' as const },
-            { username: 'TankMaster', start: hoursFromNow(-3), end: hoursFromNow(5), status: 'available' as const },
-            { username: 'ProRaider', start: hoursFromNow(1), end: hoursFromNow(8), status: 'available' as const },
-
-            // Blocked slots (will show gray/locked on heatmap)
-            { username: 'HealzForDayz', start: hoursFromNow(3), end: hoursFromNow(6), status: 'blocked' as const },
-            { username: 'CasualCarl', start: hoursFromNow(-1), end: hoursFromNow(2), status: 'blocked' as const },
-            { username: 'NightOwlGamer', start: hoursFromNow(0), end: hoursFromNow(4), status: 'blocked' as const },
-
-            // Future unavailability 
-            { username: 'DragonSlayer99', start: daysFromNow(2), end: daysFromNow(4), status: 'blocked' as const },
-            { username: 'TankMaster', start: daysFromNow(5), end: daysFromNow(7), status: 'blocked' as const },
-        ];
-
-        for (const avail of availabilityData) {
-            const user = createdUsers.find((u) => u.username === avail.username);
-            if (!user) continue;
-
-            // Create availability record
-            try {
-                await db.insert(schema.availability).values({
-                    userId: user.id,
-                    timeRange: [avail.start, avail.end],
-                    status: avail.status,
-                });
-                const icon = avail.status === 'available' ? '✅' : '❌';
-                console.log(`  ${icon} ${user.username}: ${avail.status} (${avail.start.toLocaleTimeString()} - ${avail.end.toLocaleTimeString()})`);
-            } catch {
-                console.log(`  ⏭️  Skipped availability for ${user.username} (may exist)`);
-            }
-        }
-
-        // =====================
-        // Seed Theme Preferences (ROK-124)
-        // =====================
-        console.log('\n🎨 Setting theme preferences...\n');
-
-        const themeAssignments: Record<string, string> = {
-            ShadowMage: 'default-dark',
-            TankMaster: 'default-light',
-            HealzForDayz: 'auto',
-            DragonSlayer99: 'default-light',
-            CasualCarl: 'default-dark',
-            NightOwlGamer: 'auto',
-            ProRaider: 'auto',
-            LootGoblin: 'auto',
-        };
-
-        for (const [username, theme] of Object.entries(themeAssignments)) {
-            const user = createdUsers.find((u) => u.username === username);
-            if (!user) continue;
-
-            try {
-                await db
-                    .insert(schema.userPreferences)
-                    .values({
-                        userId: user.id,
-                        key: 'theme',
-                        value: theme,
-                    })
-                    .onConflictDoNothing();
-                console.log(`  🎨 ${username} → ${theme}`);
-            } catch {
-                console.log(`  ⏭️  Skipped theme for ${username} (may exist)`);
-            }
-        }
-
-        // Also set admin theme preference
-        const adminUser = await db
-            .select()
-            .from(schema.users)
-            .where(eq(schema.users.role, 'admin'))
-            .limit(1)
-            .then((rows) => rows[0]);
-
-        if (adminUser) {
-            try {
-                await db
-                    .insert(schema.userPreferences)
-                    .values({
-                        userId: adminUser.id,
-                        key: 'theme',
-                        value: 'auto',
-                    })
-                    .onConflictDoNothing();
-                console.log(`  🎨 ${adminUser.username} (admin) → auto`);
-            } catch {
-                console.log(`  ⏭️  Skipped theme for admin (may exist)`);
-            }
-        }
-
-        // =====================
-        // Seed Game Time Templates (ROK-227)
-        // =====================
-        console.log('\n🕹️  Seeding game time templates...\n');
-
-        // dayOfWeek: 0=Mon, 1=Tue, 2=Wed, 3=Thu, 4=Fri, 5=Sat, 6=Sun
-        function expandHours(
-            username: string,
-            dayOfWeek: number,
-            startHour: number,
-            endHour: number,
-        ) {
-            const slots: { username: string; dayOfWeek: number; startHour: number }[] = [];
-            if (endHour > startHour) {
-                for (let h = startHour; h < endHour; h++)
-                    slots.push({ username, dayOfWeek, startHour: h });
-            } else {
-                // wraps past midnight — same day gets startHour..23, next day gets 0..endHour
-                for (let h = startHour; h < 24; h++)
-                    slots.push({ username, dayOfWeek, startHour: h });
-                const nextDay = (dayOfWeek + 1) % 7;
-                for (let h = 0; h < endHour; h++)
-                    slots.push({ username, dayOfWeek: nextDay, startHour: h });
-            }
-            return slots;
-        }
-
-        function expandDays(
-            username: string,
-            days: number[],
-            startHour: number,
-            endHour: number,
-        ) {
-            return days.flatMap((d) => expandHours(username, d, startHour, endHour));
-        }
-
-        const weekdays = [0, 1, 2, 3, 4]; // Mon-Fri
-        const weekends = [5, 6]; // Sat, Sun
-        const allDays = [0, 1, 2, 3, 4, 5, 6];
-
-        const gameTimeSlots = [
-            // ShadowMage — Raid leader, wide availability
-            ...expandDays('ShadowMage', weekdays, 18, 23),
-            ...expandDays('ShadowMage', weekends, 10, 23),
-            // TankMaster — Weekday evenings + full weekends
-            ...expandDays('TankMaster', weekdays, 19, 22),
-            ...expandDays('TankMaster', weekends, 8, 23),
-            // HealzForDayz — Late nights + weekend afternoons
-            ...expandDays('HealzForDayz', weekdays, 21, 1), // wraps to next day 0
-            ...expandDays('HealzForDayz', weekends, 13, 20),
-            // DragonSlayer99 — Early evenings weekdays, scattered weekend
-            ...expandDays('DragonSlayer99', weekdays, 17, 21),
-            ...expandHours('DragonSlayer99', 5, 10, 14), // Sat 10-14
-            ...expandHours('DragonSlayer99', 6, 16, 20), // Sun 16-20
-            // LootGoblin — Night owl, daily 22-03
-            ...expandDays('LootGoblin', allDays, 22, 3),
-            // NightOwlGamer — Night owl variant
-            ...expandDays('NightOwlGamer', weekdays, 23, 4),
-            ...expandDays('NightOwlGamer', weekends, 21, 4),
-            // CasualCarl — Light schedule
-            ...expandHours('CasualCarl', 2, 18, 22), // Wed 18-22
-            ...expandHours('CasualCarl', 4, 19, 23), // Fri 19-23
-            ...expandHours('CasualCarl', 5, 12, 18), // Sat 12-18
-            // ProRaider — Hardcore, big blocks
-            ...expandDays('ProRaider', [0, 1, 2, 3], 17, 23), // Mon-Thu 17-23
-            ...expandDays('ProRaider', [4, 5], 15, 2),         // Fri-Sat 15-02
-            ...expandHours('ProRaider', 6, 12, 22),            // Sun 12-22
-        ];
-
-        // Map usernames to user IDs
-        const gameTimeValues = gameTimeSlots
-            .map((slot) => {
-                const user = createdUsers.find((u) => u.username === slot.username);
-                if (!user) return null;
-                return {
-                    userId: user.id,
-                    dayOfWeek: slot.dayOfWeek,
-                    startHour: slot.startHour,
-                };
-            })
-            .filter((v): v is NonNullable<typeof v> => v !== null);
-
-        if (gameTimeValues.length > 0) {
-            await db
-                .insert(schema.gameTimeTemplates)
-                .values(gameTimeValues)
-                .onConflictDoNothing();
-            console.log(`  ✅ Seeded ${gameTimeValues.length} game time slots across ${FAKE_GAMERS.length} users`);
-        }
-
-        console.log('\n🎉 Testing data seed complete!');
-        console.log('\n📍 View events at: http://localhost:80/events');
-        console.log('📍 View calendar at: http://localhost:80/calendar');
-    } catch (err) {
-        console.error('❌ Seeding failed:', err);
-        await app.close();
-        process.exit(1);
+      }
     }
 
+    // =====================
+    // Create Unavailability
+    // =====================
+    console.log('\n⏰ Creating unavailability periods...\n');
+
+    const now = new Date();
+    const roundToHour = (date: Date): Date => {
+      const rounded = new Date(date);
+      rounded.setMinutes(0, 0, 0);
+      return rounded;
+    };
+    const baseHour = roundToHour(now);
+
+    // Helper functions
+    const hoursFromNow = (hours: number) =>
+      new Date(baseHour.getTime() + hours * 60 * 60 * 1000);
+    const daysFromNow = (days: number) =>
+      new Date(baseHour.getTime() + days * 24 * 60 * 60 * 1000);
+
+    // Define availability/unavailability for heatmap testing
+    // Need to overlap with event times for visibility
+    const availabilityData = [
+      // Available slots (will show green on heatmap)
+      {
+        username: 'ShadowMage',
+        start: hoursFromNow(-2),
+        end: hoursFromNow(4),
+        status: 'available' as const,
+      },
+      {
+        username: 'DragonSlayer99',
+        start: hoursFromNow(-1),
+        end: hoursFromNow(6),
+        status: 'available' as const,
+      },
+      {
+        username: 'HealzForDayz',
+        start: hoursFromNow(0),
+        end: hoursFromNow(3),
+        status: 'available' as const,
+      },
+      {
+        username: 'TankMaster',
+        start: hoursFromNow(-3),
+        end: hoursFromNow(5),
+        status: 'available' as const,
+      },
+      {
+        username: 'ProRaider',
+        start: hoursFromNow(1),
+        end: hoursFromNow(8),
+        status: 'available' as const,
+      },
+
+      // Blocked slots (will show gray/locked on heatmap)
+      {
+        username: 'HealzForDayz',
+        start: hoursFromNow(3),
+        end: hoursFromNow(6),
+        status: 'blocked' as const,
+      },
+      {
+        username: 'CasualCarl',
+        start: hoursFromNow(-1),
+        end: hoursFromNow(2),
+        status: 'blocked' as const,
+      },
+      {
+        username: 'NightOwlGamer',
+        start: hoursFromNow(0),
+        end: hoursFromNow(4),
+        status: 'blocked' as const,
+      },
+
+      // Future unavailability
+      {
+        username: 'DragonSlayer99',
+        start: daysFromNow(2),
+        end: daysFromNow(4),
+        status: 'blocked' as const,
+      },
+      {
+        username: 'TankMaster',
+        start: daysFromNow(5),
+        end: daysFromNow(7),
+        status: 'blocked' as const,
+      },
+    ];
+
+    for (const avail of availabilityData) {
+      const user = createdUsers.find((u) => u.username === avail.username);
+      if (!user) continue;
+
+      // Create availability record
+      try {
+        await db.insert(schema.availability).values({
+          userId: user.id,
+          timeRange: [avail.start, avail.end],
+          status: avail.status,
+        });
+        const icon = avail.status === 'available' ? '✅' : '❌';
+        console.log(
+          `  ${icon} ${user.username}: ${avail.status} (${avail.start.toLocaleTimeString()} - ${avail.end.toLocaleTimeString()})`,
+        );
+      } catch {
+        console.log(
+          `  ⏭️  Skipped availability for ${user.username} (may exist)`,
+        );
+      }
+    }
+
+    // =====================
+    // Seed Theme Preferences (ROK-124)
+    // =====================
+    console.log('\n🎨 Setting theme preferences...\n');
+
+    const themeAssignments: Record<string, string> = {
+      ShadowMage: 'default-dark',
+      TankMaster: 'default-light',
+      HealzForDayz: 'auto',
+      DragonSlayer99: 'default-light',
+      CasualCarl: 'default-dark',
+      NightOwlGamer: 'auto',
+      ProRaider: 'auto',
+      LootGoblin: 'auto',
+    };
+
+    for (const [username, theme] of Object.entries(themeAssignments)) {
+      const user = createdUsers.find((u) => u.username === username);
+      if (!user) continue;
+
+      try {
+        await db
+          .insert(schema.userPreferences)
+          .values({
+            userId: user.id,
+            key: 'theme',
+            value: theme,
+          })
+          .onConflictDoNothing();
+        console.log(`  🎨 ${username} → ${theme}`);
+      } catch {
+        console.log(`  ⏭️  Skipped theme for ${username} (may exist)`);
+      }
+    }
+
+    // Also set admin theme preference
+    const adminUser = await db
+      .select()
+      .from(schema.users)
+      .where(eq(schema.users.role, 'admin'))
+      .limit(1)
+      .then((rows) => rows[0]);
+
+    if (adminUser) {
+      try {
+        await db
+          .insert(schema.userPreferences)
+          .values({
+            userId: adminUser.id,
+            key: 'theme',
+            value: 'auto',
+          })
+          .onConflictDoNothing();
+        console.log(`  🎨 ${adminUser.username} (admin) → auto`);
+      } catch {
+        console.log(`  ⏭️  Skipped theme for admin (may exist)`);
+      }
+    }
+
+    // =====================
+    // Seed Game Time Templates (ROK-227)
+    // =====================
+    console.log('\n🕹️  Seeding game time templates...\n');
+
+    // dayOfWeek: 0=Mon, 1=Tue, 2=Wed, 3=Thu, 4=Fri, 5=Sat, 6=Sun
+    function expandHours(
+      username: string,
+      dayOfWeek: number,
+      startHour: number,
+      endHour: number,
+    ) {
+      const slots: {
+        username: string;
+        dayOfWeek: number;
+        startHour: number;
+      }[] = [];
+      if (endHour > startHour) {
+        for (let h = startHour; h < endHour; h++)
+          slots.push({ username, dayOfWeek, startHour: h });
+      } else {
+        // wraps past midnight — same day gets startHour..23, next day gets 0..endHour
+        for (let h = startHour; h < 24; h++)
+          slots.push({ username, dayOfWeek, startHour: h });
+        const nextDay = (dayOfWeek + 1) % 7;
+        for (let h = 0; h < endHour; h++)
+          slots.push({ username, dayOfWeek: nextDay, startHour: h });
+      }
+      return slots;
+    }
+
+    function expandDays(
+      username: string,
+      days: number[],
+      startHour: number,
+      endHour: number,
+    ) {
+      return days.flatMap((d) => expandHours(username, d, startHour, endHour));
+    }
+
+    const weekdays = [0, 1, 2, 3, 4]; // Mon-Fri
+    const weekends = [5, 6]; // Sat, Sun
+    const allDays = [0, 1, 2, 3, 4, 5, 6];
+
+    const gameTimeSlots = [
+      // ShadowMage — Raid leader, wide availability
+      ...expandDays('ShadowMage', weekdays, 18, 23),
+      ...expandDays('ShadowMage', weekends, 10, 23),
+      // TankMaster — Weekday evenings + full weekends
+      ...expandDays('TankMaster', weekdays, 19, 22),
+      ...expandDays('TankMaster', weekends, 8, 23),
+      // HealzForDayz — Late nights + weekend afternoons
+      ...expandDays('HealzForDayz', weekdays, 21, 1), // wraps to next day 0
+      ...expandDays('HealzForDayz', weekends, 13, 20),
+      // DragonSlayer99 — Early evenings weekdays, scattered weekend
+      ...expandDays('DragonSlayer99', weekdays, 17, 21),
+      ...expandHours('DragonSlayer99', 5, 10, 14), // Sat 10-14
+      ...expandHours('DragonSlayer99', 6, 16, 20), // Sun 16-20
+      // LootGoblin — Night owl, daily 22-03
+      ...expandDays('LootGoblin', allDays, 22, 3),
+      // NightOwlGamer — Night owl variant
+      ...expandDays('NightOwlGamer', weekdays, 23, 4),
+      ...expandDays('NightOwlGamer', weekends, 21, 4),
+      // CasualCarl — Light schedule
+      ...expandHours('CasualCarl', 2, 18, 22), // Wed 18-22
+      ...expandHours('CasualCarl', 4, 19, 23), // Fri 19-23
+      ...expandHours('CasualCarl', 5, 12, 18), // Sat 12-18
+      // ProRaider — Hardcore, big blocks
+      ...expandDays('ProRaider', [0, 1, 2, 3], 17, 23), // Mon-Thu 17-23
+      ...expandDays('ProRaider', [4, 5], 15, 2), // Fri-Sat 15-02
+      ...expandHours('ProRaider', 6, 12, 22), // Sun 12-22
+    ];
+
+    // Map usernames to user IDs
+    const gameTimeValues = gameTimeSlots
+      .map((slot) => {
+        const user = createdUsers.find((u) => u.username === slot.username);
+        if (!user) return null;
+        return {
+          userId: user.id,
+          dayOfWeek: slot.dayOfWeek,
+          startHour: slot.startHour,
+        };
+      })
+      .filter((v): v is NonNullable<typeof v> => v !== null);
+
+    if (gameTimeValues.length > 0) {
+      await db
+        .insert(schema.gameTimeTemplates)
+        .values(gameTimeValues)
+        .onConflictDoNothing();
+      console.log(
+        `  ✅ Seeded ${gameTimeValues.length} game time slots across ${FAKE_GAMERS.length} users`,
+      );
+    }
+
+    console.log('\n🎉 Testing data seed complete!');
+    console.log('\n📍 View events at: http://localhost:80/events');
+    console.log('📍 View calendar at: http://localhost:80/calendar');
+  } catch (err) {
+    console.error('❌ Seeding failed:', err);
     await app.close();
-    process.exit(0);
+    process.exit(1);
+  }
+
+  await app.close();
+  process.exit(0);
 }
 
 bootstrap();

--- a/api/scripts/seed-testing.ts
+++ b/api/scripts/seed-testing.ts
@@ -14,6 +14,7 @@ import {
   seedUsers,
   seedCharacters,
 } from './seed-testing-users.helpers';
+import { seedThemePreferences } from './seed-testing-theme.helpers';
 
 dotenv.config();
 
@@ -195,64 +196,7 @@ async function bootstrap() {
       }
     }
 
-    // =====================
-    // Seed Theme Preferences (ROK-124)
-    // =====================
-    console.log('\n🎨 Setting theme preferences...\n');
-
-    const themeAssignments: Record<string, string> = {
-      ShadowMage: 'default-dark',
-      TankMaster: 'default-light',
-      HealzForDayz: 'auto',
-      DragonSlayer99: 'default-light',
-      CasualCarl: 'default-dark',
-      NightOwlGamer: 'auto',
-      ProRaider: 'auto',
-      LootGoblin: 'auto',
-    };
-
-    for (const [username, theme] of Object.entries(themeAssignments)) {
-      const user = createdUsers.find((u) => u.username === username);
-      if (!user) continue;
-
-      try {
-        await db
-          .insert(schema.userPreferences)
-          .values({
-            userId: user.id,
-            key: 'theme',
-            value: theme,
-          })
-          .onConflictDoNothing();
-        console.log(`  🎨 ${username} → ${theme}`);
-      } catch {
-        console.log(`  ⏭️  Skipped theme for ${username} (may exist)`);
-      }
-    }
-
-    // Also set admin theme preference
-    const adminUser = await db
-      .select()
-      .from(schema.users)
-      .where(eq(schema.users.role, 'admin'))
-      .limit(1)
-      .then((rows) => rows[0]);
-
-    if (adminUser) {
-      try {
-        await db
-          .insert(schema.userPreferences)
-          .values({
-            userId: adminUser.id,
-            key: 'theme',
-            value: 'auto',
-          })
-          .onConflictDoNothing();
-        console.log(`  🎨 ${adminUser.username} (admin) → auto`);
-      } catch {
-        console.log(`  ⏭️  Skipped theme for admin (may exist)`);
-      }
-    }
+    await seedThemePreferences(db, createdUsers);
 
     // =====================
     // Seed Game Time Templates (ROK-227)

--- a/api/src/cron-jobs/cron-job.constants.spec.ts
+++ b/api/src/cron-jobs/cron-job.constants.spec.ts
@@ -24,4 +24,24 @@ describe('CORE_JOB_METADATA', () => {
       expect(meta.category).toBe('Events');
     });
   });
+
+  describe('ROK-1163', () => {
+    it('should include ActiveEventCacheService_refresh', () => {
+      const meta = CORE_JOB_METADATA['ActiveEventCacheService_refresh'];
+
+      expect(meta).toBeDefined();
+      expect(meta.description).toEqual(expect.any(String));
+      expect(meta.description.length).toBeGreaterThan(0);
+      expect(meta.category).toBe('Events');
+    });
+
+    it('should include AdHocReaperService_reapOrphans', () => {
+      const meta = CORE_JOB_METADATA['AdHocReaperService_reapOrphans'];
+
+      expect(meta).toBeDefined();
+      expect(meta.description).toEqual(expect.any(String));
+      expect(meta.description.length).toBeGreaterThan(0);
+      expect(meta.category).toBe('Events');
+    });
+  });
 });

--- a/api/src/cron-jobs/cron-job.constants.ts
+++ b/api/src/cron-jobs/cron-job.constants.ts
@@ -190,4 +190,14 @@ export const CORE_JOB_METADATA: Record<string, CoreJobMetadata> = {
       'Reads pg_stat_statements every hour and appends a top-N digest to slow-queries.log',
     category: 'Monitoring',
   },
+  ActiveEventCacheService_refresh: {
+    description:
+      'Safety-net refresh of the in-memory active-event cache (recently-ended, active, upcoming) every 5 minutes',
+    category: 'Events',
+  },
+  AdHocReaperService_reapOrphans: {
+    description:
+      'Force-finalizes orphaned Quick Play (ad-hoc) events whose end time passed >30 min ago every 5 minutes',
+    category: 'Events',
+  },
 };

--- a/api/src/discord-bot/ai-chat/tree/events.tree.ts
+++ b/api/src/discord-bot/ai-chat/tree/events.tree.ts
@@ -1,6 +1,9 @@
 import { aiCustomId } from '../ai-chat.constants';
 import type { TreeResult, AiChatDeps, TreeSession } from './tree.types';
 
+const TOP_RANKED_GAME_FANOUT = 5;
+const MERGED_EVENT_CAP = 10;
+
 const SUB_BUTTONS = [
   { customId: aiCustomId('events:this-week'), label: 'This Week' },
   { customId: aiCustomId('events:next-week'), label: 'Next Week' },
@@ -113,7 +116,7 @@ function mergeRankedEvents(
       (a, b) =>
         new Date(a.startTime).getTime() - new Date(b.startTime).getTime(),
     )
-    .slice(0, 10);
+    .slice(0, MERGED_EVENT_CAP);
 }
 
 /** Fan out findAll across the top 5 ranked games (ROK-1084). */
@@ -121,7 +124,7 @@ async function fetchEventsForTopGames(
   deps: AiChatDeps,
   games: { id: number; name: string }[],
 ): Promise<RankedEvent[]> {
-  const top = games.slice(0, 5);
+  const top = games.slice(0, TOP_RANKED_GAME_FANOUT);
   const settled = await Promise.allSettled(
     top.map((g) =>
       deps.eventsService.findAll({


### PR DESCRIPTION
## Summary

Bulk batch of 3 small-scope tech-debt / chore stories. All per-story reviewers APPROVED, full local CI passing.

| Story | Label | Files | Reviewer |
|-------|-------|-------|----------|
| [ROK-1166](https://linear.app/roknua-projects/issue/ROK-1166) | Tech Debt | `api/src/discord-bot/ai-chat/tree/events.tree.ts` (+5/-2) | APPROVED |
| [ROK-1163](https://linear.app/roknua-projects/issue/ROK-1163) | Chore | `api/src/cron-jobs/cron-job.constants{.ts,.spec.ts}` (+30) | APPROVED |
| [ROK-1183](https://linear.app/roknua-projects/issue/ROK-1183) | Tech Debt | `api/scripts/seed-testing.ts` split into 4 helpers (+501/-406) | APPROVED |

## What

- **ROK-1166:** Extract `TOP_RANKED_GAME_FANOUT = 5` and `MERGED_EVENT_CAP = 10` as named constants at the top of `events.tree.ts`, replacing two magic numbers in the search-by-game fan-out.
- **ROK-1163:** Add `CORE_JOB_METADATA` entries for `ActiveEventCacheService_refresh` and `AdHocReaperService_reapOrphans` so they no longer warn `Core cron job ... is missing CORE_JOB_METADATA entry` at every container boot. Updated `cron-job.constants.spec.ts` to assert presence of both new keys.
- **ROK-1183:** Split `api/scripts/seed-testing.ts` (was 315 effective lines, over the 300-line ESLint cap) into 4 per-domain helper modules: `seed-testing-users.helpers.ts` (users + characters, 169 lines), `seed-testing-events.helpers.ts` (signups, 50 lines), `seed-testing-availability.helpers.ts` (availability + game time slots, 216 lines), `seed-testing-theme.helpers.ts` (theme prefs incl. admin upsert, 66 lines). Orchestrator now 48 effective / 61 raw lines. No behavior change — `createdUsers` passed in-memory, helper order preserved (`seedCharacters` runs before `seedEventSignups` as before), idempotency guards intact, `expandHours` wrap-past-midnight branch preserved verbatim.

## Why

Routine tech-debt cleanup: kill magic numbers, silence boot warnings, and trim a script that crossed the lint cap. None of these unblock a feature; together they reduce noise across logs, lint output, and admin UI.

## Test plan

- [x] **Build (all workspaces):** PASS
- [x] **TypeScript (api + web):** PASS
- [x] **Lint (api + web):** PASS
- [x] **Unit tests:** 5719/5719 (api), web suite green
- [x] **Integration (api):** 811/812 — the 1 failure (`lineups/lineups-metadata.integration.spec.ts` › 403 non-creator member, `socket hang up`) reproduces the documented suite-pollution flake from [ROK-1055](https://linear.app/roknua-projects/issue/ROK-1055) and [ROK-1058](https://linear.app/roknua-projects/issue/ROK-1058). Re-running the spec in isolation: 14/14 pass. Failure scope is `lineups` (no overlap with this batch's surface).
- [x] **Playwright smoke (desktop + mobile):** 484 passed / 186 intentionally skipped / 6 did-not-run / 0 failed. Both projects green.
- [x] **Per-story reviewer:** all 3 APPROVED with no auto-fix loops needed.
- [x] **ROK-1183 idempotency:** seed script run twice locally — second run shows `Skipped` for users + characters, confirming `onConflictDoNothing` / existence-check guards preserved across the split.

## Notes for review

- `CWD slip recovery (informational, no production impact):` During step 2 of the bulk pipeline, the Lead accidentally ran `git merge --no-ff batch/rok-1163` in the wrong worktree, which caused ROK-1163 to land on `batch/rok-1183` instead of `batch/2026-04-29`. Recovered by rebasing `batch/rok-1183` onto `58c15b09` to drop the bad merge (the events.helpers commit was cherry-picked, so its SHA changed `1fe5fabe → 14e8f3fb`) and re-merging the ROK-1163 dev SHA `67b18c0e` properly into the batch branch. Final tree state matches what would have shipped under a clean run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)