### PR TITLE
ROK-1191: pre-fix @eslint/js v10 lint + guard discord-smoke for Dependabot

### DIFF
--- a/.github/workflows/discord-smoke.yml
+++ b/.github/workflows/discord-smoke.yml
@@ -145,7 +145,22 @@ jobs:
           echo "API failed to start within 60s"
           exit 1
 
+      # Dependabot PRs don't have access to repository secrets. The
+      # test-bot smoke tests require Discord credentials, so we short-circuit
+      # the secret-dependent steps and report success when they're unavailable.
+      # Real validation runs on push to main.
+      - name: Check for Discord secrets
+        id: secrets
+        run: |
+          if [ -z "$DISCORD_BOT_TOKEN" ] || [ -z "$TEST_BOT_TOKEN" ]; then
+            echo "available=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Discord secrets unavailable — skipping live smoke tests (likely a Dependabot PR). Push to main runs the full suite."
+          else
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Configure and connect Discord bot
+        if: steps.secrets.outputs.available == 'true'
         run: |
           echo "Authenticating..."
           TOKEN=$(curl -sf http://localhost:3000/auth/local \
@@ -191,30 +206,35 @@ jobs:
       # locally with: SMOKE_CATEGORY=cdp-command npx tsx src/smoke/run.ts
 
       - name: Run embed smoke tests
+        if: steps.secrets.outputs.available == 'true'
         run: npx tsx src/smoke/run.ts
         working-directory: tools/test-bot
         env:
           SMOKE_CATEGORY: embed
 
       - name: Run flow smoke tests
+        if: steps.secrets.outputs.available == 'true'
         run: npx tsx src/smoke/run.ts
         working-directory: tools/test-bot
         env:
           SMOKE_CATEGORY: flow
 
       - name: Run DM smoke tests
+        if: steps.secrets.outputs.available == 'true'
         run: npx tsx src/smoke/run.ts
         working-directory: tools/test-bot
         env:
           SMOKE_CATEGORY: dm
 
       - name: Run command smoke tests
+        if: steps.secrets.outputs.available == 'true'
         run: npx tsx src/smoke/run.ts
         working-directory: tools/test-bot
         env:
           SMOKE_CATEGORY: command
 
       - name: Run voice smoke tests
+        if: steps.secrets.outputs.available == 'true'
         run: npx tsx src/smoke/run.ts
         working-directory: tools/test-bot
         env:

--- a/api/src/ai/llm-pipeline.helpers.spec.ts
+++ b/api/src/ai/llm-pipeline.helpers.spec.ts
@@ -144,15 +144,12 @@ describe('llm-pipeline.helpers (adversarial)', () => {
   describe('executeWithTimeout — edge cases', () => {
     it('does not reject before timeout expires', async () => {
       jest.useFakeTimers();
-      let resolved = false;
       const promise = executeWithTimeout(
         () => new Promise<string>((res) => setTimeout(() => res('done'), 50)),
         200,
       );
       jest.advanceTimersByTime(50);
       const result = await promise;
-      resolved = true;
-      expect(resolved).toBe(true);
       expect(result).toBe('done');
     });
 

--- a/api/src/backup/backup.service.ts
+++ b/api/src/backup/backup.service.ts
@@ -284,7 +284,7 @@ export class BackupService implements OnModuleInit {
       const msg = err instanceof Error ? err.message : String(err);
       this.logger.error(`pg_dump failed: ${msg}`);
       cleanupPartialFile(outputPath);
-      throw new Error(`pg_dump failed: ${msg}`);
+      throw new Error(`pg_dump failed: ${msg}`, { cause: err });
     }
   }
 

--- a/web/src/plugins/ai/register.ts
+++ b/web/src/plugins/ai/register.ts
@@ -1,16 +1,10 @@
 import { registerPlugin } from '../plugin-registry';
 import { AiPluginContent } from './slots/ai-plugin-content';
 
-// Guard against HMR re-execution pushing duplicate registrations
-let registered = false;
-if (!registered) {
-    registered = true;
+const ai = registerPlugin('ai', {
+    icon: '/plugins/ai/badge.svg',
+    color: '#8B5CF6',
+    label: 'AI Features',
+});
 
-    const ai = registerPlugin('ai', {
-        icon: '/plugins/ai/badge.svg',
-        color: '#8B5CF6',
-        label: 'AI Features',
-    });
-
-    ai.registerSlot('admin-settings:plugin-content', AiPluginContent);
-}
+ai.registerSlot('admin-settings:plugin-content', AiPluginContent);

--- a/web/src/plugins/discord/register.ts
+++ b/web/src/plugins/discord/register.ts
@@ -1,13 +1,7 @@
 import { registerPlugin } from '../plugin-registry';
 
-// Guard against HMR re-execution pushing duplicate registrations
-let registered = false;
-if (!registered) {
-    registered = true;
-
-    registerPlugin('discord', {
-        icon: '/plugins/discord/badge.svg',
-        color: '#5865F2',
-        label: 'Discord',
-    });
-}
+registerPlugin('discord', {
+    icon: '/plugins/discord/badge.svg',
+    color: '#5865F2',
+    label: 'Discord',
+});

--- a/web/src/plugins/wow/register.ts
+++ b/web/src/plugins/wow/register.ts
@@ -11,27 +11,21 @@ import { ProfileCharacterActions } from './slots/profile-character-actions';
 import { QuestPrepPanel } from './slots/quest-prep-panel';
 import { BossLootPanel } from './slots/boss-loot-panel';
 
-// Guard against HMR re-execution pushing duplicate registrations
-let registered = false;
-if (!registered) {
-    registered = true;
+const blizzard = registerPlugin('blizzard', {
+    icon: '/plugins/blizzard/badge.jpg',
+    iconSmall: '/plugins/blizzard/badge-32.jpg',
+    color: 'blue',
+    label: 'World of Warcraft Plugin',
+});
 
-    const blizzard = registerPlugin('blizzard', {
-        icon: '/plugins/blizzard/badge.jpg',
-        iconSmall: '/plugins/blizzard/badge-32.jpg',
-        color: 'blue',
-        label: 'World of Warcraft Plugin',
-    });
-
-    blizzard.registerSlot('character-detail:sections', CharacterDetailSections);
-    blizzard.registerSlot('character-detail:header-badges', CharacterDetailHeaderBadges);
-    blizzard.registerSlot('character-create:import-form', CharacterCreateImportForm);
-    blizzard.registerSlot('character-create:inline-import', CharacterCreateInlineImport);
-    blizzard.registerSlot('event-create:content-browser', EventCreateContentBrowser);
-    blizzard.registerSlot('event-detail:content-sections', EventDetailContentSections);
-    blizzard.registerSlot('event-detail:content-sections', BossLootPanel, 5);
-    blizzard.registerSlot('event-detail:content-sections', QuestPrepPanel, 10);
-    blizzard.registerSlot('event-detail:signup-warnings', EventDetailSignupWarnings);
-    blizzard.registerSlot('admin-settings:plugin-content', BlizzardIntegrationSlot);
-    blizzard.registerSlot('profile:character-actions', ProfileCharacterActions);
-}
+blizzard.registerSlot('character-detail:sections', CharacterDetailSections);
+blizzard.registerSlot('character-detail:header-badges', CharacterDetailHeaderBadges);
+blizzard.registerSlot('character-create:import-form', CharacterCreateImportForm);
+blizzard.registerSlot('character-create:inline-import', CharacterCreateInlineImport);
+blizzard.registerSlot('event-create:content-browser', EventCreateContentBrowser);
+blizzard.registerSlot('event-detail:content-sections', EventDetailContentSections);
+blizzard.registerSlot('event-detail:content-sections', BossLootPanel, 5);
+blizzard.registerSlot('event-detail:content-sections', QuestPrepPanel, 10);
+blizzard.registerSlot('event-detail:signup-warnings', EventDetailSignupWarnings);
+blizzard.registerSlot('admin-settings:plugin-content', BlizzardIntegrationSlot);
+blizzard.registerSlot('profile:character-actions', ProfileCharacterActions);


### PR DESCRIPTION
## Summary

Unblocks 3 stuck Dependabot PRs by pre-fixing two underlying issues:

- **#690** (@eslint/js 9.39 → 10): the v10 release adds two new rules (`no-useless-assignment`, `preserve-caught-error`) that surface 5 existing violations. Pre-fixed all 5; once #690 rebases it should land clean.
- **#681** (typescript 5 → 6 in /tools/test-bot) and **#682** (dotenv 16 → 17 in /tools/test-bot): both fail \`discord-smoke\` because GitHub strips secrets on Dependabot PRs (security policy), so \`DISCORD_BOT_TOKEN\` is empty and a curl + python3 chain crashes with JSONDecodeError. The TS/dotenv bumps themselves are fine. Added a guard step that detects missing secrets and skips the secret-dependent steps. Real validation still runs on push to main.

## Linear

ROK-1191

## Lint fixes (@eslint/js v10)

- \`api/src/ai/llm-pipeline.helpers.spec.ts\`: removed dead \`let resolved = false; ... resolved = true; expect(resolved).toBe(true)\` flag — \`expect(result).toBe('done')\` already proves the promise resolved.
- \`api/src/backup/backup.service.ts:287\`: \`throw new Error(...)\` now attaches \`{ cause: err }\` so the caught error chain is preserved.
- \`web/src/plugins/{ai,discord,wow}/register.ts\`: removed \`let registered = false; if (!registered) { registered = true; ... }\` HMR guard — \`registerSlotComponent\` already dedupes per ROK-206 (see \`plugin-registry.ts:76\`).

## Workflow guard

\`.github/workflows/discord-smoke.yml\` — added a \"Check for Discord secrets\" step that sets \`steps.secrets.outputs.available\`. The configure-bot step and all five \`Run * smoke tests\` steps now gate on \`steps.secrets.outputs.available == 'true'\`. Dependabot PRs short-circuit successfully; main pushes still run the full live suite.

## Test plan

- [x] \`npx eslint\` clean on all 5 changed files (under v9 — v10 errors only fire when @eslint/js v10 is installed; #690's rebase will validate)
- [x] No behavior change in the 3 register.ts files — \`registerSlotComponent\` dedup already exists
- [x] \`backup.service.ts\` change is purely additive (new \`cause\` arg)
- [x] \`llm-pipeline.helpers.spec.ts\` test still asserts \`result === 'done'\` (only removed the redundant flag check)

## Risk

Low. Plugin register guards were no-ops anyway; backup error change is additive; spec change preserves the actual assertion. Workflow guard only changes behavior for Dependabot PRs (no secrets context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)