### PR TITLE
ci: use REBASE_PAT so dependabot rebases trigger CI

### DIFF
--- a/.github/workflows/dependabot-rebase-on-main.yml
+++ b/.github/workflows/dependabot-rebase-on-main.yml
@@ -50,7 +50,15 @@ jobs:
     steps:
       - name: Update branch on every open Dependabot PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use REBASE_PAT (fine-grained personal access token, contents+PRs
+          # read/write on this repo) instead of GITHUB_TOKEN. The merge commit
+          # update-branch creates is pushed using this token's identity, and
+          # GitHub explicitly does NOT trigger downstream workflows
+          # (e.g. CI's `on: pull_request`) when the push originates from
+          # GITHUB_TOKEN — that's the anti-recursion default. PAT-driven
+          # pushes do trigger downstream workflows, so CI re-runs on the
+          # rebased PR head and auto-merge can fire when it goes green.
+          GH_TOKEN: ${{ secrets.REBASE_PAT }}
           GH_REPO: ${{ github.repository }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

Bug 4 (final, hopefully) in the dependabot rebase saga.

After #722, #723, #724 the workflow finally had the correct trigger, the correct API call, and the correct permissions. The first run with all three fixes in place revealed the next layer: the merge commit \`update-branch\` creates is pushed using the workflow's \`GITHUB_TOKEN\`, and GitHub explicitly does NOT fire downstream workflows from \`GITHUB_TOKEN\`-pushed commits (anti-recursion default). So CI never re-ran on the new merge commit, branch protection blocked the merge, and the cascade stalled.

## Fix

Switch to a fine-grained personal access token (\`REBASE_PAT\` repo secret), scoped to:
- Repository: \`sjdodge123/Raid-Ledger\` only
- Permissions: \`Contents: read+write\`, \`Pull requests: read+write\`

PAT-driven pushes DO trigger downstream workflows. After this lands, the cascade is end-to-end:

1. Dependabot PR auto-merges → \`pull_request_target: closed\` fires
2. Rebase workflow runs, calls \`update-branch\` on remaining open dependabot PRs
3. The merge commit pushes use REBASE_PAT → CI re-runs on each rebased PR head
4. As each PR goes green, auto-merge fires
5. That merge fires step 1 again. Loop until queue is empty.

## Test plan

- [ ] Merge this PR
- [ ] \`gh workflow run dependabot-rebase-on-main.yml\` manually
- [ ] Watch run logs — expect \"Updating branch on PR #X\" without 4xx
- [ ] Watch dependabot PR \"Checks\" tab — expect new CI run on the merge commit head
- [ ] Each dependabot PR with green CI auto-merges
- [ ] Verify cascade kicks the next one without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)