### PR TITLE
chore: bulk batch 2026-04-30 (4 tech-debt stories)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,7 +28,19 @@ CORS_ORIGIN=http://localhost:5173
 # Optional: Node environment
 # NODE_ENV=development
 
-# Debug logging (default: false)
-# When true, enables debug and verbose log levels in the API
-# When false (or unset), only error, warn, and log levels are active
+# Nest logger threshold (default: "log" in production, "debug" in development)
+# Valid values: error | warn | log | debug | verbose
+# Levels at or above the threshold are emitted; "fatal" is always included.
+# LOG_LEVEL=log
+
+# Bootstrap logger self-test (default: false)
+# When true, the API emits one sentinel WARN and one sentinel ERROR line after
+# app.listen() so operators can verify the warn/error channels reach the log sink.
+# LOGGER_SELF_TEST=false
+
+# Debug logging — PERF gate only (default: false)
+# When true, enables [PERF] instrumentation lines (perf-logger, perf-memory-monitor,
+# perf-logging.interceptor). Does NOT control Nest log levels — use LOG_LEVEL for that.
+# Legacy bridge: if LOG_LEVEL is unset and DEBUG=true, Nest threshold is upgraded
+# to "debug" so dev environments that only set DEBUG=true keep their current behavior.
 DEBUG=false

--- a/.github/workflows/dependabot-rebase-on-main.yml
+++ b/.github/workflows/dependabot-rebase-on-main.yml
@@ -1,21 +1,26 @@
 name: Rebase Dependabot PRs after main update
 
 # When main moves, branch protection's "up to date" requirement causes any open
-# Dependabot PR to become BEHIND and stop auto-merging. This workflow nudges
-# Dependabot to rebase every open bot PR so auto-merge can resume.
+# Dependabot PR to become BEHIND and stop auto-merging. The previous version
+# of this workflow posted "@dependabot rebase" comments, but Dependabot
+# rejects @-commands from the github-actions[bot] account ("only users with
+# push access can use that command"). Use the REST update-branch endpoint
+# instead — it runs under the workflow's own contents: write token, so the
+# permission check is satisfied without involving Dependabot's parser.
 
 on:
   push:
     branches: [main]
 
 permissions:
-  pull-requests: write
+  contents: write
+  pull-requests: read
 
 jobs:
   rebase:
     runs-on: ubuntu-latest
     steps:
-      - name: Comment '@dependabot rebase' on every open Dependabot PR
+      - name: Update branch on every open Dependabot PR
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -31,6 +36,13 @@ jobs:
             exit 0
           fi
           for n in $numbers; do
-            echo "Triggering rebase on PR #$n"
-            gh pr comment "$n" --body "@dependabot rebase" || true
+            echo "Updating branch on PR #$n"
+            # update-branch is a no-op when the PR is already current with
+            # the base branch. `expected_head_sha=` skips the optimistic
+            # concurrency check; we tolerate the rare 422 (e.g. PR closed
+            # mid-loop) so one bad PR doesn't fail the whole job.
+            gh api "repos/$GH_REPO/pulls/$n/update-branch" \
+              -X PUT \
+              -f expected_head_sha= \
+              || true
           done

--- a/api/src/common/perf-logger.spec.ts
+++ b/api/src/common/perf-logger.spec.ts
@@ -1,0 +1,103 @@
+import { Logger } from '@nestjs/common';
+import { formatDurationMs, isPerfEnabled, perfLog } from './perf-logger';
+
+describe('formatDurationMs', () => {
+  it('clamps zero/negative to 0ms', () => {
+    expect(formatDurationMs(0)).toBe('0ms');
+    expect(formatDurationMs(-5)).toBe('0ms');
+  });
+
+  it('keeps two decimals for sub-ms durations (so cached lookups differ from 0)', () => {
+    expect(formatDurationMs(0.4)).toBe('0.40ms');
+    expect(formatDurationMs(0.123)).toBe('0.12ms');
+    expect(formatDurationMs(0.999)).toBe('1.00ms');
+  });
+
+  it('rounds to integer ms for >= 1ms', () => {
+    expect(formatDurationMs(1)).toBe('1ms');
+    expect(formatDurationMs(50)).toBe('50ms');
+    expect(formatDurationMs(50.4)).toBe('50ms');
+    expect(formatDurationMs(50.6)).toBe('51ms');
+    expect(formatDurationMs(1500)).toBe('1500ms');
+  });
+
+  it('returns 0ms for non-finite input', () => {
+    expect(formatDurationMs(NaN)).toBe('0ms');
+    expect(formatDurationMs(Infinity)).toBe('0ms');
+  });
+});
+
+describe('isPerfEnabled', () => {
+  const originalDebug = process.env.DEBUG;
+  afterEach(() => {
+    process.env.DEBUG = originalDebug;
+  });
+
+  it('returns true only when DEBUG is exactly "true"', () => {
+    process.env.DEBUG = 'true';
+    expect(isPerfEnabled()).toBe(true);
+    process.env.DEBUG = 'false';
+    expect(isPerfEnabled()).toBe(false);
+    process.env.DEBUG = '1';
+    expect(isPerfEnabled()).toBe(false);
+    delete process.env.DEBUG;
+    expect(isPerfEnabled()).toBe(false);
+  });
+});
+
+describe('perfLog', () => {
+  const originalDebug = process.env.DEBUG;
+  let debugSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    debugSpy = jest
+      .spyOn(Logger.prototype, 'debug')
+      .mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    debugSpy.mockRestore();
+    process.env.DEBUG = originalDebug;
+  });
+
+  it('emits nothing when DEBUG is not "true"', () => {
+    process.env.DEBUG = 'false';
+    perfLog('DB', 'query', 12.4);
+    expect(debugSpy).not.toHaveBeenCalled();
+  });
+
+  it('emits a sub-ms-aware [PERF] DB line for sub-ms durations', () => {
+    process.env.DEBUG = 'true';
+    perfLog('DB', 'query', 0.42, { table: 'users' });
+    expect(debugSpy).toHaveBeenCalledTimes(1);
+    const line = debugSpy.mock.calls[0][0] as string;
+    expect(line).toBe('[PERF] DB | query | 0.42ms | table=users');
+  });
+
+  it('emits an integer-ms [PERF] HTTP line for >= 1ms durations (no regression for HTTP/CRON)', () => {
+    process.env.DEBUG = 'true';
+    perfLog('HTTP', 'GET /api/events', 50, { status: 200, userId: 7 });
+    const line = debugSpy.mock.calls[0][0] as string;
+    expect(line).toBe(
+      '[PERF] HTTP | GET /api/events | 50ms | status=200 userId=7',
+    );
+  });
+
+  it('emits 1500ms for a slow CRON job (no regression for CRON)', () => {
+    process.env.DEBUG = 'true';
+    perfLog('CRON', 'reminder-sweep', 1500, { status: 'ok' });
+    const line = debugSpy.mock.calls[0][0] as string;
+    expect(line).toBe('[PERF] CRON | reminder-sweep | 1500ms | status=ok');
+  });
+
+  it('skips empty meta values', () => {
+    process.env.DEBUG = 'true';
+    perfLog('DB', 'query', 0.5, {
+      table: 'users',
+      userId: undefined,
+      foo: null,
+    });
+    const line = debugSpy.mock.calls[0][0] as string;
+    expect(line).toBe('[PERF] DB | query | 0.50ms | table=users');
+  });
+});

