### PR TITLE
ci: grant pull-requests:write to dependabot rebase workflow

### DIFF
--- a/.github/workflows/dependabot-rebase-on-main.yml
+++ b/.github/workflows/dependabot-rebase-on-main.yml
@@ -29,7 +29,11 @@ on:
 
 permissions:
   contents: write
-  pull-requests: read
+  # pull-requests: write is required by `PUT /repos/{owner}/{repo}/pulls/{n}/update-branch`.
+  # `read` 403's with "Resource not accessible by integration". The previous
+  # version of this file had `read` and silently 403'd inside `|| true`, so
+  # every workflow run reported success while doing nothing.
+  pull-requests: write
 
 jobs:
   rebase:


### PR DESCRIPTION
## Summary

Third (and hopefully last) bug in the dependabot-rebase-on-main workflow.

The \`PUT /repos/{owner}/{repo}/pulls/{n}/update-branch\` endpoint requires \`pull-requests: write\` on the workflow's GITHUB_TOKEN. The file declared \`pull-requests: read\`, which 403's with \"Resource not accessible by integration\" on every call. The trailing \`|| true\` swallowed the 403 silently, so every workflow run reported success while updating exactly zero branches.

## Evidence

After #722 + #723 landed, the workflow finally fired on a Dependabot merge (good — trigger fix worked). But the actual update-branch calls all 403'd. Run 25287529879 log:

\`\`\`
Updating branch on PR #719
gh: Resource not accessible by integration (HTTP 403)
{\"message\":\"Resource not accessible by integration\",...}
Updating branch on PR #718
gh: Resource not accessible by integration (HTTP 403)
...
\`\`\`

(Same 403 for all 6 open dependabot PRs.)

My earlier manual calls with \`gh api ... update-branch\` succeeded because my CLI uses a personal token with full \`repo\` scope — not the constrained workflow token.

## Fix

\`pull-requests: read\` → \`pull-requests: write\`. One-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)