### PR TITLE
ci: use REBASE_PAT in dependabot auto-merge so cascade chains

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -23,5 +23,12 @@ jobs:
       - name: Enable auto-merge
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use REBASE_PAT (fine-grained PAT) instead of GITHUB_TOKEN. When the
+          # PR eventually auto-merges, the merge commit is attributed to the
+          # token's owner. GITHUB_TOKEN-attributed merges do NOT trigger
+          # downstream workflows (anti-recursion default), so the rebase
+          # workflow's `pull_request_target: closed` trigger never fired and
+          # the cascade stopped after the first dependabot merge in a batch.
+          # PAT-attributed merges trigger downstream workflows normally.
+          GH_TOKEN: ${{ secrets.REBASE_PAT }}
         run: gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary

Bug 5 in the rebase cascade saga.

When \`dependabot-auto-merge.yml\` uses \`GITHUB_TOKEN\` to call \`gh pr merge --auto --squash\`, the eventual squash-merge commit is attributed to \`github-actions[bot]\`. The anti-recursion default kicks in: that push doesn't trigger downstream workflows. So the rebase workflow's \`pull_request_target: closed\` trigger never fired after a dependabot PR merged, and the cascade stopped one PR in.

## Fix

Switch the auto-merge enabler to \`REBASE_PAT\` (same fine-grained token used by \`dependabot-rebase-on-main.yml\` since #725). Merge commits are then attributed to a real user and downstream workflows chain normally.

## Why this wasn't caught earlier

Operator-merged PRs (yours, manually enabling auto-merge) chained fine because the actor was \`sjdodge123\`, not a bot. Only Dependabot's own auto-merge used \`GITHUB_TOKEN\`, so the breakage was specific to dependabot batches and didn't show up while we were testing with our own follow-up PRs.

## Test plan

- [x] YAML valid
- [ ] After this lands, next dependabot PR that auto-merges should fire the rebase workflow on its close event (visible in Actions tab)
- [ ] Next BEHIND PR (any author) gets rebased without manual \`gh workflow run\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)