### PR TITLE
ci: add workflow_dispatch trigger for dependabot rebase

### DIFF
--- a/.github/workflows/dependabot-rebase-on-main.yml
+++ b/.github/workflows/dependabot-rebase-on-main.yml
@@ -21,6 +21,11 @@ on:
     branches: [main]
   pull_request_target:
     types: [closed]
+  # Manual kickstart: useful when a batch of Dependabot PRs is already
+  # rebased and waiting on CI, but main has moved (so they're BEHIND again)
+  # and no further merge events are pending to fire the auto-rebase. Run
+  # via `gh workflow run dependabot-rebase-on-main.yml` or the Actions UI.
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -28,10 +33,12 @@ permissions:
 
 jobs:
   rebase:
-    # Run on push-to-main, or on a merged PR targeting main. Skip non-merged
-    # closes (PRs closed without merging don't change main).
+    # Run on push-to-main, on a merged PR targeting main, or when manually
+    # dispatched. Skip non-merged closes (PRs closed without merging don't
+    # change main).
     if: |
       github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request_target' &&
        github.event.pull_request.merged == true &&
        github.event.pull_request.base.ref == 'main')


### PR DESCRIPTION
## Summary

Adds \`workflow_dispatch\` to the Dependabot rebase workflow so it can be manually triggered. Useful when:
- A batch of Dependabot PRs is already rebased and waiting on CI, but main has moved underneath them and no further merge events are pending.
- Recovering from edge cases where the auto-trigger missed (e.g., the workflow was broken before).

## Usage

\`\`\`bash
gh workflow run dependabot-rebase-on-main.yml
\`\`\`

…or hit \"Run workflow\" in the Actions UI.

## Why it didn't ride along with #722

Pushed the second commit a few seconds after #722 had already auto-merged, so it missed that PR. Cherry-picked onto main as a one-line follow-up.