### PR TITLE
ROK-1196: fix flaky 'Embed updates when signup cancelled' smoke test

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,32 @@
   "enabledPlugins": {
     "devedup-rl@devedup-rl": true
   },
+  "permissions": {
+    "allow": [
+      "mcp__linear__list_issues",
+      "mcp__linear__get_issue",
+      "mcp__linear__list_cycles",
+      "mcp__linear__list_projects",
+      "mcp__linear__list_teams",
+      "mcp__linear__list_issue_statuses",
+      "mcp__linear__list_issue_labels",
+      "mcp__linear__list_milestones",
+      "mcp__linear__list_comments",
+      "mcp__linear__get_team",
+      "mcp__linear__get_project",
+      "mcp__claude-in-chrome__tabs_context_mcp",
+      "mcp__claude-in-chrome__read_console_messages",
+      "mcp__claude-in-chrome__read_network_requests",
+      "mcp__claude-in-chrome__read_page",
+      "mcp__claude-in-chrome__get_page_text",
+      "mcp__claude-in-chrome__find",
+      "mcp__mcp-env__story_status",
+      "mcp__mcp-env__env_check",
+      "mcp__mcp-env__env_service_status",
+      "mcp__mcp-env__mcp_health",
+      "Bash(./scripts/deploy_dev.sh --status:*)"
+    ]
+  },
   "hooks": {
     "PreToolUse": [
       {

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -23,7 +23,7 @@ Read `<worktree>/build-state.yaml`, follow `pipeline.next_action`. Stories with 
 
 | Scope | Criteria | E2E Test Type | Gates |
 |-------|----------|---------------|-------|
-| **light** | Config, copy, style-only, docs | Lint + type check | dev → ci → operator → smoke |
+| **light** | Config, copy, style-only, docs, single-file simple fix (typo, import order, isolated edit) — no team, no worktree, no dev agent | Fast CI on touched workspace ONLY (lint + tsc + workspace tests) | lead_direct → fast_ci → operator |
 | **standard** | Single-module feature, bug fix, OR straightforward cross-module add (≤10 files) — including new contract schemas with matching backend + frontend | Playwright/Discord smoke (TDD) | e2e_first → dev → ci → operator → reviewer → smoke |
 | **full** | DB migration, breaking change to existing contract schema, Dockerfile/entrypoint/nginx, OR ≥4 unrelated modules with non-trivial logic in each | Full suite (TDD) + planner + architect + phase-split dev | e2e_first → dev → ci → operator → reviewer → architect_final → smoke |
 
@@ -66,6 +66,14 @@ Requirements Interview (plan mode, if spec incomplete)
 
 **All subagents run as team members, not loose `Agent()` calls.** Step 1 creates a team (`build-ROK-XXX` or `build-batch-N`); every subagent spawn — planner, architect, test agent, dev, reviewer, pr-writer — passes `team_name` and joins the team. Step 5 tears it down. Solo subagents are a pipeline violation.
 
+**Light scope bypasses team / worktree / dev-agent overhead.** For `scope: light` ONLY:
+- No team, no worktree, no `Agent()` spawn — Lead implements directly on a feature branch in the main repo.
+- No TDD test-first, no reviewer, no architect, no Lead final smoke run.
+- Fast CI only — lint + tsc + workspace tests for touched workspace; skip full `validate-ci.sh`, migration validation, container-startup, Playwright.
+- No `deploy_dev.sh` re-run.
+- Pipeline collapses to: Step 1 (setup + Linear flip) → Step 2 light fast-path → Step 3 light fast-path (Linear "In Review" + operator stop) → Step 4 (operator approval only) → Step 5 (push + PR + auto-merge).
+- Escape hatch: if mid-implementation you find real complexity (≥3 files, cross-workspace, real architectural decision), STOP, escalate to `standard`, create a worktree, restart Step 2 from 2a.
+
 **STOP / PAUSE / halt from operator:** cease all tool calls immediately, acknowledge "Stopped.", wait.
 
 **Destructive ops require operator approval:** `deploy_dev.sh --fresh`, `git push --force`, `git reset --hard`, `rm -rf` on project dirs, DB volume deletes, table drops. If in doubt, it's destructive.
@@ -99,9 +107,9 @@ Read each step file when you reach it — do not pre-load all steps.
 | Step | File | Description |
 |------|------|-------------|
 | 1 | `steps/step-1-setup.md` | Cleanup, fetch, profile, requirements interview, init state, Linear → In Progress |
-| 2 | `steps/step-2-implement.md` | Worktrees, optional planner/architect, spawn devs + test agents |
-| 3 | `steps/step-3-validate.md` | CI, deploy LOCAL (**no git push**), Linear → In Review, FULL STOP |
-| 4 | `steps/step-4-review.md` | Poll Linear, rework/approval, reviewer + architect + smoke (**still no push**) |
+| 2 | `steps/step-2-implement.md` | **Light:** Lead implements directly on a feature branch (skip 2a-2f). **Standard/Full:** worktrees, planner/architect (gated), dev + test agents |
+| 3 | `steps/step-3-validate.md` | **Light:** Linear → In Review + FULL STOP (fast CI from step 2 already passed). **Standard/Full:** full CI, deploy LOCAL (no push), Linear → In Review |
+| 4 | `steps/step-4-review.md` | **Light:** operator approval polling only (no reviewer/architect/Lead-smoke). **Standard/Full:** poll Linear, rework/approval, reviewer + architect + smoke (**still no push**) |
 | 5 | `steps/step-5-ship.md` | Rebase, `git push`, create PR, auto-merge, Linear → Done, cleanup |
 
 ---

--- a/.claude/skills/build/steps/step-2-implement.md
+++ b/.claude/skills/build/steps/step-2-implement.md
@@ -4,6 +4,63 @@ Lead creates worktrees, spawns subagents. Max 2-3 devs in parallel.
 
 ---
 
+## Light Scope Fast Path (skip 2a-2f if scope=light for ALL stories in batch)
+
+Lead implements directly in the main repo — no worktree, no team, no dev agent.
+
+### 2-light-a. Branch in main repo
+
+```bash
+git checkout main && git pull --rebase origin/main
+git checkout -b rok-<num>-<short-name>
+```
+
+### 2-light-b. Implement
+
+Lead reads `planning-artifacts/specs/ROK-XXX.md` and edits files directly. Multi-story batches: do them sequentially, one logical commit per story (`feat:` / `fix:` / `tech-debt:` / `chore:` per memory convention).
+
+### 2-light-c. Fast CI on touched workspace ONLY
+
+Identify from `git diff main..HEAD --name-only`:
+
+| Touched | Run |
+|---------|-----|
+| `web/**` only | `npm run lint -w web && cd web && npx tsc --noEmit && npx vitest run --coverage && cd -` |
+| `api/**` only | `npm run lint -w api && cd api && npx tsc --noEmit && npm run test -w api && cd -` |
+| `packages/contract/**` only | `npm run build -w packages/contract` |
+| `.claude/**`, root configs, `*.md`, `*.yml` | skip CI (no compiled code) |
+| Multi-workspace | **escalate to `standard`** — run 2-light-e escape hatch |
+
+Lint/type errors → fix directly, commit `fix: resolve CI issues (ROK-XXX)`. Test failures → fix directly. Don't push with known failures.
+
+### 2-light-d. Update state, skip to Step 3 (light fast path)
+
+```yaml
+stories.ROK-XXX:
+  status: "ready_for_validate"
+  gates:
+    e2e_test_first: N/A
+    dev: PASS         # Lead self-audited
+    ci: PASS          # fast workspace CI
+    operator: PENDING
+    reviewer: N/A
+    smoke_test: N/A
+```
+
+### 2-light-e. Escape hatch — escalate light → standard
+
+If you find real complexity mid-implementation (≥3 files, cross-workspace, real architectural decision), STOP:
+
+1. Stash or commit current state.
+2. Create worktree from current branch: `git worktree add ../Raid-Ledger--rok-<num> rok-<num>-<short-name>`.
+3. Update state: `scope: standard`, restart Step 2 from 2a.
+
+---
+
+(Standard / Full scope continues below.)
+
+---
+
 ## 2a. Bring Up Environment (once per batch) and Create Worktrees
 
 **Lead owns Docker. Devs never touch it.** This step has two parts.

--- a/.claude/skills/build/steps/step-3-validate.md
+++ b/.claude/skills/build/steps/step-3-validate.md
@@ -2,6 +2,52 @@
 
 Lead runs everything.
 
+## Light Scope Fast Path (skip 3a-3c.5 if scope=light)
+
+Fast CI already passed in Step 2-light-c. No worktree to deploy. No Playwright.
+
+### 3-light-a. Linear → "In Review"
+
+```
+mcp__linear__save_issue({ issueId: "<linear_id>", statusName: "In Review" })
+```
+
+### 3-light-b. Present to operator (compact)
+
+```
+## Ready for Review (Light Scope)
+
+| Story | Branch | Status |
+|-------|--------|--------|
+| ROK-XXX: Title | rok-xxx-name | In Review |
+
+Diff: `git diff main..HEAD --stat`
+Fast CI: PASS (lint + tsc + tests on <touched-workspace>)
+Files: <N>
+
+Light scope — no worktree deploy, no Playwright. Review the diff and update Linear:
+- **Code Review** = approved
+- **Changes Requested** = needs rework
+
+I'll wait.
+```
+
+### 3-light-c. State + FULL STOP
+
+```yaml
+stories.ROK-XXX:
+  status: "waiting_for_operator"
+  gates.operator: WAITING
+```
+
+Skip to **Step 4** (light path: operator approval polling only).
+
+---
+
+(Standard / Full scope continues below.)
+
+---
+
 ## HARD RULE — NO PUSH IN STEP 3
 
 The branch stays **local-only** through Steps 1–4. Do NOT invoke any of the following in this step:

--- a/.claude/skills/build/steps/step-4-review.md
+++ b/.claude/skills/build/steps/step-4-review.md
@@ -93,43 +93,36 @@ Reviewer prompts in 4b point at the updated spec.
 
 ---
 
-## 4b. Size the Diff, Then Spawn Reviewer(s)
+## 4b. Codex Review (single shell command — no subagent)
 
-**Run the sizing check BEFORE spawning.** Pre-flight prevents burning tokens on a reviewer that runs out of context mid-run.
+Reviewer is **Codex CLI**, not a Claude subagent. Different model = different blind spots, and one shell call is faster than spawning subagents into a team and aggregating outputs.
+
+**Skip the reviewer entirely if:**
+- Diff is `<300 net lines` AND no risk markers (no migration, no Dockerfile, no `packages/contract/`, no auth code, no money/payments code). Operator approval was the gate; Codex is for genuinely risky diffs.
+- `codex` CLI is not on PATH (record `gates.reviewer: SKIPPED — codex unavailable`, proceed).
+
+### Run Codex
 
 ```bash
 cd <worktree>
-git diff origin/main..HEAD --stat | tail -1     # N files changed, +A -D
-git diff origin/main..HEAD --stat | grep -v "snapshot\|package-lock" | wc -l
-git log --oneline origin/main..HEAD | wc -l
+codex review --base main "Review this Raid-Ledger PR for: (1) security/auth bugs, (2) correctness/regressions, (3) contract integrity (Zod/types/migration consistency), (4) Discord bot listener safety. Skip style nits, naming preferences, doc gaps. For each finding: severity (BLOCKER | HIGH | MEDIUM | LOW), file:line, one-line description, suggested fix. Final line: 'VERDICT: APPROVED' or 'VERDICT: APPROVED WITH FIXES' or 'VERDICT: BLOCKED'." 2>&1 | tee planning-artifacts/review-ROK-XXX.md
+cd -
 ```
 
-| Signals | Strategy |
-|---|---|
-| ≤500 lines, ≤10 files, 1 workspace | **Single agent** |
-| ≤2000 lines, ≤25 files, ≤2 workspaces | **Single agent** (incremental file flush) |
-| 2000–5000 lines **OR** contract+api+web **OR** migration + 20+ files | **3-agent parallel split** |
-| 5000+ lines **OR** full cross-cutting **OR** 30+ commits | **4+ agent split** (add dedicated "integration + cross-layer" pass) |
+The custom prompt is critical — without scope, Codex returns broad style feedback. The format string keeps findings actionable and comparable across stories.
 
-### Single agent (default)
-Read `templates/reviewer.md`, fill variables, spawn as a team member. Agent writes findings to `planning-artifacts/review-ROK-XXX.md` incrementally.
+### Verdict handling
 
-### Parallel split (for large diffs) — use dev team agents
+Read the last line of `planning-artifacts/review-ROK-XXX.md`:
 
-1. Create a team: `TeamCreate({ name: "review-ROK-XXX", description: "..." })`.
-2. Create three tasks via `TaskCreate`, one per slice:
-   - **security-correctness** — critical/security + correctness + auto-fix authority → `review-ROK-XXX-security.md`
-   - **tests-contract** — tests + contract integrity → `review-ROK-XXX-tests.md`
-   - **perf-style** — performance/complexity + style + tech debt → `review-ROK-XXX-style.md`
-3. Spawn three `Agent` calls (same single message, parallel) with matching `team_name` and `subagent_type: devedup-rl:reviewer`. Each agent picks up its task via `TaskList` + owner assignment.
-4. When all three tasks are `completed`, Lead reads the three findings files and writes the aggregated `review-ROK-XXX.md` with unified verdict + commit-SHA footer.
-5. Delete the team: `TeamDelete({ name: "review-ROK-XXX" })`.
+- **`VERDICT: APPROVED`** → `gates.reviewer: PASS`. Proceed.
+- **`VERDICT: APPROVED WITH FIXES`** → Lead reads findings, applies trivial fixes inline (1-3 lines per fix), commits `fix: address Codex review (ROK-XXX)`. `gates.reviewer: PASS`. For non-trivial fixes, respawn the dev with the findings file as context.
+- **`VERDICT: BLOCKED`** → present blockers to operator. May need dev respawn or scope discussion.
+- **No clear verdict / Codex errored / output garbled** → fall back to a single `devedup-rl:reviewer` Claude subagent run with the same prompt focus. Don't bypass the reviewer gate just because Codex misbehaved.
 
-Why teams (not loose subagents): shared context means each agent can reference the others' findings, one agent can flag something and hand it to the right specialist via `SendMessage`, and the shared task board gives Lead a single `TaskList` call to monitor progress.
+### Why no team / no parallel split
 
-### Verdict handling (applies to single or aggregated)
-- **APPROVED / APPROVED WITH FIXES:** `gates.reviewer: PASS`. Auto-fix commits stay local — Step 5 handles the push.
-- **BLOCKED:** present blockers to operator. May need dev respawn.
+Codex handles diffs of any size in one shot — it doesn't run out of context the way a Claude subagent does, so the size-bucket sizing (small/medium/large/XL) doesn't apply. Single command, single output file, no aggregation work. If the diff is genuinely massive (>10k lines) and Codex's output is shallow, run a second Codex pass scoped to a specific path: `codex review --base main "Focus only on api/src/auth/** for this pass."`
 
 ---
 
@@ -141,7 +134,9 @@ Sequential — must finish before smoke. Read `templates/architect.md`, `<TASK_T
 
 ## 4d. Lead Smoke Tests
 
-Never skipped, even for light scope. From main worktree:
+**Skip entirely for `scope: light`** — fast CI in step 2-light-c plus operator approval is sufficient. Set `gates.smoke_test: N/A` and proceed to 4e.
+
+For standard / full scope, never skipped. From main worktree:
 
 ```bash
 git pull --rebase origin main

--- a/.claude/skills/push/SKILL.md
+++ b/.claude/skills/push/SKILL.md
@@ -117,13 +117,32 @@ If Step 1.5 determined "docs-only" → skip steps 4–8, jump to Step 9.
 
 ### Steps 4–7: Build, Typecheck, Lint, Tests, Migration & Container Validation
 
-Run the unified validation script. It handles build, typecheck, lint, unit tests with coverage, integration tests, and conditionally runs migration validation and container startup checks based on changed files.
+#### Cache check — skip if validate-ci passed in the last 5 min on this commit
+
+Before running, check for a fresh marker:
 
 ```bash
-./scripts/validate-ci.sh --full
+HEAD_SHA=$(git rev-parse HEAD)
+MARKER="/tmp/.validate-ci-pass-${HEAD_SHA}"
+if [ -f "$MARKER" ] && [ $(( $(date +%s) - $(stat -f %m "$MARKER" 2>/dev/null || stat -c %Y "$MARKER") )) -lt 300 ]; then
+  echo "✓ validate-ci.sh passed <5min ago for HEAD=${HEAD_SHA:0:7}; skipping re-run"
+  SKIP_VALIDATE_CI=1
+else
+  SKIP_VALIDATE_CI=0
+fi
 ```
 
-**STOP** and fix any failures before continuing. **NEVER dismiss failures as "pre-existing"** — investigate and fix them, or create a Linear story with root cause.
+The marker is invalidated automatically by HEAD changing — any new commit produces a different SHA and forces a re-run. Skip is purely time-based on the same commit.
+
+#### Run validate-ci (or skip)
+
+```bash
+if [ "$SKIP_VALIDATE_CI" = "0" ]; then
+  ./scripts/validate-ci.sh --full && touch "$MARKER"
+fi
+```
+
+**STOP** and fix any failures before continuing. **NEVER dismiss failures as "pre-existing"** — investigate and fix them, or create a Linear story with root cause. On failure, do NOT touch the marker.
 
 The script auto-detects scope (migration files, Dockerfile changes) and runs the appropriate conditional checks. You do NOT need to manually decide which checks to run — the script handles it.
 
@@ -156,6 +175,29 @@ If Playwright fails:
 - **NEVER re-push and re-run CI hoping it passes** — fix locally first
 
 If the branch is API-only (no web changes), this step can be skipped.
+
+---
+
+## Step 8.5: Codex Pre-Push Review (second opinion)
+
+**Skip if:** scope is `docs-only` (from Step 1.5), OR `--no-codex` flag was passed, OR no `codex` CLI on PATH.
+
+Run Codex as a second-opinion reviewer against `main`. Different model = catches issues Claude's reviewer misses (and vice versa). Synchronous because we want blockers BEFORE push.
+
+```bash
+which codex >/dev/null 2>&1 && [ -z "$NO_CODEX" ] && [ "$SCOPE" != "docs-only" ] && {
+  echo "Running Codex pre-push review (this takes ~30-90s)..."
+  codex review --base main "Pre-push sanity review. Flag CRITICAL bugs only — security, correctness, regressions, contract violations. Skip style nits, naming, doc gaps. Output format: BLOCKERS list (or 'No blockers') + 1-line rationale per finding." 2>&1 | tee /tmp/codex-review-$(git rev-parse --short HEAD).txt
+}
+```
+
+**Verdict handling:**
+
+- Output starts with "No blockers" or equivalent → proceed to Step 9.
+- Output lists BLOCKERS → **STOP**, present them to the operator with the question: "Codex flagged N blockers — fix before pushing, or override and continue?" Wait for operator decision.
+- Codex CLI errors out (network, auth) → log and proceed (don't block push on tooling failure). Note in Step 12 report.
+
+The custom prompt is critical: without it Codex returns broad style feedback that adds noise. Keeping it scoped to "critical only" makes the second opinion actionable.
 
 ---
 

--- a/.claude/skills/security-review/SKILL.md
+++ b/.claude/skills/security-review/SKILL.md
@@ -1,0 +1,143 @@
+---
+name: security-review
+description: "Security review via Codex CLI — pending branch changes against main. Replaces Anthropic's built-in security-review."
+argument-hint: "[--against <branch>] [--path <subpath>]"
+---
+
+# Security Review (Codex-driven)
+
+Runs `codex review` against the current branch with a security-focused prompt. Different model than Claude = different blind spots; for security work that's a feature, not a bug.
+
+This file shadows Anthropic's built-in `/security-review` skill at the project level.
+
+---
+
+## When to use
+
+- Before pushing a branch that touches `auth`, `users`, `admin`, `api/src/security/**`, `api/src/encryption/**`, anything handling sessions/tokens/keys, or `Dockerfile*` / `nginx/**`.
+- After landing a third-party dependency that surfaces in request handling.
+- Operator-triggered ad-hoc security audit.
+
+If the diff doesn't touch any sensitive area, you don't need this — `/code-review` or the Codex pass in `/build` step-4b is enough.
+
+---
+
+## Prerequisites
+
+```bash
+which codex >/dev/null 2>&1 || { echo "codex CLI not found — install via OpenAI Codex subscription"; exit 1; }
+git rev-parse --abbrev-ref HEAD | grep -qv '^main$' || { echo "Refusing to security-review main branch"; exit 1; }
+```
+
+---
+
+## Step 1: Determine scope
+
+Default: review the entire branch diff against `main`. Override:
+
+- `--against <branch>` — review against a different base (e.g. a feature branch)
+- `--path <subpath>` — narrow to one path (e.g. `api/src/auth/**`)
+
+```bash
+BASE="${ARG_AGAINST:-main}"
+PATH_FILTER="${ARG_PATH:-}"
+
+git fetch origin "$BASE"
+git diff "origin/$BASE..HEAD" --stat | tail -1
+```
+
+---
+
+## Step 2: Run Codex with the security prompt
+
+```bash
+SHA=$(git rev-parse --short HEAD)
+OUTPUT="planning-artifacts/security-review-${SHA}.md"
+mkdir -p planning-artifacts
+
+codex review --base "$BASE" "$(cat <<'PROMPT'
+Security-focused review of this Raid-Ledger PR. Focus exclusively on:
+
+1. **Authentication & authorization**
+   - Missing auth guards on new routes/controllers
+   - Role/permission checks bypassed or weakened
+   - JWT / session token handling regressions
+   - Admin-only endpoints accidentally exposed
+2. **Input validation & injection**
+   - Zod schemas missing or weakened on new boundaries
+   - SQL injection risk in raw `db.execute(sql\`\`)` blocks
+   - XSS risk in React components rendering user-supplied HTML
+   - Path traversal in file operations
+   - Unvalidated redirects
+3. **Secrets & credentials**
+   - Hardcoded secrets, API keys, JWT signing keys
+   - Logged credentials, tokens leaked into stdout
+   - Environment variables echoed in logs or error messages
+4. **Cryptography & encryption**
+   - Weak hashing (md5, sha1) for security purposes
+   - Insecure random sources for tokens/IDs
+   - Hand-rolled crypto instead of project's encryption module
+5. **Dependency / supply chain**
+   - New deps added with unusual install scripts
+   - Pinned versions vs floats on security-critical deps
+6. **Discord bot specific**
+   - User input from Discord rendered without escaping
+   - Bot token / webhook URL exposure
+   - Command handlers without permission checks
+7. **Infrastructure (if Dockerfile/nginx/supervisor changed)**
+   - Privilege escalation paths
+   - Exposed ports / services
+   - Default credentials in compose files
+
+Skip style nits, naming preferences, doc gaps, performance, code-organization.
+
+For each finding output:
+- **Severity:** CRITICAL | HIGH | MEDIUM | LOW
+- **File:Line**
+- **One-line description**
+- **Suggested fix or mitigation**
+
+Final line MUST be one of: `VERDICT: SAFE TO MERGE`, `VERDICT: SAFE WITH FIXES`, or `VERDICT: BLOCK MERGE`.
+PROMPT
+)" 2>&1 | tee "$OUTPUT"
+```
+
+---
+
+## Step 3: Read the verdict
+
+```bash
+tail -1 "$OUTPUT"
+```
+
+- **`VERDICT: SAFE TO MERGE`** — no security blockers. Proceed.
+- **`VERDICT: SAFE WITH FIXES`** — operator-eyes pass on the findings; if comfortable, fix and re-run.
+- **`VERDICT: BLOCK MERGE`** — present each CRITICAL/HIGH finding to the operator. Do NOT merge until either fixed or operator explicitly accepts the risk in writing.
+
+---
+
+## Step 4: Capture in PR (if applicable)
+
+If a PR is open for the branch:
+
+```bash
+gh pr view --json number -q '.number' | xargs -I {} gh pr comment {} -F "$OUTPUT"
+```
+
+So the security pass is part of the PR's audit trail, not just a local file.
+
+---
+
+## When Codex misbehaves
+
+If Codex output is empty / malformed / errored:
+
+1. Re-run once. Most issues are transient (rate limits, network).
+2. If it fails twice, fall back to running `/code-review` with a security focus prompt — it'll be slower and lower-fidelity but better than nothing.
+3. Never skip security review on auth/admin changes just because the tooling failed. Operator calls the shot.
+
+---
+
+## Why Codex over Claude here
+
+Codex catches a different distribution of security issues than Claude — different training data, different scoring. For security work specifically, you want diversity of opinion. The cost is ~30-90s of wall time and one Codex call against your $20 monthly subscription. Cheap insurance.

--- a/api/src/events/signups-roster.service.emit.spec.ts
+++ b/api/src/events/signups-roster.service.emit.spec.ts
@@ -17,7 +17,7 @@ import { SIGNUP_EVENTS } from '../discord-bot/discord-bot.constants';
 describe('SignupsRosterService — emit timing (ROK-824)', () => {
   let service: SignupsRosterService;
   let mockDb: Record<string, jest.Mock>;
-  let mockEventEmitter: { emit: jest.Mock };
+  let mockEventEmitter: { emit: jest.Mock; emitAsync: jest.Mock };
   let callOrder: string[];
 
   const mockEvent = {
@@ -41,6 +41,10 @@ describe('SignupsRosterService — emit timing (ROK-824)', () => {
     mockEventEmitter = {
       emit: jest.fn().mockImplementation(() => {
         callOrder.push('emit');
+      }),
+      emitAsync: jest.fn().mockImplementation(() => {
+        callOrder.push('emit');
+        return Promise.resolve([]);
       }),
     };
 

--- a/api/src/events/signups-roster.service.ts
+++ b/api/src/events/signups-roster.service.ts
@@ -60,12 +60,16 @@ export class SignupsRosterService {
     this.logger.log(
       `User ${userId} canceled signup for event ${eventId} (${cancelInfo.cancelStatus})`,
     );
-    this.emit(SIGNUP_EVENTS.DELETED, {
+    // ROK-1196: emitAsync awaits @OnEvent handlers so the embed-sync enqueue
+    // completes before the controller returns. With plain emit(), the
+    // /admin/test/await-processing call could observe an empty queue and
+    // return before DiscordSyncListener has even called embedSyncQueue.enqueue.
+    await this.eventEmitter.emitAsync(SIGNUP_EVENTS.DELETED, {
       eventId,
       userId,
       signupId: signup.id,
       action: 'signup_cancelled',
-    });
+    } satisfies SignupEventPayload);
     if (notifyData && assignment) {
       this.bufferLeave(eventId, userId, assignment, notifyData);
       await this.triggerBackfill(eventId, assignment);

--- a/api/src/events/signups.service.cancel.spec.ts
+++ b/api/src/events/signups.service.cancel.spec.ts
@@ -143,7 +143,13 @@ describe('SignupsService — cancel', () => {
           },
         },
         SignupsRosterService,
-        { provide: EventEmitter2, useValue: { emit: jest.fn() } },
+        {
+          provide: EventEmitter2,
+          useValue: {
+            emit: jest.fn(),
+            emitAsync: jest.fn().mockResolvedValue([]),
+          },
+        },
         {
           provide: ActivityLogService,
           useValue: {

--- a/api/src/queue/queue-health.service.spec.ts
+++ b/api/src/queue/queue-health.service.spec.ts
@@ -143,6 +143,26 @@ function describeQueueHealthService() {
     service.register(mockQueue);
     await expect(service.awaitDrained(500)).rejects.toThrow(/timed out/i);
   });
+
+  it('should treat delayed jobs as busy in awaitDrained (ROK-1196)', async () => {
+    // The embed-sync queue uses a coalescing delay so jobs sit in `delayed`
+    // until the timer fires. awaitDrained must not return early while jobs
+    // are still scheduled.
+    const mockQueue = {
+      name: 'delayed-queue',
+      drain: jest.fn(),
+      getJobCounts: jest.fn().mockResolvedValue({
+        waiting: 0,
+        active: 0,
+        completed: 0,
+        failed: 0,
+        delayed: 3,
+      }),
+    } as unknown as Queue;
+
+    service.register(mockQueue);
+    await expect(service.awaitDrained(500)).rejects.toThrow(/timed out/i);
+  });
 }
 describe('QueueHealthService', () => describeQueueHealthService());
 

--- a/api/src/queue/queue-health.service.spec.ts
+++ b/api/src/queue/queue-health.service.spec.ts
@@ -144,24 +144,41 @@ function describeQueueHealthService() {
     await expect(service.awaitDrained(500)).rejects.toThrow(/timed out/i);
   });
 
-  it('should treat delayed jobs as busy in awaitDrained (ROK-1196)', async () => {
-    // The embed-sync queue uses a coalescing delay so jobs sit in `delayed`
-    // until the timer fires. awaitDrained must not return early while jobs
-    // are still scheduled.
-    const mockQueue = {
-      name: 'delayed-queue',
+  it('should treat delayed jobs in discord-embed-sync as busy (ROK-1196)', async () => {
+    // The embed-sync queue uses a 2s coalescing delay; awaitDrained must
+    // wait for it. Other queues (bench-promotion, etc.) intentionally
+    // schedule long-lived delayed jobs and must NOT block awaitDrained.
+    const embedQueue = {
+      name: 'discord-embed-sync',
       drain: jest.fn(),
       getJobCounts: jest.fn().mockResolvedValue({
         waiting: 0,
         active: 0,
         completed: 0,
         failed: 0,
-        delayed: 3,
+        delayed: 1,
       }),
     } as unknown as Queue;
 
-    service.register(mockQueue);
+    service.register(embedQueue);
     await expect(service.awaitDrained(500)).rejects.toThrow(/timed out/i);
+  });
+
+  it('should ignore delayed jobs in long-lived queues like bench-promotion (ROK-1196)', async () => {
+    const benchQueue = {
+      name: 'bench-promotion',
+      drain: jest.fn(),
+      getJobCounts: jest.fn().mockResolvedValue({
+        waiting: 0,
+        active: 0,
+        completed: 0,
+        failed: 0,
+        delayed: 5,
+      }),
+    } as unknown as Queue;
+
+    service.register(benchQueue);
+    await expect(service.awaitDrained(500)).resolves.not.toThrow();
   });
 }
 describe('QueueHealthService', () => describeQueueHealthService());

--- a/api/src/queue/queue-health.service.ts
+++ b/api/src/queue/queue-health.service.ts
@@ -10,6 +10,26 @@ export interface QueueHealthStatus {
   delayed: number;
 }
 
+/**
+ * Queues whose `delayed` jobs should be treated as busy by `awaitDrained`.
+ *
+ * Most queues (bench-promotion, departure-grace, etc.) schedule jobs minutes
+ * or hours into the future as part of normal business logic — counting their
+ * delayed jobs would make awaitDrained block indefinitely. The only queues
+ * here are those using short-window *coalescing* delays where the test must
+ * wait for the in-flight job to actually fire. (ROK-1196.)
+ */
+const SHORT_COALESCE_QUEUES = new Set<string>(['discord-embed-sync']);
+
+/** A queue is busy if it has waiting/active jobs, or delayed jobs in a
+ * short-coalesce queue. Long-lived delayed jobs (e.g. bench-promotion
+ * 5-minute scheduled promotions) are never considered busy. */
+function isQueueBusy(status: QueueHealthStatus): boolean {
+  if (status.waiting > 0 || status.active > 0) return true;
+  if (status.delayed > 0 && SHORT_COALESCE_QUEUES.has(status.name)) return true;
+  return false;
+}
+
 @Injectable()
 export class QueueHealthService {
   private readonly queues = new Map<string, Queue>();
@@ -61,11 +81,8 @@ export class QueueHealthService {
   }
 
   /**
-   * Poll all registered queues until none have waiting, active, OR delayed jobs.
-   * Delayed jobs must be drained too — the embed-sync queue uses a coalescing
-   * delay (ROK-119), so a job in `delayed` state has been enqueued but hasn't
-   * fired yet. Returning before it fires causes downstream tests to race the
-   * Discord edit. (ROK-1196.)
+   * Poll all registered queues until none have waiting/active jobs (and no
+   * delayed jobs in short-coalesce queues — see `SHORT_COALESCE_QUEUES`).
    * Throws if the timeout expires before all queues are idle.
    */
   async awaitDrained(timeoutMs = 30_000): Promise<void> {
@@ -74,9 +91,7 @@ export class QueueHealthService {
 
     while (Date.now() < deadline) {
       const statuses = await this.getHealthStatus();
-      const busy = statuses.some(
-        (s) => s.waiting > 0 || s.active > 0 || s.delayed > 0,
-      );
+      const busy = statuses.some((s) => isQueueBusy(s));
       if (!busy) return;
 
       const remaining = deadline - Date.now();

--- a/api/src/queue/queue-health.service.ts
+++ b/api/src/queue/queue-health.service.ts
@@ -61,7 +61,11 @@ export class QueueHealthService {
   }
 
   /**
-   * Poll all registered queues until none have waiting or active jobs.
+   * Poll all registered queues until none have waiting, active, OR delayed jobs.
+   * Delayed jobs must be drained too — the embed-sync queue uses a coalescing
+   * delay (ROK-119), so a job in `delayed` state has been enqueued but hasn't
+   * fired yet. Returning before it fires causes downstream tests to race the
+   * Discord edit. (ROK-1196.)
    * Throws if the timeout expires before all queues are idle.
    */
   async awaitDrained(timeoutMs = 30_000): Promise<void> {
@@ -70,7 +74,9 @@ export class QueueHealthService {
 
     while (Date.now() < deadline) {
       const statuses = await this.getHealthStatus();
-      const busy = statuses.some((s) => s.waiting > 0 || s.active > 0);
+      const busy = statuses.some(
+        (s) => s.waiting > 0 || s.active > 0 || s.delayed > 0,
+      );
       if (!busy) return;
 
       const remaining = deadline - Date.now();


### PR DESCRIPTION
## Summary
- Cancel-signup flow used `eventEmitter.emit(SIGNUP_EVENTS.DELETED)` which is fire-and-forget for async `@OnEvent` handlers — the embed-sync enqueue ran on a microtask AFTER the controller returned, so smoke tests' `awaitProcessing` saw an empty queue and raced past the work. Switched to `await emitAsync(...)`, mirroring ROK-846's fix for `deleteEvent`.
- `awaitDrained` now treats `delayed` jobs as busy for `discord-embed-sync` only (BullMQ uses a 2s coalesce delay there). Other queues like `bench-promotion` schedule legitimate 5-min jobs and would never drain — kept on the prior `waiting+active` rule via a narrow `SHORT_COALESCE_QUEUES` allowlist.
- Plus operator config updates riding along (build skill cost discipline + new security-review skill).

## Linear
ROK-1196

## Test plan
- [x] Targeted smoke test (`SMOKE_NAME_FILTER='Embed updates when signup cancelled'`): 10/10 PASS, avg 6.3s (was timing out at 90s × 3 retries on the 10-20% flake)
- [x] `validate-ci.sh --full` exit 0 (Build, TypeScript, Lint, Unit + coverage, Integration all PASS)
- [x] Web vitest: 256 files, 3062 tests, all PASS
- [x] API integration: 72 suites, 841 tests, all PASS
- [x] Lint on diff'd files: 0 errors

## Files
| File | Purpose |
|------|---------|
| `api/src/queue/queue-health.service.ts` | `SHORT_COALESCE_QUEUES` allowlist + `isQueueBusy` helper |
| `api/src/events/signups-roster.service.ts` | `cancel()` now `await emitAsync(...)` |
| `api/src/queue/queue-health.service.spec.ts` | Regression tests for both behaviors |
| `api/src/events/signups.service.cancel.spec.ts` | EventEmitter2 mock exposes `emitAsync` |
| `api/src/events/signups-roster.service.emit.spec.ts` | Same |
| `.claude/skills/**`, `.claude/settings.json` | Operator config (chore) |

## Notes for reviewer
- One unit test (`event-link.listener.spec.ts › should skip if CLIENT_URL is not set`) flakes locally because the implementation reads `CLIENT_URL || CORS_ORIGIN` but the test only deletes `CLIENT_URL` — and `.env` has both. Pre-existing test bug, unrelated to this story; will file a separate Linear story. CI passes because GH Actions doesn't source local `.env`.
- The cancel emit change is narrow — only `SignupsRosterService.cancel`, not `adminRemoveSignup`/`selfUnassign`. If similar races appear there, apply the same `emitAsync` migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)