### PR TITLE
ROK-1190: tech-debt: bump testcontainers startup timeout to 60s for macOS local

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -249,6 +249,12 @@ describe('My Feature (integration)', () => {
 - **Timeout:** 120s per test (container startup takes ~10-20s on first run).
 - **Teardown:** `closeTestApp()` runs automatically via a global `afterAll` hook registered in `setupFilesAfterEnv`. Do not call it manually in your test files.
 
+### Local startup timeout (macOS, parallel jest)
+
+`provisionDatabase()` in `api/src/common/testing/test-app.ts` chains `.withStartupTimeout(60_000)` on the `pgvector/pgvector:pg16` testcontainer to absorb macOS Docker Desktop's vmnet port-binding latency under parallel jest workers. The library default of 10s is too tight when multiple suites spin containers simultaneously and was tripping `Timed out after 10000ms while waiting for container ports to be bound to the host` during `./scripts/validate-ci.sh --full`.
+
+CI is unaffected: GitHub Actions sets `DATABASE_URL` to a Postgres service container, which short-circuits `provisionDatabase()` before testcontainers is touched. The 60s timeout only governs the local fallback path.
+
 ### HTTP endpoints vs direct DB operations
 
 Prefer **HTTP endpoints** (`testApp.request.get/post/put/delete`) for tests that verify the full request-response cycle — auth, validation, serialization, and persistence through the real controller+service stack.

--- a/api/src/common/testing/test-app.ts
+++ b/api/src/common/testing/test-app.ts
@@ -158,6 +158,7 @@ async function provisionDatabase(): Promise<{
     .withDatabase('raid_ledger_test')
     .withUsername('test')
     .withPassword('test')
+    .withStartupTimeout(60_000)
     .start();
   return { connectionString: container.getConnectionUri(), container };
 }


### PR DESCRIPTION
## Summary
- Chains `.withStartupTimeout(60_000)` on the `pgvector/pgvector:pg16` `PostgreSqlContainer` builder in `api/src/common/testing/test-app.ts` so parallel jest workers absorb macOS Docker Desktop's vmnet port-binding latency instead of failing with the 10s default.
- Documents the choice + the CI-vs-local divergence in `TESTING.md`. CI is unaffected — GitHub Actions sets `DATABASE_URL` to a Postgres service container, which short-circuits `provisionDatabase()` before testcontainers is touched.

## Linear
ROK-1190

## Test plan
- [x] `npm run build -w api` clean
- [x] `npx tsc --noEmit -p api/tsconfig.json` clean
- [x] `npm run lint -w api` 0 errors / 898 pre-existing warnings (none introduced)
- [x] `npm run test -w api` — 424 suites / 5740 tests PASS (~38s)
- [x] `npm run test:integration -w api` — 70 suites / 824 tests PASS, run twice green (508s + 624s) on macOS Docker Desktop
- [x] Operator reviewed diff and approved