### PR TITLE
ci: fix dependabot rebase workflow (empty SHA + PR-merge trigger)

### DIFF
--- a/.github/workflows/dependabot-rebase-on-main.yml
+++ b/.github/workflows/dependabot-rebase-on-main.yml
@@ -1,16 +1,26 @@
 name: Rebase Dependabot PRs after main update
 
 # When main moves, branch protection's "up to date" requirement causes any open
-# Dependabot PR to become BEHIND and stop auto-merging. The previous version
-# of this workflow posted "@dependabot rebase" comments, but Dependabot
-# rejects @-commands from the github-actions[bot] account ("only users with
-# push access can use that command"). Use the REST update-branch endpoint
-# instead — it runs under the workflow's own contents: write token, so the
-# permission check is satisfied without involving Dependabot's parser.
+# Dependabot PR to become BEHIND and stop auto-merging. This workflow updates
+# every open Dependabot PR to the latest main via the REST update-branch endpoint.
+#
+# Triggers:
+#   - push to main: covers normal merges from human/PR contributors.
+#   - pull_request_target closed (merged): covers Dependabot's own auto-merges.
+#     Pushes resulting from GITHUB_TOKEN-driven merges do NOT fire `on: push`
+#     workflows (GitHub anti-recursion default), so without this second trigger
+#     the first Dependabot merge in a batch silently leaves the rest BEHIND.
+#
+# Past bug (fixed here): the previous `-f expected_head_sha=` argument sent an
+# empty string, which the API rejects as 422 ("expected head sha didn't match").
+# Omitting the parameter makes the API default to the PR's current HEAD, which
+# is exactly what we want for an opportunistic update.
 
 on:
   push:
     branches: [main]
+  pull_request_target:
+    types: [closed]
 
 permissions:
   contents: write
@@ -18,6 +28,13 @@ permissions:
 
 jobs:
   rebase:
+    # Run on push-to-main, or on a merged PR targeting main. Skip non-merged
+    # closes (PRs closed without merging don't change main).
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'pull_request_target' &&
+       github.event.pull_request.merged == true &&
+       github.event.pull_request.base.ref == 'main')
     runs-on: ubuntu-latest
     steps:
       - name: Update branch on every open Dependabot PR
@@ -37,12 +54,12 @@ jobs:
           fi
           for n in $numbers; do
             echo "Updating branch on PR #$n"
-            # update-branch is a no-op when the PR is already current with
-            # the base branch. `expected_head_sha=` skips the optimistic
-            # concurrency check; we tolerate the rare 422 (e.g. PR closed
+            # Omit expected_head_sha — the API defaults to the PR's current
+            # HEAD. The previous `-f expected_head_sha=` (empty string) form
+            # always 422'd, and `|| true` silently swallowed it, so the
+            # workflow looked successful while doing nothing.
+            #
+            # `|| true` is still kept to tolerate the rare 422 (e.g. PR closed
             # mid-loop) so one bad PR doesn't fail the whole job.
-            gh api "repos/$GH_REPO/pulls/$n/update-branch" \
-              -X PUT \
-              -f expected_head_sha= \
-              || true
+            gh api "repos/$GH_REPO/pulls/$n/update-branch" -X PUT || true
           done


### PR DESCRIPTION
## Summary

Fixes two bugs in \`.github/workflows/dependabot-rebase-on-main.yml\` that left batched Dependabot PRs stuck BEHIND main after the first one auto-merged.

### Bug 1: 422 from empty \`expected_head_sha\`

The previous \`gh api ... -f expected_head_sha= || true\` sent an **empty string** as the SHA. GitHub rejects this every time with \`422 Unprocessable Entity\` (\"expected head sha didn't match current head ref\"). The \`|| true\` swallowed the error, so the workflow always reported success while doing nothing. Omitting the parameter makes the API default to the PR's current HEAD — which is the desired behaviour for an opportunistic update-branch.

### Bug 2: \`on: push\` doesn't fire for GITHUB_TOKEN-driven merges

GitHub's anti-recursion default: pushes resulting from a workflow's own \`GITHUB_TOKEN\` (e.g. our \`Dependabot auto-merge\` workflow squash-merging a PR) do **not** trigger other \`on: push\` workflows. So as soon as the first Dependabot PR auto-merged, the rebase workflow never re-fired, and the rest of the batch silently stayed BEHIND.

Added \`pull_request_target: types: [closed]\` (gated to merged PRs targeting main) so the rebase fires regardless of who/what triggered the merge — human, our own workflows, or Dependabot.

## How this manifested

PRs #710-#719 today: all auto-merge enabled, all CI green (except #718's major bump), all stuck BEHIND main with no further activity. Recovered by manually calling \`update-branch\` with a real head SHA on each.

## Test plan

- [x] YAML lint clean
- [x] Verified the empty-SHA fix manually unblocked #710, #711, #712, #716, #717, #719
- [ ] Next time a Dependabot PR auto-merges, the workflow should now fire on the resulting close event and rebase the rest

🤖 Generated with [Claude Code](https://claude.com/claude-code)