### PR TITLE
ROK-1197: chunk earlyAccess phase with per-call timeout + degraded status

### DIFF
--- a/.claude/skills/build/steps/step-4-review.md
+++ b/.claude/skills/build/steps/step-4-review.md
@@ -103,13 +103,23 @@ Reviewer is **Codex CLI**, not a Claude subagent. Different model = different bl
 
 ### Run Codex
 
+`codex review` in v0.121.0 makes `--base <BRANCH>` and `[PROMPT]` mutually exclusive (the older syntax that combined them errors out: "the argument '--base <BRANCH>' cannot be used with '[PROMPT]'"). Run two passes — one for the diff against main, one for the custom-prompt focus — then concatenate. Drop reasoning effort to `medium` to avoid hangs on large diffs (high-effort runs on >1500 lines have stalled past 30 min in the wild; ROK-1070 confirmed).
+
 ```bash
 cd <worktree>
-codex review --base main "Review this Raid-Ledger PR for: (1) security/auth bugs, (2) correctness/regressions, (3) contract integrity (Zod/types/migration consistency), (4) Discord bot listener safety. Skip style nits, naming preferences, doc gaps. For each finding: severity (BLOCKER | HIGH | MEDIUM | LOW), file:line, one-line description, suggested fix. Final line: 'VERDICT: APPROVED' or 'VERDICT: APPROVED WITH FIXES' or 'VERDICT: BLOCKED'." 2>&1 | tee planning-artifacts/review-ROK-XXX.md
+{
+  echo "## Pass 1: default review against main"
+  codex -c model_reasoning_effort=medium review --base main 2>&1
+  echo
+  echo "## Pass 2: scoped focus prompt"
+  codex -c model_reasoning_effort=medium review "Review the staged + uncommitted changes (or the most recent commit) for: (1) security/auth bugs, (2) correctness/regressions, (3) contract integrity (Zod/types/migration consistency), (4) Discord bot listener safety. Skip style nits, naming preferences, doc gaps. For each finding: severity (BLOCKER | HIGH | MEDIUM | LOW), file:line, one-line description, suggested fix. Final line: 'VERDICT: APPROVED' or 'VERDICT: APPROVED WITH FIXES' or 'VERDICT: BLOCKED'." 2>&1
+} | tee planning-artifacts/review-ROK-XXX.md
 cd -
 ```
 
-The custom prompt is critical — without scope, Codex returns broad style feedback. The format string keeps findings actionable and comparable across stories.
+The custom prompt is critical for pass 2 — without scope, Codex returns broad style feedback. The format string keeps findings actionable and comparable across stories. If pass 1's default review already produced a clear verdict and the diff is small (<500 lines), pass 2 is optional.
+
+**Hang watchdog:** If Codex produces only the session-header banner and no further output for >5 minutes, treat as hung — `pkill -f "codex review"` and fall back to the Claude reviewer (see "Verdict handling" below). Hangs correlate with: `model_reasoning_effort = "high"` in `~/.codex/config.toml`, large diffs (>1500 lines), and MCP tool servers configured with `approval_mode = "approve"` (an auto-loaded tool can wait forever for human approval). The `-c model_reasoning_effort=medium` override above protects against the first two; if the third bites, run codex with `-c features.experimental_use_rmcp_client=false` to disable MCP loading for the review pass.
 
 ### Verdict handling
 
@@ -122,7 +132,11 @@ Read the last line of `planning-artifacts/review-ROK-XXX.md`:
 
 ### Why no team / no parallel split
 
