### PR TITLE
ROK-1192: feat: standalone scheduling poll deadline reminders (24h + 1h DMs)

### DIFF
--- a/api/src/admin/admin.module.ts
+++ b/api/src/admin/admin.module.ts
@@ -9,6 +9,7 @@ import { DemoTestScheduledEventsController } from './demo-test-scheduled-events.
 import { DemoTestSignupsController } from './demo-test-signups.controller';
 import { DemoTestGamesController } from './demo-test-games.controller';
 import { DemoTestResetController } from './demo-test-reset.controller';
+import { DemoTestStandalonePollController } from './demo-test-standalone-poll.controller';
 import { SlashCommandTestController } from './slash-command-test.controller';
 import { ItadSettingsController } from './itad-settings.controller';
 import { LineupSettingsController } from './settings-lineup.controller';
@@ -23,6 +24,7 @@ import { DemoTestResetService } from './demo-test-reset.service';
 import { DemoTestLineupService } from './demo-test-lineup.service';
 import { SlashCommandTestService } from './slash-command-test.service';
 import { LineupsModule } from '../lineups/lineups.module';
+import { StandalonePollModule } from '../lineups/standalone-poll/standalone-poll.module';
 import { AiChatModule } from '../discord-bot/ai-chat/ai-chat.module';
 import { TasteProfileModule } from '../taste-profile/taste-profile.module';
 import { CommunityInsightsModule } from '../community-insights/community-insights.module';
@@ -34,6 +36,7 @@ import { AiChatTestController } from './ai-chat-test.controller';
     AuthModule,
     IgdbModule,
     LineupsModule,
+    StandalonePollModule,
     AiChatModule,
     TasteProfileModule,
     CommunityInsightsModule,
@@ -49,6 +52,7 @@ import { AiChatTestController } from './ai-chat-test.controller';
     DemoTestSignupsController,
     DemoTestGamesController,
     DemoTestResetController,
+    DemoTestStandalonePollController,
     AiChatTestController,
     SlashCommandTestController,
     ItadSettingsController,

