### PR TITLE
ROK-1121: fix: gate Create Event behind majority-voter threshold with operator override modal

### DIFF
--- a/api/src/common/testing/drizzle-mock.ts
+++ b/api/src/common/testing/drizzle-mock.ts
@@ -36,8 +36,20 @@ const CHAIN_METHODS = [
   'as',
 ];
 
-export function createDrizzleMock() {
-  const mock: Record<string, jest.Mock> = {};
+/**
+ * `query` mirrors Drizzle's relational-query namespace. Tests may overwrite
+ * this object wholesale (with arbitrary subsets of relations), so we keep it
+ * loose to match runtime flexibility.
+ */
+
+type DrizzleQueryNamespace = Record<string, any>;
+
+export type MockDb = Record<string, jest.Mock> & {
+  query: DrizzleQueryNamespace;
+};
+
+export function createDrizzleMock(): MockDb {
+  const mock = {} as MockDb;
   for (const m of CHAIN_METHODS) {
     mock[m] = jest.fn().mockReturnThis();
   }
@@ -49,8 +61,6 @@ export function createDrizzleMock() {
   mock.query = {
     users: { findFirst: jest.fn(), findMany: jest.fn() },
     events: { findFirst: jest.fn(), findMany: jest.fn() },
-  } as unknown as jest.Mock;
+  };
   return mock;
 }
-
-export type MockDb = ReturnType<typeof createDrizzleMock>;

--- a/api/src/events/events.integration.spec.ts
+++ b/api/src/events/events.integration.spec.ts
@@ -5,11 +5,13 @@
  * like slotConfig, recurrence, and content instances. This catches bugs where
  * optional fields are silently dropped during DB persistence.
  */
+import { eq } from 'drizzle-orm';
 import { getTestApp, type TestApp } from '../common/testing/test-app';
 import {
   truncateAllTables,
   loginAsAdmin,
 } from '../common/testing/integration-helpers';
+import { events } from '../drizzle/schema';
 
 let testApp: TestApp;
 let adminToken: string;
@@ -310,8 +312,6 @@ async function testDetailHonorsNotificationChannelOverride() {
   // Architect §3: the override branch (event.notificationChannelOverride ?? …)
   // was missing from the original brief. Without it, every event with a custom
   // channel returns null. Set the override directly via DB to bypass /bind.
-  const { events } = await import('../drizzle/schema');
-  const { eq } = await import('drizzle-orm');
   await testApp.db
     .update(events)
     .set({ notificationChannelOverride: overrideChannelId })

--- a/api/src/lineups/scheduling/scheduling-response.helpers.spec.ts
+++ b/api/src/lineups/scheduling/scheduling-response.helpers.spec.ts
@@ -175,4 +175,71 @@ describe('buildMatchDetailDto', () => {
     expect(dto.createdAt).toMatch(/^\d{4}-/);
     expect(dto.members[0].displayName).toBe('Alice');
   });
+
+  it('omits lineupCreatedById when not provided (ROK-1121)', () => {
+    const dto = buildMatchDetailDto(
+      baseMatch,
+      baseMembers,
+      'Elden Ring',
+      'https://img.example.com/cover.jpg',
+    );
+
+    expect(dto.lineupCreatedById).toBeUndefined();
+  });
+
+  it('omits lineupCreatedById when null is passed (ROK-1121)', () => {
+    const dto = buildMatchDetailDto(
+      baseMatch,
+      baseMembers,
+      'Elden Ring',
+      'https://img.example.com/cover.jpg',
+      null,
+    );
+
+    expect(dto.lineupCreatedById).toBeUndefined();
+  });
+
+  it('emits lineupCreatedById when supplied (ROK-1121)', () => {
+    const dto = buildMatchDetailDto(
+      baseMatch,
+      baseMembers,
+      'Elden Ring',
+      'https://img.example.com/cover.jpg',
+      42,
+    );
+
+    expect(dto.lineupCreatedById).toBe(42);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ROK-1121: lineupCreatedById flows through buildPollResponse
+// ---------------------------------------------------------------------------
+
+describe('buildPollResponse — lineupCreatedById (ROK-1121)', () => {
+  it('passes lineupCreatedById from match input through to match DTO', () => {
+    const result = buildPollResponse(
+      { ...baseMatch, lineupCreatedById: 77 },
+      baseMembers,
+      baseSlots,
+      baseVotes,
+      100,
+      'decided',
+    );
+
+    expect(result.match.lineupCreatedById).toBe(77);
+  });
+
+  it('omits lineupCreatedById when match input does not include it', () => {
+    const result = buildPollResponse(
+      baseMatch,
+      baseMembers,
+      baseSlots,
+      baseVotes,
+      100,
+      'decided',
+    );
+
+    expect(result.match.lineupCreatedById).toBeUndefined();
+  });
 });

--- a/api/src/lineups/scheduling/scheduling-response.helpers.ts
+++ b/api/src/lineups/scheduling/scheduling-response.helpers.ts
@@ -40,6 +40,7 @@ export function buildMatchDetailDto(
   members: MatchMemberRow[],
   gameName: string,
   gameCoverUrl: string | null,
+  lineupCreatedById: number | null = null,
 ): MatchDetailResponseDto {
   return {
     id: match.id,
@@ -56,6 +57,7 @@ export function buildMatchDetailDto(
     updatedAt: match.updatedAt.toISOString(),
     gameName,
     gameCoverUrl,
+    ...(lineupCreatedById !== null ? { lineupCreatedById } : {}),
     members: members.map((m) => ({
       id: m.id,
       matchId: m.matchId,
@@ -108,7 +110,11 @@ function extractMyVotedSlotIds(
 
 /** Build the full poll page response. */
 export function buildPollResponse(
-  match: MatchRow & { gameName?: string; gameCoverUrl?: string | null },
+  match: MatchRow & {
+    gameName?: string;
+    gameCoverUrl?: string | null;
+    lineupCreatedById?: number | null;
+  },
   members: MatchMemberRow[],
   slots: SlotRow[],
   votes: ScheduleVoteRow[],
@@ -118,9 +124,17 @@ export function buildPollResponse(
   const gameName = (match as { gameName?: string }).gameName ?? 'Unknown';
   const gameCoverUrl =
     (match as { gameCoverUrl?: string | null }).gameCoverUrl ?? null;
+  const lineupCreatedById =
+    (match as { lineupCreatedById?: number | null }).lineupCreatedById ?? null;
 
   return {
-    match: buildMatchDetailDto(match, members, gameName, gameCoverUrl),
+    match: buildMatchDetailDto(
+      match,
+      members,
+      gameName,
+      gameCoverUrl,
+      lineupCreatedById,
+    ),
     slots: mapSlotsWithVotes(slots, votes),
     myVotedSlotIds: extractMyVotedSlotIds(votes, userId),
     lineupStatus,

--- a/api/src/lineups/scheduling/scheduling.service.ts
+++ b/api/src/lineups/scheduling/scheduling.service.ts
@@ -77,7 +77,10 @@ export class SchedulingService {
     const [gameInfo, [lineup], members, slots, voterCount] = await Promise.all([
       resolveGameInfo(this.db, match.gameId),
       this.db
-        .select({ status: schema.communityLineups.status })
+        .select({
+          status: schema.communityLineups.status,
+          createdBy: schema.communityLineups.createdBy,
+        })
         .from(schema.communityLineups)
         .where(eq(schema.communityLineups.id, match.lineupId))
         .limit(1),
@@ -92,7 +95,7 @@ export class SchedulingService {
       : undefined;
     return {
       ...buildPollResponse(
-        { ...match, ...gameInfo },
+        { ...match, ...gameInfo, lineupCreatedById: lineup?.createdBy ?? null },
         members,
         slots,
         votes,

--- a/api/src/steam/steam-wishlist.service.spec.ts
+++ b/api/src/steam/steam-wishlist.service.spec.ts
@@ -46,7 +46,7 @@ describe('SteamWishlistService', () => {
             steamId: '76561198000000001',
           }),
         },
-      } as unknown as jest.Mock;
+      };
 
       (steamHttp.getPlayerSummary as jest.Mock).mockResolvedValue({
         communityvisibilitystate: 3,
@@ -121,7 +121,7 @@ describe('SteamWishlistService', () => {
         users: {
           findFirst: jest.fn().mockResolvedValue({ id: 1, steamId: null }),
         },
-      } as unknown as jest.Mock;
+      };
 
       await expect(service.syncWishlist(1)).rejects.toThrow(
         'User has no linked Steam account',
@@ -171,7 +171,7 @@ describe('SteamWishlistService', () => {
         users: {
           findFirst: jest.fn().mockResolvedValue(null),
         },
-      } as unknown as jest.Mock;
+      };
 
       await expect(service.syncWishlist(1)).rejects.toThrow(
         'User has no linked Steam account',
@@ -287,7 +287,7 @@ describe('SteamWishlistService', () => {
             steamId: '76561198000000001',
           }),
         },
-      } as unknown as jest.Mock;
+      };
 
       (steamHttp.getPlayerSummary as jest.Mock).mockResolvedValue({
         communityvisibilitystate: 3,

--- a/api/src/steam/steam.service.spec.ts
+++ b/api/src/steam/steam.service.spec.ts
@@ -56,7 +56,7 @@ describe('SteamService', () => {
           }),
         },
         games: { findFirst: jest.fn().mockResolvedValue(null) },
-      } as unknown as jest.Mock;
+      };
 
       (steamHttp.getPlayerSummary as jest.Mock).mockResolvedValue({
         communityvisibilitystate: 3,

--- a/packages/contract/src/lineup-match.schema.ts
+++ b/packages/contract/src/lineup-match.schema.ts
@@ -100,6 +100,8 @@ export type LineupScheduleVoteDto = z.infer<typeof LineupScheduleVoteSchema>;
 export const MatchDetailResponseSchema = LineupMatchSchema.extend({
     gameName: z.string(),
     gameCoverUrl: z.string().nullable(),
+    /** ROK-1121: lineup creator user ID for early-create override. */
+    lineupCreatedById: z.number().int().optional(),
     members: z.array(
         LineupMatchMemberSchema.extend({
             displayName: z.string(),

--- a/web/src/pages/scheduling/CreateEventSection.test.tsx
+++ b/web/src/pages/scheduling/CreateEventSection.test.tsx
@@ -1,0 +1,468 @@
+/**
+ * ROK-1121 — failing TDD tests for CreateEventSection majority-voter gate.
+ *
+ * The Create Event button on the scheduling poll page must be gated behind
+ * a real participation threshold so a single voter cannot lock in a slot.
+ *
+ * Required formula: requiredVoters = max(2, floor(N/2) + 1) where
+ * N = match.members.length.
+ *
+ * Override roles: operator OR admin OR lineupCreatedById === user.id.
+ *
+ * The same gate must apply to BOTH CreateFromSlot and RescheduleFromSlot.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type {
+    MatchDetailResponseDto,
+    ScheduleSlotWithVotesDto,
+} from '@raid-ledger/contract';
+import { renderWithProviders } from '../../test/render-helpers';
+import { CreateEventSection } from './CreateEventSection';
+
+// ─── Hook mocks ────────────────────────────────────────────────────────────────
+
+const mockUseAuth = vi.fn();
+const mockIsAdmin = vi.fn();
+const mockIsOperatorOrAdmin = vi.fn();
+
+vi.mock('../../hooks/use-auth', () => ({
+    useAuth: () => mockUseAuth(),
+    isAdmin: (...args: unknown[]) => mockIsAdmin(...args),
+    isOperatorOrAdmin: (...args: unknown[]) => mockIsOperatorOrAdmin(...args),
+    getAuthToken: vi.fn(() => 'test-token'),
+}));
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+    const actual = await vi.importActual<typeof import('react-router-dom')>(
+        'react-router-dom',
+    );
+    return {
+        ...actual,
+        useNavigate: () => mockNavigate,
+    };
+});
+
+const mockRescheduleMutate = vi.fn();
+vi.mock('../../hooks/use-reschedule', () => ({
+    useRescheduleEvent: vi.fn(() => ({
+        mutate: mockRescheduleMutate,
+        isPending: false,
+    })),
+}));
+
+vi.mock('../../lib/api-client', () => ({
+    completeStandalonePoll: vi.fn(() => Promise.resolve()),
+}));
+
+vi.mock('../../lib/toast', () => ({
+    toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+// ─── Fixture builders ──────────────────────────────────────────────────────────
+
+type MatchOverrides = Partial<MatchDetailResponseDto> & {
+    /** New optional contract field that the dev will add (ROK-1121). */
+    lineupCreatedById?: number;
+    members?: MatchDetailResponseDto['members'];
+};
+
+function buildMember(
+    userId: number,
+    displayName: string,
+): MatchDetailResponseDto['members'][number] {
+    return {
+        id: userId,
+        matchId: 10,
+        userId,
+        source: 'voted',
+        createdAt: '2026-01-01T00:00:00Z',
+        displayName,
+        avatar: null,
+        discordId: null,
+        customAvatarUrl: null,
+    };
+}
+
+function buildMatch(overrides: MatchOverrides = {}): MatchDetailResponseDto {
+    const base: MatchDetailResponseDto = {
+        id: 10,
+        lineupId: 1,
+        gameId: 5,
+        status: 'scheduling',
+        thresholdMet: true,
+        voteCount: 3,
+        votePercentage: 75,
+        fitType: 'normal',
+        linkedEventId: null,
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+        gameName: 'Test Game',
+        gameCoverUrl: null,
+        members: [
+            buildMember(1, 'Alice'),
+            buildMember(2, 'Bob'),
+            buildMember(3, 'Carol'),
+            buildMember(4, 'Dan'),
+        ],
+    };
+    return { ...base, ...overrides } as MatchDetailResponseDto;
+}
+
+function buildSlot(
+    voterIds: number[],
+    overrides: Partial<ScheduleSlotWithVotesDto> = {},
+): ScheduleSlotWithVotesDto {
+    return {
+        id: 100,
+        matchId: 10,
+        proposedTime: '2099-04-10T19:00:00.000Z',
+        overlapScore: null,
+        suggestedBy: 'system',
+        createdAt: '2026-01-01T00:00:00Z',
+        votes: voterIds.map((userId) => ({
+            userId,
+            displayName: `User ${userId}`,
+            avatar: null,
+            discordId: null,
+            customAvatarUrl: null,
+        })),
+        ...overrides,
+    };
+}
+
+interface RenderArgs {
+    voterIds?: number[];
+    members?: MatchDetailResponseDto['members'];
+    hasVoted?: boolean;
+    role?: 'user' | 'operator' | 'admin';
+    userId?: number;
+    lineupCreatedById?: number;
+    linkedEventId?: number | null;
+}
+
+function renderSection(args: RenderArgs = {}) {
+    const {
+        voterIds = [2],
+        members,
+        hasVoted = true,
+        role = 'user',
+        userId = 999,
+        lineupCreatedById,
+        linkedEventId = null,
+    } = args;
+
+    mockUseAuth.mockReturnValue({
+        user: { id: userId, role, displayName: 'Test User' },
+    });
+    mockIsAdmin.mockReturnValue(role === 'admin');
+    mockIsOperatorOrAdmin.mockReturnValue(role === 'operator' || role === 'admin');
+
+    const slot = buildSlot(voterIds);
+    const match = buildMatch({
+        members:
+            members ??
+            [
+                buildMember(1, 'Alice'),
+                buildMember(2, 'Bob'),
+                buildMember(3, 'Carol'),
+                buildMember(4, 'Dan'),
+            ],
+        lineupCreatedById,
+        linkedEventId,
+    });
+
+    return renderWithProviders(
+        <CreateEventSection
+            slots={[slot]}
+            match={match}
+            matchId={10}
+            hasVoted={hasVoted}
+            readOnly={false}
+            createdEventId={null}
+            linkedEventId={linkedEventId}
+            matchStatus="scheduling"
+        />,
+    );
+}
+
+// ─── beforeEach reset ──────────────────────────────────────────────────────────
+
+beforeEach(() => {
+    mockNavigate.mockReset();
+    mockRescheduleMutate.mockReset();
+    mockUseAuth.mockReset();
+    mockIsAdmin.mockReset();
+    mockIsOperatorOrAdmin.mockReset();
+});
+
+// ─── AC1: Button disabled below threshold for non-operator who has voted ──────
+
+describe('CreateEventSection — AC1: button disabled below threshold (non-operator)', () => {
+    it('disables Create Event when distinctVoters < requiredVoters', () => {
+        renderSection({ voterIds: [2], hasVoted: true, role: 'user' });
+
+        const button = screen.getByRole('button', { name: /create event/i });
+        expect(button).toBeInTheDocument();
+        expect(button).toBeDisabled();
+    });
+});
+
+// ─── AC2: Helper text shows X of Y wording ─────────────────────────────────────
+
+describe('CreateEventSection — AC2: helper text X of Y when disabled', () => {
+    it('renders the exact "X of Y participants have voted — Create Event unlocks when majority has chosen a time" copy', () => {
+        renderSection({ voterIds: [2], hasVoted: true, role: 'user' });
+
+        expect(
+            screen.getByText(
+                /1 of 4 participants have voted — Create Event unlocks when majority has chosen a time/i,
+            ),
+        ).toBeInTheDocument();
+    });
+});
+
+// ─── AC3: Section hidden when non-operator has not voted ───────────────────────
+
+describe('CreateEventSection — AC3: section hidden when non-operator has not voted', () => {
+    it('renders nothing (no Create Event heading, no button) when !canBypass && !hasVoted', () => {
+        renderSection({ voterIds: [], hasVoted: false, role: 'user' });
+
+        expect(
+            screen.queryByRole('heading', { name: /create event/i }),
+        ).not.toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: /create event/i }),
+        ).not.toBeInTheDocument();
+    });
+});
+
+// ─── AC4: Override roles always see enabled button ─────────────────────────────
+
+describe('CreateEventSection — AC4: bypass roles see button enabled regardless of votes', () => {
+    it('AC4a: operator sees Create Event enabled even when not voted and 0 voters', () => {
+        renderSection({
+            voterIds: [],
+            hasVoted: false,
+            role: 'operator',
+        });
+
+        const button = screen.getByRole('button', { name: /create event/i });
+        expect(button).toBeInTheDocument();
+        expect(button).toBeEnabled();
+    });
+
+    it('AC4b: admin sees Create Event enabled even when not voted and 0 voters', () => {
+        renderSection({
+            voterIds: [],
+            hasVoted: false,
+            role: 'admin',
+        });
+
+        const button = screen.getByRole('button', { name: /create event/i });
+        expect(button).toBeInTheDocument();
+        expect(button).toBeEnabled();
+    });
+
+    it('AC4c: lineup creator (regular role) sees Create Event enabled even when not voted', () => {
+        renderSection({
+            voterIds: [],
+            hasVoted: false,
+            role: 'user',
+            userId: 42,
+            lineupCreatedById: 42,
+        });
+
+        const button = screen.getByRole('button', { name: /create event/i });
+        expect(button).toBeInTheDocument();
+        expect(button).toBeEnabled();
+    });
+});
+
+// ─── AC5: Operator below threshold → confirm modal ─────────────────────────────
+
+describe('CreateEventSection — AC5: confirm modal when bypass user clicks below threshold', () => {
+    it('shows the warning modal with the exact "Only X of Y participants have voted on this time. Create event anyway?" copy', async () => {
+        const user = userEvent.setup();
+        renderSection({ voterIds: [2], hasVoted: false, role: 'operator' });
+
+        const button = screen.getByRole('button', { name: /create event/i });
+        await user.click(button);
+
+        expect(
+            screen.getByText(
+                /Only 1 of 4 participants have voted on this time\. Create event anyway\?/i,
+            ),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: /^cancel$/i }),
+        ).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: /create anyway/i }),
+        ).toBeInTheDocument();
+    });
+});
+
+// ─── AC6: Threshold met → no modal ─────────────────────────────────────────────
+
+describe('CreateEventSection — AC6: no modal when threshold is met', () => {
+    it('contrast: bypass-user-below-threshold opens modal AND non-bypass-user-at-threshold does NOT', async () => {
+        const user = userEvent.setup();
+
+        // First half: operator below threshold → modal MUST appear.
+        // (Today's code has no modal at all, so this assertion FAILS today.)
+        const { unmount } = renderSection({
+            voterIds: [2],
+            hasVoted: false,
+            role: 'operator',
+        });
+        await user.click(screen.getByRole('button', { name: /create event/i }));
+        expect(
+            screen.getByText(/create event anyway\?/i),
+        ).toBeInTheDocument();
+        unmount();
+        mockNavigate.mockReset();
+
+        // Second half: non-operator with threshold met (3/4 voters) → no modal,
+        // immediate navigation.
+        renderSection({ voterIds: [2, 3, 4], hasVoted: true, role: 'user' });
+
+        const button = screen.getByRole('button', { name: /create event/i });
+        expect(button).toBeEnabled();
+        await user.click(button);
+
+        expect(
+            screen.queryByText(/create event anyway\?/i),
+        ).not.toBeInTheDocument();
+        expect(mockNavigate).toHaveBeenCalledTimes(1);
+        const navArg = mockNavigate.mock.calls[0][0] as string;
+        expect(navArg).toMatch(/^\/events\/new\?/);
+        expect(navArg).toContain('matchId=10');
+    });
+});
+
+// ─── AC7: Modal Cancel / Create anyway buttons ────────────────────────────────
+
+describe('CreateEventSection — AC7: confirm modal actions', () => {
+    it('AC7a: Cancel closes the modal and does not navigate', async () => {
+        const user = userEvent.setup();
+        renderSection({ voterIds: [2], hasVoted: false, role: 'operator' });
+
+        await user.click(screen.getByRole('button', { name: /create event/i }));
+
+        const modalText = screen.getByText(/create event anyway\?/i);
+        expect(modalText).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: /^cancel$/i }));
+
+        expect(
+            screen.queryByText(/create event anyway\?/i),
+        ).not.toBeInTheDocument();
+        expect(mockNavigate).not.toHaveBeenCalled();
+    });
+
+    it('AC7b: "Create anyway" proceeds with the original navigation', async () => {
+        const user = userEvent.setup();
+        renderSection({ voterIds: [2], hasVoted: false, role: 'operator' });
+
+        await user.click(screen.getByRole('button', { name: /create event/i }));
+        await user.click(
+            screen.getByRole('button', { name: /create anyway/i }),
+        );
+
+        expect(mockNavigate).toHaveBeenCalledTimes(1);
+        const navArg = mockNavigate.mock.calls[0][0] as string;
+        expect(navArg).toMatch(/^\/events\/new\?/);
+        expect(navArg).toContain('matchId=10');
+    });
+});
+
+// ─── AC8: Threshold formula coverage ───────────────────────────────────────────
+
+describe('CreateEventSection — AC8: threshold formula max(2, floor(N/2)+1)', () => {
+    const cases: Array<{ n: number; required: number }> = [
+        { n: 1, required: 2 },
+        { n: 2, required: 2 },
+        { n: 3, required: 2 },
+        { n: 4, required: 3 },
+        { n: 5, required: 3 },
+        { n: 6, required: 4 },
+    ];
+
+    cases.forEach(({ n, required }) => {
+        it(`N=${n} requires ${required} voters — button disabled with ${required - 1} voters, enabled with ${required}`, () => {
+            const members = Array.from({ length: n }, (_, i) =>
+                buildMember(i + 1, `User${i + 1}`),
+            );
+
+            // With required - 1 voters: still below threshold → disabled.
+            const justBelow = Math.max(0, required - 1);
+            const voterIdsBelow = Array.from(
+                { length: justBelow },
+                (_, i) => i + 1,
+            );
+
+            const { unmount } = renderSection({
+                voterIds: voterIdsBelow,
+                members,
+                hasVoted: true,
+                role: 'user',
+                userId: 9999, // non-member voter so we don't accidentally hit bypass
+            });
+
+            const buttonBelow = screen.getByRole('button', {
+                name: /create event/i,
+            });
+            expect(buttonBelow).toBeDisabled();
+            unmount();
+
+            // With required voters: meets threshold → enabled.
+            const voterIdsAt = Array.from(
+                { length: required },
+                (_, i) => i + 1,
+            );
+
+            renderSection({
+                voterIds: voterIdsAt,
+                members,
+                hasVoted: true,
+                role: 'user',
+                userId: 9999,
+            });
+
+            const buttonAt = screen.getByRole('button', {
+                name: /create event/i,
+            });
+            expect(buttonAt).toBeEnabled();
+        });
+    });
+});
+
+// ─── AC9: Reschedule path also gated ───────────────────────────────────────────
+
+describe('CreateEventSection — AC9: reschedule path is also gated', () => {
+    it('disables Reschedule Event button and shows helper text when below threshold', () => {
+        renderSection({
+            voterIds: [2],
+            hasVoted: true,
+            role: 'user',
+            linkedEventId: 555,
+        });
+
+        const button = screen.getByRole('button', {
+            name: /reschedule event/i,
+        });
+        expect(button).toBeInTheDocument();
+        expect(button).toBeDisabled();
+        expect(
+            screen.getByText(
+                /1 of 4 participants have voted — Create Event unlocks when majority has chosen a time/i,
+            ),
+        ).toBeInTheDocument();
+    });
+});
+
+// Helper export to silence "within is unused" if it isn't referenced.
+void within;

--- a/web/src/pages/scheduling/CreateEventSection.tsx
+++ b/web/src/pages/scheduling/CreateEventSection.tsx
@@ -203,7 +203,7 @@ function RescheduleFromSlot({ slots, match, matchId, linkedEventId, hasVoted, re
       {gate.showHelperText && (
         <p className="text-xs text-muted">{gate.helperText}</p>
       )}
-      {!gate.showHelperText && !hasVoted && !readOnly && (
+      {!gate.showHelperText && !gate.canBypass && !hasVoted && !readOnly && (
         <p className="text-xs text-muted">Vote on a time slot to enable rescheduling.</p>
       )}
       {showConfirm && (
@@ -280,7 +280,7 @@ function CreateFromSlot({ slots, match, matchId, hasVoted, readOnly }: {
       {gate.showHelperText && (
         <p className="text-xs text-muted">{gate.helperText}</p>
       )}
-      {!gate.showHelperText && !hasVoted && !readOnly && (
+      {!gate.showHelperText && !gate.canBypass && !hasVoted && !readOnly && (
         <p className="text-xs text-muted">Vote on a time slot to enable event creation.</p>
       )}
       {showConfirm && (

--- a/web/src/pages/scheduling/CreateEventSection.tsx
+++ b/web/src/pages/scheduling/CreateEventSection.tsx
@@ -1,14 +1,28 @@
 /**
  * Create Event section for the scheduling poll page (ROK-965).
  * User picks a slot, optionally enables recurring, then creates the event.
+ *
+ * ROK-1121: Create / Reschedule actions are gated behind a majority-voter
+ * threshold (max(2, floor(N/2)+1) distinct voters on the selected slot).
+ * Operators, admins, and the lineup creator can bypass with a confirm modal.
  */
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import type { JSX } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import type { ScheduleSlotWithVotesDto, MatchDetailResponseDto } from '@raid-ledger/contract';
+import type {
+    ScheduleSlotWithVotesDto,
+    MatchDetailResponseDto,
+} from '@raid-ledger/contract';
+import { useAuth } from '../../hooks/use-auth';
 import { useRescheduleEvent } from '../../hooks/use-reschedule';
 import { completeStandalonePoll } from '../../lib/api-client';
 import { toast } from '../../lib/toast';
+import {
+    computeRequiredVoters,
+    countDistinctVoters,
+    canBypassThreshold,
+} from './threshold';
+import { EarlyCreateConfirmModal } from './EarlyCreateConfirmModal';
 
 interface CreateEventSectionProps {
   slots: ScheduleSlotWithVotesDto[];
@@ -77,11 +91,49 @@ function CreatedSuccessState({ eventId, matchStatus }: {
   );
 }
 
+interface ThresholdGate {
+  canBypass: boolean;
+  requiredVoters: number;
+  distinctVoters: number;
+  thresholdMet: boolean;
+  shouldHide: boolean;
+  showHelperText: boolean;
+  helperText: string;
+}
+
+/** Compute the gate state for a slot + match + user. */
+function useThresholdGate(
+  match: MatchDetailResponseDto,
+  selectedSlot: ScheduleSlotWithVotesDto | undefined,
+  hasVoted: boolean,
+): ThresholdGate {
+  const { user } = useAuth();
+  return useMemo(() => {
+    const memberCount = match.members.length;
+    const canBypass = canBypassThreshold(user, match);
+    const requiredVoters = computeRequiredVoters(memberCount);
+    const distinctVoters = countDistinctVoters(selectedSlot);
+    const thresholdMet = distinctVoters >= requiredVoters;
+    const shouldHide = !canBypass && !hasVoted;
+    const showHelperText = !canBypass && hasVoted && !thresholdMet;
+    const helperText = `${distinctVoters} of ${memberCount} participants have voted — Create Event unlocks when majority has chosen a time`;
+    return {
+      canBypass,
+      requiredVoters,
+      distinctVoters,
+      thresholdMet,
+      shouldHide,
+      showHelperText,
+      helperText,
+    };
+  }, [user, match, selectedSlot, hasVoted]);
+}
+
 /** Section for creating an event or rescheduling from a selected slot. */
 export function CreateEventSection({
   slots, match, matchId, hasVoted, readOnly, createdEventId, linkedEventId,
   matchStatus,
-}: CreateEventSectionProps): JSX.Element {
+}: CreateEventSectionProps): JSX.Element | null {
   const isReschedule = linkedEventId !== null;
 
   if (createdEventId) {
@@ -89,7 +141,7 @@ export function CreateEventSection({
   }
 
   if (isReschedule) {
-    return <RescheduleFromSlot slots={slots} matchId={matchId}
+    return <RescheduleFromSlot slots={slots} match={match} matchId={matchId}
       linkedEventId={linkedEventId} hasVoted={hasVoted} readOnly={readOnly} />;
   }
 
@@ -98,18 +150,19 @@ export function CreateEventSection({
 }
 
 /** Reschedule the linked event to the selected slot's time. */
-function RescheduleFromSlot({ slots, matchId, linkedEventId, hasVoted, readOnly }: {
-  slots: ScheduleSlotWithVotesDto[]; matchId: number; linkedEventId: number;
-  hasVoted: boolean; readOnly: boolean;
-}): JSX.Element {
+function RescheduleFromSlot({ slots, match, matchId, linkedEventId, hasVoted, readOnly }: {
+  slots: ScheduleSlotWithVotesDto[]; match: MatchDetailResponseDto; matchId: number;
+  linkedEventId: number; hasVoted: boolean; readOnly: boolean;
+}): JSX.Element | null {
   const sorted = sortedSlots(slots);
   const [selectedSlotId, setSelectedSlotId] = useState<number | null>(sorted[0]?.id ?? null);
   const [done, setDone] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
   const reschedule = useRescheduleEvent(linkedEventId);
   const selectedSlot = slots.find((s) => s.id === selectedSlotId);
-  const canAct = hasVoted && !readOnly && !reschedule.isPending && selectedSlotId !== null;
+  const gate = useThresholdGate(match, selectedSlot, hasVoted);
 
-  const handleReschedule = () => {
+  const performReschedule = () => {
     if (!selectedSlot) return;
     const start = new Date(selectedSlot.proposedTime);
     if (start <= new Date()) {
@@ -126,20 +179,16 @@ function RescheduleFromSlot({ slots, matchId, linkedEventId, hasVoted, readOnly 
     );
   };
 
-  if (done) {
-    return (
-      <div className="space-y-3">
-        <div className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-full bg-emerald-500/15 text-emerald-300 border border-emerald-500/30">
-          Rescheduled
-        </div>
-        <p className="text-sm text-emerald-400">Event rescheduled successfully!</p>
-        <Link to={`/events/${linkedEventId}`}
-          className="inline-flex items-center gap-1 text-sm text-emerald-400 hover:text-emerald-300 transition-colors">
-          View Event &rarr;
-        </Link>
-      </div>
-    );
-  }
+  const handleClick = () => {
+    if (!gate.thresholdMet) { setShowConfirm(true); return; }
+    performReschedule();
+  };
+
+  if (done) return <RescheduledSuccessState linkedEventId={linkedEventId} />;
+  if (gate.shouldHide) return null;
+
+  const canAct = gate.canBypass || (hasVoted && gate.thresholdMet);
+  const buttonDisabled = !canAct || readOnly || reschedule.isPending || selectedSlotId === null;
 
   return (
     <div className="space-y-3">
@@ -147,13 +196,40 @@ function RescheduleFromSlot({ slots, matchId, linkedEventId, hasVoted, readOnly 
       {slots.length > 0 && (
         <SlotSelector slots={slots} selectedId={selectedSlotId} onChange={setSelectedSlotId} />
       )}
-      <button type="button" onClick={handleReschedule} disabled={!canAct}
+      <button type="button" onClick={handleClick} disabled={buttonDisabled}
         className="px-6 py-2.5 text-sm font-medium bg-cyan-600 text-white rounded-lg hover:bg-cyan-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
         {reschedule.isPending ? 'Rescheduling...' : 'Reschedule Event'}
       </button>
-      {!hasVoted && !readOnly && (
+      {gate.showHelperText && (
+        <p className="text-xs text-muted">{gate.helperText}</p>
+      )}
+      {!gate.showHelperText && !hasVoted && !readOnly && (
         <p className="text-xs text-muted">Vote on a time slot to enable rescheduling.</p>
       )}
+      {showConfirm && (
+        <EarlyCreateConfirmModal
+          distinctVoters={gate.distinctVoters}
+          memberCount={match.members.length}
+          onCancel={() => setShowConfirm(false)}
+          onConfirm={() => { setShowConfirm(false); performReschedule(); }}
+        />
+      )}
+    </div>
+  );
+}
+
+/** Success state for a completed reschedule. */
+function RescheduledSuccessState({ linkedEventId }: { linkedEventId: number }): JSX.Element {
+  return (
+    <div className="space-y-3">
+      <div className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium rounded-full bg-emerald-500/15 text-emerald-300 border border-emerald-500/30">
+        Rescheduled
+      </div>
+      <p className="text-sm text-emerald-400">Event rescheduled successfully!</p>
+      <Link to={`/events/${linkedEventId}`}
+        className="inline-flex items-center gap-1 text-sm text-emerald-400 hover:text-emerald-300 transition-colors">
+        View Event &rarr;
+      </Link>
     </div>
   );
 }
@@ -162,14 +238,15 @@ function RescheduleFromSlot({ slots, matchId, linkedEventId, hasVoted, readOnly 
 function CreateFromSlot({ slots, match, matchId, hasVoted, readOnly }: {
   slots: ScheduleSlotWithVotesDto[]; match: MatchDetailResponseDto;
   matchId: number; hasVoted: boolean; readOnly: boolean;
-}): JSX.Element {
+}): JSX.Element | null {
   const navigate = useNavigate();
   const sorted = sortedSlots(slots);
   const [selectedSlotId, setSelectedSlotId] = useState<number | null>(sorted[0]?.id ?? null);
+  const [showConfirm, setShowConfirm] = useState(false);
   const selectedSlot = slots.find((s) => s.id === selectedSlotId);
-  const canCreate = hasVoted && !readOnly && selectedSlotId !== null;
+  const gate = useThresholdGate(match, selectedSlot, hasVoted);
 
-  const handleCreate = () => {
+  const performNavigate = () => {
     if (!selectedSlot) return;
     const start = new Date(selectedSlot.proposedTime);
     if (start <= new Date()) { toast.error('Cannot create event for a past time slot'); return; }
@@ -180,18 +257,39 @@ function CreateFromSlot({ slots, match, matchId, hasVoted, readOnly }: {
     navigate(`/events/new?${params.toString()}`);
   };
 
+  const handleClick = () => {
+    if (!gate.thresholdMet) { setShowConfirm(true); return; }
+    performNavigate();
+  };
+
+  if (gate.shouldHide) return null;
+
+  const canAct = gate.canBypass || (hasVoted && gate.thresholdMet);
+  const buttonDisabled = !canAct || readOnly || selectedSlotId === null;
+
   return (
     <div className="space-y-3">
       <h3 className="text-sm font-semibold text-foreground uppercase tracking-wide">Create Event</h3>
       {slots.length > 0 && (
         <SlotSelector slots={slots} selectedId={selectedSlotId} onChange={setSelectedSlotId} />
       )}
-      <button type="button" onClick={handleCreate} disabled={!canCreate}
+      <button type="button" onClick={handleClick} disabled={buttonDisabled}
         className="px-6 py-2.5 text-sm font-medium bg-emerald-600 text-white rounded-lg hover:bg-emerald-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
         Create Event
       </button>
-      {!hasVoted && !readOnly && (
+      {gate.showHelperText && (
+        <p className="text-xs text-muted">{gate.helperText}</p>
+      )}
+      {!gate.showHelperText && !hasVoted && !readOnly && (
         <p className="text-xs text-muted">Vote on a time slot to enable event creation.</p>
+      )}
+      {showConfirm && (
+        <EarlyCreateConfirmModal
+          distinctVoters={gate.distinctVoters}
+          memberCount={match.members.length}
+          onCancel={() => setShowConfirm(false)}
+          onConfirm={() => { setShowConfirm(false); performNavigate(); }}
+        />
       )}
     </div>
   );

--- a/web/src/pages/scheduling/EarlyCreateConfirmModal.tsx
+++ b/web/src/pages/scheduling/EarlyCreateConfirmModal.tsx
@@ -1,0 +1,52 @@
+/**
+ * Confirmation modal for early Create/Reschedule when the majority-voter
+ * threshold is not met (ROK-1121).
+ */
+import type { JSX } from 'react';
+
+interface EarlyCreateConfirmModalProps {
+    distinctVoters: number;
+    memberCount: number;
+    onCancel: () => void;
+    onConfirm: () => void;
+}
+
+export function EarlyCreateConfirmModal({
+    distinctVoters,
+    memberCount,
+    onCancel,
+    onConfirm,
+}: EarlyCreateConfirmModalProps): JSX.Element {
+    return (
+        <div
+            role="dialog"
+            aria-modal="true"
+            className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+        >
+            <div className="w-full max-w-md rounded-lg border border-edge bg-panel p-5 shadow-xl">
+                <h4 className="text-base font-semibold text-foreground">
+                    Create event below majority?
+                </h4>
+                <p className="mt-2 text-sm text-muted">
+                    Only {distinctVoters} of {memberCount} participants have voted on this time. Create event anyway?
+                </p>
+                <div className="mt-4 flex justify-end gap-2">
+                    <button
+                        type="button"
+                        onClick={onCancel}
+                        className="px-4 py-2 text-sm font-medium rounded-lg border border-edge text-foreground hover:bg-panel-hover transition-colors"
+                    >
+                        Cancel
+                    </button>
+                    <button
+                        type="button"
+                        onClick={onConfirm}
+                        className="px-4 py-2 text-sm font-medium rounded-lg bg-emerald-600 text-white hover:bg-emerald-500 transition-colors"
+                    >
+                        Create anyway
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/web/src/pages/scheduling/threshold.ts
+++ b/web/src/pages/scheduling/threshold.ts
@@ -1,0 +1,42 @@
+/**
+ * Majority-voter threshold helpers for the scheduling poll page (ROK-1121).
+ *
+ * Gates the "Create Event" / "Reschedule Event" actions behind a real
+ * participation floor so a single voter cannot lock in a time slot.
+ */
+import type {
+    MatchDetailResponseDto,
+    ScheduleSlotWithVotesDto,
+} from '@raid-ledger/contract';
+import { isOperatorOrAdmin } from '../../hooks/use-auth';
+
+export interface ThresholdUser {
+    id?: number;
+    role?: string;
+}
+
+/** Required voters: max(2, floor(N/2) + 1). */
+export function computeRequiredVoters(memberCount: number): number {
+    return Math.max(2, Math.floor(memberCount / 2) + 1);
+}
+
+/** Distinct voter count on the currently-selected slot. */
+export function countDistinctVoters(
+    slot: ScheduleSlotWithVotesDto | undefined,
+): number {
+    if (!slot) return 0;
+    return new Set(slot.votes.map((v) => v.userId)).size;
+}
+
+/** True if the user can override the gate (operator, admin, or lineup creator). */
+export function canBypassThreshold(
+    user: ThresholdUser | null | undefined,
+    match: MatchDetailResponseDto,
+): boolean {
+    if (!user) return false;
+    if (isOperatorOrAdmin({ ...user, role: user.role as never })) return true;
+    return (
+        typeof match.lineupCreatedById === 'number' &&
+        match.lineupCreatedById === user.id
+    );
+}

--- a/web/src/pages/scheduling/threshold.ts
+++ b/web/src/pages/scheduling/threshold.ts
@@ -8,7 +8,6 @@ import type {
     MatchDetailResponseDto,
     ScheduleSlotWithVotesDto,
 } from '@raid-ledger/contract';
-import { isOperatorOrAdmin } from '../../hooks/use-auth';
 
 export interface ThresholdUser {
     id?: number;
@@ -34,7 +33,7 @@ export function canBypassThreshold(
     match: MatchDetailResponseDto,
 ): boolean {
     if (!user) return false;
-    if (isOperatorOrAdmin({ ...user, role: user.role as never })) return true;
+    if (user.role === 'operator' || user.role === 'admin') return true;
     return (
         typeof match.lineupCreatedById === 'number' &&
         match.lineupCreatedById === user.id


### PR DESCRIPTION
## Summary
- Gate the Create Event button on `/community-lineup/:id/schedule/:matchId` behind a real majority-voter threshold (`max(2, floor(N/2)+1)` distinct voters on the selected slot, where `N = match.members.length`).
- Operators / admins / lineup creators bypass the gate but get a confirm modal when clicking below threshold ("Only X of Y participants have voted on this time. Create event anyway?" with Cancel + Create anyway).
- Section is hidden entirely for non-bypass users who haven't voted yet (preserves the original Q10 intent).
- Same gate applied to the `RescheduleFromSlot` path so the bug isn't fixed only in `CreateFromSlot`.
- Adds an optional `lineupCreatedById` field to `MatchDetailResponseSchema` and threads `community_lineups.created_by` through `SchedulingService.getSchedulePoll` → `buildPollResponse` → `buildMatchDetailDto` so the frontend can detect "lineup creator" without a separate API call.
- Bundles a `chore:` commit unblocking origin/main typecheck (NestJS group + Jest 30 dep bumps left `users.service.spec.ts`, `events.integration.spec.ts`, and the steam specs in a non-compiling state — caught while preparing this story).

## Linear
ROK-1121

## Workspaces touched
- `packages/contract` — optional `lineupCreatedById?: number` on `MatchDetailResponseSchema`.
- `api` — `scheduling.service.ts` selects `created_by`; `scheduling-response.helpers.ts` plumbs it through; spec updated.
- `web` — `CreateEventSection.tsx` reorganized around a shared `useThresholdGate` hook; new `threshold.ts` and `EarlyCreateConfirmModal.tsx`; new test file.
- Cross-cutting `chore:` — drizzle-mock typing fix + import-extension fix to unblock `validate-ci.sh --full` after Dependabot bumps.

## Test plan
- [x] Vitest: `web/src/pages/scheduling/CreateEventSection.test.tsx` — 17 tests covering all 9 ACs (button states, helper text, hide rule, modal copy, threshold formula N=1..6, reschedule path).
- [x] Backend unit: `scheduling-response.helpers.spec.ts` extended for `lineupCreatedById` flow.
- [x] `./scripts/validate-ci.sh --full` — build, typecheck, lint, unit tests (api + web), integration tests (api) all green.
- [x] Playwright (desktop + mobile, matches CI): 526 passed, 0 failed.
- [x] Operator browser end-to-end — verified all 9 ACs in real browser (operator below threshold → modal; threshold met → direct nav; non-operator hide; non-operator disabled with helper text).
- [x] Code review pass: APPROVED, 0 blocking issues, 5 tech-debt items recorded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)