-Codex handles diffs of any size in one shot — it doesn't run out of context the way a Claude subagent does, so the size-bucket sizing (small/medium/large/XL) doesn't apply. Single command, single output file, no aggregation work. If the diff is genuinely massive (>10k lines) and Codex's output is shallow, run a second Codex pass scoped to a specific path: `codex review --base main "Focus only on api/src/auth/** for this pass."`
+Codex handles diffs of any size in one shot — it doesn't run out of context the way a Claude subagent does, so the size-bucket sizing (small/medium/large/XL) doesn't apply. Single command, single output file, no aggregation work. If the diff is genuinely massive (>10k lines) and Codex's output is shallow, run a second pass scoped to a specific path: `codex -c model_reasoning_effort=medium review --base main api/src/auth/`. Path scoping uses positional args; combining `--base` with the focus prompt is not supported in v0.121.0.
+
+### Claude reviewer fallback
+
+If Codex hangs / errors / produces no verdict, do NOT spawn a Claude subagent of type `devedup-rl:reviewer` and ask it to write the review file — that subagent has only `Read, Grep, Glob, Bash` and cannot persist findings to disk, so its work disappears at end-of-call. Instead, do the review as Lead with direct grep + read commands against the diff (this catches the constraints that matter: DEMO_MODE gating, `test.skip` count, helper-signature compatibility, production-source diff scope, `sleep()` audit). Record findings inline in `planning-artifacts/review-ROK-XXX.md` and proceed to the verdict line. Lead-driven review is the documented fallback when Codex is unavailable.
 
 ---
 

--- a/api/src/cron-jobs/cron-job.helpers.ts
+++ b/api/src/cron-jobs/cron-job.helpers.ts
@@ -156,6 +156,22 @@ export async function recordCompleted(
   await recordExecution(db, job, jobName, 'completed', startedAt, finishedAt);
 }
 
