### PR TITLE
ROK-1153: chore: configure Dependabot + auto-merge for monorepo deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,76 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 5
+    versioning-strategy: "increase"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+    groups:
+      nestjs:
+        patterns:
+          - "@nestjs/*"
+      tanstack:
+        patterns:
+          - "@tanstack/*"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "npm"
+    directory: "/tools/test-bot"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 2
+    versioning-strategy: "increase"
+    commit-message:
+      prefix: "chore(deps,test-bot)"
+      include: "scope"
+    labels:
+      - "dependencies"
+    groups:
+      test-bot-dev:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "America/Los_Angeles"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "chore(ci)"
+    labels:
+      - "dependencies"
+      - "ci"
+    groups:
+      gh-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for minor and patch updates
+        if: steps.meta.outputs.update-type == 'version-update:semver-minor' || steps.meta.outputs.update-type == 'version-update:semver-patch'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## What

Adds two new GitHub config files to automate dependency updates:

- `.github/dependabot.yml` — three update entries:
  - `npm` at `/` (covers root + `api`, `web`, `packages/contract`, `tools/mcp-discord`, `tools/mcp-env` via npm-workspaces auto-detection). Limit 5. Groups: `nestjs` (`@nestjs/*`), `tanstack` (`@tanstack/*`), `react` (`react`, `react-dom`, `@types/react*`), `dev-dependencies` (devDeps minor/patch).
  - `npm` at `/tools/test-bot` (separate entry — outside the workspaces array). Limit 2. Group: `test-bot-dev` (devDeps minor/patch).
  - `github-actions` at `/`. Limit 3. Group: all actions, minor/patch only.
- `.github/workflows/dependabot-auto-merge.yml` — gates on `github.actor == 'dependabot[bot]'` + `update-type == semver-minor || semver-patch`, calls `gh pr merge --auto --squash`. Major bumps stay parked for manual review.

## Why

Resolves [ROK-1153](https://linear.app/roknua-projects/issue/ROK-1153). Without automated dependency PRs, security patches and minor bumps accumulate into giant quarterly upgrade piles that are risky to land all at once. Operator chose Dependabot (GitHub-native) over Renovate after pro/con review.

## Acceptance criteria (build-time)

- [x] Config file committed
- [x] YAML parses (`js-yaml`)
- [x] `actionlint` clean on the new workflow
- [x] Local CI green (build, type, lint, unit tests, coverage)
- [x] Operator-approved
- [ ] No more than 5 concurrent PRs from the bot — *will verify post-merge*
- [ ] First batch of update PRs has appeared and at least one minor/patch update has merged via auto-merge — *tracked as a follow-up Linear story; cannot be satisfied in this PR*

## Test plan

- [x] `python3 -c "import js_yaml..."` (via `npx js-yaml`) parses both files
- [x] `actionlint` passes on `dependabot-auto-merge.yml`
- [x] `./scripts/validate-ci.sh --full` ran in worktree: Build / TS / Lint / Unit + coverage all PASS
- [x] Branch rebased on `origin/main`

## Notes

- Max-PRs caps are per Dependabot entry: 5 (npm root) + 2 (test-bot) + 3 (gh-actions) = 10 ceiling.
- Security updates are managed independently (repo Settings → Security & analysis), not by `dependabot.yml`.
- An integration-test flake (testcontainers 10s port-bind timeout under parallel jest load on macOS Docker Desktop) was caught during local CI — re-run in isolation passed 18/18. Tracked as ROK-1190 with root cause + fix options. CI uses `DATABASE_URL` so this never affects GitHub CI.
- A follow-up Linear story will be created to schedule a +3 day verification agent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)