--- a/api/src/admin/demo-test-standalone-poll.controller.ts
+++ b/api/src/admin/demo-test-standalone-poll.controller.ts
@@ -1,0 +1,83 @@
+/**
+ * Standalone scheduling poll test endpoints (ROK-1192).
+ * DEMO_MODE-only — used by smoke tests to exercise the deadline
+ * reminder cron without waiting 23 real hours for the 1h window.
+ */
+import {
+  Body,
+  Controller,
+  ForbiddenException,
+  HttpCode,
+  HttpStatus,
+  Inject,
+  NotFoundException,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { SkipThrottle } from '@nestjs/throttler';
+import { eq } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { AdminGuard } from '../auth/admin.guard';
+import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
+import * as schema from '../drizzle/schema';
+import { SettingsService } from '../settings/settings.service';
+import { StandalonePollReminderService } from '../lineups/standalone-poll/standalone-poll-reminder.service';
+import { AdvanceStandalonePollDeadlineSchema } from './demo-test.schemas';
+import { parseDemoBody } from './demo-test.utils';
+
+@Controller('admin/test')
+@SkipThrottle()
+@UseGuards(AuthGuard('jwt'), AdminGuard)
+export class DemoTestStandalonePollController {
+  constructor(
+    @Inject(DrizzleAsyncProvider)
+    private readonly db: PostgresJsDatabase<typeof schema>,
+    private readonly settingsService: SettingsService,
+    private readonly reminderService: StandalonePollReminderService,
+  ) {}
+
+  private async assertDemoMode(): Promise<void> {
+    if (process.env.DEMO_MODE !== 'true') {
+      throw new ForbiddenException('Only available in DEMO_MODE');
+    }
+    const demoMode = await this.settingsService.getDemoMode();
+    if (!demoMode) {
+      throw new ForbiddenException('Only available in DEMO_MODE');
+    }
+  }
+
+  /**
+   * Reset a standalone poll's `phase_deadline` to `now + hoursUntilDeadline`.
+   * Pass a fractional value (e.g. 0.5) to land inside the 1h window.
+   */
+  @Post('advance-standalone-poll-deadline')
+  @HttpCode(HttpStatus.OK)
+  async advancePollDeadline(
+    @Body() body: unknown,
+  ): Promise<{ success: boolean; phaseDeadline: string }> {
+    await this.assertDemoMode();
+    const parsed = parseDemoBody(AdvanceStandalonePollDeadlineSchema, body);
+    const newDeadline = new Date(
+      Date.now() + parsed.hoursUntilDeadline * 60 * 60 * 1000,
+    );
+    const updated = await this.db
+      .update(schema.communityLineups)
+      .set({ phaseDeadline: newDeadline, updatedAt: new Date() })
+      .where(eq(schema.communityLineups.id, parsed.lineupId))
+      .returning({ id: schema.communityLineups.id });
+    if (updated.length === 0) {
+      throw new NotFoundException(`Lineup ${parsed.lineupId} not found`);
+    }
+    return { success: true, phaseDeadline: newDeadline.toISOString() };
+  }
+
+  /** Run the standalone-poll reminder cron once, on demand. */
+  @Post('trigger-standalone-poll-reminders')
+  @HttpCode(HttpStatus.OK)
+  async triggerReminders(): Promise<{ success: boolean }> {
+    await this.assertDemoMode();
+    await this.reminderService.runReminders();
+    return { success: true };
+  }
+}

--- a/api/src/admin/demo-test.schemas.ts
+++ b/api/src/admin/demo-test.schemas.ts
@@ -127,3 +127,8 @@ export const ExpireAiChatSessionSchema = z.object({
 export const SetAiChatEnabledSchema = z.object({
   enabled: z.boolean(),
 });
+
+export const AdvanceStandalonePollDeadlineSchema = z.object({
+  lineupId: z.number().int().positive(),
+  hoursUntilDeadline: z.number().min(-720).max(720),
+});

--- a/api/src/drizzle/migrations/0133_standalone_poll_deadline_backfill.sql
+++ b/api/src/drizzle/migrations/0133_standalone_poll_deadline_backfill.sql
@@ -1,0 +1,12 @@
+-- ROK-1192: Backfill phase_deadline for active standalone scheduling polls.
+--
+-- Pre-ROK-1192 standalone polls were created without a deadline if the
+-- caller omitted `durationHours`. The new reminder cron + archive
+-- reconciler both require a non-null phase_deadline, so we set existing
+-- decided standalone rows to created_at + 36h (midpoint between the
+-- 24h-min and 72h-default of the new picker).
+UPDATE community_lineups
+SET phase_deadline = created_at + interval '36 hours'
+WHERE status = 'decided'
+  AND phase_duration_override->>'standalone' = 'true'
+  AND phase_deadline IS NULL;

--- a/api/src/drizzle/migrations/meta/_journal.json
+++ b/api/src/drizzle/migrations/meta/_journal.json
@@ -932,6 +932,13 @@
       "when": 1777593700000,
       "tag": "0132_equal_mandarin",
       "breakpoints": true
+    },
+    {
+      "idx": 133,
+      "version": "7",
+      "when": 1777680000000,
+      "tag": "0133_standalone_poll_deadline_backfill",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/lineups/queue/lineup-phase.queue.ts
+++ b/api/src/lineups/queue/lineup-phase.queue.ts
@@ -16,7 +16,19 @@ import {
 
 interface ActiveStandaloneArchiveCandidate {
   lineupId: number;
-  phaseDeadline: Date;
+  phaseDeadline: Date | string;
+}
+
+/**
+ * `phase_deadline` is a `timestamp without time zone` column. postgres-js
+ * returns it as a naïve string; default `new Date()` parses in local TZ.
+ * We INSERT JS Dates as UTC, so re-parse with an explicit UTC suffix.
+ */
+function parsePhaseDeadlineUtc(value: Date | string): Date {
+  if (value instanceof Date) return value;
+  const s = String(value);
+  if (s.endsWith('Z') || /[+-]\d{2}:?\d{2}$/.test(s)) return new Date(s);
+  return new Date(s.replace(' ', 'T') + 'Z');
 }
 
 @Injectable()
@@ -56,7 +68,8 @@ export class LineupPhaseQueueService implements OnModuleInit {
       `Reconciling ${candidates.length} standalone archive job(s)`,
     );
     for (const { lineupId, phaseDeadline } of candidates) {
-      const delayMs = phaseDeadline.getTime() - Date.now();
+      const deadline = parsePhaseDeadlineUtc(phaseDeadline);
+      const delayMs = deadline.getTime() - Date.now();
       if (delayMs <= 0) continue;
       await this.scheduleTransition(lineupId, 'archived', delayMs);
     }

--- a/api/src/lineups/queue/lineup-phase.queue.ts
+++ b/api/src/lineups/queue/lineup-phase.queue.ts
@@ -2,19 +2,80 @@
  * BullMQ producer for lineup phase transitions (ROK-946).
  * Follows the embed-sync.queue.ts pattern.
  */
-import { Injectable, Logger } from '@nestjs/common';
+import { Inject, Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { InjectQueue } from '@nestjs/bullmq';
 import { Queue } from 'bullmq';
+import { sql } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { DrizzleAsyncProvider } from '../../drizzle/drizzle.module';
+import * as schema from '../../drizzle/schema';
 import {
   LINEUP_PHASE_QUEUE,
   type LineupPhaseJobData,
 } from './lineup-phase.constants';
 
+interface ActiveStandaloneArchiveCandidate {
+  lineupId: number;
+  phaseDeadline: Date;
+}
+
 @Injectable()
-export class LineupPhaseQueueService {
+export class LineupPhaseQueueService implements OnModuleInit {
   private readonly logger = new Logger(LineupPhaseQueueService.name);
 
-  constructor(@InjectQueue(LINEUP_PHASE_QUEUE) private readonly queue: Queue) {}
+  constructor(
+    @InjectQueue(LINEUP_PHASE_QUEUE) private readonly queue: Queue,
+    @Inject(DrizzleAsyncProvider)
+    private readonly db: PostgresJsDatabase<typeof schema>,
+  ) {}
+
+  /**
+   * Re-queue missing archive transitions for active standalone polls
+   * (ROK-1192). Runs at boot so a deploy that drops the BullMQ queue
+   * doesn't leave decided-state polls without a deadline job.
+   */
+  async onModuleInit(): Promise<void> {
+    try {
+      await this.reconcileArchiveJobs();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.logger.warn(`reconcileArchiveJobs failed at boot: ${msg}`);
+    }
+  }
+
+  /**
+   * Idempotent: re-schedule the `decided → archived` transition for
+   * every active standalone poll whose `phase_deadline` is still in
+   * the future. Safe to call repeatedly — `scheduleTransition`
+   * removes the existing delayed job before re-adding it.
+   */
+  async reconcileArchiveJobs(): Promise<void> {
+    const candidates = await this.findStandaloneArchiveCandidates();
+    if (candidates.length === 0) return;
+    this.logger.log(
+      `Reconciling ${candidates.length} standalone archive job(s)`,
+    );
+    for (const { lineupId, phaseDeadline } of candidates) {
+      const delayMs = phaseDeadline.getTime() - Date.now();
+      if (delayMs <= 0) continue;
+      await this.scheduleTransition(lineupId, 'archived', delayMs);
+    }
+  }
+
+  /** Decided standalone lineups with a future deadline. */
+  private async findStandaloneArchiveCandidates(): Promise<
+    ActiveStandaloneArchiveCandidate[]
+  > {
+    return (await this.db.execute(sql`
+      SELECT id AS "lineupId",
+             phase_deadline AS "phaseDeadline"
+      FROM community_lineups
+      WHERE status = 'decided'
+        AND phase_duration_override->>'standalone' = 'true'
+        AND phase_deadline IS NOT NULL
+        AND phase_deadline > NOW()
+    `)) as unknown as ActiveStandaloneArchiveCandidate[];
+  }
 
   /** Schedule a phase transition after the given delay. */
   async scheduleTransition(

--- a/api/src/lineups/standalone-poll/standalone-poll-reminder.integration.spec.ts
+++ b/api/src/lineups/standalone-poll/standalone-poll-reminder.integration.spec.ts
@@ -228,9 +228,8 @@ function describeStandalonePollReminders() {
     expect(createSpy).toHaveBeenCalled();
     const subtypes = dmSubtypesSent();
     expect(
-      subtypes.filter(
-        (s) => s === 'standalone_scheduling_poll_reminder',
-      ).length,
+      subtypes.filter((s) => s === 'standalone_scheduling_poll_reminder')
+        .length,
     ).toBeGreaterThanOrEqual(memberIds.length);
 
     // Each DM carries the correct payload + the 24h window marker.
@@ -316,9 +315,7 @@ function describeStandalonePollReminders() {
 
     // Sanity: dedup key uses the spec's exact shape.
     expect(dedup.checkAndMarkSent).toHaveBeenCalledWith(
-      expect.stringMatching(
-        /^standalone-poll-reminder:\d+:\d+:(24h|1h)$/,
-      ),
+      expect.stringMatching(/^standalone-poll-reminder:\d+:\d+:(24h|1h)$/),
       expect.anything(),
     );
     // Window-by-user: each user got at most one window across both runs.

--- a/api/src/lineups/standalone-poll/standalone-poll-reminder.integration.spec.ts
+++ b/api/src/lineups/standalone-poll/standalone-poll-reminder.integration.spec.ts
@@ -1,0 +1,445 @@
+/**
+ * ROK-1192 — Standalone scheduling poll deadline reminders (integration).
+ *
+ * TDD gate: these tests pin down the spec for the new
+ * `StandalonePollReminderService` cron, the deadline-backfill migration,
+ * and the archive-recovery reconciler. They MUST fail until the dev
+ * agent wires:
+ *   - `StandalonePollReminderService.checkReminders()` / `runReminders()`
+ *   - The backfill migration that fills `phase_deadline` on existing
+ *     active standalone polls.
+ *   - The boot-time `reconcileArchiveJobs()` hook on the lineup phase queue.
+ *
+ * Coverage (8 cases):
+ *   1. 24h reminder fires for non-voter
+ *   2. 1h reminder fires for non-voter
+ *   3. Voter who voted before 1h tick does NOT get the 1h DM
+ *   4. Same window dedup — running cron twice = one DM per non-voter
+ *   5. Polls with `phase_deadline = NULL` are skipped
+ *   6. Concluded poll (status='archived') generates no further reminders
+ *   7. Backfill migration: active standalone lineup w/ null deadline gets
+ *      `created_at + 36h` after the migration query runs.
+ *   8. Reconciler: active decided standalone lineup with phase_deadline
+ *      future-of-now has an archive job queued after boot.
+ */
+import { eq, sql } from 'drizzle-orm';
+import { getTestApp, type TestApp } from '../../common/testing/test-app';
+import {
+  truncateAllTables,
+  loginAsAdmin,
+} from '../../common/testing/integration-helpers';
+import * as schema from '../../drizzle/schema';
+import { NotificationService } from '../../notifications/notification.service';
+import { NotificationDedupService } from '../../notifications/notification-dedup.service';
+import { LineupPhaseQueueService } from '../queue/lineup-phase.queue';
+// NOTE: this import target does NOT yet exist — the dev agent creates it
+// in this story. Importing here is what makes the test fail (compile-time)
+// until the service file is added.
+import { StandalonePollReminderService } from './standalone-poll-reminder.service';
+
+interface StandaloneSetup {
+  lineupId: number;
+  matchId: number;
+  gameId: number;
+  memberIds: number[];
+}
+
+const HOUR_MS = 60 * 60 * 1000;
+
+function describeStandalonePollReminders() {
+  let testApp: TestApp;
+  let adminToken: string;
+  let reminderService: StandalonePollReminderService;
+  let notificationService: NotificationService;
+  let dedup: NotificationDedupService;
+  let phaseQueue: LineupPhaseQueueService;
+  let createSpy: jest.SpyInstance;
+
+  beforeAll(async () => {
+    testApp = await getTestApp();
+    adminToken = await loginAsAdmin(testApp.request, testApp.seed);
+    reminderService = testApp.app.get(StandalonePollReminderService);
+    notificationService = testApp.app.get(NotificationService);
+    dedup = testApp.app.get(NotificationDedupService);
+    phaseQueue = testApp.app.get(LineupPhaseQueueService);
+    void adminToken;
+  });
+
+  beforeEach(() => {
+    createSpy = jest
+      .spyOn(notificationService, 'create')
+      .mockResolvedValue({ id: 'mock-notif' } as never);
+    // Reset dedup behaviour to "never seen before" each test; specific
+    // tests override this when they need to assert dedup short-circuits.
+    jest.spyOn(dedup, 'checkAndMarkSent').mockResolvedValue(false);
+  });
+
+  afterEach(async () => {
+    createSpy.mockRestore();
+    jest.restoreAllMocks();
+    testApp.seed = await truncateAllTables(testApp.db);
+    adminToken = await loginAsAdmin(testApp.request, testApp.seed);
+  });
+
+  // ── helpers ──────────────────────────────────────────────────────
+
+  async function createMember(tag: string): Promise<number> {
+    const [user] = await testApp.db
+      .insert(schema.users)
+      .values({
+        discordId: `discord:${tag}`,
+        username: `mem-${tag}`,
+        role: 'member',
+      })
+      .returning();
+    return user.id;
+  }
+
+  async function createGame(name: string): Promise<number> {
+    const [g] = await testApp.db
+      .insert(schema.games)
+      .values({ name, slug: `${name.toLowerCase()}-${Date.now()}` })
+      .returning();
+    return g.id;
+  }
+
+  /**
+   * Build a standalone scheduling poll directly in the DB so we control
+   * `phase_deadline` to the millisecond. Mirrors the shape produced by
+   * `StandalonePollService.create()` (decided lineup +
+   * `phaseDurationOverride.standalone=true` marker + scheduling match +
+   * one match member per provided id).
+   */
+  async function setupStandalonePoll(
+    tag: string,
+    hoursUntilDeadline: number | null,
+    extraMembers = 2,
+    overrides: { status?: 'decided' | 'archived' } = {},
+  ): Promise<StandaloneSetup> {
+    const creatorId = testApp.seed.adminUser.id;
+    const memberIds: number[] = [];
+    for (let i = 0; i < extraMembers; i++) {
+      memberIds.push(await createMember(`${tag}-m${i}`));
+    }
+    const gameId = await createGame(`Game-${tag}`);
+
+    const phaseDeadline =
+      hoursUntilDeadline === null
+        ? null
+        : new Date(Date.now() + hoursUntilDeadline * HOUR_MS);
+
+    const [lineup] = await testApp.db
+      .insert(schema.communityLineups)
+      .values({
+        title: 'Standalone Scheduling Poll',
+        status: overrides.status ?? 'decided',
+        visibility: 'public',
+        createdBy: creatorId,
+        phaseDeadline,
+        phaseDurationOverride: { standalone: true },
+      })
+      .returning();
+
+    const [match] = await testApp.db
+      .insert(schema.communityLineupMatches)
+      .values({
+        lineupId: lineup.id,
+        gameId,
+        status: 'scheduling',
+        thresholdMet: true,
+        voteCount: 0,
+      })
+      .returning();
+
+    await testApp.db.insert(schema.communityLineupMatchMembers).values(
+      [creatorId, ...memberIds].map((userId) => ({
+        matchId: match.id,
+        userId,
+        source: 'voted' as const,
+      })),
+    );
+
+    return {
+      lineupId: lineup.id,
+      matchId: match.id,
+      gameId,
+      memberIds,
+    };
+  }
+
+  /** Insert a schedule slot + a vote from `userId` so they count as a voter. */
+  async function castScheduleVote(
+    matchId: number,
+    userId: number,
+  ): Promise<void> {
+    const [slot] = await testApp.db
+      .insert(schema.communityLineupScheduleSlots)
+      .values({
+        matchId,
+        proposedTime: new Date(Date.now() + 7 * 24 * HOUR_MS),
+        suggestedBy: 'user',
+      })
+      .returning();
+    await testApp.db.insert(schema.communityLineupScheduleVotes).values({
+      slotId: slot.id,
+      userId,
+    });
+  }
+
+  function dmSubtypesSent(): string[] {
+    return createSpy.mock.calls.map((c) => {
+      const arg = c[0] as { payload?: { subtype?: string } };
+      return arg.payload?.subtype ?? '';
+    });
+  }
+
+  function dmsForUser(userId: number): Array<Record<string, unknown>> {
+    return createSpy.mock.calls
+      .map((c) => c[0] as Record<string, unknown>)
+      .filter((arg) => arg.userId === userId);
+  }
+
+  function dmWindowsByUser(): Map<number, Set<string>> {
+    const out = new Map<number, Set<string>>();
+    for (const call of createSpy.mock.calls) {
+      const arg = call[0] as {
+        userId: number;
+        payload?: { window?: string };
+      };
+      if (!out.has(arg.userId)) out.set(arg.userId, new Set());
+      if (arg.payload?.window) out.get(arg.userId)!.add(arg.payload.window);
+    }
+    return out;
+  }
+
+  // ── AC #2 / Test 1: 24h reminder fires for non-voters ────────────
+
+  it('fires 24h DM with subtype standalone_scheduling_poll_reminder for non-voters', async () => {
+    const { matchId, lineupId, memberIds } = await setupStandalonePoll(
+      'a24',
+      20, // 20h until deadline → 24h window
+      2,
+    );
+    void matchId;
+
+    await reminderService.runReminders();
+
+    // Both invited members + creator are non-voters → 3 DMs.
+    expect(createSpy).toHaveBeenCalled();
+    const subtypes = dmSubtypesSent();
+    expect(
+      subtypes.filter(
+        (s) => s === 'standalone_scheduling_poll_reminder',
+      ).length,
+    ).toBeGreaterThanOrEqual(memberIds.length);
+
+    // Each DM carries the correct payload + the 24h window marker.
+    for (const memberId of memberIds) {
+      const calls = dmsForUser(memberId);
+      expect(calls.length).toBe(1);
+      expect(calls[0]).toMatchObject({
+        type: 'community_lineup',
+        title: expect.stringMatching(/closing soon|24 hours/i),
+        payload: expect.objectContaining({
+          subtype: 'standalone_scheduling_poll_reminder',
+          lineupId,
+          matchId,
+          window: '24h',
+        }),
+      });
+    }
+  });
+
+  // ── AC #3 / Test 2: 1h reminder fires for non-voters ─────────────
+
+  it('fires 1h DM with copy "closing now" / "1 hour" when <= 1h remains', async () => {
+    const { memberIds, lineupId, matchId } = await setupStandalonePoll(
+      'a1h',
+      0.5, // 30 minutes left → 1h window
+      1,
+    );
+
+    await reminderService.runReminders();
+
+    expect(createSpy).toHaveBeenCalled();
+    for (const memberId of memberIds) {
+      const calls = dmsForUser(memberId);
+      expect(calls.length).toBe(1);
+      expect(calls[0]).toMatchObject({
+        title: expect.stringMatching(/closing now|1 hour/i),
+        payload: expect.objectContaining({
+          subtype: 'standalone_scheduling_poll_reminder',
+          lineupId,
+          matchId,
+          window: '1h',
+        }),
+      });
+    }
+  });
+
+  // ── AC #4 / Test 3: voted-before-1h users skip the 1h DM ─────────
+
+  it('does NOT fire a 1h DM to a member who already voted on a slot', async () => {
+    const { memberIds, matchId } = await setupStandalonePoll('voted', 0.5, 2);
+    const voter = memberIds[0];
+    const nonVoter = memberIds[1];
+    await castScheduleVote(matchId, voter);
+
+    await reminderService.runReminders();
+
+    // The voter is excluded by the non-voters query.
+    expect(dmsForUser(voter).length).toBe(0);
+    expect(dmsForUser(nonVoter).length).toBe(1);
+  });
+
+  // ── AC #5 / Test 4: dedup — 2nd cron tick = no second DM ─────────
+
+  it('dedup key prevents double-fire when cron runs twice in the same window', async () => {
+    const { memberIds } = await setupStandalonePoll('dedup', 20, 1);
+    const dedupSpy = jest
+      .spyOn(dedup, 'checkAndMarkSent')
+      // First tick: no key seen yet → false (DM goes out)
+      // Second tick: key already marked → true (skip)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false) // creator (first run)
+      .mockResolvedValue(true); // every subsequent call
+    void dedupSpy;
+
+    await reminderService.runReminders();
+    const firstRun = createSpy.mock.calls.length;
+    expect(firstRun).toBeGreaterThan(0);
+
+    await reminderService.runReminders();
+
+    // Total calls did NOT grow on the second run because dedup blocked.
+    expect(createSpy.mock.calls.length).toBe(firstRun);
+
+    // Sanity: dedup key uses the spec's exact shape.
+    expect(dedup.checkAndMarkSent).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /^standalone-poll-reminder:\d+:\d+:(24h|1h)$/,
+      ),
+      expect.anything(),
+    );
+    // Window-by-user: each user got at most one window across both runs.
+    for (const memberId of memberIds) {
+      const wins = dmWindowsByUser().get(memberId) ?? new Set();
+      expect(wins.size).toBeLessThanOrEqual(1);
+    }
+  });
+
+  // ── AC #6 / Test 5: phase_deadline IS NULL → no DMs ──────────────
+
+  it('skips polls with phase_deadline = NULL (no reminders fired)', async () => {
+    await setupStandalonePoll('null-deadline', null, 2);
+
+    await reminderService.runReminders();
+
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  // ── AC #7 / Test 6: archived poll → no DMs (concluded-poll guard) ─
+
+  it('skips concluded polls (status flipped to archived)', async () => {
+    await setupStandalonePoll('archived', 0.5, 2, { status: 'archived' });
+
+    await reminderService.runReminders();
+
+    expect(createSpy).not.toHaveBeenCalled();
+  });
+
+  // ── AC #10 / Test 7: backfill migration ─────────────────────────
+
+  it(
+    'backfill migration sets phase_deadline = created_at + 36h on active ' +
+      'standalone polls with NULL deadline (idempotent)',
+    async () => {
+      // Insert a standalone lineup that was created 12h ago with NULL
+      // deadline — mimics the production state described in the spec.
+      const creatorId = testApp.seed.adminUser.id;
+      const createdAt = new Date(Date.now() - 12 * HOUR_MS);
+      const [lineup] = await testApp.db
+        .insert(schema.communityLineups)
+        .values({
+          title: 'Standalone Scheduling Poll',
+          status: 'decided',
+          visibility: 'public',
+          createdBy: creatorId,
+          phaseDeadline: null,
+          phaseDurationOverride: { standalone: true },
+          createdAt,
+          updatedAt: createdAt,
+        })
+        .returning();
+
+      // Re-run the migration body verbatim. Idempotent on its own and
+      // should leave non-standalone rows untouched.
+      const migrationSql = sql`
+        UPDATE community_lineups
+        SET phase_deadline = created_at + interval '36 hours'
+        WHERE status = 'decided'
+          AND phase_duration_override->>'standalone' = 'true'
+          AND phase_deadline IS NULL
+      `;
+      await testApp.db.execute(migrationSql);
+
+      const [after] = await testApp.db
+        .select()
+        .from(schema.communityLineups)
+        .where(eq(schema.communityLineups.id, lineup.id));
+
+      expect(after.phaseDeadline).not.toBeNull();
+      const expected = new Date(createdAt.getTime() + 36 * HOUR_MS).getTime();
+      const actual = (after.phaseDeadline as Date).getTime();
+      // Allow 5s slack for clock skew between insert and migration body.
+      expect(Math.abs(actual - expected)).toBeLessThan(5_000);
+
+      // Idempotent: running the same SQL again must not change the row.
+      await testApp.db.execute(migrationSql);
+      const [afterSecond] = await testApp.db
+        .select()
+        .from(schema.communityLineups)
+        .where(eq(schema.communityLineups.id, lineup.id));
+      expect((afterSecond.phaseDeadline as Date).getTime()).toBe(actual);
+    },
+  );
+
+  // ── AC #11 / Test 8: archive reconciler ─────────────────────────
+
+  it(
+    'reconcileArchiveJobs() schedules an archive job for every active ' +
+      'standalone lineup with phase_deadline > now()',
+    async () => {
+      const { lineupId } = await setupStandalonePoll('reconcile', 6, 0);
+
+      const scheduleSpy = jest
+        .spyOn(phaseQueue, 'scheduleTransition')
+        .mockResolvedValue(undefined as never);
+
+      // The reconciler is a method on the service that owns the queue;
+      // by spec it is invoked via `OnModuleInit` at boot but exposed as
+      // a public method we can call directly in tests. Until the dev
+      // agent adds it, this `(... as ...).reconcileArchiveJobs` access
+      // is `undefined` and the call below throws — which is the failure
+      // we want pre-implementation.
+      const svc = phaseQueue as unknown as {
+        reconcileArchiveJobs?: () => Promise<unknown>;
+      };
+      expect(typeof svc.reconcileArchiveJobs).toBe('function');
+      await svc.reconcileArchiveJobs!();
+
+      // Reconciler MUST have asked the queue to schedule a transition
+      // for our lineup → archived, with a positive delay.
+      const archiveCalls = scheduleSpy.mock.calls.filter(
+        (c) => c[0] === lineupId && c[1] === 'archived',
+      );
+      expect(archiveCalls.length).toBeGreaterThanOrEqual(1);
+      expect(archiveCalls[0][2]).toBeGreaterThan(0);
+    },
+  );
+}
+
+describe(
+  'Standalone scheduling poll reminders (integration, ROK-1192)',
+  describeStandalonePollReminders,
+);

--- a/api/src/lineups/standalone-poll/standalone-poll-reminder.service.ts
+++ b/api/src/lineups/standalone-poll/standalone-poll-reminder.service.ts
@@ -1,0 +1,165 @@
+/**
+ * Standalone scheduling poll deadline reminders (ROK-1192).
+ *
+ * Sends 24h + 1h DMs to non-voters before a standalone poll's
+ * `phase_deadline`. Distinct from `LineupReminderService` because
+ * standalone polls live in `decided` state with
+ * `phase_duration_override.standalone = true`, which the existing
+ * scheduling-reminder query explicitly excludes.
+ *
+ * Dedup key shape: `standalone-poll-reminder:{matchId}:{userId}:{window}`
+ */
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { sql } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { DrizzleAsyncProvider } from '../../drizzle/drizzle.module';
+import * as schema from '../../drizzle/schema';
+import { NotificationService } from '../../notifications/notification.service';
+import { NotificationDedupService } from '../../notifications/notification-dedup.service';
+import { CronJobService } from '../../cron-jobs/cron-job.service';
+import { DEDUP_TTL } from '../lineup-notification.constants';
+
+interface ActiveStandalonePoll {
+  lineupId: number;
+  matchId: number;
+  phaseDeadline: Date;
+}
+
+interface StandaloneNonVoter {
+  userId: number;
+}
+
+const MS_PER_HOUR = 3_600_000;
+
+@Injectable()
+export class StandalonePollReminderService {
+  private readonly logger = new Logger(StandalonePollReminderService.name);
+
+  constructor(
+    @Inject(DrizzleAsyncProvider)
+    private readonly db: PostgresJsDatabase<typeof schema>,
+    private readonly notificationService: NotificationService,
+    private readonly dedupService: NotificationDedupService,
+    private readonly cronJobService: CronJobService,
+  ) {}
+
+  @Cron(CronExpression.EVERY_5_MINUTES, {
+    name: 'StandalonePollReminderService_runReminders',
+  })
+  async handleCron(): Promise<void> {
+    await this.cronJobService.executeWithTracking(
+      'StandalonePollReminderService_runReminders',
+      () => this.runReminders(),
+    );
+  }
+
+  /** Process every active standalone poll for reminder dispatch. */
+  async runReminders(): Promise<void> {
+    const polls = await this.findActivePolls();
+    for (const poll of polls) {
+      try {
+        await this.processPoll(poll);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        this.logger.warn(
+          `Standalone reminder failed for lineup ${poll.lineupId}: ${msg}`,
+        );
+      }
+    }
+  }
+
+  /** Process one poll: classify window, fan out DMs to non-voters. */
+  private async processPoll(poll: ActiveStandalonePoll): Promise<void> {
+    const window = this.classifyWindow(poll.phaseDeadline);
+    if (!window) return;
+    const nonVoters = await this.findNonVoters(poll.matchId);
+    for (const v of nonVoters) {
+      await this.sendReminder(poll, v.userId, window);
+    }
+  }
+
+  /** Decide which reminder window applies, or null if outside both. */
+  private classifyWindow(deadline: Date): '24h' | '1h' | null {
+    const hoursLeft = (deadline.getTime() - Date.now()) / MS_PER_HOUR;
+    if (hoursLeft <= 0 || hoursLeft > 24) return null;
+    return hoursLeft <= 1 ? '1h' : '24h';
+  }
+
+  /** Send one reminder DM if dedup hasn't already marked it sent. */
+  private async sendReminder(
+    poll: ActiveStandalonePoll,
+    userId: number,
+    window: '24h' | '1h',
+  ): Promise<void> {
+    const key = `standalone-poll-reminder:${poll.matchId}:${userId}:${window}`;
+    if (await this.dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
+
+    const { title, message } = this.buildCopy(window);
+    await this.notificationService.create({
+      userId,
+      type: 'community_lineup',
+      title,
+      message,
+      payload: {
+        subtype: 'standalone_scheduling_poll_reminder',
+        lineupId: poll.lineupId,
+        matchId: poll.matchId,
+        window,
+      },
+    });
+  }
+
+  /** Title + message copy for the reminder window. */
+  private buildCopy(window: '24h' | '1h'): { title: string; message: string } {
+    if (window === '1h') {
+      return {
+        title: 'Scheduling poll closing now',
+        message:
+          'Your scheduling poll closes in 1 hour — vote on a time before it locks.',
+      };
+    }
+    return {
+      title: 'Scheduling poll closing soon (24 hours)',
+      message:
+        "You haven't voted on a time yet — the scheduling poll closes in 24 hours.",
+    };
+  }
+
+  /**
+   * Active standalone polls = decided community lineups whose
+   * `phase_duration_override->>'standalone'` is `'true'`, with a
+   * non-null `phase_deadline` and a `scheduling` match attached.
+   */
+  private async findActivePolls(): Promise<ActiveStandalonePoll[]> {
+    const rows = (await this.db.execute(sql`
+      SELECT cl.id AS "lineupId",
+             clm.id AS "matchId",
+             cl.phase_deadline AS "phaseDeadline"
+      FROM community_lineups cl
+      JOIN community_lineup_matches clm ON clm.lineup_id = cl.id
+      WHERE cl.status = 'decided'
+        AND cl.phase_duration_override->>'standalone' = 'true'
+        AND cl.phase_deadline IS NOT NULL
+        AND clm.status = 'scheduling'
+    `)) as unknown as ActiveStandalonePoll[];
+    return rows;
+  }
+
+  /** Match members who haven't voted on any schedule slot for this match. */
+  private async findNonVoters(matchId: number): Promise<StandaloneNonVoter[]> {
+    return (await this.db.execute(sql`
+      SELECT lmm.user_id AS "userId"
+      FROM community_lineup_match_members lmm
+      WHERE lmm.match_id = ${matchId}
+        AND NOT EXISTS (
+          SELECT 1
+          FROM community_lineup_schedule_votes csv
+          JOIN community_lineup_schedule_slots css
+            ON css.id = csv.slot_id
+          WHERE css.match_id = lmm.match_id
+            AND csv.user_id = lmm.user_id
+        )
+    `)) as unknown as StandaloneNonVoter[];
+  }
+}

--- a/api/src/lineups/standalone-poll/standalone-poll-reminder.service.ts
+++ b/api/src/lineups/standalone-poll/standalone-poll-reminder.service.ts
@@ -32,6 +32,19 @@ interface StandaloneNonVoter {
 
 const MS_PER_HOUR = 3_600_000;
 
+/**
+ * `phase_deadline` is a `timestamp without time zone` column. postgres-js
+ * returns it as a naïve string ("YYYY-MM-DD HH:MM:SS.SSS") which `new Date()`
+ * would parse in the runtime's local TZ, shifting the value by hours. We
+ * INSERT JS Dates as UTC, so re-parse with an explicit UTC suffix.
+ */
+function parseTimestampUtc(value: Date | string): Date {
+  if (value instanceof Date) return value;
+  const s = String(value);
+  if (s.endsWith('Z') || /[+-]\d{2}:?\d{2}$/.test(s)) return new Date(s);
+  return new Date(s.replace(' ', 'T') + 'Z');
+}
+
 @Injectable()
 export class StandalonePollReminderService {
   private readonly logger = new Logger(StandalonePollReminderService.name);
@@ -142,8 +155,16 @@ export class StandalonePollReminderService {
         AND cl.phase_duration_override->>'standalone' = 'true'
         AND cl.phase_deadline IS NOT NULL
         AND clm.status = 'scheduling'
-    `)) as unknown as ActiveStandalonePoll[];
-    return rows;
+    `)) as unknown as Array<{
+      lineupId: number;
+      matchId: number;
+      phaseDeadline: Date | string;
+    }>;
+    return rows.map((r) => ({
+      lineupId: r.lineupId,
+      matchId: r.matchId,
+      phaseDeadline: parseTimestampUtc(r.phaseDeadline),
+    }));
   }
 
   /** Match members who haven't voted on any schedule slot for this match. */

--- a/api/src/lineups/standalone-poll/standalone-poll.module.ts
+++ b/api/src/lineups/standalone-poll/standalone-poll.module.ts
@@ -7,6 +7,7 @@ import { Module } from '@nestjs/common';
 import { BullModule } from '@nestjs/bullmq';
 import { DrizzleModule } from '../../drizzle/drizzle.module';
 import { NotificationModule } from '../../notifications/notification.module';
+import { CronJobModule } from '../../cron-jobs/cron-job.module';
 import { LINEUP_PHASE_QUEUE } from '../queue/lineup-phase.constants';
 import { LineupPhaseQueueService } from '../queue/lineup-phase.queue';
 import { SchedulingModule } from '../scheduling/scheduling.module';
@@ -14,6 +15,7 @@ import { EventsModule } from '../../events/events.module';
 import { StandalonePollController } from './standalone-poll.controller';
 import { StandalonePollService } from './standalone-poll.service';
 import { StandalonePollNotificationService } from './standalone-poll-notification.service';
+import { StandalonePollReminderService } from './standalone-poll-reminder.service';
 
 @Module({
   imports: [
@@ -21,14 +23,16 @@ import { StandalonePollNotificationService } from './standalone-poll-notificatio
     NotificationModule,
     SchedulingModule,
     EventsModule,
+    CronJobModule,
     BullModule.registerQueue({ name: LINEUP_PHASE_QUEUE }),
   ],
   controllers: [StandalonePollController],
   providers: [
     StandalonePollService,
     StandalonePollNotificationService,
+    StandalonePollReminderService,
     LineupPhaseQueueService,
   ],
-  exports: [StandalonePollService],
+  exports: [StandalonePollService, StandalonePollReminderService],
 })
 export class StandalonePollModule {}

--- a/tools/test-bot/src/smoke/run.ts
+++ b/tools/test-bot/src/smoke/run.ts
@@ -28,6 +28,7 @@ import { aiChatTests } from './tests/ai-chat.test.js';
 import { lineupTitleTests } from './tests/lineup-title.test.js';
 import { privateLineupTests } from './tests/private-lineup.test.js';
 import { lineupTiebreakerOpenTests } from './tests/lineup-tiebreaker-open.test.js';
+import { standalonePollReminderTests } from './tests/standalone-poll-reminders.test.js';
 
 /** Build a TestResult from a test, status, and timing info. */
 function buildResult(
@@ -145,6 +146,7 @@ function collectTests(filterCat?: string): SmokeTest[] {
     ...lineupTitleTests,
     ...privateLineupTests,
     ...lineupTiebreakerOpenTests,
+    ...standalonePollReminderTests,
   ].filter((t) => !filterCat || t.category === filterCat);
 }
 

--- a/tools/test-bot/src/smoke/tests/standalone-poll-reminders.test.ts
+++ b/tools/test-bot/src/smoke/tests/standalone-poll-reminders.test.ts
@@ -118,8 +118,21 @@ const standalonePoll1hReminderDm: SmokeTest = {
   name: 'Standalone poll fires 1h "Vote on a Time" reminder DM (ROK-1192)',
   category: 'dm',
   async run(ctx: TestContext) {
-    if (!ctx.games.length) throw new Error('Need at least 1 configured game');
-    const gameId = ctx.games[0].id;
+    // Prefer ctx.games (built from MMO binding); fall back to
+    // /games/configured for environments without an MMO binding —
+    // matches the lineup-tiebreaker-open.test pattern.
+    let gameId = ctx.games[0]?.id;
+    if (!gameId) {
+      const gamesRes = await ctx.api.get<{ data: { id: number }[] }>(
+        '/games/configured',
+      );
+      gameId = gamesRes?.data?.[0]?.id;
+    }
+    if (!gameId) {
+      throw new Error(
+        'Need at least 1 configured game (MMO binding or /games/configured)',
+      );
+    }
 
     // 1. Create the poll. `durationHours: 24` → poll's phase_deadline
     //    sits 24h in the future and the invited member is on the

--- a/tools/test-bot/src/smoke/tests/standalone-poll-reminders.test.ts
+++ b/tools/test-bot/src/smoke/tests/standalone-poll-reminders.test.ts
@@ -1,0 +1,187 @@
+/**
+ * ROK-1192 — Standalone scheduling poll deadline reminders.
+ *
+ * AC #13 (smoke): create a standalone poll with `durationHours: 24` and
+ * one invited member, advance the poll's deadline to T-1h via the
+ * (DEMO_MODE-only) `/admin/test/advance-standalone-poll-deadline`
+ * endpoint, await processing, then verify:
+ *   - the invited member receives a community_lineup notification with
+ *     `payload.subtype === 'standalone_scheduling_poll_reminder'` and
+ *     `payload.window === '1h'` and title containing "closing now",
+ *   - the notification's matchId/lineupId match the created poll, which
+ *     is what `notification-embed.buttons.ts:buildLineupButton` uses to
+ *     auto-render a "Vote on a Time" button pointing at
+ *     `${clientUrl}/community-lineup/{lineupId}/schedule/{matchId}`.
+ *
+ * TDD gate: this test must FAIL until the dev agent ships:
+ *   - `StandalonePollReminderService` (cron + DM dispatch)
+ *   - `/admin/test/advance-standalone-poll-deadline` (DEMO_MODE-only
+ *     fast-forward of `phase_deadline` for the lineup)
+ *   - `/admin/test/trigger-standalone-poll-reminders` (DEMO_MODE-only
+ *     run-now hook for the cron, identical to other `trigger-*` admins)
+ *
+ * Bot DM rationale: companion bot cannot receive DMs from another bot
+ * (Discord API 50007). The in-app notification row is the canonical
+ * proof of dispatch — same approach used by `lineup-tiebreaker-open.test.ts`.
+ */
+import { pollForCondition } from '../../helpers/polling.js';
+import { awaitProcessing } from '../fixtures.js';
+import type { SmokeTest, TestContext } from '../types.js';
+import type { ApiClient } from '../api.js';
+
+interface CreatePollResponse {
+  id: number;
+  lineupId: number;
+  gameId: number;
+  gameName: string;
+  status: string;
+  memberCount: number;
+}
+
+interface TestNotification {
+  id: number;
+  type: string;
+  title?: string;
+  message?: string;
+  payload?: {
+    subtype?: string;
+    lineupId?: number;
+    matchId?: number;
+    window?: string;
+  } | null;
+  createdAt?: string;
+}
+
+async function fetchCommunityLineupNotifications(
+  api: ApiClient,
+  userId: number,
+): Promise<TestNotification[]> {
+  const res = await api
+    .get<TestNotification[]>(
+      `/admin/test/notifications?userId=${userId}&type=community_lineup&limit=25`,
+    )
+    .catch(() => [] as TestNotification[]);
+  return Array.isArray(res) ? res : [];
+}
+
+/** Wait for the standalone-poll 1h reminder DM to land in `userId`'s notifications. */
+async function waitForReminderDM(
+  ctx: TestContext,
+  userId: number,
+  matchId: number,
+  lineupId: number,
+  timeoutMs: number,
+): Promise<TestNotification> {
+  return pollForCondition(
+    async () => {
+      const list = await fetchCommunityLineupNotifications(ctx.api, userId);
+      return (
+        list.find(
+          (n) =>
+            n.payload?.subtype === 'standalone_scheduling_poll_reminder' &&
+            n.payload?.matchId === matchId &&
+            n.payload?.lineupId === lineupId &&
+            n.payload?.window === '1h',
+        ) ?? null
+      );
+    },
+    timeoutMs,
+    { intervalMs: 1500 },
+  );
+}
+
+/**
+ * Fast-forward the lineup's `phase_deadline` so it lands inside the 1h
+ * window. The dev agent ships this DEMO_MODE-only endpoint as part of
+ * ROK-1192 so the smoke test doesn't have to wait 23 real hours.
+ *
+ * Body: { lineupId, hoursUntilDeadline } — sets phase_deadline =
+ *   now() + hoursUntilDeadline.
+ */
+async function advancePollDeadline(
+  api: ApiClient,
+  lineupId: number,
+  hoursUntilDeadline: number,
+): Promise<void> {
+  await api.post('/admin/test/advance-standalone-poll-deadline', {
+    lineupId,
+    hoursUntilDeadline,
+  });
+}
+
+/** Trigger the standalone-poll reminder cron once, on demand. */
+async function triggerReminderCron(api: ApiClient): Promise<void> {
+  await api.post('/admin/test/trigger-standalone-poll-reminders', {});
+}
+
+const standalonePoll1hReminderDm: SmokeTest = {
+  name: 'Standalone poll fires 1h "Vote on a Time" reminder DM (ROK-1192)',
+  category: 'dm',
+  async run(ctx: TestContext) {
+    if (!ctx.games.length) throw new Error('Need at least 1 configured game');
+    const gameId = ctx.games[0].id;
+
+    // 1. Create the poll. `durationHours: 24` → poll's phase_deadline
+    //    sits 24h in the future and the invited member is on the
+    //    match's member list (a non-voter at this point).
+    const poll = await ctx.api.post<CreatePollResponse>('/scheduling-polls', {
+      gameId,
+      durationHours: 24,
+      memberUserIds: [ctx.dmRecipientUserId],
+      // No `minVoteThreshold` so the cron isn't pre-empted by completion.
+    });
+
+    try {
+      // 2. Drain queues so the initial-create notifications settle
+      //    before we reset the clock — keeps the assertion targeted at
+      //    the deadline reminder, not the create-time DM.
+      await awaitProcessing(ctx.api);
+
+      // 3. Fast-forward the deadline into the 1h window.
+      await advancePollDeadline(ctx.api, poll.lineupId, 0.5);
+
+      // 4. Run the cron once.
+      await triggerReminderCron(ctx.api);
+      await awaitProcessing(ctx.api);
+
+      // 5. Poll for the 1h reminder notification on the invited member.
+      const dm = await waitForReminderDM(
+        ctx,
+        ctx.dmRecipientUserId,
+        poll.id,
+        poll.lineupId,
+        ctx.config.timeoutMs,
+      );
+
+      // Title copy: spec mandates "Scheduling poll closing now".
+      if (!/closing now|1 hour/i.test(dm.title ?? '')) {
+        throw new Error(
+          `Expected DM title to mention "closing now" / "1 hour", got: ${dm.title ?? '<missing>'}`,
+        );
+      }
+
+      // The auto-rendered button URL is built by the client at render
+      // time; our contract here is the IDs that go into it. Failing one
+      // of these means buildLineupButton will produce the wrong URL.
+      if (dm.payload?.lineupId !== poll.lineupId) {
+        throw new Error(
+          `Expected payload.lineupId=${poll.lineupId}, got ${dm.payload?.lineupId}`,
+        );
+      }
+      if (dm.payload?.matchId !== poll.id) {
+        throw new Error(
+          `Expected payload.matchId=${poll.id}, got ${dm.payload?.matchId}`,
+        );
+      }
+    } finally {
+      // Best-effort cleanup — archive the lineup so it doesn't pile up.
+      await ctx.api
+        .patch(`/lineups/${poll.lineupId}/status`, { status: 'archived' })
+        .catch(() => null);
+    }
+  },
+};
+
+export const standalonePollReminderTests: SmokeTest[] = [
+  standalonePoll1hReminderDm,
+];

--- a/web/src/components/scheduling/create-poll-modal.test.tsx
+++ b/web/src/components/scheduling/create-poll-modal.test.tsx
@@ -1,0 +1,165 @@
+/**
+ * ROK-1192 — failing TDD test for CreatePollModal duration picker.
+ *
+ * Frontend AC #1:
+ *   - The create-poll modal renders a duration picker (24h / 48h / 72h /
+ *     7d) defaulted to 72.
+ *   - When the user submits, `useCreateSchedulingPoll().mutateAsync` is
+ *     called with `durationHours: 72` (default) — and with the picked
+ *     value when the user changes it.
+ *
+ * Today the modal sends `{ gameId, memberUserIds, minVoteThreshold }`
+ * with NO `durationHours`. These tests must FAIL until the dev wires the
+ * picker through `useCreatePollForm` into the mutation payload.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { IgdbGameDto } from '@raid-ledger/contract';
+import { renderWithProviders } from '../../test/render-helpers';
+import { CreatePollModal } from './create-poll-modal';
+
+vi.mock('../../hooks/use-standalone-poll', () => ({
+  useCreateSchedulingPoll: vi.fn(),
+}));
+
+vi.mock('../../lib/api-client', () => ({
+  getPlayers: vi.fn(),
+}));
+
+vi.mock('../../hooks/use-game-search', () => ({
+  useGameSearch: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<typeof import('react-router-dom')>(
+    'react-router-dom',
+  );
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+import { useCreateSchedulingPoll } from '../../hooks/use-standalone-poll';
+import { getPlayers } from '../../lib/api-client';
+import { useGameSearch } from '../../hooks/use-game-search';
+
+const mutateAsync = vi.fn();
+
+const fakeGame: IgdbGameDto = {
+  id: 9001,
+  name: 'Civ VI',
+  slug: 'civ-vi',
+  coverUrl: null,
+  releaseDate: null,
+  summary: null,
+  igdbId: null,
+  // Some required-by-zod fields the contract type may demand at runtime
+  // are not strictly needed by the modal's selection flow, so we fill a
+  // minimum-shape that the component reads.
+} as unknown as IgdbGameDto;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mutateAsync.mockResolvedValue({ id: 1, lineupId: 2 });
+  vi.mocked(useCreateSchedulingPoll).mockReturnValue({
+    mutateAsync,
+    isPending: false,
+    isError: false,
+    error: null,
+  } as unknown as ReturnType<typeof useCreateSchedulingPoll>);
+  vi.mocked(getPlayers).mockResolvedValue({
+    data: [
+      { id: 10, username: 'alice', avatar: null, discordId: 'd-10' },
+      { id: 11, username: 'bob', avatar: null, discordId: null },
+    ],
+    meta: { total: 2, page: 1, pageSize: 20, hasMore: false },
+  } as unknown as Awaited<ReturnType<typeof getPlayers>>);
+  vi.mocked(useGameSearch).mockReturnValue({
+    data: { data: [fakeGame] },
+    isLoading: false,
+    isError: false,
+    error: null,
+  } as unknown as ReturnType<typeof useGameSearch>);
+});
+
+/** Pick `fakeGame` in the search box so the Create Poll button enables. */
+async function pickFakeGame(user: ReturnType<typeof userEvent.setup>) {
+  const input = screen.getByTestId('game-search-input');
+  await user.type(input, 'Ci');
+  // The dropdown renders one game from useGameSearch — click it.
+  const option = await screen.findByText(fakeGame.name);
+  await user.click(option);
+}
+
+describe('CreatePollModal — duration picker (ROK-1192)', () => {
+  it('renders a duration picker with options 24h / 48h / 72h / 7d', () => {
+    renderWithProviders(<CreatePollModal isOpen={true} onClose={vi.fn()} />);
+
+    const picker = screen.getByTestId('poll-duration-picker');
+    expect(picker).toBeInTheDocument();
+
+    // Each option must be discoverable by accessible name.
+    expect(
+      screen.getByRole('radio', { name: /24 hours/i }) ??
+        screen.getByRole('option', { name: /24 hours/i }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole('radio', { name: /48 hours/i }) ??
+        screen.getByRole('option', { name: /48 hours/i }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole('radio', { name: /72 hours/i }) ??
+        screen.getByRole('option', { name: /72 hours/i }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole('radio', { name: /7 days/i }) ??
+        screen.getByRole('option', { name: /7 days/i }),
+    ).toBeTruthy();
+  });
+
+  it('defaults the duration picker to 72 hours', () => {
+    renderWithProviders(<CreatePollModal isOpen={true} onClose={vi.fn()} />);
+    // The default-selected option should be the 72-hour one.
+    const seventyTwo =
+      screen.queryByRole('radio', { name: /72 hours/i, checked: true }) ??
+      (screen.queryByLabelText(/72 hours/i) as HTMLInputElement | null);
+    expect(seventyTwo).toBeTruthy();
+    if (seventyTwo && 'checked' in seventyTwo) {
+      expect((seventyTwo as HTMLInputElement).checked).toBe(true);
+    }
+  });
+
+  it('sends durationHours: 72 in the mutation payload by default', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<CreatePollModal isOpen={true} onClose={vi.fn()} />);
+
+    await pickFakeGame(user);
+
+    await user.click(screen.getByRole('button', { name: /create poll/i }));
+
+    expect(mutateAsync).toHaveBeenCalledTimes(1);
+    expect(mutateAsync.mock.calls[0][0]).toMatchObject({
+      gameId: fakeGame.id,
+      durationHours: 72,
+    });
+  });
+
+  it('sends durationHours: 168 when the user picks "7 days"', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<CreatePollModal isOpen={true} onClose={vi.fn()} />);
+
+    await pickFakeGame(user);
+
+    // The 7-day option may render as a radio or a labeled input — find by name.
+    const sevenDay = (screen.queryByRole('radio', { name: /7 days/i }) ??
+      screen.getByLabelText(/7 days/i)) as HTMLElement;
+    await user.click(sevenDay);
+
+    await user.click(screen.getByRole('button', { name: /create poll/i }));
+
+    expect(mutateAsync).toHaveBeenCalledTimes(1);
+    expect(mutateAsync.mock.calls[0][0]).toMatchObject({
+      gameId: fakeGame.id,
+      durationHours: 168,
+    });
+  });
+});

--- a/web/src/components/scheduling/create-poll-modal.tsx
+++ b/web/src/components/scheduling/create-poll-modal.tsx
@@ -17,11 +17,24 @@ interface CreatePollModalProps {
   onClose: () => void;
 }
 
+/** Duration options for the standalone poll picker (ROK-1192). */
+const DURATION_OPTIONS = [
+  { hours: 24, label: '24 hours' },
+  { hours: 48, label: '48 hours' },
+  { hours: 72, label: '72 hours' },
+  { hours: 168, label: '7 days' },
+] as const;
+
+const DEFAULT_DURATION_HOURS = 72;
+
 /** Form state for the create poll modal. */
 function useCreatePollForm() {
   const [selectedGame, setSelectedGame] = useState<IgdbGameDto | null>(null);
   const [memberIds, setMemberIdsRaw] = useState<number[]>([]);
   const [minVoteThreshold, setMinVoteThreshold] = useState<number>(3);
+  const [durationHours, setDurationHours] = useState<number>(
+    DEFAULT_DURATION_HOURS,
+  );
 
   // Sync threshold to member count on change (ROK-1015)
   const setMemberIds = useCallback((ids: number[]) => {
@@ -33,11 +46,13 @@ function useCreatePollForm() {
     setSelectedGame(null);
     setMemberIdsRaw([]);
     setMinVoteThreshold(3);
+    setDurationHours(DEFAULT_DURATION_HOURS);
   }, []);
   return {
     selectedGame, setSelectedGame,
     memberIds, setMemberIds,
     minVoteThreshold, setMinVoteThreshold,
+    durationHours, setDurationHours,
     reset,
   };
 }
@@ -62,6 +77,7 @@ export function CreatePollModal({ isOpen, onClose }: CreatePollModalProps) {
       gameId: form.selectedGame.id,
       memberUserIds: form.memberIds.length > 0 ? form.memberIds : undefined,
       minVoteThreshold: form.minVoteThreshold > 0 ? form.minVoteThreshold : undefined,
+      durationHours: form.durationHours,
     });
     handleClose();
     navigate(`/community-lineup/${result.lineupId}/schedule/${result.id}`);
@@ -80,6 +96,41 @@ export function CreatePollModal({ isOpen, onClose }: CreatePollModalProps) {
         onSubmit={handleSubmit}
       />
     </Modal>
+  );
+}
+
+/** Duration picker — voting window for the poll (ROK-1192). */
+function DurationPicker({ value, onChange }: {
+  value: number; onChange: (v: number) => void;
+}) {
+  return (
+    <div data-testid="poll-duration-picker">
+      <label className="text-sm font-medium text-secondary mb-2 block">
+        Voting window
+      </label>
+      <div className="flex flex-wrap gap-2">
+        {DURATION_OPTIONS.map((opt) => (
+          <label
+            key={opt.hours}
+            className={`flex items-center gap-2 px-3 py-2 rounded-lg cursor-pointer text-sm border transition-colors ${
+              value === opt.hours
+                ? 'bg-emerald-600 border-emerald-500 text-foreground'
+                : 'bg-surface/50 border-surface text-muted hover:border-emerald-500/50'
+            }`}
+          >
+            <input
+              type="radio"
+              name="poll-duration"
+              value={opt.hours}
+              checked={value === opt.hours}
+              onChange={() => onChange(opt.hours)}
+              className="sr-only"
+            />
+            {opt.label}
+          </label>
+        ))}
+      </div>
+    </div>
   );
 }
 
@@ -135,6 +186,10 @@ function CreatePollFormBody({ form, isPending, onSubmit }: {
       <MemberPicker
         selectedIds={form.memberIds}
         onChange={form.setMemberIds}
+      />
+      <DurationPicker
+        value={form.durationHours}
+        onChange={form.setDurationHours}
       />
       <MinVoteThresholdSlider
         value={form.minVoteThreshold}

--- a/web/src/components/scheduling/create-poll-modal.tsx
+++ b/web/src/components/scheduling/create-poll-modal.tsx
@@ -104,15 +104,18 @@ function DurationPicker({ value, onChange }: {
   value: number; onChange: (v: number) => void;
 }) {
   return (
-    <div data-testid="poll-duration-picker">
-      <label className="text-sm font-medium text-secondary mb-2 block">
+    <div
+      data-testid="poll-duration-picker"
+      className="flex items-center justify-between gap-3"
+    >
+      <label className="text-sm font-medium text-secondary shrink-0">
         Voting window
       </label>
-      <div className="flex flex-wrap gap-2">
+      <div className="flex gap-1">
         {DURATION_OPTIONS.map((opt) => (
           <label
             key={opt.hours}
-            className={`flex items-center gap-2 px-3 py-2 rounded-lg cursor-pointer text-sm border transition-colors ${
+            className={`px-2.5 py-1 rounded-md cursor-pointer text-xs border transition-colors ${
               value === opt.hours
                 ? 'bg-emerald-600 border-emerald-500 text-foreground'
                 : 'bg-surface/50 border-surface text-muted hover:border-emerald-500/50'

--- a/web/src/components/scheduling/create-poll-modal.tsx
+++ b/web/src/components/scheduling/create-poll-modal.tsx
@@ -181,7 +181,7 @@ function CreatePollFormBody({ form, isPending, onSubmit }: {
   const totalMembers = players?.length ?? 20;
   const sliderMax = Math.max(1, form.memberIds.length > 0 ? form.memberIds.length : totalMembers);
   return (
-    <div className="space-y-4">
+    <div className="space-y-3">
       <PollGameSearch
         value={form.selectedGame}
         onChange={form.setSelectedGame}

--- a/web/src/components/scheduling/member-picker-modal.tsx
+++ b/web/src/components/scheduling/member-picker-modal.tsx
@@ -83,7 +83,7 @@ export function MemberPicker({ selectedIds, onChange }: MemberPickerProps) {
         aria-label="Search members"
         className="w-full px-3 py-2 bg-panel border border-edge rounded-lg text-sm text-foreground placeholder-dim focus:outline-none focus:ring-2 focus:ring-emerald-500 mb-2"
       />
-      <div className="max-h-40 overflow-y-auto border border-edge rounded-lg">
+      <div className="max-h-32 overflow-y-auto border border-edge rounded-lg">
         {isLoading && (
           <div className="px-3 py-2 text-sm text-muted">Loading...</div>
         )}


### PR DESCRIPTION
## Summary

- New `StandalonePollReminderService` cron (every 5 min) sends 24h + 1h DMs to non-voters before a standalone scheduling poll's `phase_deadline`. Auto-renders a "Vote on a Time" button via existing `buildLineupButton` (matchId + lineupId in payload).
- New `create-poll-modal` duration picker (24h / 48h / 72h / 7 days, default 72h) — wires `durationHours` into the create payload. Without it, every prod standalone poll had `phase_deadline = null` and the cron would have shipped dead.
- Backfill migration `0133_standalone_poll_deadline_backfill.sql` sets `phase_deadline = created_at + 36h` for active null-deadline standalone lineups (≈1 row in prod today, query is shape-safe at any count).
- Archive recovery reconciler in `LineupPhaseQueueService.onModuleInit` ensures every active decided standalone lineup with a future `phase_deadline` has a scheduled BullMQ archive job. Idempotent via deterministic `lineup-phase-{lineupId}-{targetStatus}` jobIds — also self-heals Redis flushes.
- Two DEMO_MODE-only test endpoints (`/admin/test/advance-standalone-poll-deadline`, `/admin/test/trigger-standalone-poll-reminders`) for the smoke fixture.
- UTC parse fix for `phase_deadline` (`timestamp without time zone` returned as naïve string by postgres-js; default `new Date()` was shifting deadlines by ~7h in PDT and misrouting 1h reminders to the 24h window).

## Linear
ROK-1192

## Test plan
- [x] Integration spec covers all 8 cases (24h fires, 1h fires, post-vote silence, null-deadline skipped, dedup, concluded-poll skipped, backfill migration, reconciler) — `api/src/lineups/standalone-poll/standalone-poll-reminder.integration.spec.ts`
- [x] Vitest unit tests for the duration picker (4/4 pass) — `web/src/components/scheduling/create-poll-modal.test.tsx`
- [x] Discord smoke test (T-1h fast-forward via test-only endpoint, asserts DM with "Vote on a Time" button) — `tools/test-bot/src/smoke/tests/standalone-poll-reminders.test.ts`
- [x] Local CI passes (`./scripts/validate-ci.sh --full`: build, tsc, lint, unit + coverage, integration, migration validation)
- [x] Operator tested duration picker + modal layout in browser
- [x] Code review APPROVED — 0 critical/correctness/tests/perf/style issues, 3 non-blocking notes (parseTimestampUtc duplicated, DurationPicker could be its own file, LineupPhaseQueueService double-provided)
- [x] Smoke tests pass (38/38 DM-category, ROK-1192 green)