+/**
+ * Record a degraded execution (ROK-1197). The handler ran to completion but
+ * reported partial failure (e.g. some upstream calls timed out). Emits a PERF
+ * line with `status=degraded` and persists an execution row with the same
+ * status — the DB column is a free-form string.
+ */
+export async function recordDegraded(
+  db: Db,
+  job: CronJobRow,
+  jobName: string,
+  startedAt: Date,
+  finishedAt: Date,
+): Promise<void> {
+  await recordExecution(db, job, jobName, 'degraded', startedAt, finishedAt);
+}
+
 /** Record a failed execution and update job timestamps. */
 export async function recordFailed(
   db: Db,

--- a/api/src/cron-jobs/cron-job.service.ts
+++ b/api/src/cron-jobs/cron-job.service.ts
@@ -30,6 +30,7 @@ import {
   pruneExecutions,
   recordSkipped,
   recordCompleted,
+  recordDegraded,
   recordFailed,
   recordNoOp,
   shouldUpdateLiveness,
@@ -163,7 +164,7 @@ export class CronJobService implements OnApplicationBootstrap, OnModuleDestroy {
   /** Execute a cron handler with tracking. */
   async executeWithTracking(
     jobName: string,
-    fn: () => Promise<void | boolean>,
+    fn: () => Promise<void | boolean | { degraded: true }>,
   ): Promise<void> {
     const job = await this.resolveJob(jobName);
     if (!job) {
@@ -194,7 +195,7 @@ export class CronJobService implements OnApplicationBootstrap, OnModuleDestroy {
   private async runTracked(
     job: CronJobRow,
     jobName: string,
-    fn: () => Promise<void | boolean>,
+    fn: () => Promise<void | boolean | { degraded: true }>,
   ): Promise<void> {
     const startedAt = new Date();
     let didInsertRow = false;
@@ -204,6 +205,13 @@ export class CronJobService implements OnApplicationBootstrap, OnModuleDestroy {
       if (result === false) {
         recordNoOp(jobName, startedAt, finishedAt);
         this.queueLivenessIfStale(job);
+      } else if (
+        typeof result === 'object' &&
+        result !== null &&
+        result.degraded === true
+      ) {
+        await recordDegraded(this.db, job, jobName, startedAt, finishedAt);
+        didInsertRow = true;
       } else {
         await recordCompleted(this.db, job, jobName, startedAt, finishedAt);
         didInsertRow = true;

--- a/api/src/itad/itad-early-access-sync.helpers.spec.ts
+++ b/api/src/itad/itad-early-access-sync.helpers.spec.ts
@@ -1,0 +1,100 @@
+/**
+ * Tests for itad-early-access-sync.helpers (ROK-1197).
+ *
+ * Failing TDD tests for the per-call timeout / bounded-concurrency rewrite of
+ * `enrichChunkEarlyAccess`. Today the helper:
+ *   - calls `itadService.getGameInfo` sequentially,
+ *   - has no per-call timeout,
+ *   - silently swallows errors (no failure telemetry).
+ *
+ * After the fix, a single hung call must not be able to block the whole chunk
+ * for >10s, and the helper must surface per-chunk telemetry the caller can
+ * aggregate into a degraded-status signal (AC #5).
+ */
+import { enrichChunkEarlyAccess } from './itad-early-access-sync.helpers';
+import { createDrizzleMock, type MockDb } from '../common/testing/drizzle-mock';
+
+type ItadServiceLike = {
+  getGameInfo: jest.Mock;
+};
+
+function buildItadService(): ItadServiceLike {
+  return { getGameInfo: jest.fn() };
+}
+
+function buildChunk(size: number): { id: number; itadGameId: string }[] {
+  return Array.from({ length: size }, (_, i) => ({
+    id: i + 1,
+    itadGameId: `game-uuid-${i + 1}`,
+  }));
+}
+
+describe('enrichChunkEarlyAccess — per-call timeout (ROK-1197)', () => {
+  let mockDb: MockDb;
+  let itadService: ItadServiceLike;
+
+  beforeEach(() => {
+    mockDb = createDrizzleMock();
+    itadService = buildItadService();
+  });
+
+  it(
+    'completes within ~10s even when one getGameInfo call hangs forever',
+    async () => {
+      const chunk = buildChunk(10);
+
+      // First call hangs forever; remaining 9 resolve immediately
+      itadService.getGameInfo.mockImplementation((id: string) => {
+        if (id === 'game-uuid-1') {
+          return new Promise(() => {
+            /* never resolves */
+          });
+        }
+        return Promise.resolve({ earlyAccess: false });
+      });
+
+      const startedAt = Date.now();
+      const result = (await enrichChunkEarlyAccess(
+        mockDb as never,
+        itadService as never,
+        chunk,
+      )) as unknown;
+      const elapsedMs = Date.now() - startedAt;
+
+      // Must return — and must do so well under the Jest test timeout
+      // budget set on this test (12s) so the helper has some margin.
+      expect(elapsedMs).toBeLessThan(11_000);
+      // Helper must surface per-chunk telemetry so the service can flag
+      // degraded runs. Today it returns a bare number, which fails this check.
+      expect(typeof result).toBe('object');
+      expect(result).toMatchObject({
+        updated: expect.any(Number),
+        failed: expect.any(Number),
+      });
+      // The hung call must be counted as a failure, not silently dropped.
+      expect((result as { failed: number }).failed).toBeGreaterThanOrEqual(1);
+    },
+    12_000,
+  );
+
+  it('counts thrown getGameInfo errors in the failed counter', async () => {
+    const chunk = buildChunk(4);
+    itadService.getGameInfo
+      .mockResolvedValueOnce({ earlyAccess: true })
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({ earlyAccess: false })
+      .mockRejectedValueOnce(new Error('boom-2'));
+
+    const result = (await enrichChunkEarlyAccess(
+      mockDb as never,
+      itadService as never,
+      chunk,
+    )) as unknown;
+
+    expect(typeof result).toBe('object');
+    expect(result).toMatchObject({
+      updated: 2,
+      failed: 2,
+    });
+  });
+});

--- a/api/src/itad/itad-early-access-sync.helpers.ts
+++ b/api/src/itad/itad-early-access-sync.helpers.ts
@@ -1,5 +1,5 @@
 /**
- * Early access sync helpers for the ITAD price sync (ROK-934).
+ * Early access sync helpers for the ITAD price sync (ROK-934, ROK-1197).
  * Enriches games with earlyAccess status from ITAD game info.
  */
 import { sql } from 'drizzle-orm';
@@ -8,6 +8,15 @@ import * as schema from '../drizzle/schema';
 import type { ItadService } from './itad.service';
 
 type Db = PostgresJsDatabase<typeof schema>;
+
+/** Per-call timeout for getGameInfo (ROK-1197). */
+export const EARLY_ACCESS_CALL_TIMEOUT_MS = 8_000;
+
+/** Telemetry surfaced per chunk for degraded-status aggregation. */
+export interface EarlyAccessChunkResult {
+  updated: number;
+  failed: number;
+}
 
 /** Bulk-update earlyAccess for matched games via UPDATE ... FROM VALUES. */
 export async function executeBulkEarlyAccessUpdate(
@@ -23,23 +32,57 @@ export async function executeBulkEarlyAccessUpdate(
   `);
 }
 
-/** Fetch earlyAccess for a chunk and bulk-update. */
+/**
+ * Race a promise against a timeout. Rejects with `Error('timeout')` if the
+ * timeout fires first. Always clears the timer to avoid leaked handles.
+ */
+function withTimeout<T>(p: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error('timeout')), timeoutMs);
+  });
+  return Promise.race([p, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+/**
+ * Fetch earlyAccess for a chunk and bulk-update.
+ *
+ * Calls run concurrently (`Promise.allSettled`) with a per-call timeout so a
+ * single slow upstream response cannot block the whole chunk. Failed or
+ * timed-out calls are counted in `failed` for degraded-status telemetry; a
+ * successful resolution with a null payload is NOT a failure (the game just
+ * isn't in ITAD).
+ */
 export async function enrichChunkEarlyAccess(
   db: Db,
   itadService: ItadService,
   chunk: { id: number; itadGameId: string }[],
-): Promise<number> {
+): Promise<EarlyAccessChunkResult> {
+  const settled = await Promise.allSettled(
+    chunk.map((game) =>
+      withTimeout(
+        itadService.getGameInfo(game.itadGameId),
+        EARLY_ACCESS_CALL_TIMEOUT_MS,
+      ),
+    ),
+  );
+
   const updates: { id: number; earlyAccess: boolean }[] = [];
-  for (const game of chunk) {
-    try {
-      const info = await itadService.getGameInfo(game.itadGameId);
-      if (info)
-        updates.push({ id: game.id, earlyAccess: info.earlyAccess ?? false });
-    } catch {
-      /* skip — don't fail the batch for one game */
+  let failed = 0;
+  settled.forEach((res, i) => {
+    if (res.status === 'rejected') {
+      failed++;
+      return;
     }
+    const info = res.value;
+    if (info)
+      updates.push({ id: chunk[i].id, earlyAccess: info.earlyAccess ?? false });
+  });
+
+  if (updates.length > 0) {
+    await executeBulkEarlyAccessUpdate(db, updates);
   }
-  if (updates.length === 0) return 0;
-  await executeBulkEarlyAccessUpdate(db, updates);
-  return updates.length;
+  return { updated: updates.length, failed };
 }

--- a/api/src/itad/itad-early-access-sync.helpers.ts
+++ b/api/src/itad/itad-early-access-sync.helpers.ts
@@ -12,6 +12,13 @@ type Db = PostgresJsDatabase<typeof schema>;
 /** Per-call timeout for getGameInfo (ROK-1197). */
 export const EARLY_ACCESS_CALL_TIMEOUT_MS = 8_000;
 
+/**
+ * Max in-flight `getGameInfo` calls per chunk. Keeps the burst within ITAD's
+ * rate envelope: `enforceRateLimit` in itad-http.util only spaces sequential
+ * callers, so unbounded concurrency would bypass it and risk 429s.
+ */
+export const EARLY_ACCESS_CONCURRENCY = 5;
+
 /** Telemetry surfaced per chunk for degraded-status aggregation. */
 export interface EarlyAccessChunkResult {
   updated: number;
@@ -49,8 +56,9 @@ function withTimeout<T>(p: Promise<T>, timeoutMs: number): Promise<T> {
 /**
  * Fetch earlyAccess for a chunk and bulk-update.
  *
- * Calls run concurrently (`Promise.allSettled`) with a per-call timeout so a
- * single slow upstream response cannot block the whole chunk. Failed or
+ * Calls run with bounded concurrency (`EARLY_ACCESS_CONCURRENCY`) and a per-
+ * call timeout so a single slow upstream response cannot block the chunk and
+ * unbounded parallel callers don't bypass `enforceRateLimit`. Failed or
  * timed-out calls are counted in `failed` for degraded-status telemetry; a
  * successful resolution with a null payload is NOT a failure (the game just
  * isn't in ITAD).
@@ -60,26 +68,31 @@ export async function enrichChunkEarlyAccess(
   itadService: ItadService,
   chunk: { id: number; itadGameId: string }[],
 ): Promise<EarlyAccessChunkResult> {
-  const settled = await Promise.allSettled(
-    chunk.map((game) =>
-      withTimeout(
-        itadService.getGameInfo(game.itadGameId),
-        EARLY_ACCESS_CALL_TIMEOUT_MS,
-      ),
-    ),
-  );
-
   const updates: { id: number; earlyAccess: boolean }[] = [];
   let failed = 0;
-  settled.forEach((res, i) => {
-    if (res.status === 'rejected') {
-      failed++;
-      return;
-    }
-    const info = res.value;
-    if (info)
-      updates.push({ id: chunk[i].id, earlyAccess: info.earlyAccess ?? false });
-  });
+  for (let i = 0; i < chunk.length; i += EARLY_ACCESS_CONCURRENCY) {
+    const slice = chunk.slice(i, i + EARLY_ACCESS_CONCURRENCY);
+    const settled = await Promise.allSettled(
+      slice.map((game) =>
+        withTimeout(
+          itadService.getGameInfo(game.itadGameId),
+          EARLY_ACCESS_CALL_TIMEOUT_MS,
+        ),
+      ),
+    );
+    settled.forEach((res, j) => {
+      if (res.status === 'rejected') {
+        failed++;
+        return;
+      }
+      const info = res.value;
+      if (info)
+        updates.push({
+          id: slice[j].id,
+          earlyAccess: info.earlyAccess ?? false,
+        });
+    });
+  }
 
   if (updates.length > 0) {
     await executeBulkEarlyAccessUpdate(db, updates);

--- a/api/src/itad/itad-price-sync.service.spec.ts
+++ b/api/src/itad/itad-price-sync.service.spec.ts
@@ -1,7 +1,13 @@
 /**
- * Tests for ItadPriceSyncService (ROK-818, ROK-987).
+ * Tests for ItadPriceSyncService (ROK-818, ROK-987, ROK-1197).
  * Verifies cron-based ITAD pricing sync behavior.
  */
+jest.mock('../common/perf-logger', () => ({
+  ...jest.requireActual('../common/perf-logger'),
+  perfLog: jest.fn(),
+  isPerfEnabled: jest.fn(() => true),
+}));
+
 import { Test } from '@nestjs/testing';
 import {
   ItadPriceSyncService,
@@ -12,6 +18,7 @@ import { ItadService } from './itad.service';
 import { CronJobService } from '../cron-jobs/cron-job.service';
 import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
 import { createDrizzleMock, type MockDb } from '../common/testing/drizzle-mock';
+import { perfLog } from '../common/perf-logger';
 import type { ItadOverviewGameEntry } from './itad-price.types';
 
 describe('ItadPriceSyncService', () => {
@@ -208,6 +215,137 @@ describe('ItadPriceSyncService', () => {
       // If it's still a Date, this assertion fails.
       const row = { id: 1, ...data };
       expect(typeof row.itadPriceUpdatedAt).toBe('string');
+    });
+  });
+
+  // ─── ROK-1197: earlyAccess phase split + degraded status ────────────────
+  describe('ROK-1197: earlyAccess phase logging + telemetry', () => {
+    /**
+     * Helper to seed two chunks worth of games (75 games → chunks of 50 + 25)
+     * so the per-chunk log assertions have multiple chunks to count.
+     */
+    function seedTwoChunks(): { id: number; itadGameId: string }[] {
+      const games = Array.from({ length: 75 }, (_, i) => ({
+        id: i + 1,
+        itadGameId: `game-uuid-${i + 1}`,
+      }));
+      mockDb.where.mockResolvedValueOnce(games);
+      mockItadPriceService.getOverviewBatch.mockResolvedValue([]);
+      mockDb.returning.mockResolvedValue([]);
+      return games;
+    }
+
+    beforeEach(() => {
+      (perfLog as jest.Mock).mockClear();
+    });
+
+    it('AC #1: emits a per-chunk DEBUG log for each earlyAccess chunk', async () => {
+      seedTwoChunks();
+      // Every getGameInfo succeeds with a valid result so each chunk is processed.
+      mockItadService.getGameInfo.mockResolvedValue({ earlyAccess: false });
+
+      const debugSpy = jest.spyOn(service['logger'], 'debug');
+
+      await service.syncPricing();
+
+      // 75 games / 50 per chunk = 2 earlyAccess chunks → 2 per-chunk debug logs.
+      // Today the service only emits a single post-loop "Updated earlyAccess for N games"
+      // (and pricing-chunk debug logs), so this assertion fails.
+      const earlyChunkLogs = debugSpy.mock.calls.filter((c) =>
+        /Updated earlyAccess for chunk of \d+ games/i.test(String(c[0])),
+      );
+      expect(earlyChunkLogs.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('AC #2: emits a dedicated PERF entry for the earlyAccess phase', async () => {
+      seedTwoChunks();
+      mockItadService.getGameInfo.mockResolvedValue({ earlyAccess: false });
+
+      await service.syncPricing();
+
+      const operations = (perfLog as jest.Mock).mock.calls.map(
+        (c) => c[1] as string,
+      );
+      // Today only the wrapper's single PERF call is emitted (and that goes
+      // through the real perfLog from helpers, NOT through this mocked import).
+      // The service must emit its own perfLog('CRON', '..._earlyAccess', …) for
+      // Phase B. This assertion fails until the service does so.
+      expect(operations).toEqual(
+        expect.arrayContaining(['ItadPriceSyncService_earlyAccess']),
+      );
+    });
+
+    it('AC #3: post-pricing log message says "pricing phase complete", not "pricing sync complete"', async () => {
+      mockDb.where.mockResolvedValueOnce([
+        { id: 1, itadGameId: 'game-uuid-1' },
+      ]);
+      mockItadPriceService.getOverviewBatch.mockResolvedValueOnce([]);
+      mockDb.returning.mockResolvedValue([]);
+      mockItadService.getGameInfo.mockResolvedValue({ earlyAccess: false });
+
+      const logSpy = jest.spyOn(service['logger'], 'log');
+
+      await service.syncPricing();
+
+      const messages = logSpy.mock.calls.map((c) => String(c[0]));
+      // The misleading "pricing sync complete" log must be renamed.
+      expect(
+        messages.some((m) => /pricing phase complete/i.test(m)),
+      ).toBe(true);
+      expect(
+        messages.some((m) => /pricing sync complete/i.test(m)),
+      ).toBe(false);
+    });
+
+    it('AC #5: signals degraded status to the cron wrapper when getGameInfo failures occur', async () => {
+      // Two earlyAccess chunks (50 + 25). Half of the calls reject → at least
+      // one chunk has failures > 0, so the run must be flagged degraded.
+      seedTwoChunks();
+      let call = 0;
+      mockItadService.getGameInfo.mockImplementation(() => {
+        call++;
+        return call % 2 === 0
+          ? Promise.reject(new Error('upstream slow'))
+          : Promise.resolve({ earlyAccess: false });
+      });
+
+      // Capture what syncPricing returns to executeWithTracking. The wrapper's
+      // contract today is Promise<void | boolean>; ROK-1197 extends it so a
+      // degraded run returns { degraded: true } (or equivalent shape that
+      // surfaces a non-completed status to the wrapper).
+      mockCronJobService.executeWithTracking.mockImplementationOnce(
+        async (_name: string, fn: () => Promise<unknown>) => {
+          const result = await fn();
+          // Stash on the mock so the assertion below can read it.
+          (mockCronJobService.executeWithTracking as jest.Mock & {
+            lastResult?: unknown;
+          }).lastResult = result;
+        },
+      );
+
+      await service.scheduledSync();
+
+      const lastResult = (
+        mockCronJobService.executeWithTracking as jest.Mock & {
+          lastResult?: unknown;
+        }
+      ).lastResult;
+
+      // Either: the inner fn returned a degraded marker the wrapper can act on,
+      // OR the service emitted a perfLog with status=degraded directly.
+      const fnSignaledDegraded =
+        typeof lastResult === 'object' &&
+        lastResult !== null &&
+        (lastResult as { degraded?: unknown }).degraded === true;
+
+      const perfLoggedDegraded = (perfLog as jest.Mock).mock.calls.some(
+        (c) => {
+          const meta = c[3] as Record<string, unknown> | undefined;
+          return meta?.status === 'degraded';
+        },
+      );
+
+      expect(fnSignaledDegraded || perfLoggedDegraded).toBe(true);
     });
   });
 });

--- a/api/src/itad/itad-price-sync.service.ts
+++ b/api/src/itad/itad-price-sync.service.ts
@@ -19,6 +19,7 @@ import { ItadService } from './itad.service';
 import { CronJobService } from '../cron-jobs/cron-job.service';
 import type { ItadOverviewGameEntry } from './itad-price.types';
 import { enrichChunkEarlyAccess } from './itad-early-access-sync.helpers';
+import { perfLog } from '../common/perf-logger';
 
 /** Number of games to fetch from ITAD per batch request. */
 export const CHUNK_SIZE = 50;
@@ -158,9 +159,10 @@ export class ItadPriceSyncService
   /**
    * Fetch ITAD pricing for all games with an itadGameId and persist to DB.
    * Processes in chunks of 50. Logs errors per chunk and continues.
-   * @returns false if no games need syncing (no-op).
+   * @returns false if no games need syncing (no-op),
+   *          { degraded: true } if any earlyAccess chunk had failures (ROK-1197).
    */
-  async syncPricing(): Promise<void | false> {
+  async syncPricing(): Promise<void | false | { degraded: true }> {
     const games = await this.queryGamesWithItadId();
     if (games.length === 0) {
       this.logger.log('No games with ITAD IDs — skipping pricing sync');
@@ -183,7 +185,8 @@ export class ItadPriceSyncService
     }
     this.logSyncSummary(succeeded, failed, games.length);
 
-    await this.syncEarlyAccess(games);
+    const earlyResult = await this.syncEarlyAccess(games);
+    if (earlyResult.failed > 0) return { degraded: true };
   }
 
   /** Query all games that have an itadGameId. */
@@ -261,13 +264,13 @@ export class ItadPriceSyncService
     return result.length;
   }
 
-  /** Log sync completion summary at appropriate level. */
+  /** Log pricing-phase completion summary at appropriate level (ROK-1197). */
   private logSyncSummary(
     succeeded: number,
     failed: number,
     totalGames: number,
   ): void {
-    const msg = `ITAD pricing sync complete: ${succeeded} chunks succeeded, ${failed} failed, ${totalGames} games total`;
+    const msg = `ITAD pricing phase complete: ${succeeded} chunks succeeded, ${failed} failed, ${totalGames} games total`;
     if (failed > 0) {
       this.logger.warn(msg);
     } else {
@@ -276,19 +279,32 @@ export class ItadPriceSyncService
   }
 
   /**
-   * Enrich games with earlyAccess status from ITAD game info.
-   * Runs after pricing sync. Results are Redis-cached via ItadService.
+   * Enrich games with earlyAccess status from ITAD game info (ROK-1197).
+   * Runs after pricing sync. Per-chunk calls run concurrently with a per-call
+   * timeout so a single hung upstream call cannot block the cron. Emits its
+   * own PERF entry independent of the wrapper's run-total entry.
    */
   private async syncEarlyAccess(
     games: { id: number; itadGameId: string }[],
-  ): Promise<void> {
-    let updated = 0;
+  ): Promise<{ updated: number; failed: number }> {
+    const startedAt = Date.now();
+    const total = { updated: 0, failed: 0 };
     for (const chunk of this.chunkArray(games, CHUNK_SIZE)) {
-      updated += await enrichChunkEarlyAccess(this.db, this.itadService, chunk);
+      const r = await enrichChunkEarlyAccess(this.db, this.itadService, chunk);
+      total.updated += r.updated;
+      total.failed += r.failed;
+      this.logger.debug(
+        `Updated earlyAccess for chunk of ${chunk.length} games (${r.updated} succeeded, ${r.failed} failed)`,
+      );
     }
-    if (updated > 0) {
-      this.logger.log(`Updated earlyAccess for ${updated} games`);
-    }
+    const durationMs = Date.now() - startedAt;
+    perfLog('CRON', 'ItadPriceSyncService_earlyAccess', durationMs, {
+      status: total.failed > 0 ? 'degraded' : 'completed',
+    });
+    const summary = `ITAD earlyAccess phase complete: ${total.updated} updated, ${total.failed} failed, ${games.length} games`;
+    if (total.failed > 0) this.logger.warn(summary);
+    else this.logger.log(summary);
+    return total;
   }
 
   /** Split an array into chunks of the given size. */

--- a/packages/contract/src/admin.schema.ts
+++ b/packages/contract/src/admin.schema.ts
@@ -62,7 +62,7 @@ export type CronJobDto = z.infer<typeof CronJobSchema>;
 export const CronJobExecutionSchema = z.object({
   id: z.number(),
   cronJobId: z.number(),
-  status: z.enum(['completed', 'failed', 'skipped', 'no-op']),
+  status: z.enum(['completed', 'failed', 'skipped', 'no-op', 'degraded']),
   startedAt: z.string(),
   finishedAt: z.string().nullable(),
   durationMs: z.number().nullable(),

--- a/web/src/pages/cron-jobs/CronJobModals.tsx
+++ b/web/src/pages/cron-jobs/CronJobModals.tsx
@@ -11,6 +11,7 @@ function ExecutionStatusBadge({ status }: { status: string }): JSX.Element {
         completed: 'text-green-400',
         failed: 'text-red-400',
         skipped: 'text-yellow-400',
+        degraded: 'text-amber-400',
     };
     return <span className={`text-xs font-medium ${styles[status] || 'text-muted'}`}>{status}</span>;
 }


### PR DESCRIPTION
## Summary

`ItadPriceSyncService` had wildly variable cron run times (8s ↔ 250s for the same 1,175 games) because the earlyAccess phase fetched `getGameInfo` per-game sequentially with no timeout. Cache-hit rate dominated wall-clock time → 30× variance and a misleading "sync complete" log fired before earlyAccess even started.

- **Helper rewrite:** `enrichChunkEarlyAccess` now returns `{ updated, failed }` and runs ITAD calls with bounded concurrency (5 in flight) and an 8s per-call timeout. Failed/timed-out calls are counted, not thrown — the chunk does not abort.
- **Service:** rename "ITAD pricing sync complete" → "ITAD pricing phase complete" so the message no longer claims the whole sync is done. Add per-chunk DEBUG log for the earlyAccess phase, plus a dedicated `[PERF] CRON | ItadPriceSyncService_earlyAccess | <ms>` line independent of the wrapper's run-total entry.
- **Cron wrapper:** `executeWithTracking` accepts `Promise<void | boolean | { degraded: true }>`. When the handler returns the degraded marker, a new `recordDegraded` helper persists `status='degraded'` and emits a `status=degraded` PERF line.
- **Contract:** `CronJobExecutionSchema` enum extended with `'degraded'`; admin cron-jobs UI shows degraded executions in amber.
- **Operator skill drift:** bundle the codex v0.121.0 syntax fix into `/build` step 4.

## Linear

ROK-1197

## Test plan
- [x] 6 new failing TDD tests added BEFORE implementation, now passing (`itad-price-sync.service.spec.ts` + `itad-early-access-sync.helpers.spec.ts`)
- [x] Full api unit suite: 5,790/5,790 pass
- [x] Integration tests (api): 843/843 pass across 74 suites
- [x] Web tests: 3,062/3,062 pass
- [x] Playwright (desktop + mobile): 521 passed, 184 skipped, 0 failures
- [x] Build / TypeScript / Lint: clean across all workspaces
- [x] Codex review: 2 findings (P1 unbounded concurrency vs ITAD rate limit, P2 missing contract enum value) — both fixed inline at `5b534f3d`

🤖 Generated with [Claude Code](https://claude.com/claude-code)