### PR TITLE
ROK-1061: test: lock in admin/operator-gated lineup creation

### DIFF
--- a/web/src/components/lineups/LineupBanner.test.tsx
+++ b/web/src/components/lineups/LineupBanner.test.tsx
@@ -19,9 +19,22 @@ vi.mock('./NominateModal', () => ({
     NominateModal: () => null,
 }));
 
+// Mock StartLineupModal — its internals (useCreateLineup, durations, etc.)
+// are out of scope for banner-level role-gating tests.
+vi.mock('./start-lineup-modal', () => ({
+    StartLineupModal: () => null,
+}));
+
+vi.mock('../../hooks/use-auth', () => ({
+    useAuth: vi.fn(() => ({ user: null })),
+    isOperatorOrAdmin: vi.fn(() => false),
+}));
+
 import { useLineupBanner } from '../../hooks/use-lineups';
+import { isOperatorOrAdmin } from '../../hooks/use-auth';
 
 const mockUseLineupBanner = vi.mocked(useLineupBanner);
+const mockIsOperatorOrAdmin = vi.mocked(isOperatorOrAdmin);
 
 function mockHookReturn(data: ReturnType<typeof createMockBanner> | null | undefined, isLoading = false) {
     mockUseLineupBanner.mockReturnValue({
@@ -110,5 +123,39 @@ describe('LineupBanner — populated state', () => {
         renderWithProviders(<LineupBanner />);
         // Should render a formatted date string
         expect(screen.getByText(/mar/i)).toBeInTheDocument();
+    });
+});
+
+// ROK-1061: admin/operator-gated lineup creation. The "Start Lineup" CTA
+// (no active lineup) and the "Start another lineup" button (active lineup
+// present) must only render for users with operator or admin role.
+describe('LineupBanner — role gating (ROK-1061)', () => {
+    it('renders nothing when no banner and user lacks operator/admin role', () => {
+        mockIsOperatorOrAdmin.mockReturnValue(false);
+        mockHookReturn(null);
+        const { container } = renderWithProviders(<LineupBanner />);
+        expect(container.firstChild).toBeNull();
+        expect(screen.queryByRole('button', { name: /start lineup/i })).not.toBeInTheDocument();
+    });
+
+    it('renders Start Lineup CTA when no banner and user is operator/admin', () => {
+        mockIsOperatorOrAdmin.mockReturnValue(true);
+        mockHookReturn(null);
+        renderWithProviders(<LineupBanner />);
+        expect(screen.getByRole('button', { name: /start lineup/i })).toBeInTheDocument();
+    });
+
+    it('hides "Start another lineup" button on populated banner for non-role users', () => {
+        mockIsOperatorOrAdmin.mockReturnValue(false);
+        mockHookReturn(createMockBanner());
+        renderWithProviders(<LineupBanner />);
+        expect(screen.queryByTestId('start-another-lineup')).not.toBeInTheDocument();
+    });
+
+    it('shows "Start another lineup" button on populated banner for operator/admin', () => {
+        mockIsOperatorOrAdmin.mockReturnValue(true);
+        mockHookReturn(createMockBanner());
+        renderWithProviders(<LineupBanner />);
+        expect(screen.getByTestId('start-another-lineup')).toBeInTheDocument();
     });
 });


### PR DESCRIPTION
## Summary

- Audit confirmed the production gating for `POST /lineups` and the LineupBanner "Start Lineup" / "Start another" CTAs is already in place from prior work (RolesGuard + `@Roles('operator')` on the controller; `isOperatorOrAdmin(user)` on the banner). Jest integration coverage already exercises 401 / 403 (member) / 201 (admin + operator) paths.
- Adds the Vitest regression-locking coverage that was the only outstanding AC item: a `LineupBanner — role gating (ROK-1061)` block in `web/src/components/lineups/LineupBanner.test.tsx` mocking `useAuth` + `isOperatorOrAdmin` and asserting the four role × banner-state combinations.
- Mutation check (temporarily removing the guard) confirmed the new tests fail without the gating — i.e. they're meaningful regression locks rather than tautological pass-by-default.

## Linear

ROK-1061

## AC trace

| AC | Status | Evidence |
|---|---|---|
| `POST /lineups` requires admin OR operator; 403 otherwise | Already shipped | `api/src/lineups/lineups.controller.ts:51-56` |
| Permission check uses existing RBAC helpers | Already shipped | Reuses `RolesGuard`, `@Roles`, `isOperatorOrAdmin` |
| 403 surfaced as toast on FE | Already shipped | `start-lineup-modal.tsx:107-109` catches and toasts `err.message` |
| "Start Lineup" button hidden for non-role users | Already shipped | `LineupBanner.tsx:215, 224, 236` |
| Integration test: non-admin → 403 | Already shipped | `lineups.integration.spec.ts:142-146` |
| Integration test: admin + operator → 201 | Already shipped | `lineups.integration.spec.ts:95-105`, `:148-152` |
| **Vitest covering UI button visibility per role** | **Added in this PR** | `LineupBanner.test.tsx` — 4 new assertions |

## Note on Playwright

The original test plan also listed "Playwright: member login → button hidden". After investigation: there is no seeded member user with local credentials and no existing test-only endpoint to mint a member JWT. The AC is "Smoke test **OR** Vitest covering UI button visibility per role" — the Vitest coverage above (with mutation-check confirmation) satisfies that clause. Adding a Playwright path would require introducing a new DEMO_MODE-only credential-minting endpoint, which is out of scope and adds attack-surface risk. Decision documented here so the omission is intentional, not an oversight.

## Test plan

- [x] `validate-ci.sh --full` passes locally (build, typecheck, lint, unit + coverage, integration on real Postgres) — see worktree run `bk6fk707b` (824/824 integration tests pass)
- [x] Mutation check: temporarily commenting out `if (!isOperatorOrAdmin(user)) return null;` and `const canStartAnother = isOperatorOrAdmin(user);` causes the two member-role assertions to fail; restoring re-greens
- [x] No backend, contract, or migration changes; integration suite untouched
- [ ] CI green on remote (auto-merge enabled below)

🤖 Generated with [Claude Code](https://claude.com/claude-code)