--- a/api/src/common/perf-logger.ts
+++ b/api/src/common/perf-logger.ts
@@ -11,6 +11,23 @@ export function isPerfEnabled(): boolean {
 }
 
 /**
+ * Format a duration in ms for log output.
+ *
+ * - `< 0`         → `0ms` (clamp negative)
+ * - `< 1ms`       → two decimals (e.g. `0.42ms`) so sub-ms queries differ from 0
+ * - `>= 1ms`      → integer ms (e.g. `6ms`, `129ms`)
+ *
+ * Sub-ms precision is kept only below 1ms because indexed Drizzle reads
+ * commonly take 0.1–0.9ms and would otherwise floor to `0ms` and lose signal.
+ */
+export function formatDurationMs(durationMs: number): string {
+  if (!Number.isFinite(durationMs) || durationMs <= 0) return '0ms';
+  if (durationMs < 1)
+    return `${(Math.round(durationMs * 100) / 100).toFixed(2)}ms`;
+  return `${Math.round(durationMs)}ms`;
+}
+
+/**
  * Emit a structured performance log line.
  *
  * Format: `[PERF] <CATEGORY> | <operation> | <duration>ms | key=value key=value`
@@ -30,7 +47,7 @@ export function perfLog(
 ): void {
   if (!isPerfEnabled()) return;
 
-  let line = `[PERF] ${category} | ${operation} | ${Math.round(durationMs)}ms`;
+  let line = `[PERF] ${category} | ${operation} | ${formatDurationMs(durationMs)}`;
 
   if (meta) {
     const pairs = Object.entries(meta)

--- a/api/src/drizzle/drizzle.module.ts
+++ b/api/src/drizzle/drizzle.module.ts
@@ -3,8 +3,7 @@ import { ConfigModule, ConfigService } from '@nestjs/config';
 import { drizzle } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 import * as schema from './schema';
-import { isPerfEnabled } from '../common/perf-logger';
-import { PerfDrizzleLogger } from './perf-drizzle-logger';
+import { withQueryPerfLogging } from './perf-drizzle-logger';
 
 export const DrizzleAsyncProvider = 'drizzleProvider';
 
@@ -20,14 +19,13 @@ export const DrizzleAsyncProvider = 'drizzleProvider';
         if (!connectionString) {
           throw new Error('DATABASE_URL is undefined');
         }
-        const client = postgres(connectionString, {
-          max: configService.get<number>('DB_POOL_MAX', 10),
-          idle_timeout: configService.get<number>('DB_IDLE_TIMEOUT', 0),
-        });
-        const db = drizzle(client, {
-          schema,
-          logger: isPerfEnabled() ? new PerfDrizzleLogger() : undefined,
-        });
+        const client = withQueryPerfLogging(
+          postgres(connectionString, {
+            max: configService.get<number>('DB_POOL_MAX', 10),
+            idle_timeout: configService.get<number>('DB_IDLE_TIMEOUT', 0),
+          }),
+        );
+        const db = drizzle(client, { schema });
         return db;
       },
     },

--- a/api/src/drizzle/perf-drizzle-logger.spec.ts
+++ b/api/src/drizzle/perf-drizzle-logger.spec.ts
@@ -1,0 +1,136 @@
+import type { Sql } from 'postgres';
+import { withQueryPerfLogging } from './perf-drizzle-logger';
+import * as perfLoggerModule from '../common/perf-logger';
+
+jest.mock('../common/perf-logger', () => ({
+  isPerfEnabled: jest.fn(),
+  perfLog: jest.fn(),
+}));
+
+const mockIsPerfEnabled = perfLoggerModule.isPerfEnabled as jest.Mock;
+const mockPerfLog = perfLoggerModule.perfLog as jest.Mock;
+
+interface FakePending {
+  then: (
+    onFulfilled?: (v: unknown) => unknown,
+    onRejected?: (e: unknown) => unknown,
+  ) => Promise<unknown>;
+  values: () => FakePending;
+}
+
+/**
+ * Build a fake postgres-js client whose `unsafe` returns a thenable that
+ * resolves after `delayMs` (uses real time so duration is non-zero in tests).
+ */
+function buildFakeClient(delayMs: number, fail = false): Sql {
+  const unsafe = jest.fn(() => {
+    let resolve: (v: unknown) => void = () => {};
+    let reject: (e: unknown) => void = () => {};
+    const promise = new Promise<unknown>((res, rej) => {
+      resolve = res;
+      reject = rej;
+    });
+
+    setTimeout(() => {
+      if (fail) reject(new Error('boom'));
+      else resolve([{ id: 1 }]);
+    }, delayMs);
+
+    const pending: FakePending = {
+      then: (onFulfilled, onRejected) => promise.then(onFulfilled, onRejected),
+      values: () => pending,
+    };
+    return pending;
+  });
+
+  return { unsafe } as unknown as Sql;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('withQueryPerfLogging — disabled', () => {
+  it('returns the client unchanged when perf logging is disabled', () => {
+    mockIsPerfEnabled.mockReturnValue(false);
+    const client = buildFakeClient(1);
+    const wrapped = withQueryPerfLogging(client);
+    expect(wrapped).toBe(client);
+  });
+});
+
+describe('withQueryPerfLogging — duration & meta', () => {
+  it('emits a [PERF] DB log with non-zero duration when the query resolves', async () => {
+    mockIsPerfEnabled.mockReturnValue(true);
+    const client = buildFakeClient(20);
+    withQueryPerfLogging(client);
+
+    await client.unsafe('SELECT * FROM users WHERE id = $1', [1]);
+
+    expect(mockPerfLog).toHaveBeenCalledTimes(1);
+    const [category, operation, durationMs, meta] = mockPerfLog.mock
+      .calls[0] as [string, string, number, Record<string, unknown>];
+    expect(category).toBe('DB');
+    expect(operation).toBe('query');
+    expect(durationMs).toBeGreaterThan(0);
+    expect(meta).toMatchObject({ status: 'ok', table: 'users' });
+  });
+
+  it('extracts the table name for INSERT, UPDATE, JOIN', async () => {
+    mockIsPerfEnabled.mockReturnValue(true);
+    const tables: string[] = [];
+    const cases = [
+      'INSERT INTO events (id) VALUES ($1)',
+      'UPDATE characters SET name = $1',
+      'SELECT * FROM events JOIN signups ON ...',
+    ];
+    for (const sql of cases) {
+      jest.clearAllMocks();
+      const client = buildFakeClient(1);
+      withQueryPerfLogging(client);
+      await client.unsafe(sql, []);
+      const meta = mockPerfLog.mock.calls[0][3] as { table: string };
+      tables.push(meta.table);
+    }
+    expect(tables).toEqual(['events', 'characters', 'events']);
+  });
+
+  it('truncates long query text in the log meta', async () => {
+    mockIsPerfEnabled.mockReturnValue(true);
+    const longQuery = 'SELECT ' + 'x,'.repeat(200) + ' FROM users';
+    const client = buildFakeClient(1);
+    withQueryPerfLogging(client);
+    await client.unsafe(longQuery, []);
+
+    const meta = mockPerfLog.mock.calls[0][3] as { query: string };
+    expect(meta.query.length).toBeLessThanOrEqual(203);
+    expect(meta.query.endsWith('...')).toBe(true);
+  });
+});
+
+describe('withQueryPerfLogging — failure & chained paths', () => {
+  it('logs status=err and rethrows when the query rejects', async () => {
+    mockIsPerfEnabled.mockReturnValue(true);
+    const client = buildFakeClient(5, true);
+    withQueryPerfLogging(client);
+
+    await expect(client.unsafe('SELECT 1', [])).rejects.toThrow('boom');
+    expect(mockPerfLog).toHaveBeenCalledTimes(1);
+    expect(mockPerfLog.mock.calls[0][3]).toMatchObject({ status: 'err' });
+  });
+
+  it('times the chained .values() form (drizzle path B)', async () => {
+    mockIsPerfEnabled.mockReturnValue(true);
+    const client = buildFakeClient(15);
+    withQueryPerfLogging(client);
+
+    const pending = client.unsafe('SELECT id FROM users', []) as unknown as {
+      values: () => Promise<unknown>;
+    };
+    await pending.values();
+
+    expect(mockPerfLog).toHaveBeenCalledTimes(1);
+    const durationMs = mockPerfLog.mock.calls[0][2] as number;
+    expect(durationMs).toBeGreaterThan(0);
+  });
+});

--- a/api/src/drizzle/perf-drizzle-logger.ts
+++ b/api/src/drizzle/perf-drizzle-logger.ts
@@ -1,26 +1,126 @@
-import type { Logger as DrizzleLogger } from 'drizzle-orm';
-import { perfLog } from '../common/perf-logger';
+import type { Sql } from 'postgres';
+import { isPerfEnabled, perfLog } from '../common/perf-logger';
+
+type Thenable = {
+  then: (
+    onFulfilled?: (v: unknown) => unknown,
+    onRejected?: (e: unknown) => unknown,
+  ) => unknown;
+};
+
+type UnsafeFn = Sql['unsafe'];
 
 /**
- * Drizzle ORM Logger implementation that emits [PERF] DB lines (ROK-563).
+ * Wrap a postgres-js `Sql` client so every `unsafe(query, params)` call
+ * is timed and emits a `[PERF] DB | query | <ms>ms` line on resolution
+ * (ROK-1199; replaces the prior Drizzle Logger approach which couldn't
+ * observe execution duration — Drizzle's `Logger.logQuery` fires before
+ * execution and never carries a duration).
  *
- * Drizzle calls `logQuery(query, params)` for every executed query.
- * Since Drizzle doesn't provide execution duration, we log 0ms and
- * include the query text + extracted table name for grep analysis.
+ * Drizzle's postgres-js session uses `client.unsafe(query, params)` and
+ * either awaits it directly or chains `.values()`. Both paths return a
+ * thenable; we wrap the `then` so duration is captured on the actual
+ * settle of the query, regardless of which chained form Drizzle picks.
+ *
+ * No-op (passes the client through unchanged) when DEBUG is not enabled,
+ * to avoid any per-query overhead in production.
  */
-export class PerfDrizzleLogger implements DrizzleLogger {
-  logQuery(query: string, params: unknown[]): void {
-    void params; // Required by DrizzleLogger interface but unused
-    const table = this.extractTable(query);
-    perfLog('DB', 'query', 0, {
-      table,
+export function withQueryPerfLogging(client: Sql): Sql {
+  if (!isPerfEnabled()) return client;
+
+  const originalUnsafe = client.unsafe.bind(client);
+
+  const timedUnsafe = ((
+    query: Parameters<UnsafeFn>[0],
+    parameters?: Parameters<UnsafeFn>[1],
+    queryOptions?: Parameters<UnsafeFn>[2],
+  ) =>
+    wrapPending(
+      originalUnsafe(query, parameters, queryOptions) as unknown as Thenable,
+      query,
+    )) as UnsafeFn;
+
+  (client as { unsafe: UnsafeFn }).unsafe = timedUnsafe;
+
+  return client;
+}
+
+/**
+ * Wrap a postgres-js PendingQuery (or chained PendingValuesQuery / PendingRawQuery)
+ * so that resolving/rejecting emits a perf log with the actual duration.
+ *
+ * Uses a Proxy so chained methods (`.values()`, `.raw()`, `.describe()`) are
+ * themselves wrapped — the timer starts on the original `unsafe()` call and
+ * fires whenever the chosen terminal thenable settles.
+ */
+function wrapPending<T extends Thenable>(pending: T, query: string): T {
+  const start = performance.now();
+  let logged = false;
+  const log = (status: 'ok' | 'err'): void => {
+    if (logged) return;
+    logged = true;
+    perfLog('DB', 'query', performance.now() - start, {
+      status,
+      table: extractTable(query),
       query: query.length > 200 ? query.slice(0, 200) + '...' : query,
     });
-  }
+  };
+  return new Proxy(pending, {
+    get: (target, prop, receiver) =>
+      proxyGet(target, prop, receiver, query, log),
+  });
+}
 
-  private extractTable(query: string): string {
-    // Match FROM "table", INTO "table", UPDATE "table", JOIN "table"
-    const match = /(?:from|into|update|join)\s+"?(\w+)"?/i.exec(query);
-    return match?.[1] ?? 'unknown';
+const CHAINED_METHODS = new Set(['values', 'raw', 'describe']);
+
+function proxyGet(
+  target: Thenable,
+  prop: string | symbol,
+  receiver: unknown,
+  query: string,
+  log: (status: 'ok' | 'err') => void,
+): unknown {
+  const value = Reflect.get(target, prop, receiver) as unknown;
+  if (prop === 'then' && typeof value === 'function') {
+    return wrapThen(target, value as Thenable['then'], log);
   }
+  if (
+    typeof prop === 'string' &&
+    CHAINED_METHODS.has(prop) &&
+    typeof value === 'function'
+  ) {
+    const fn = value as (...args: unknown[]) => Thenable;
+    return (...args: unknown[]) => wrapPending(fn.apply(target, args), query);
+  }
+  return typeof value === 'function'
+    ? (value as (...args: unknown[]) => unknown).bind(target)
+    : value;
+}
+
+function wrapThen(
+  target: Thenable,
+  originalThen: Thenable['then'],
+  log: (status: 'ok' | 'err') => void,
+) {
+  return (
+    onFulfilled?: (v: unknown) => unknown,
+    onRejected?: (e: unknown) => unknown,
+  ) =>
+    originalThen.call(
+      target,
+      (v: unknown) => {
+        log('ok');
+        return onFulfilled ? onFulfilled(v) : v;
+      },
+      (e: unknown) => {
+        log('err');
+        if (onRejected) return onRejected(e);
+        throw e;
+      },
+    );
+}
+
+function extractTable(query: string): string {
+  const match = /(?:from|into|update|join)\s+"?(\w+)"?/i.exec(query);
+  return match?.[1] ?? 'unknown';
 }

--- a/api/src/lineups/scheduling/scheduling-response.helpers.ts
+++ b/api/src/lineups/scheduling/scheduling-response.helpers.ts
@@ -121,11 +121,9 @@ export function buildPollResponse(
   userId: number | null,
   lineupStatus: string,
 ): SchedulePollPageResponseDto {
-  const gameName = (match as { gameName?: string }).gameName ?? 'Unknown';
-  const gameCoverUrl =
-    (match as { gameCoverUrl?: string | null }).gameCoverUrl ?? null;
-  const lineupCreatedById =
-    (match as { lineupCreatedById?: number | null }).lineupCreatedById ?? null;
+  const gameName = match.gameName ?? 'Unknown';
+  const gameCoverUrl = match.gameCoverUrl ?? null;
+  const lineupCreatedById = match.lineupCreatedById ?? null;
 
   return {
     match: buildMatchDetailDto(

--- a/api/src/lineups/scheduling/scheduling.controller.ts
+++ b/api/src/lineups/scheduling/scheduling.controller.ts
@@ -99,7 +99,13 @@ export class SchedulingController {
     );
   }
 
-  /** POST /lineups/:lineupId/schedule/:matchId/create-event — create event. */
+  /**
+   * POST /lineups/:lineupId/schedule/:matchId/create-event — create event.
+   *
+   * @deprecated Use POST /events with matchId param instead (ROK-1121).
+   * Endpoint retained for smoke-test compatibility — full removal tracked
+   * separately.
+   */
   @Post(':lineupId/schedule/:matchId/create-event')
   @UseGuards(AuthGuard('jwt'))
   @HttpCode(HttpStatus.CREATED)

--- a/api/src/lineups/scheduling/scheduling.service.spec.ts
+++ b/api/src/lineups/scheduling/scheduling.service.spec.ts
@@ -31,6 +31,22 @@ jest.mock('./scheduling-auto-heart.helpers', () => ({
 jest.mock('./scheduling-query.helpers', () => ({
   ...jest.requireActual('./scheduling-query.helpers'),
   findScheduleVotes: jest.fn().mockResolvedValue([]),
+  findScheduleSlots: jest.fn().mockResolvedValue([]),
+  countUniqueVoters: jest.fn().mockResolvedValue(0),
+}));
+jest.mock('../lineups-match-query.helpers', () => ({
+  ...jest.requireActual('../lineups-match-query.helpers'),
+  findMatchMembers: jest.fn().mockResolvedValue([]),
+}));
+jest.mock('./scheduling-event.helpers', () => ({
+  ...jest.requireActual('./scheduling-event.helpers'),
+  resolveGameInfo: jest
+    .fn()
+    .mockResolvedValue({ gameName: 'Test Game', gameCoverUrl: null }),
+}));
+jest.mock('./scheduling-conflict.helpers', () => ({
+  ...jest.requireActual('./scheduling-conflict.helpers'),
+  findConflictingSlotIds: jest.fn().mockResolvedValue([]),
 }));
 
 /* eslint-disable @typescript-eslint/no-require-imports */
@@ -361,6 +377,46 @@ describe('SchedulingService', () => {
       await expect(service.retractAllVotes(10, 1)).rejects.toThrow(
         BadRequestException,
       );
+    });
+  });
+
+  // ROK-1194 item 4: pin the community_lineups.created_by join wired through
+  // getSchedulePoll → buildPollResponse so future refactors don't accidentally
+  // drop lineupCreatedById on the way to the response DTO.
+  describe('getSchedulePoll lineupCreatedById', () => {
+    const FULL_MATCH = {
+      ...SCHEDULING_MATCH,
+      thresholdMet: false,
+      voteCount: 0,
+      votePercentage: null,
+      fitType: null,
+      minVoteThreshold: null,
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-01-01T00:00:00.000Z'),
+    };
+
+    it('passes lineupCreatedById from the lineup join into the response', async () => {
+      // 1. findMatchOrThrow
+      mockDb.limit.mockResolvedValueOnce([FULL_MATCH]);
+      // 2. lineup status + createdBy join (the row under test)
+      mockDb.limit.mockResolvedValueOnce([
+        { status: 'decided', createdBy: 42 },
+      ]);
+
+      const result = await service.getSchedulePoll(10, null);
+      expect(result.match.lineupCreatedById).toBe(42);
+    });
+
+    it('omits lineupCreatedById when lineup row is missing', async () => {
+      // 1. findMatchOrThrow
+      mockDb.limit.mockResolvedValueOnce([FULL_MATCH]);
+      // 2. lineup join returns no rows
+      mockDb.limit.mockResolvedValueOnce([]);
+
+      const result = await service.getSchedulePoll(10, null);
+      // buildPollResponse → buildMatchDetailDto omits the field when null,
+      // so the contract DTO surfaces it as undefined rather than null.
+      expect(result.match.lineupCreatedById).toBeUndefined();
     });
   });
 });

--- a/api/src/main.helpers.spec.ts
+++ b/api/src/main.helpers.spec.ts
@@ -2,6 +2,11 @@ import {
   validateCorsConfig,
   buildCorsOriginFn,
   buildHelmetOptions,
+  getLogLevels,
+  parseLogLevel,
+  buildLoggerSelfTest,
+  LOGGER_SELF_TEST_WARN_SENTINEL,
+  LOGGER_SELF_TEST_ERROR_SENTINEL,
 } from './main.helpers';
 
 type CorsCallback = (err: Error | null, allow?: boolean) => void;
@@ -129,8 +134,131 @@ function describeBuildHelmetOptions() {
   });
 }
 
+function describeParseLogLevel() {
+  it('returns null for undefined / empty input', () => {
+    expect(parseLogLevel(undefined)).toBeNull();
+    expect(parseLogLevel('')).toBeNull();
+  });
+
+  it('accepts each valid level', () => {
+    expect(parseLogLevel('error')).toBe('error');
+    expect(parseLogLevel('warn')).toBe('warn');
+    expect(parseLogLevel('log')).toBe('log');
+    expect(parseLogLevel('debug')).toBe('debug');
+    expect(parseLogLevel('verbose')).toBe('verbose');
+  });
+
+  it('normalizes case and whitespace', () => {
+    expect(parseLogLevel('  WARN ')).toBe('warn');
+    expect(parseLogLevel('Debug')).toBe('debug');
+  });
+
+  it('rejects unknown values', () => {
+    expect(parseLogLevel('banana')).toBeNull();
+  });
+}
+
+function describeGetLogLevels() {
+  it('defaults to error/warn/log when nothing is set', () => {
+    const consoleLike = { warn: jest.fn() };
+    expect(getLogLevels({}, consoleLike)).toEqual(['error', 'warn', 'log']);
+    expect(consoleLike.warn).not.toHaveBeenCalled();
+  });
+
+  it('LOG_LEVEL=warn keeps error/warn only', () => {
+    expect(getLogLevels({ LOG_LEVEL: 'warn' })).toEqual(['error', 'warn']);
+  });
+
+  it('LOG_LEVEL=error keeps only error', () => {
+    expect(getLogLevels({ LOG_LEVEL: 'error' })).toEqual(['error']);
+  });
+
+  it('LOG_LEVEL=debug includes debug + everything more severe', () => {
+    expect(getLogLevels({ LOG_LEVEL: 'debug' })).toEqual([
+      'error',
+      'warn',
+      'log',
+      'debug',
+    ]);
+  });
+
+  it('LOG_LEVEL=verbose includes every level', () => {
+    expect(getLogLevels({ LOG_LEVEL: 'verbose' })).toEqual([
+      'error',
+      'warn',
+      'log',
+      'debug',
+      'verbose',
+    ]);
+  });
+
+  it('legacy bridge: DEBUG=true upgrades threshold to debug', () => {
+    expect(getLogLevels({ DEBUG: 'true' })).toEqual([
+      'error',
+      'warn',
+      'log',
+      'debug',
+    ]);
+  });
+
+  it('legacy bridge does not fire when DEBUG is anything other than "true"', () => {
+    expect(getLogLevels({ DEBUG: 'false' })).not.toContain('debug');
+    expect(getLogLevels({ DEBUG: '1' })).not.toContain('debug');
+  });
+
+  it('LOG_LEVEL takes precedence over DEBUG=true', () => {
+    expect(getLogLevels({ LOG_LEVEL: 'warn', DEBUG: 'true' })).toEqual([
+      'error',
+      'warn',
+    ]);
+  });
+
+  it('falls back to "log" and warns once when LOG_LEVEL is invalid', () => {
+    const consoleLike = { warn: jest.fn() };
+    const levels = getLogLevels({ LOG_LEVEL: 'banana' }, consoleLike);
+    expect(levels).toEqual(['error', 'warn', 'log']);
+    expect(consoleLike.warn).toHaveBeenCalledTimes(1);
+    expect(consoleLike.warn).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid LOG_LEVEL="banana"'),
+    );
+  });
+
+  it('NODE_ENV=production keeps "log" threshold', () => {
+    expect(getLogLevels({ NODE_ENV: 'production' })).toEqual([
+      'error',
+      'warn',
+      'log',
+    ]);
+  });
+
+  it('NODE_ENV=development upgrades threshold to debug', () => {
+    expect(getLogLevels({ NODE_ENV: 'development' })).toContain('debug');
+  });
+
+  it('explicit LOG_LEVEL beats NODE_ENV=development', () => {
+    expect(
+      getLogLevels({ NODE_ENV: 'development', LOG_LEVEL: 'warn' }),
+    ).toEqual(['error', 'warn']);
+  });
+}
+
+function describeBuildLoggerSelfTest() {
+  it('returns a function that logs one warn and one error sentinel', () => {
+    const logger = { warn: jest.fn(), error: jest.fn() };
+    const run = buildLoggerSelfTest(logger);
+    run();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+    expect(logger.warn).toHaveBeenCalledWith(LOGGER_SELF_TEST_WARN_SENTINEL);
+    expect(logger.error).toHaveBeenCalledTimes(1);
+    expect(logger.error).toHaveBeenCalledWith(LOGGER_SELF_TEST_ERROR_SENTINEL);
+  });
+}
+
 describe('main.helpers', () => {
   describe('validateCorsConfig', () => describeValidateCorsConfig());
   describe('buildCorsOriginFn', () => describeBuildCorsOriginFn());
   describe('buildHelmetOptions', () => describeBuildHelmetOptions());
+  describe('parseLogLevel', () => describeParseLogLevel());
+  describe('getLogLevels', () => describeGetLogLevels());
+  describe('buildLoggerSelfTest', () => describeBuildLoggerSelfTest());
 });

--- a/api/src/main.helpers.ts
+++ b/api/src/main.helpers.ts
@@ -3,8 +3,86 @@
  * These configure CORS, helmet CSP, and validate environment settings.
  */
 
+import type { LogLevel } from '@nestjs/common';
+
 type CorsCallback = (err: Error | null, allow?: boolean) => void;
 type CorsOriginFn = (origin: string | undefined, cb: CorsCallback) => void;
+
+// Descending severity. A threshold like 'log' enables itself plus everything
+// to its left (more severe), e.g. error+warn+log. Order matches the original
+// inline whitelist that used to live in main.ts so existing log-shipping
+// behavior is preserved.
+const LOG_LEVELS_DESCENDING: readonly LogLevel[] = [
+  'error',
+  'warn',
+  'log',
+  'debug',
+  'verbose',
+];
+
+export function parseLogLevel(value: string | undefined): LogLevel | null {
+  if (!value) return null;
+  const normalized = value.trim().toLowerCase();
+  if ((LOG_LEVELS_DESCENDING as readonly string[]).includes(normalized)) {
+    return normalized as LogLevel;
+  }
+  return null;
+}
+
+export interface LogLevelEnv {
+  DEBUG?: string;
+  LOG_LEVEL?: string;
+  NODE_ENV?: string;
+}
+
+interface ConsoleLike {
+  warn: (msg: string) => void;
+}
+
+export function getLogLevels(
+  env: LogLevelEnv,
+  consoleLike: ConsoleLike = console,
+): LogLevel[] {
+  const rawLogLevel = env.LOG_LEVEL?.trim();
+  let threshold: LogLevel;
+  if (rawLogLevel) {
+    const parsed = parseLogLevel(rawLogLevel);
+    if (parsed) {
+      threshold = parsed;
+    } else {
+      consoleLike.warn(
+        `Invalid LOG_LEVEL="${rawLogLevel}" — falling back to "log". ` +
+          `Valid values: ${LOG_LEVELS_DESCENDING.join(', ')}`,
+      );
+      threshold = 'log';
+    }
+  } else if (env.DEBUG === 'true') {
+    threshold = 'debug';
+  } else if (env.NODE_ENV === 'development') {
+    threshold = 'debug';
+  } else {
+    threshold = 'log';
+  }
+  const endIdx = LOG_LEVELS_DESCENDING.indexOf(threshold);
+  return LOG_LEVELS_DESCENDING.slice(0, endIdx + 1);
+}
+
+interface LoggerLike {
+  warn: (message: string) => void;
+  error: (message: string) => void;
+}
+
+export const LOGGER_SELF_TEST_WARN_SENTINEL =
+  '[bootstrap-self-test] logger.warn channel active';
+export const LOGGER_SELF_TEST_ERROR_SENTINEL =
+  '[bootstrap-self-test] logger.error channel active';
+
+export function buildLoggerSelfTest(logger: LoggerLike): () => void {
+  return () => {
+    logger.warn(LOGGER_SELF_TEST_WARN_SENTINEL);
+    logger.error(LOGGER_SELF_TEST_ERROR_SENTINEL);
+  };
+}
 
 export interface HelmetOptions {
   crossOriginResourcePolicy: { policy: 'cross-origin' };

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -3,7 +3,7 @@
 import './sentry/instrument';
 
 import { NestFactory } from '@nestjs/core';
-import type { LogLevel } from '@nestjs/common';
+import { Logger } from '@nestjs/common';
 import type { NestExpressApplication } from '@nestjs/platform-express';
 import compression from 'compression';
 import helmet from 'helmet';
@@ -15,13 +15,9 @@ import {
   validateCorsConfig,
   buildCorsOriginFn,
   buildHelmetOptions,
+  getLogLevels,
+  buildLoggerSelfTest,
 } from './main.helpers';
-
-function getLogLevels(): LogLevel[] {
-  return process.env.DEBUG === 'true'
-    ? ['error', 'warn', 'log', 'debug', 'verbose']
-    : ['error', 'warn', 'log'];
-}
 
 function installAutoClientUrlDetection(app: NestExpressApplication): void {
   app.use(
@@ -70,7 +66,11 @@ function configureStaticAssets(
 
 async function bootstrap() {
   const app = await NestFactory.create<NestExpressApplication>(AppModule, {
-    logger: getLogLevels(),
+    logger: getLogLevels({
+      DEBUG: process.env.DEBUG,
+      LOG_LEVEL: process.env.LOG_LEVEL,
+      NODE_ENV: process.env.NODE_ENV,
+    }),
     rawBody: false,
   });
   app.useBodyParser('json', { limit: '2mb' });
@@ -93,5 +93,8 @@ async function bootstrap() {
     new ThrottlerExceptionFilter(),
   );
   await app.listen(process.env.PORT ?? 3000);
+  if (process.env.LOGGER_SELF_TEST === 'true') {
+    buildLoggerSelfTest(new Logger('Bootstrap'))();
+  }
 }
 void bootstrap();

--- a/web/src/hooks/use-scheduling.ts
+++ b/web/src/hooks/use-scheduling.ts
@@ -88,7 +88,13 @@ export function useRetractAllVotes() {
   });
 }
 
-/** Hook for creating an event from a selected slot. */
+/**
+ * Hook for creating an event from a selected slot.
+ *
+ * @deprecated Use POST /events with matchId param instead (ROK-1121).
+ * Endpoint retained for smoke-test compatibility — full removal tracked
+ * separately.
+ */
 export function useCreateEventFromSlot() {
   const qc = useQueryClient();
   return useMutation<{ eventId: number }, Error, { lineupId: number; matchId: number; slotId: number; recurring?: boolean }>({

--- a/web/src/lib/api/scheduling-api.ts
+++ b/web/src/lib/api/scheduling-api.ts
@@ -42,7 +42,13 @@ export async function toggleScheduleVote(
   });
 }
 
-/** Create an event from a schedule slot. */
+/**
+ * Create an event from a schedule slot.
+ *
+ * @deprecated Use POST /events with matchId param instead (ROK-1121).
+ * Endpoint retained for smoke-test compatibility — full removal tracked
+ * separately.
+ */
 export async function createEventFromSlot(
   lineupId: number,
   matchId: number,

--- a/web/src/pages/scheduling/CreateEventSection.test.tsx
+++ b/web/src/pages/scheduling/CreateEventSection.test.tsx
@@ -12,7 +12,7 @@
  * The same gate must apply to BOTH CreateFromSlot and RescheduleFromSlot.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { screen, within } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type {
     MatchDetailResponseDto,
@@ -463,6 +463,3 @@ describe('CreateEventSection — AC9: reschedule path is also gated', () => {
         ).toBeInTheDocument();
     });
 });
-
-// Helper export to silence "within is unused" if it isn't referenced.
-void within;

--- a/web/src/pages/scheduling/CreateEventSection.tsx
+++ b/web/src/pages/scheduling/CreateEventSection.tsx
@@ -149,22 +149,112 @@ export function CreateEventSection({
     hasVoted={hasVoted} readOnly={readOnly} />;
 }
 
-/** Reschedule the linked event to the selected slot's time. */
-function RescheduleFromSlot({ slots, match, matchId, linkedEventId, hasVoted, readOnly }: {
-  slots: ScheduleSlotWithVotesDto[]; match: MatchDetailResponseDto; matchId: number;
-  linkedEventId: number; hasVoted: boolean; readOnly: boolean;
+interface SlotPickerAction {
+  /** Button label when idle. */
+  label: string;
+  /** Optional pending label shown when `pending` is true. */
+  pendingLabel?: string;
+  /** Whether the action is currently executing (drives pending label + disabled). */
+  pending?: boolean;
+  /** Tailwind class fragment for the button — e.g. "bg-emerald-600 hover:bg-emerald-500". */
+  colorClass: string;
+  /** Helper text shown when user hasn't voted yet — e.g. "Vote on a time slot to enable event creation.". */
+  unvotedHint: string;
+  /** Called with the selected slot once threshold is met (or after the early-create modal confirms). */
+  onConfirm: (slot: ScheduleSlotWithVotesDto) => void;
+}
+
+/** Helper text below the action button — gate-aware + unvoted-hint fallback. */
+function SlotGateHint({ gate, hasVoted, readOnly, unvotedHint }: {
+  gate: ThresholdGate; hasVoted: boolean; readOnly: boolean; unvotedHint: string;
 }): JSX.Element | null {
+  if (gate.showHelperText) {
+    return <p className="text-xs text-muted">{gate.helperText}</p>;
+  }
+  if (!gate.canBypass && !hasVoted && !readOnly) {
+    return <p className="text-xs text-muted">{unvotedHint}</p>;
+  }
+  return null;
+}
+
+/** Internal state machine for SlotPickerWithGate — selection + confirm modal + gate. */
+function useSlotPickerState(
+  slots: ScheduleSlotWithVotesDto[],
+  match: MatchDetailResponseDto,
+  hasVoted: boolean,
+  onConfirm: (slot: ScheduleSlotWithVotesDto) => void,
+) {
   const sorted = sortedSlots(slots);
   const [selectedSlotId, setSelectedSlotId] = useState<number | null>(sorted[0]?.id ?? null);
-  const [done, setDone] = useState(false);
   const [showConfirm, setShowConfirm] = useState(false);
-  const reschedule = useRescheduleEvent(linkedEventId);
   const selectedSlot = slots.find((s) => s.id === selectedSlotId);
   const gate = useThresholdGate(match, selectedSlot, hasVoted);
-
-  const performReschedule = () => {
+  const handleClick = () => {
     if (!selectedSlot) return;
-    const start = new Date(selectedSlot.proposedTime);
+    if (!gate.thresholdMet) { setShowConfirm(true); return; }
+    onConfirm(selectedSlot);
+  };
+  return {
+    selectedSlotId, setSelectedSlotId, selectedSlot,
+    showConfirm, setShowConfirm,
+    gate, handleClick,
+  };
+}
+
+/** Action button driven by SlotPickerAction config + gate state. */
+function SlotActionButton({ action, gate, hasVoted, readOnly, selectedSlotId, onClick }: {
+  action: SlotPickerAction; gate: ThresholdGate; hasVoted: boolean; readOnly: boolean;
+  selectedSlotId: number | null; onClick: () => void;
+}): JSX.Element {
+  const canAct = gate.canBypass || (hasVoted && gate.thresholdMet);
+  const disabled = !canAct || readOnly || !!action.pending || selectedSlotId === null;
+  const label = action.pending && action.pendingLabel ? action.pendingLabel : action.label;
+  return (
+    <button type="button" onClick={onClick} disabled={disabled}
+      className={`px-6 py-2.5 text-sm font-medium ${action.colorClass} text-white rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed`}>
+      {label}
+    </button>
+  );
+}
+
+/** Slot picker + action button + helper text + early-create confirm modal. */
+function SlotPickerWithGate({ slots, match, hasVoted, readOnly, heading, action }: {
+  slots: ScheduleSlotWithVotesDto[];
+  match: MatchDetailResponseDto;
+  hasVoted: boolean;
+  readOnly: boolean;
+  heading: string;
+  action: SlotPickerAction;
+}): JSX.Element | null {
+  const s = useSlotPickerState(slots, match, hasVoted, action.onConfirm);
+  if (s.gate.shouldHide) return null;
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-semibold text-foreground uppercase tracking-wide">{heading}</h3>
+      {slots.length > 0 && (
+        <SlotSelector slots={slots} selectedId={s.selectedSlotId} onChange={s.setSelectedSlotId} />
+      )}
+      <SlotActionButton action={action} gate={s.gate} hasVoted={hasVoted} readOnly={readOnly}
+        selectedSlotId={s.selectedSlotId} onClick={s.handleClick} />
+      <SlotGateHint gate={s.gate} hasVoted={hasVoted} readOnly={readOnly} unvotedHint={action.unvotedHint} />
+      {s.showConfirm && s.selectedSlot && (
+        <EarlyCreateConfirmModal
+          distinctVoters={s.gate.distinctVoters}
+          memberCount={match.members.length}
+          onCancel={() => s.setShowConfirm(false)}
+          onConfirm={() => { s.setShowConfirm(false); action.onConfirm(s.selectedSlot!); }}
+        />
+      )}
+    </div>
+  );
+}
+
+/** Hook owning the reschedule mutation + done state for RescheduleFromSlot. */
+function useReschedulePerformer(matchId: number, linkedEventId: number) {
+  const [done, setDone] = useState(false);
+  const reschedule = useRescheduleEvent(linkedEventId);
+  const perform = (slot: ScheduleSlotWithVotesDto) => {
+    const start = new Date(slot.proposedTime);
     if (start <= new Date()) {
       toast.error('Cannot reschedule to a time in the past');
       return;
@@ -178,43 +268,29 @@ function RescheduleFromSlot({ slots, match, matchId, linkedEventId, hasVoted, re
       },
     );
   };
+  return { done, isPending: reschedule.isPending, perform };
+}
 
-  const handleClick = () => {
-    if (!gate.thresholdMet) { setShowConfirm(true); return; }
-    performReschedule();
-  };
-
-  if (done) return <RescheduledSuccessState linkedEventId={linkedEventId} />;
-  if (gate.shouldHide) return null;
-
-  const canAct = gate.canBypass || (hasVoted && gate.thresholdMet);
-  const buttonDisabled = !canAct || readOnly || reschedule.isPending || selectedSlotId === null;
-
+/** Reschedule the linked event to the selected slot's time. */
+function RescheduleFromSlot({ slots, match, matchId, linkedEventId, hasVoted, readOnly }: {
+  slots: ScheduleSlotWithVotesDto[]; match: MatchDetailResponseDto; matchId: number;
+  linkedEventId: number; hasVoted: boolean; readOnly: boolean;
+}): JSX.Element | null {
+  const r = useReschedulePerformer(matchId, linkedEventId);
+  if (r.done) return <RescheduledSuccessState linkedEventId={linkedEventId} />;
   return (
-    <div className="space-y-3">
-      <h3 className="text-sm font-semibold text-foreground uppercase tracking-wide">Reschedule Event</h3>
-      {slots.length > 0 && (
-        <SlotSelector slots={slots} selectedId={selectedSlotId} onChange={setSelectedSlotId} />
-      )}
-      <button type="button" onClick={handleClick} disabled={buttonDisabled}
-        className="px-6 py-2.5 text-sm font-medium bg-cyan-600 text-white rounded-lg hover:bg-cyan-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
-        {reschedule.isPending ? 'Rescheduling...' : 'Reschedule Event'}
-      </button>
-      {gate.showHelperText && (
-        <p className="text-xs text-muted">{gate.helperText}</p>
-      )}
-      {!gate.showHelperText && !gate.canBypass && !hasVoted && !readOnly && (
-        <p className="text-xs text-muted">Vote on a time slot to enable rescheduling.</p>
-      )}
-      {showConfirm && (
-        <EarlyCreateConfirmModal
-          distinctVoters={gate.distinctVoters}
-          memberCount={match.members.length}
-          onCancel={() => setShowConfirm(false)}
-          onConfirm={() => { setShowConfirm(false); performReschedule(); }}
-        />
-      )}
-    </div>
+    <SlotPickerWithGate
+      slots={slots} match={match} hasVoted={hasVoted} readOnly={readOnly}
+      heading="Reschedule Event"
+      action={{
+        label: 'Reschedule Event',
+        pendingLabel: 'Rescheduling...',
+        pending: r.isPending,
+        colorClass: 'bg-cyan-600 hover:bg-cyan-500',
+        unvotedHint: 'Vote on a time slot to enable rescheduling.',
+        onConfirm: r.perform,
+      }}
+    />
   );
 }
 
@@ -240,57 +316,30 @@ function CreateFromSlot({ slots, match, matchId, hasVoted, readOnly }: {
   matchId: number; hasVoted: boolean; readOnly: boolean;
 }): JSX.Element | null {
   const navigate = useNavigate();
-  const sorted = sortedSlots(slots);
-  const [selectedSlotId, setSelectedSlotId] = useState<number | null>(sorted[0]?.id ?? null);
-  const [showConfirm, setShowConfirm] = useState(false);
-  const selectedSlot = slots.find((s) => s.id === selectedSlotId);
-  const gate = useThresholdGate(match, selectedSlot, hasVoted);
 
-  const performNavigate = () => {
-    if (!selectedSlot) return;
-    const start = new Date(selectedSlot.proposedTime);
+  const performNavigate = (slot: ScheduleSlotWithVotesDto) => {
+    const start = new Date(slot.proposedTime);
     if (start <= new Date()) { toast.error('Cannot create event for a past time slot'); return; }
     const params = new URLSearchParams();
     if (match.gameId) params.set('gameId', String(match.gameId));
-    params.set('startTime', selectedSlot.proposedTime);
+    params.set('startTime', slot.proposedTime);
     params.set('matchId', String(matchId));
     navigate(`/events/new?${params.toString()}`);
   };
 
-  const handleClick = () => {
-    if (!gate.thresholdMet) { setShowConfirm(true); return; }
-    performNavigate();
-  };
-
-  if (gate.shouldHide) return null;
-
-  const canAct = gate.canBypass || (hasVoted && gate.thresholdMet);
-  const buttonDisabled = !canAct || readOnly || selectedSlotId === null;
-
   return (
-    <div className="space-y-3">
-      <h3 className="text-sm font-semibold text-foreground uppercase tracking-wide">Create Event</h3>
-      {slots.length > 0 && (
-        <SlotSelector slots={slots} selectedId={selectedSlotId} onChange={setSelectedSlotId} />
-      )}
-      <button type="button" onClick={handleClick} disabled={buttonDisabled}
-        className="px-6 py-2.5 text-sm font-medium bg-emerald-600 text-white rounded-lg hover:bg-emerald-500 transition-colors disabled:opacity-50 disabled:cursor-not-allowed">
-        Create Event
-      </button>
-      {gate.showHelperText && (
-        <p className="text-xs text-muted">{gate.helperText}</p>
-      )}
-      {!gate.showHelperText && !gate.canBypass && !hasVoted && !readOnly && (
-        <p className="text-xs text-muted">Vote on a time slot to enable event creation.</p>
-      )}
-      {showConfirm && (
-        <EarlyCreateConfirmModal
-          distinctVoters={gate.distinctVoters}
-          memberCount={match.members.length}
-          onCancel={() => setShowConfirm(false)}
-          onConfirm={() => { setShowConfirm(false); performNavigate(); }}
-        />
-      )}
-    </div>
+    <SlotPickerWithGate
+      slots={slots}
+      match={match}
+      hasVoted={hasVoted}
+      readOnly={readOnly}
+      heading="Create Event"
+      action={{
+        label: 'Create Event',
+        colorClass: 'bg-emerald-600 hover:bg-emerald-500',
+        unvotedHint: 'Vote on a time slot to enable event creation.',
+        onConfirm: performNavigate,
+      }}
+    />
   );
 }


### PR DESCRIPTION
## Summary

Batch of 4 tech-debt stories — observability + CI workflow + scheduling-poll cleanups. All per-story reviews APPROVED before merge; full local CI green (build / TypeScript / lint / unit + coverage / integration).

## Stories

| Story | Label | Reviewer | Dev SHA |
|---|---|---|---|
| **ROK-1198** | Tech Debt (High) | APPROVED | `2ac1d2b1` — separate `LOG_LEVEL` from `DEBUG`, add boot self-test |
| **ROK-1195** | Tech Debt (Med) | APPROVED | `144cd14a` — dependabot rebase via `update-branch` API instead of bot comment |
| **ROK-1199** | Tech Debt (Med) | APPROVED | `3c3d596f` — time DB queries in postgres-js wrapper, sub-ms aware formatter |
| **ROK-1194** | Tech Debt (Low) | APPROVED | `4e272ff8` (+3) — scheduling poll cleanups (5 items, 4 atomic commits) |

## What

### ROK-1198 — Production logger level inversion
- Symptom: prod logs had 25,711 DEBUG / 632 LOG / **0 WARN/ERROR/FATAL** (9.4hr window). Real warnings were being dropped silently.
- Root cause: `DEBUG` env var was overloaded for both PERF gating AND Nest log levels.
- Fix: extract pure helper `getLogLevels(env)` driven by new `LOG_LEVEL` (error/warn/log/debug/verbose). Production default `log`, dev default `debug`. Legacy `DEBUG=true` bridge preserves dev behavior. Boot self-test gated on `LOGGER_SELF_TEST=true`.
- **Operator post-merge action:** in the production Synology NAS env (wherever `DEBUG=true` is currently set — docker-compose env, mounted `.env`, or Synology Docker UI), either remove `DEBUG=true` or explicitly set `LOG_LEVEL=log` so prod threshold matches the new default. `DEBUG` retains PERF semantics — leave that knob alone if you want PERF lines.

### ROK-1195 — Dependabot rebase workflow
- Symptom: `@dependabot rebase` comments were being rejected ("only users with push access can use that command") because `github-actions[bot]` lacks push.
- Fix: replace comment trick with `gh api repos/.../pulls/{n}/update-branch -X PUT` — uses workflow's own `contents: write` token. Permissions flipped to `contents: write` + `pull-requests: read`.

### ROK-1199 — DB query duration logging
- Symptom: every `[PERF] DB | query | <ms>ms` line read `0ms` (16,642 entries, distinct values = `{0}`).
- Root cause was deeper than initial integer-rounding hypothesis: Drizzle's `Logger` interface doesn't carry duration (`logQuery` has no end-of-query callback). The 0 was hardcoded, not floored.
- Fix: replace `PerfDrizzleLogger` with `withQueryPerfLogging(client: Sql)` Proxy wrapper around `postgres-js`'s `unsafe()` — times queries via `then` interception (settles when Drizzle awaits the PendingQuery). Plus sub-ms aware formatter (`<1ms` two decimals, `>=1ms` integer).

### ROK-1194 — Scheduling poll cleanups (5 items)
1. Extract `<SlotPickerWithGate>` from `CreateEventSection.tsx` — `RescheduleFromSlot` 62→24 lines, `CreateFromSlot` 54→18, both under 30-line cap. Render shape preserved (selectors still match).
2. Drop redundant `(match as { ... }).foo` casts in `buildPollResponse` — type already declares fields optional.
3. Mark legacy `POST /lineups/:id/schedule/:matchId/create-event` `@deprecated` (zero web UI callers; smoke tests still use it as test setup).
4. Add `getSchedulePoll` integration test pinning `lineupCreatedById` join (placed in `scheduling.service.spec.ts` per planner correction — story file pointer was wrong).
5. Remove unused `void within;` line + `within` import in `CreateEventSection.test.tsx`.

## Validation

| Check | Result |
|---|---|
| Build (all workspaces) | PASS |
| TypeScript (all) | PASS |
| Lint (all) | PASS |
| Unit tests + coverage | PASS |
| Integration tests (api) | PASS — 841 tests / 72 suites |
| Migration validation | SKIPPED (no migration files) |
| Container startup | SKIPPED (no infra files) |
| Per-story code review | APPROVED ×4 |
| Playwright smoke | Deferred to CI (no UI shape changes; render selectors verified by 17/17 vitest in `CreateEventSection.test.tsx`) |

## Branch hygiene

Rebased onto `origin/main` post-merge of #699 (unblock combined: ROK-1062 + ROK-1192). No merge commits — 7 linear commits.

## Tech debt for follow-up (low priority, captured during review)

- ROK-1198: `LOG_LEVELS_DESCENDING` array name slightly misleading (sorted error→verbose, descending by Nest severity-value mapping). Inline comment explains intent. Cosmetic.
- ROK-1195: `for n in $numbers` relies on default IFS word-split; safe because `--jq '.[].number'` only emits integers, but `mapfile -t` would be marginally cleaner. Cosmetic.
- ROK-1199: doc comment in `wrapPending` says "timer starts on the original `unsafe()` call" but each chained `.values()`/`.raw()`/`.describe()` invocation actually resets the timer. Microsecond gap in Drizzle's hot path so functionally equivalent; comment slightly misleading.
- ROK-1199: `CHAINED_METHODS` does not include `cursor`/`execute`/`simple` from postgres-js's `PendingQuery` API. Drizzle doesn't call them so dormant; future cursor-based callers would silently skip timing. Not a regression vs prior behavior (which always logged 0ms).
- ROK-1194: `scheduling.service.spec.ts` outer describe arrow-fn 249→275 lines vs 60-cap (warn). Pre-existing in relaxed (750-line) test file context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)