### PR TITLE
ROK-1126: fix: wire lineup phase reminder cron + nominations + private/participated filter

### DIFF
--- a/api/src/cron-jobs/cron-job.constants.ts
+++ b/api/src/cron-jobs/cron-job.constants.ts
@@ -185,6 +185,21 @@ export const CORE_JOB_METADATA: Record<string, CoreJobMetadata> = {
       'DMs lineup tiebreaker participants 24h and 1h before round deadline every 5 minutes',
     category: 'Notifications',
   },
+  LineupReminderService_checkVoteReminders: {
+    description:
+      'DMs lineup voters 24h and 1h before voting-phase deadline every 5 minutes',
+    category: 'Notifications',
+  },
+  LineupReminderService_checkSchedulingReminders: {
+    description:
+      'DMs lineup match members 24h and 1h before decided/scheduling-phase deadline every 5 minutes',
+    category: 'Notifications',
+  },
+  LineupReminderService_checkNominationReminders: {
+    description:
+      'DMs lineup nominators 24h and 1h before building-phase deadline every 5 minutes',
+    category: 'Notifications',
+  },
   StandalonePollReminderService_runReminders: {
     description:
       'DMs standalone scheduling poll non-voters 24h and 1h before phase deadline every 5 minutes',

--- a/api/src/lineups/lineup-reminder-dispatch.helpers.ts
+++ b/api/src/lineups/lineup-reminder-dispatch.helpers.ts
@@ -1,0 +1,75 @@
+/**
+ * DM dispatch helpers for the lineup phase reminder cron (ROK-1126).
+ *
+ * Composed by `LineupReminderService` — each helper checks the dedup
+ * cache, builds the windowed copy, and creates a `community_lineup`
+ * notification. Kept in its own file to keep the service under the
+ * 300-line ESLint ceiling.
+ */
+import type { NotificationService } from '../notifications/notification.service';
+import type { NotificationDedupService } from '../notifications/notification-dedup.service';
+import { DEDUP_TTL } from './lineup-notification.constants';
+
+interface DispatchDeps {
+  notificationService: NotificationService;
+  dedupService: NotificationDedupService;
+}
+
+export async function sendVoteReminder(
+  deps: DispatchDeps,
+  lineupId: number,
+  userId: number,
+  window: '24h' | '1h',
+): Promise<void> {
+  const key = `lineup-reminder-${window}:${lineupId}:${userId}`;
+  if (await deps.dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
+  const message =
+    window === '1h'
+      ? 'Last chance to vote -- voting closes in 1 hour'
+      : "You haven't voted yet -- voting closes in 24 hours";
+  await deps.notificationService.create({
+    userId,
+    type: 'community_lineup',
+    title: 'Vote Reminder',
+    message,
+    payload: { subtype: 'lineup_vote_reminder', lineupId },
+  });
+}
+
+export async function sendSchedulingReminder(
+  deps: DispatchDeps,
+  matchId: number,
+  userId: number,
+  window: '24h' | '1h',
+): Promise<void> {
+  const key = `lineup-sched-remind:${matchId}:${userId}:${window}`;
+  if (await deps.dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
+  await deps.notificationService.create({
+    userId,
+    type: 'community_lineup',
+    title: 'Scheduling Reminder',
+    message: 'Your match is waiting -- pick a time!',
+    payload: { subtype: 'lineup_scheduling_reminder', matchId },
+  });
+}
+
+export async function sendNominationReminder(
+  deps: DispatchDeps,
+  lineupId: number,
+  userId: number,
+  window: '24h' | '1h',
+): Promise<void> {
+  const key = `lineup-nominate-remind:${lineupId}:${userId}:${window}`;
+  if (await deps.dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
+  const message =
+    window === '1h'
+      ? 'Last chance to nominate -- the building phase closes in 1 hour'
+      : 'Nominations are closing in 24 hours -- add your picks before the cut';
+  await deps.notificationService.create({
+    userId,
+    type: 'community_lineup',
+    title: 'Nomination Reminder',
+    message,
+    payload: { subtype: 'lineup_nominate_reminder', lineupId },
+  });
+}

--- a/api/src/lineups/lineup-reminder-target.helpers.spec.ts
+++ b/api/src/lineups/lineup-reminder-target.helpers.spec.ts
@@ -1,0 +1,244 @@
+/**
+ * TDD unit tests for `resolveLineupReminderTargets` (ROK-1126).
+ *
+ * Covers AC #4: helper signature, public/private branches × nominate/vote/
+ * schedule actions, plus edge cases (no invitees, no participants, all
+ * already participated → empty array).
+ *
+ * The helper does not exist yet — this spec MUST fail on import until the
+ * dev agent creates `lineup-reminder-target.helpers.ts`.
+ */
+import {
+  resolveLineupReminderTargets,
+  type ReminderAction,
+} from './lineup-reminder-target.helpers';
+
+// ---------------------------------------------------------------------------
+// Mocked Drizzle: a single `db.execute` that returns whatever the test queues.
+// Mirrors the pattern in `lineup-reminder.service.spec.ts`.
+// ---------------------------------------------------------------------------
+
+interface MockDb {
+  execute: jest.Mock;
+}
+
+function makeMockDb(): MockDb {
+  return { execute: jest.fn() };
+}
+
+const LINEUP_ID = 42;
+const MATCH_ID = 100;
+
+function lineup(visibility: 'public' | 'private', createdBy = 1) {
+  return { id: LINEUP_ID, visibility, createdBy };
+}
+
+function user(id: number) {
+  return { id, userId: id };
+}
+
+// ---------------------------------------------------------------------------
+
+describe('resolveLineupReminderTargets', () => {
+  let db: MockDb;
+
+  beforeEach(() => {
+    db = makeMockDb();
+  });
+
+  // ─── exported types / signature ──────────────────────────────────────────
+
+  it('exports ReminderAction type union including nominate, vote, schedule', () => {
+    // Compile-time check — if the type is missing or wrong this fails to compile.
+    const actions: ReminderAction[] = ['nominate', 'vote', 'schedule'];
+    expect(actions).toHaveLength(3);
+  });
+
+  it('returns Promise<number[]>', async () => {
+    db.execute.mockResolvedValueOnce([lineup('public')]).mockResolvedValue([]);
+    const result = await resolveLineupReminderTargets(
+      db as unknown as Parameters<typeof resolveLineupReminderTargets>[0],
+      LINEUP_ID,
+      'nominate',
+    );
+    expect(Array.isArray(result)).toBe(true);
+  });
+
+  // ─── PRIVATE branch ──────────────────────────────────────────────────────
+
+  describe('private lineup', () => {
+    it('nominate → invitees + creator minus existing nominators', async () => {
+      // 1) load lineup
+      db.execute.mockResolvedValueOnce([lineup('private', 100)]);
+      // 2) invitees ∪ {createdBy} (already deduped by helper) — invitees with discord_id
+      db.execute.mockResolvedValueOnce([user(21), user(22)]);
+      // 3) participants (already nominated)
+      db.execute.mockResolvedValueOnce([{ userId: 21 }]);
+
+      const result = await resolveLineupReminderTargets(
+        db as unknown as Parameters<typeof resolveLineupReminderTargets>[0],
+        LINEUP_ID,
+        'nominate',
+      );
+
+      // 100 (creator) + 22 — 21 already nominated, dropped
+      expect(new Set(result)).toEqual(new Set([100, 22]));
+    });
+
+    it('vote → invitees + creator minus existing voters', async () => {
+      db.execute.mockResolvedValueOnce([lineup('private', 100)]);
+      db.execute.mockResolvedValueOnce([user(31), user(32), user(33)]);
+      db.execute.mockResolvedValueOnce([{ userId: 32 }]); // already voted
+
+      const result = await resolveLineupReminderTargets(
+        db as unknown as Parameters<typeof resolveLineupReminderTargets>[0],
+        LINEUP_ID,
+        'vote',
+      );
+
+      expect(new Set(result)).toEqual(new Set([100, 31, 33]));
+    });
+
+    it('schedule → invitees + creator minus existing schedule voters (matchId required)', async () => {
+      db.execute.mockResolvedValueOnce([lineup('private', 100)]);
+      db.execute.mockResolvedValueOnce([user(41), user(42)]);
+      db.execute.mockResolvedValueOnce([{ userId: 41 }]);
+
+      const result = await resolveLineupReminderTargets(
+        db as unknown as Parameters<typeof resolveLineupReminderTargets>[0],
+        LINEUP_ID,
+        'schedule',
+        MATCH_ID,
+      );
+
+      expect(new Set(result)).toEqual(new Set([100, 42]));
+    });
+
+    it('returns only the creator when there are no invitees', async () => {
+      db.execute.mockResolvedValueOnce([lineup('private', 100)]);
+      db.execute.mockResolvedValueOnce([]); // no invitees
+      db.execute.mockResolvedValueOnce([]); // no participants
+
+      const result = await resolveLineupReminderTargets(
+        db as unknown as Parameters<typeof resolveLineupReminderTargets>[0],
+        LINEUP_ID,
+        'nominate',
+      );
+
+      expect(new Set(result)).toEqual(new Set([100]));
+    });
+
+    it('returns [] when every invitee + creator has already participated', async () => {
+      db.execute.mockResolvedValueOnce([lineup('private', 100)]);
+      db.execute.mockResolvedValueOnce([user(21), user(22)]);
+      db.execute.mockResolvedValueOnce([
+        { userId: 100 },
+        { userId: 21 },
+        { userId: 22 },
+      ]);
+
+      const result = await resolveLineupReminderTargets(
+        db as unknown as Parameters<typeof resolveLineupReminderTargets>[0],
+        LINEUP_ID,
+        'vote',
+      );
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ─── PUBLIC branch ───────────────────────────────────────────────────────
+
+  describe('public lineup', () => {
+    it('nominate → all Discord-linked users minus existing nominators', async () => {
+      db.execute.mockResolvedValueOnce([lineup('public', 1)]);
+      // all discord-linked users
+      db.execute.mockResolvedValueOnce([user(10), user(11), user(12)]);
+      // existing nominators
+      db.execute.mockResolvedValueOnce([{ userId: 11 }]);
+
+      const result = await resolveLineupReminderTargets(
+        db as unknown as Parameters<typeof resolveLineupReminderTargets>[0],
+        LINEUP_ID,
+        'nominate',
+      );
+
+      expect(new Set(result)).toEqual(new Set([10, 12]));
+    });
+
+    it('vote → participants so far (nominators ∪ voters) minus existing voters', async () => {
+      db.execute.mockResolvedValueOnce([lineup('public', 1)]);
+      // candidate set — nominators ∪ voters (helper may run a single union query)
+      db.execute.mockResolvedValueOnce([user(20), user(21), user(22)]);
+      // existing voters
+      db.execute.mockResolvedValueOnce([{ userId: 22 }]);
+
+      const result = await resolveLineupReminderTargets(
+        db as unknown as Parameters<typeof resolveLineupReminderTargets>[0],
+        LINEUP_ID,
+        'vote',
+      );
+
+      expect(new Set(result)).toEqual(new Set([20, 21]));
+    });
+
+    it('schedule → match members (with discord_id) minus existing schedule voters', async () => {
+      db.execute.mockResolvedValueOnce([lineup('public', 1)]);
+      // match members
+      db.execute.mockResolvedValueOnce([user(30), user(31)]);
+      // existing schedule voters for this match
+      db.execute.mockResolvedValueOnce([{ userId: 30 }]);
+
+      const result = await resolveLineupReminderTargets(
+        db as unknown as Parameters<typeof resolveLineupReminderTargets>[0],
+        LINEUP_ID,
+        'schedule',
+        MATCH_ID,
+      );
+
+      expect(new Set(result)).toEqual(new Set([31]));
+    });
+
+    it('returns [] for vote action when no users have participated yet', async () => {
+      db.execute.mockResolvedValueOnce([lineup('public', 1)]);
+      db.execute.mockResolvedValueOnce([]); // nominators ∪ voters — empty
+      db.execute.mockResolvedValueOnce([]);
+
+      const result = await resolveLineupReminderTargets(
+        db as unknown as Parameters<typeof resolveLineupReminderTargets>[0],
+        LINEUP_ID,
+        'vote',
+      );
+
+      expect(result).toEqual([]);
+    });
+
+    it('returns [] when every Discord-linked user has already nominated', async () => {
+      db.execute.mockResolvedValueOnce([lineup('public', 1)]);
+      db.execute.mockResolvedValueOnce([user(10), user(11)]);
+      db.execute.mockResolvedValueOnce([{ userId: 10 }, { userId: 11 }]);
+
+      const result = await resolveLineupReminderTargets(
+        db as unknown as Parameters<typeof resolveLineupReminderTargets>[0],
+        LINEUP_ID,
+        'nominate',
+      );
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ─── Misc edge cases ─────────────────────────────────────────────────────
+
+  it('returns [] if the lineup row does not exist', async () => {
+    db.execute.mockResolvedValueOnce([]); // no lineup row
+
+    const result = await resolveLineupReminderTargets(
+      db as unknown as Parameters<typeof resolveLineupReminderTargets>[0],
+      LINEUP_ID,
+      'nominate',
+    );
+
+    expect(result).toEqual([]);
+  });
+});

--- a/api/src/lineups/lineup-reminder-target.helpers.spec.ts
+++ b/api/src/lineups/lineup-reminder-target.helpers.spec.ts
@@ -70,9 +70,11 @@ describe('resolveLineupReminderTargets', () => {
     it('nominate → invitees + creator minus existing nominators', async () => {
       // 1) load lineup
       db.execute.mockResolvedValueOnce([lineup('private', 100)]);
-      // 2) invitees ∪ {createdBy} (already deduped by helper) — invitees with discord_id
+      // 2) invitees with discord_id
       db.execute.mockResolvedValueOnce([user(21), user(22)]);
-      // 3) participants (already nominated)
+      // 3) creator-with-discord lookup
+      db.execute.mockResolvedValueOnce([{ userId: 100 }]);
+      // 4) participants (already nominated)
       db.execute.mockResolvedValueOnce([{ userId: 21 }]);
 
       const result = await resolveLineupReminderTargets(
@@ -88,6 +90,7 @@ describe('resolveLineupReminderTargets', () => {
     it('vote → invitees + creator minus existing voters', async () => {
       db.execute.mockResolvedValueOnce([lineup('private', 100)]);
       db.execute.mockResolvedValueOnce([user(31), user(32), user(33)]);
+      db.execute.mockResolvedValueOnce([{ userId: 100 }]); // creator has discord
       db.execute.mockResolvedValueOnce([{ userId: 32 }]); // already voted
 
       const result = await resolveLineupReminderTargets(
@@ -99,9 +102,16 @@ describe('resolveLineupReminderTargets', () => {
       expect(new Set(result)).toEqual(new Set([100, 31, 33]));
     });
 
-    it('schedule → invitees + creator minus existing schedule voters (matchId required)', async () => {
+    it('schedule → invitees + creator scoped to match members minus existing schedule voters', async () => {
       db.execute.mockResolvedValueOnce([lineup('private', 100)]);
       db.execute.mockResolvedValueOnce([user(41), user(42)]);
+      db.execute.mockResolvedValueOnce([{ userId: 100 }]); // creator has discord
+      // match members for this matchId — excludes random invitees not in the match
+      db.execute.mockResolvedValueOnce([
+        { userId: 100 },
+        { userId: 41 },
+        { userId: 42 },
+      ]);
       db.execute.mockResolvedValueOnce([{ userId: 41 }]);
 
       const result = await resolveLineupReminderTargets(
@@ -114,9 +124,49 @@ describe('resolveLineupReminderTargets', () => {
       expect(new Set(result)).toEqual(new Set([100, 42]));
     });
 
+    it('schedule → invitee NOT in match members is excluded from the DM', async () => {
+      db.execute.mockResolvedValueOnce([lineup('private', 100)]);
+      // 3 invitees on the lineup, but only 41 is on the scheduling match.
+      db.execute.mockResolvedValueOnce([user(41), user(42), user(43)]);
+      db.execute.mockResolvedValueOnce([{ userId: 100 }]); // creator
+      // Only creator + 41 are match members.
+      db.execute.mockResolvedValueOnce([{ userId: 100 }, { userId: 41 }]);
+      db.execute.mockResolvedValueOnce([]); // nobody has voted on a slot yet
+
+      const result = await resolveLineupReminderTargets(
+        db as unknown as Parameters<typeof resolveLineupReminderTargets>[0],
+        LINEUP_ID,
+        'schedule',
+        MATCH_ID,
+      );
+
+      // 42 and 43 are invitees but not match members → should NOT be reminded.
+      expect(new Set(result)).toEqual(new Set([100, 41]));
+    });
+
+    it('schedule → creator without discord_id is excluded from the DM', async () => {
+      db.execute.mockResolvedValueOnce([lineup('private', 100)]);
+      db.execute.mockResolvedValueOnce([user(41)]);
+      // creator-with-discord lookup returns empty → creator has no discord_id
+      db.execute.mockResolvedValueOnce([]);
+      db.execute.mockResolvedValueOnce([{ userId: 41 }]); // match members
+      db.execute.mockResolvedValueOnce([]); // no participants
+
+      const result = await resolveLineupReminderTargets(
+        db as unknown as Parameters<typeof resolveLineupReminderTargets>[0],
+        LINEUP_ID,
+        'schedule',
+        MATCH_ID,
+      );
+
+      // 100 (creator) excluded — no discord_id.
+      expect(new Set(result)).toEqual(new Set([41]));
+    });
+
     it('returns only the creator when there are no invitees', async () => {
       db.execute.mockResolvedValueOnce([lineup('private', 100)]);
       db.execute.mockResolvedValueOnce([]); // no invitees
+      db.execute.mockResolvedValueOnce([{ userId: 100 }]); // creator has discord
       db.execute.mockResolvedValueOnce([]); // no participants
 
       const result = await resolveLineupReminderTargets(
@@ -131,6 +181,7 @@ describe('resolveLineupReminderTargets', () => {
     it('returns [] when every invitee + creator has already participated', async () => {
       db.execute.mockResolvedValueOnce([lineup('private', 100)]);
       db.execute.mockResolvedValueOnce([user(21), user(22)]);
+      db.execute.mockResolvedValueOnce([{ userId: 100 }]); // creator has discord
       db.execute.mockResolvedValueOnce([
         { userId: 100 },
         { userId: 21 },

--- a/api/src/lineups/lineup-reminder-target.helpers.ts
+++ b/api/src/lineups/lineup-reminder-target.helpers.ts
@@ -64,16 +64,32 @@ async function resolvePrivateTargets(
      WHERE i.lineup_id = ${lineup.id}
        AND u.discord_id IS NOT NULL
   `)) as unknown as UserRow[];
+  const pool = new Set<number>(candidates.map((r) => r.userId));
+  // Add the creator only if they have a discord_id (preserves the existing
+  // recipient invariant — every other reminder path filters on discord_id).
+  const [creator] = (await db.execute(sql`
+    SELECT id AS "userId"
+      FROM users
+     WHERE id = ${lineup.createdBy}
+       AND discord_id IS NOT NULL
+     LIMIT 1
+  `)) as unknown as UserRow[];
+  if (creator) pool.add(creator.userId);
+  // Scheduling reminders are per-match: intersect the invitee/creator pool
+  // with `community_lineup_match_members` for this match so unrelated invitees
+  // aren't pinged about polls they're not in (preserves prior behavior).
+  if (action === 'schedule' && matchId !== undefined) {
+    const memberIds = new Set(await loadMatchMembers(db, matchId));
+    for (const id of Array.from(pool)) {
+      if (!memberIds.has(id)) pool.delete(id);
+    }
+  }
   const participated = await loadParticipatedUserIds(
     db,
     lineup.id,
     action,
     matchId,
   );
-  const pool = new Set<number>([
-    lineup.createdBy,
-    ...candidates.map((r) => r.userId),
-  ]);
   for (const id of participated) pool.delete(id);
   return Array.from(pool);
 }

--- a/api/src/lineups/lineup-reminder-target.helpers.ts
+++ b/api/src/lineups/lineup-reminder-target.helpers.ts
@@ -1,0 +1,173 @@
+/**
+ * Lineup reminder target resolution (ROK-1126).
+ *
+ * Computes the recipient set for the nominate / vote / schedule reminder
+ * crons. Branches on lineup visibility:
+ *   - private → invitees ∪ {createdBy} minus users who already participated
+ *   - public  → action-specific candidate set minus already-participated
+ *
+ * For `schedule` action, `matchId` is required and gates the
+ * already-participated query against `community_lineup_schedule_votes`.
+ */
+import { sql } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from '../drizzle/schema';
+
+type Db = PostgresJsDatabase<typeof schema>;
+
+export type ReminderAction = 'nominate' | 'vote' | 'schedule';
+
+interface LineupRow {
+  id: number;
+  visibility: 'public' | 'private';
+  createdBy: number;
+}
+
+interface UserRow {
+  userId: number;
+}
+
+/**
+ * Resolve user IDs eligible to receive a reminder for `action` on `lineupId`.
+ * Returns dedup'd numeric IDs. Returns `[]` if the lineup row is missing.
+ */
+export async function resolveLineupReminderTargets(
+  db: Db,
+  lineupId: number,
+  action: ReminderAction,
+  matchId?: number,
+): Promise<number[]> {
+  const [lineup] = (await db.execute(sql`
+    SELECT id, visibility, created_by AS "createdBy"
+      FROM community_lineups
+     WHERE id = ${lineupId}
+     LIMIT 1
+  `)) as unknown as LineupRow[];
+  if (!lineup) return [];
+
+  if (lineup.visibility === 'private') {
+    return resolvePrivateTargets(db, lineup, action, matchId);
+  }
+  return resolvePublicTargets(db, lineup.id, action, matchId);
+}
+
+async function resolvePrivateTargets(
+  db: Db,
+  lineup: LineupRow,
+  action: ReminderAction,
+  matchId?: number,
+): Promise<number[]> {
+  const candidates = (await db.execute(sql`
+    SELECT u.id AS "userId"
+      FROM community_lineup_invitees i
+      JOIN users u ON u.id = i.user_id
+     WHERE i.lineup_id = ${lineup.id}
+       AND u.discord_id IS NOT NULL
+  `)) as unknown as UserRow[];
+  const participated = await loadParticipatedUserIds(
+    db,
+    lineup.id,
+    action,
+    matchId,
+  );
+  const pool = new Set<number>([
+    lineup.createdBy,
+    ...candidates.map((r) => r.userId),
+  ]);
+  for (const id of participated) pool.delete(id);
+  return Array.from(pool);
+}
+
+async function resolvePublicTargets(
+  db: Db,
+  lineupId: number,
+  action: ReminderAction,
+  matchId?: number,
+): Promise<number[]> {
+  const candidates = await loadPublicCandidates(db, lineupId, action, matchId);
+  const participated = await loadParticipatedUserIds(
+    db,
+    lineupId,
+    action,
+    matchId,
+  );
+  const skip = new Set(participated);
+  return candidates.filter((id) => !skip.has(id));
+}
+
+async function loadPublicCandidates(
+  db: Db,
+  lineupId: number,
+  action: ReminderAction,
+  matchId?: number,
+): Promise<number[]> {
+  if (action === 'nominate') {
+    const rows = (await db.execute(sql`
+      SELECT id AS "userId"
+        FROM users
+       WHERE discord_id IS NOT NULL
+    `)) as unknown as UserRow[];
+    return Array.from(new Set(rows.map((r) => r.userId)));
+  }
+  if (action === 'vote') {
+    const rows = (await db.execute(sql`
+      SELECT DISTINCT u.id AS "userId"
+        FROM users u
+       WHERE u.discord_id IS NOT NULL
+         AND (
+           u.id IN (
+             SELECT nominated_by
+               FROM community_lineup_entries
+              WHERE lineup_id = ${lineupId}
+           )
+           OR u.id IN (
+             SELECT user_id
+               FROM community_lineup_votes
+              WHERE lineup_id = ${lineupId}
+           )
+         )
+    `)) as unknown as UserRow[];
+    return Array.from(new Set(rows.map((r) => r.userId)));
+  }
+  // schedule
+  const rows = (await db.execute(sql`
+    SELECT DISTINCT u.id AS "userId"
+      FROM community_lineup_match_members lmm
+      JOIN users u ON u.id = lmm.user_id
+     WHERE lmm.match_id = ${matchId ?? -1}
+       AND u.discord_id IS NOT NULL
+  `)) as unknown as UserRow[];
+  return Array.from(new Set(rows.map((r) => r.userId)));
+}
+
+async function loadParticipatedUserIds(
+  db: Db,
+  lineupId: number,
+  action: ReminderAction,
+  matchId?: number,
+): Promise<number[]> {
+  if (action === 'nominate') {
+    const rows = (await db.execute(sql`
+      SELECT DISTINCT nominated_by AS "userId"
+        FROM community_lineup_entries
+       WHERE lineup_id = ${lineupId}
+    `)) as unknown as UserRow[];
+    return rows.map((r) => r.userId);
+  }
+  if (action === 'vote') {
+    const rows = (await db.execute(sql`
+      SELECT DISTINCT user_id AS "userId"
+        FROM community_lineup_votes
+       WHERE lineup_id = ${lineupId}
+    `)) as unknown as UserRow[];
+    return rows.map((r) => r.userId);
+  }
+  // schedule
+  const rows = (await db.execute(sql`
+    SELECT DISTINCT csv.user_id AS "userId"
+      FROM community_lineup_schedule_votes csv
+      JOIN community_lineup_schedule_slots css ON css.id = csv.slot_id
+     WHERE css.match_id = ${matchId ?? -1}
+  `)) as unknown as UserRow[];
+  return rows.map((r) => r.userId);
+}

--- a/api/src/lineups/lineup-reminder-target.helpers.ts
+++ b/api/src/lineups/lineup-reminder-target.helpers.ts
@@ -101,40 +101,50 @@ async function loadPublicCandidates(
   action: ReminderAction,
   matchId?: number,
 ): Promise<number[]> {
-  if (action === 'nominate') {
-    const rows = (await db.execute(sql`
-      SELECT id AS "userId"
-        FROM users
-       WHERE discord_id IS NOT NULL
-    `)) as unknown as UserRow[];
-    return Array.from(new Set(rows.map((r) => r.userId)));
-  }
-  if (action === 'vote') {
-    const rows = (await db.execute(sql`
-      SELECT DISTINCT u.id AS "userId"
-        FROM users u
-       WHERE u.discord_id IS NOT NULL
-         AND (
-           u.id IN (
-             SELECT nominated_by
-               FROM community_lineup_entries
-              WHERE lineup_id = ${lineupId}
-           )
-           OR u.id IN (
-             SELECT user_id
-               FROM community_lineup_votes
-              WHERE lineup_id = ${lineupId}
-           )
+  if (action === 'nominate') return loadAllDiscordLinkedUsers(db);
+  if (action === 'vote') return loadPublicVoteCandidates(db, lineupId);
+  return loadMatchMembers(db, matchId ?? -1);
+}
+
+async function loadAllDiscordLinkedUsers(db: Db): Promise<number[]> {
+  const rows = (await db.execute(sql`
+    SELECT id AS "userId"
+      FROM users
+     WHERE discord_id IS NOT NULL
+  `)) as unknown as UserRow[];
+  return Array.from(new Set(rows.map((r) => r.userId)));
+}
+
+async function loadPublicVoteCandidates(
+  db: Db,
+  lineupId: number,
+): Promise<number[]> {
+  const rows = (await db.execute(sql`
+    SELECT DISTINCT u.id AS "userId"
+      FROM users u
+     WHERE u.discord_id IS NOT NULL
+       AND (
+         u.id IN (
+           SELECT nominated_by
+             FROM community_lineup_entries
+            WHERE lineup_id = ${lineupId}
          )
-    `)) as unknown as UserRow[];
-    return Array.from(new Set(rows.map((r) => r.userId)));
-  }
-  // schedule
+         OR u.id IN (
+           SELECT user_id
+             FROM community_lineup_votes
+            WHERE lineup_id = ${lineupId}
+         )
+       )
+  `)) as unknown as UserRow[];
+  return Array.from(new Set(rows.map((r) => r.userId)));
+}
+
+async function loadMatchMembers(db: Db, matchId: number): Promise<number[]> {
   const rows = (await db.execute(sql`
     SELECT DISTINCT u.id AS "userId"
       FROM community_lineup_match_members lmm
       JOIN users u ON u.id = lmm.user_id
-     WHERE lmm.match_id = ${matchId ?? -1}
+     WHERE lmm.match_id = ${matchId}
        AND u.discord_id IS NOT NULL
   `)) as unknown as UserRow[];
   return Array.from(new Set(rows.map((r) => r.userId)));

--- a/api/src/lineups/lineup-reminder.integration.spec.ts
+++ b/api/src/lineups/lineup-reminder.integration.spec.ts
@@ -83,9 +83,7 @@ describe('LineupReminderService cron (integration, ROK-1126)', () => {
     creatorId: number;
     phaseDeadlineHoursAhead: number;
   }): Promise<number> {
-    const deadline = new Date(
-      Date.now() + opts.phaseDeadlineHoursAhead * HOUR,
-    );
+    const deadline = new Date(Date.now() + opts.phaseDeadlineHoursAhead * HOUR);
     const [lineup] = await testApp.db
       .insert(schema.communityLineups)
       .values({
@@ -129,9 +127,7 @@ describe('LineupReminderService cron (integration, ROK-1126)', () => {
       .values({ lineupId, gameId, userId });
   }
 
-  async function userIdsWhoReceivedSubtype(
-    subtype: string,
-  ): Promise<number[]> {
+  function userIdsWhoReceivedSubtype(subtype: string): number[] {
     const ids = createSpy.mock.calls
       .map((c) => c[0] as { userId: number; payload?: { subtype?: string } })
       .filter((p) => p.payload?.subtype === subtype)
@@ -141,8 +137,9 @@ describe('LineupReminderService cron (integration, ROK-1126)', () => {
 
   function dedupKeysSeen(): string[] {
     return (
-      (dedupService.checkAndMarkSent as unknown as jest.Mock | undefined)?.mock
-        ?.calls?.map((c) => String(c[0])) ?? []
+      (
+        dedupService.checkAndMarkSent as unknown as jest.Mock | undefined
+      )?.mock?.calls?.map((c) => String(c[0])) ?? []
     );
   }
 
@@ -176,9 +173,7 @@ describe('LineupReminderService cron (integration, ROK-1126)', () => {
 
       await reminderService.checkVoteReminders();
 
-      const recipients = await userIdsWhoReceivedSubtype(
-        'lineup_vote_reminder',
-      );
+      const recipients = userIdsWhoReceivedSubtype('lineup_vote_reminder');
       // Creator + 2 unvoted invitees (B, C). NOT inviteeA (voted), NOT bystander.
       expect(new Set(recipients)).toEqual(
         new Set([creatorId, inviteeB, inviteeC]),
@@ -232,9 +227,7 @@ describe('LineupReminderService cron (integration, ROK-1126)', () => {
 
       await reminderService.checkVoteReminders();
 
-      const recipients = await userIdsWhoReceivedSubtype(
-        'lineup_vote_reminder',
-      );
+      const recipients = userIdsWhoReceivedSubtype('lineup_vote_reminder');
       // nomB has nominated but not voted → reminder.
       // nomA already voted → no reminder.
       // voterC already voted → no reminder.
@@ -266,9 +259,7 @@ describe('LineupReminderService cron (integration, ROK-1126)', () => {
 
       await reminderService.checkNominationReminders();
 
-      const recipients = await userIdsWhoReceivedSubtype(
-        'lineup_nominate_reminder',
-      );
+      const recipients = userIdsWhoReceivedSubtype('lineup_nominate_reminder');
       // Creator + inviteeB (the only one who hasn't nominated yet).
       expect(new Set(recipients)).toEqual(new Set([creatorId, inviteeB]));
 
@@ -299,7 +290,7 @@ describe('LineupReminderService cron (integration, ROK-1126)', () => {
       const userB = await createDiscordUser('u-b-8');
       const userC = await createDiscordUser('u-c-8');
 
-      const lineupId = await createLineup({
+      await createLineup({
         visibility: 'public',
         status: 'building',
         creatorId,
@@ -308,9 +299,7 @@ describe('LineupReminderService cron (integration, ROK-1126)', () => {
 
       await reminderService.checkNominationReminders();
 
-      const recipients = await userIdsWhoReceivedSubtype(
-        'lineup_nominate_reminder',
-      );
+      const recipients = userIdsWhoReceivedSubtype('lineup_nominate_reminder');
       // All four discord-linked users should receive a reminder (no nominations yet).
       // Note: the seeded admin user from test-app's baseline also has discord_id
       // set, so we assert SUPERSET of our four users — not exact equality —
@@ -369,12 +358,10 @@ describe('LineupReminderService cron (integration, ROK-1126)', () => {
 
       await reminderService.checkSchedulingReminders();
 
-      const recipients = await userIdsWhoReceivedSubtype(
+      const recipients = userIdsWhoReceivedSubtype(
         'lineup_scheduling_reminder',
       );
-      expect(new Set(recipients)).toEqual(
-        new Set([creatorId, inviteeB]),
-      );
+      expect(new Set(recipients)).toEqual(new Set([creatorId, inviteeB]));
     });
   });
 

--- a/api/src/lineups/lineup-reminder.integration.spec.ts
+++ b/api/src/lineups/lineup-reminder.integration.spec.ts
@@ -1,0 +1,422 @@
+/**
+ * ROK-1126 — Lineup phase reminder cron (integration).
+ *
+ * TDD gate: pins down behavior of `LineupReminderService.checkVoteReminders`,
+ * `checkSchedulingReminders`, and the new `checkNominationReminders` against
+ * a real Postgres. These tests MUST fail until the dev agent:
+ *   1. Creates `lineup-reminder-target.helpers.ts` with
+ *      `resolveLineupReminderTargets(db, lineupId, action, matchId?)`.
+ *   2. Wires `@Cron(EVERY_5_MINUTES)` + `executeWithTracking` to
+ *      `checkVoteReminders` and `checkSchedulingReminders`.
+ *   3. Adds `checkNominationReminders` (same shape).
+ *   4. Routes recipient resolution for all three through the helper, applying
+ *      the public/private + already-participated filter rules.
+ *
+ * Coverage (10 ACs):
+ *   AC #5  — private + voting + 1h → invitees ∪ creator minus voters
+ *   AC #6  — public + voting + 1h → participants minus voters
+ *   AC #7  — private + building + 1h → invitees ∪ creator minus nominators
+ *   AC #8  — public + building + 1h → all Discord-linked users minus nominators
+ *   AC #5b — private + decided + 1h (scheduling phase) → invitees ∪ creator minus schedule-voters
+ *   AC #10 — running checkVoteReminders twice → only one DM per recipient (dedup)
+ */
+import { eq } from 'drizzle-orm';
+import { getTestApp, type TestApp } from '../common/testing/test-app';
+import { truncateAllTables } from '../common/testing/integration-helpers';
+import * as schema from '../drizzle/schema';
+import { LineupReminderService } from './lineup-reminder.service';
+import { NotificationService } from '../notifications/notification.service';
+import { NotificationDedupService } from '../notifications/notification-dedup.service';
+
+const HOUR = 60 * 60 * 1000;
+
+describe('LineupReminderService cron (integration, ROK-1126)', () => {
+  let testApp: TestApp;
+  let reminderService: LineupReminderService;
+  let notificationService: NotificationService;
+  let dedupService: NotificationDedupService;
+  let createSpy: jest.SpyInstance;
+
+  beforeAll(async () => {
+    testApp = await getTestApp();
+    reminderService = testApp.app.get(LineupReminderService);
+    notificationService = testApp.app.get(NotificationService);
+    dedupService = testApp.app.get(NotificationDedupService);
+  });
+
+  beforeEach(() => {
+    createSpy = jest.spyOn(notificationService, 'create');
+  });
+
+  afterEach(async () => {
+    createSpy.mockRestore();
+    testApp.seed = await truncateAllTables(testApp.db);
+  });
+
+  // ── Helpers ──────────────────────────────────────────────────────────────
+
+  async function createDiscordUser(tag: string): Promise<number> {
+    const [user] = await testApp.db
+      .insert(schema.users)
+      .values({
+        discordId: `discord:${tag}-${Date.now()}-${Math.random()}`,
+        username: `mem-${tag}-${Date.now()}`,
+        role: 'member',
+      })
+      .returning();
+    return user.id;
+  }
+
+  async function createGame(name: string): Promise<number> {
+    const [g] = await testApp.db
+      .insert(schema.games)
+      .values({
+        name: `${name}-${Date.now()}`,
+        slug: `${name.toLowerCase()}-${Date.now()}-${Math.random()}`,
+      })
+      .returning();
+    return g.id;
+  }
+
+  async function createLineup(opts: {
+    visibility: 'public' | 'private';
+    status: 'building' | 'voting' | 'decided';
+    creatorId: number;
+    phaseDeadlineHoursAhead: number;
+  }): Promise<number> {
+    const deadline = new Date(
+      Date.now() + opts.phaseDeadlineHoursAhead * HOUR,
+    );
+    const [lineup] = await testApp.db
+      .insert(schema.communityLineups)
+      .values({
+        title: `ROK-1126 ${opts.visibility} ${opts.status}`,
+        status: opts.status,
+        visibility: opts.visibility,
+        createdBy: opts.creatorId,
+        phaseDeadline: deadline,
+      })
+      .returning();
+    return lineup.id;
+  }
+
+  async function inviteUsers(
+    lineupId: number,
+    userIds: number[],
+  ): Promise<void> {
+    if (userIds.length === 0) return;
+    await testApp.db
+      .insert(schema.communityLineupInvitees)
+      .values(userIds.map((userId) => ({ lineupId, userId })));
+  }
+
+  async function nominateGame(
+    lineupId: number,
+    gameId: number,
+    nominatedBy: number,
+  ): Promise<void> {
+    await testApp.db
+      .insert(schema.communityLineupEntries)
+      .values({ lineupId, gameId, nominatedBy });
+  }
+
+  async function castVote(
+    lineupId: number,
+    gameId: number,
+    userId: number,
+  ): Promise<void> {
+    await testApp.db
+      .insert(schema.communityLineupVotes)
+      .values({ lineupId, gameId, userId });
+  }
+
+  async function userIdsWhoReceivedSubtype(
+    subtype: string,
+  ): Promise<number[]> {
+    const ids = createSpy.mock.calls
+      .map((c) => c[0] as { userId: number; payload?: { subtype?: string } })
+      .filter((p) => p.payload?.subtype === subtype)
+      .map((p) => p.userId);
+    return Array.from(new Set(ids));
+  }
+
+  function dedupKeysSeen(): string[] {
+    return (
+      (dedupService.checkAndMarkSent as unknown as jest.Mock | undefined)?.mock
+        ?.calls?.map((c) => String(c[0])) ?? []
+    );
+  }
+
+  // ── AC #5: private + voting + 1h ─────────────────────────────────────────
+
+  describe('AC #5 — private voting + 1h-out deadline', () => {
+    it('DMs creator + invitees who have not voted, none to non-invitees', async () => {
+      const creatorId = await createDiscordUser('creator-5');
+      const inviteeA = await createDiscordUser('inv-a-5');
+      const inviteeB = await createDiscordUser('inv-b-5');
+      const inviteeC = await createDiscordUser('inv-c-5');
+      const bystander = await createDiscordUser('bystander-5');
+      void bystander;
+
+      const gameAId = await createGame('G5A');
+      const gameBId = await createGame('G5B');
+
+      const lineupId = await createLineup({
+        visibility: 'private',
+        status: 'voting',
+        creatorId,
+        phaseDeadlineHoursAhead: 50 / 60, // ~50 minutes
+      });
+      await inviteUsers(lineupId, [inviteeA, inviteeB, inviteeC]);
+      await nominateGame(lineupId, gameAId, inviteeA);
+      await nominateGame(lineupId, gameBId, inviteeB);
+      // inviteeA already voted → must NOT receive a vote reminder.
+      await castVote(lineupId, gameBId, inviteeA);
+
+      jest.spyOn(dedupService, 'checkAndMarkSent');
+
+      await reminderService.checkVoteReminders();
+
+      const recipients = await userIdsWhoReceivedSubtype(
+        'lineup_vote_reminder',
+      );
+      // Creator + 2 unvoted invitees (B, C). NOT inviteeA (voted), NOT bystander.
+      expect(new Set(recipients)).toEqual(
+        new Set([creatorId, inviteeB, inviteeC]),
+      );
+
+      // Each DM is type=community_lineup with the right subtype.
+      const matchingCalls = createSpy.mock.calls.filter(
+        (c) =>
+          (c[0] as { payload?: { subtype?: string } }).payload?.subtype ===
+          'lineup_vote_reminder',
+      );
+      for (const [args] of matchingCalls) {
+        expect(args).toMatchObject({ type: 'community_lineup' });
+      }
+
+      // Dedup key uses lineup-reminder-1h:{lineupId}:{userId} for the 1h window.
+      const keys = dedupKeysSeen();
+      for (const userId of [creatorId, inviteeB, inviteeC]) {
+        expect(keys).toContain(`lineup-reminder-1h:${lineupId}:${userId}`);
+      }
+    });
+  });
+
+  // ── AC #6: public + voting + 1h ──────────────────────────────────────────
+
+  describe('AC #6 — public voting + 1h-out deadline', () => {
+    it('DMs only participants (nominators ∪ voters) minus already-voted', async () => {
+      const creatorId = await createDiscordUser('creator-6');
+      const nomA = await createDiscordUser('nom-a-6');
+      const nomB = await createDiscordUser('nom-b-6');
+      const voterC = await createDiscordUser('voter-c-6');
+      const bystander = await createDiscordUser('bystander-6');
+      void bystander;
+
+      const gameAId = await createGame('G6A');
+      const gameBId = await createGame('G6B');
+
+      const lineupId = await createLineup({
+        visibility: 'public',
+        status: 'voting',
+        creatorId,
+        phaseDeadlineHoursAhead: 50 / 60,
+      });
+
+      // nomA + nomB nominate; voterC votes (and is also a participant).
+      await nominateGame(lineupId, gameAId, nomA);
+      await nominateGame(lineupId, gameBId, nomB);
+      await castVote(lineupId, gameAId, voterC);
+      // nomA also already voted → exclude from reminder set.
+      await castVote(lineupId, gameBId, nomA);
+
+      await reminderService.checkVoteReminders();
+
+      const recipients = await userIdsWhoReceivedSubtype(
+        'lineup_vote_reminder',
+      );
+      // nomB has nominated but not voted → reminder.
+      // nomA already voted → no reminder.
+      // voterC already voted → no reminder.
+      // bystander did not engage → no reminder.
+      // creator did not engage → no reminder (public branch keys off participants).
+      expect(new Set(recipients)).toEqual(new Set([nomB]));
+    });
+  });
+
+  // ── AC #7: private + building + 1h ───────────────────────────────────────
+
+  describe('AC #7 — private building + 1h-out deadline', () => {
+    it('DMs creator + invitees who have not nominated', async () => {
+      const creatorId = await createDiscordUser('creator-7');
+      const inviteeA = await createDiscordUser('inv-a-7');
+      const inviteeB = await createDiscordUser('inv-b-7');
+
+      const gameAId = await createGame('G7A');
+
+      const lineupId = await createLineup({
+        visibility: 'private',
+        status: 'building',
+        creatorId,
+        phaseDeadlineHoursAhead: 50 / 60,
+      });
+      await inviteUsers(lineupId, [inviteeA, inviteeB]);
+      // inviteeA has nominated → exclude from reminders.
+      await nominateGame(lineupId, gameAId, inviteeA);
+
+      await reminderService.checkNominationReminders();
+
+      const recipients = await userIdsWhoReceivedSubtype(
+        'lineup_nominate_reminder',
+      );
+      // Creator + inviteeB (the only one who hasn't nominated yet).
+      expect(new Set(recipients)).toEqual(new Set([creatorId, inviteeB]));
+
+      // payload.subtype is 'lineup_nominate_reminder' and type is community_lineup
+      const matchingCalls = createSpy.mock.calls.filter(
+        (c) =>
+          (c[0] as { payload?: { subtype?: string } }).payload?.subtype ===
+          'lineup_nominate_reminder',
+      );
+      for (const [args] of matchingCalls) {
+        expect(args).toMatchObject({
+          type: 'community_lineup',
+          payload: expect.objectContaining({
+            subtype: 'lineup_nominate_reminder',
+            lineupId,
+          }),
+        });
+      }
+    });
+  });
+
+  // ── AC #8: public + building + 1h ────────────────────────────────────────
+
+  describe('AC #8 — public building + 1h-out deadline', () => {
+    it('DMs every Discord-linked user who has not nominated', async () => {
+      const creatorId = await createDiscordUser('creator-8');
+      const userA = await createDiscordUser('u-a-8');
+      const userB = await createDiscordUser('u-b-8');
+      const userC = await createDiscordUser('u-c-8');
+
+      const lineupId = await createLineup({
+        visibility: 'public',
+        status: 'building',
+        creatorId,
+        phaseDeadlineHoursAhead: 50 / 60,
+      });
+
+      await reminderService.checkNominationReminders();
+
+      const recipients = await userIdsWhoReceivedSubtype(
+        'lineup_nominate_reminder',
+      );
+      // All four discord-linked users should receive a reminder (no nominations yet).
+      // Note: the seeded admin user from test-app's baseline also has discord_id
+      // set, so we assert SUPERSET of our four users — not exact equality —
+      // because the public branch fans out to every linked member.
+      expect(recipients).toEqual(
+        expect.arrayContaining([creatorId, userA, userB, userC]),
+      );
+    });
+  });
+
+  // ── AC #5b: private + decided (scheduling) + 1h ──────────────────────────
+
+  describe('AC #5b — private decided (scheduling) + 1h-out deadline', () => {
+    it('DMs match members (creator + invitees) who have not voted on a slot', async () => {
+      const creatorId = await createDiscordUser('creator-5b');
+      const inviteeA = await createDiscordUser('inv-a-5b');
+      const inviteeB = await createDiscordUser('inv-b-5b');
+
+      const gameAId = await createGame('G5B-A');
+
+      const lineupId = await createLineup({
+        visibility: 'private',
+        status: 'decided',
+        creatorId,
+        phaseDeadlineHoursAhead: 50 / 60,
+      });
+      await inviteUsers(lineupId, [inviteeA, inviteeB]);
+
+      // Create a scheduling match with all 3 users as members.
+      const [match] = await testApp.db
+        .insert(schema.communityLineupMatches)
+        .values({
+          lineupId,
+          gameId: gameAId,
+          status: 'scheduling',
+        })
+        .returning();
+      await testApp.db.insert(schema.communityLineupMatchMembers).values([
+        { matchId: match.id, userId: creatorId, source: 'voted' },
+        { matchId: match.id, userId: inviteeA, source: 'voted' },
+        { matchId: match.id, userId: inviteeB, source: 'voted' },
+      ]);
+      // Add a slot and have inviteeA vote on it → exclude from reminders.
+      const [slot] = await testApp.db
+        .insert(schema.communityLineupScheduleSlots)
+        .values({
+          matchId: match.id,
+          proposedTime: new Date(Date.now() + 24 * HOUR),
+          suggestedBy: 'system',
+        })
+        .returning();
+      await testApp.db
+        .insert(schema.communityLineupScheduleVotes)
+        .values({ slotId: slot.id, userId: inviteeA });
+
+      await reminderService.checkSchedulingReminders();
+
+      const recipients = await userIdsWhoReceivedSubtype(
+        'lineup_scheduling_reminder',
+      );
+      expect(new Set(recipients)).toEqual(
+        new Set([creatorId, inviteeB]),
+      );
+    });
+  });
+
+  // ── AC #10: dedup prevents duplicate DMs across firings ──────────────────
+
+  describe('AC #10 — dedup prevents duplicate DMs across cron firings', () => {
+    it('running checkVoteReminders twice still produces 1 DM per recipient', async () => {
+      const creatorId = await createDiscordUser('creator-10');
+      const inviteeA = await createDiscordUser('inv-a-10');
+
+      const lineupId = await createLineup({
+        visibility: 'private',
+        status: 'voting',
+        creatorId,
+        phaseDeadlineHoursAhead: 50 / 60,
+      });
+      await inviteUsers(lineupId, [inviteeA]);
+
+      await reminderService.checkVoteReminders();
+      await reminderService.checkVoteReminders();
+
+      const recipients = createSpy.mock.calls
+        .map((c) => c[0] as { userId: number; payload?: { subtype?: string } })
+        .filter((p) => p.payload?.subtype === 'lineup_vote_reminder')
+        .map((p) => p.userId);
+
+      // Each recipient appears exactly once across the two cron firings.
+      const counts = new Map<number, number>();
+      for (const id of recipients) counts.set(id, (counts.get(id) ?? 0) + 1);
+      for (const [, count] of counts) {
+        expect(count).toBe(1);
+      }
+      expect(new Set(recipients)).toEqual(new Set([creatorId, inviteeA]));
+    });
+  });
+
+  // ── Sanity: the helper module + new service method exist ─────────────────
+
+  it('LineupReminderService exposes a checkNominationReminders method', () => {
+    // Compile-time: this references the new public method. Until the dev
+    // adds it, TypeScript reports "Property 'checkNominationReminders' does
+    // not exist on type 'LineupReminderService'" and the spec fails.
+    expect(typeof reminderService.checkNominationReminders).toBe('function');
+  });
+});

--- a/api/src/lineups/lineup-reminder.integration.spec.ts
+++ b/api/src/lineups/lineup-reminder.integration.spec.ts
@@ -20,7 +20,6 @@
  *   AC #5b — private + decided + 1h (scheduling phase) → invitees ∪ creator minus schedule-voters
  *   AC #10 — running checkVoteReminders twice → only one DM per recipient (dedup)
  */
-import { eq } from 'drizzle-orm';
 import { getTestApp, type TestApp } from '../common/testing/test-app';
 import { truncateAllTables } from '../common/testing/integration-helpers';
 import * as schema from '../drizzle/schema';
@@ -347,6 +346,7 @@ describe('LineupReminderService cron (integration, ROK-1126)', () => {
           lineupId,
           gameId: gameAId,
           status: 'scheduling',
+          voteCount: 0,
         })
         .returning();
       await testApp.db.insert(schema.communityLineupMatchMembers).values([

--- a/api/src/lineups/lineup-reminder.service.spec.ts
+++ b/api/src/lineups/lineup-reminder.service.spec.ts
@@ -1,15 +1,30 @@
 /**
- * TDD tests for LineupReminderService (ROK-932).
- * Validates cron-driven vote reminders (24h + 1h before voting deadline)
- * and scheduling reminders (24h + 1h before decided phase end).
+ * TDD tests for LineupReminderService (ROK-932 + ROK-1126).
+ * Validates cron-driven vote reminders (24h + 1h before voting deadline),
+ * scheduling reminders (24h + 1h before decided phase end), and the new
+ * nomination reminders (24h + 1h before building phase deadline, ROK-1126).
+ *
+ * Also asserts that all three reminder methods are decorated with
+ * `@Cron(EVERY_5_MINUTES)` and wrap their bodies in `executeWithTracking`,
+ * and route their recipient resolution through the new
+ * `resolveLineupReminderTargets` helper.
  */
 import { Test, TestingModule } from '@nestjs/testing';
+import { SchedulerRegistry } from '@nestjs/schedule';
 import { LineupReminderService } from './lineup-reminder.service';
 import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
 import { NotificationService } from '../notifications/notification.service';
 import { NotificationDedupService } from '../notifications/notification-dedup.service';
 import { SettingsService } from '../settings/settings.service';
 import { CronJobService } from '../cron-jobs/cron-job.service';
+
+// Mock the helper module so we can spy on its calls without needing real DB.
+jest.mock('./lineup-reminder-target.helpers', () => ({
+  resolveLineupReminderTargets: jest.fn().mockResolvedValue([]),
+}));
+import { resolveLineupReminderTargets } from './lineup-reminder-target.helpers';
+const mockResolveTargets =
+  resolveLineupReminderTargets as unknown as jest.Mock;
 
 // ---------------------------------------------------------------------------
 // Shared mocks
@@ -115,14 +130,18 @@ describe('LineupReminderService', () => {
   let mockDb: ReturnType<typeof makeMockDb>;
   let mockNotificationService: ReturnType<typeof makeMockNotificationService>;
   let mockDedupService: ReturnType<typeof makeMockDedupService>;
+  let mockCronJobService: { executeWithTracking: jest.Mock };
 
   beforeEach(async () => {
     jest.useFakeTimers({ now: NOW });
+    mockResolveTargets.mockReset();
+    mockResolveTargets.mockResolvedValue([]);
     const ctx = await createTestModule();
     service = ctx.service;
     mockDb = ctx.mockDb;
     mockNotificationService = ctx.mockNotificationService;
     mockDedupService = ctx.mockDedupService;
+    mockCronJobService = ctx.mockCronJobService;
   });
 
   afterEach(() => {
@@ -131,13 +150,16 @@ describe('LineupReminderService', () => {
 
   // -----------------------------------------------------------------------
   // AC-4: Vote reminders at 24h and 1h before deadline
+  //
+  // ROK-1126: vote-reminder recipient resolution is now centralized in
+  // `resolveLineupReminderTargets(db, lineupId, 'vote')`. Tests stub it
+  // and assert the call shape + downstream dispatch.
   // -----------------------------------------------------------------------
   describe('vote reminders', () => {
     it('sends 24h reminder to non-voters when <= 24h remain', async () => {
       const lineup = makeVotingLineup(23);
-      mockDb.execute
-        .mockResolvedValueOnce([lineup])
-        .mockResolvedValueOnce([makeNonVoter(1), makeNonVoter(2)]);
+      mockDb.execute.mockResolvedValueOnce([lineup]);
+      mockResolveTargets.mockResolvedValueOnce([1, 2]);
 
       await service.checkVoteReminders();
 
@@ -154,9 +176,8 @@ describe('LineupReminderService', () => {
 
     it('sends 1h reminder to non-voters when <= 1h remains', async () => {
       const lineup = makeVotingLineup(0.5);
-      mockDb.execute
-        .mockResolvedValueOnce([lineup])
-        .mockResolvedValueOnce([makeNonVoter(3)]);
+      mockDb.execute.mockResolvedValueOnce([lineup]);
+      mockResolveTargets.mockResolvedValueOnce([3]);
 
       await service.checkVoteReminders();
 
@@ -169,9 +190,8 @@ describe('LineupReminderService', () => {
 
     it('uses dedup key lineup-reminder-24h:{lineupId}:{userId}', async () => {
       const lineup = makeVotingLineup(20);
-      mockDb.execute
-        .mockResolvedValueOnce([lineup])
-        .mockResolvedValueOnce([makeNonVoter(5)]);
+      mockDb.execute.mockResolvedValueOnce([lineup]);
+      mockResolveTargets.mockResolvedValueOnce([5]);
 
       await service.checkVoteReminders();
 
@@ -181,19 +201,30 @@ describe('LineupReminderService', () => {
       );
     });
 
-    it('only targets users who have not yet voted', async () => {
+    it('only targets users returned by resolveLineupReminderTargets', async () => {
       const lineup = makeVotingLineup(12);
-      // First call returns lineup, second returns non-voter list
-      mockDb.execute
-        .mockResolvedValueOnce([lineup])
-        .mockResolvedValueOnce([makeNonVoter(8)]);
+      mockDb.execute.mockResolvedValueOnce([lineup]);
+      mockResolveTargets.mockResolvedValueOnce([8]);
 
       await service.checkVoteReminders();
 
-      // Only user 8 should receive a reminder
       expect(mockNotificationService.create).toHaveBeenCalledTimes(1);
       expect(mockNotificationService.create).toHaveBeenCalledWith(
         expect.objectContaining({ userId: 8 }),
+      );
+    });
+
+    it("delegates recipient resolution to resolveLineupReminderTargets with action='vote'", async () => {
+      const lineup = makeVotingLineup(12);
+      mockDb.execute.mockResolvedValueOnce([lineup]);
+      mockResolveTargets.mockResolvedValueOnce([]);
+
+      await service.checkVoteReminders();
+
+      expect(mockResolveTargets).toHaveBeenCalledWith(
+        expect.anything(),
+        LINEUP_ID,
+        'vote',
       );
     });
 
@@ -209,13 +240,14 @@ describe('LineupReminderService', () => {
       await service.checkVoteReminders();
 
       expect(mockNotificationService.create).not.toHaveBeenCalled();
+      // Helper not consulted when there's no deadline to act on.
+      expect(mockResolveTargets).not.toHaveBeenCalled();
     });
 
     it('skips when dedup indicates reminder already sent', async () => {
       const lineup = makeVotingLineup(20);
-      mockDb.execute
-        .mockResolvedValueOnce([lineup])
-        .mockResolvedValueOnce([makeNonVoter(6)]);
+      mockDb.execute.mockResolvedValueOnce([lineup]);
+      mockResolveTargets.mockResolvedValueOnce([6]);
       mockDedupService.checkAndMarkSent.mockResolvedValueOnce(true);
 
       await service.checkVoteReminders();
@@ -230,20 +262,38 @@ describe('LineupReminderService', () => {
 
       expect(mockNotificationService.create).not.toHaveBeenCalled();
     });
+
+    it('checkVoteReminders wraps execution in cronJobService.executeWithTracking', async () => {
+      mockDb.execute.mockResolvedValueOnce([]);
+
+      await service.checkVoteReminders();
+
+      expect(mockCronJobService.executeWithTracking).toHaveBeenCalledWith(
+        'LineupReminderService_checkVoteReminders',
+        expect.any(Function),
+      );
+    });
   });
 
   // -----------------------------------------------------------------------
   // AC-9/11: Scheduling reminders at 24h and 1h before decided phase end
+  //
+  // ROK-1126: scheduling reminders fan out per-match. The service must
+  // load the (lineupId, matchId) pairs that are still scheduling, then
+  // call `resolveLineupReminderTargets(db, lineupId, 'schedule', matchId)`
+  // for each one.
   // -----------------------------------------------------------------------
   describe('scheduling reminders', () => {
+    function makeMatch(matchId: number) {
+      return { lineupId: LINEUP_ID, matchId };
+    }
+
     it('sends 24h reminder to scheduling non-voters', async () => {
       const lineup = makeDecidedLineup(20);
       mockDb.execute
         .mockResolvedValueOnce([lineup])
-        .mockResolvedValueOnce([
-          makeSchedulingNonVoter(10),
-          makeSchedulingNonVoter(11),
-        ]);
+        .mockResolvedValueOnce([makeMatch(100)]);
+      mockResolveTargets.mockResolvedValueOnce([10, 11]);
 
       await service.checkSchedulingReminders();
 
@@ -262,12 +312,15 @@ describe('LineupReminderService', () => {
       const lineup = makeDecidedLineup(0.5);
       mockDb.execute
         .mockResolvedValueOnce([lineup])
-        .mockResolvedValueOnce([makeSchedulingNonVoter(13)]);
+        .mockResolvedValueOnce([makeMatch(100)]);
+      mockResolveTargets.mockResolvedValueOnce([13]);
 
       await service.checkSchedulingReminders();
 
+      // Dedup key shape: lineup-sched-remind:{matchId}:{userId}:{window}
+      // — userId must be the resolved target (13), NOT undefined.
       expect(mockDedupService.checkAndMarkSent).toHaveBeenCalledWith(
-        expect.stringContaining('lineup-sched-remind:'),
+        'lineup-sched-remind:100:13:1h',
         expect.anything(),
       );
     });
@@ -276,13 +329,37 @@ describe('LineupReminderService', () => {
       const lineup = makeDecidedLineup(20);
       mockDb.execute
         .mockResolvedValueOnce([lineup])
-        .mockResolvedValueOnce([makeSchedulingNonVoter(14)]);
+        .mockResolvedValueOnce([makeMatch(100)]);
+      mockResolveTargets.mockResolvedValueOnce([14]);
 
       await service.checkSchedulingReminders();
 
       expect(mockDedupService.checkAndMarkSent).toHaveBeenCalledWith(
         expect.stringMatching(/^lineup-sched-remind:\d+:\d+:(24h|1h)$/),
         expect.anything(),
+      );
+    });
+
+    it("delegates recipient resolution to resolveLineupReminderTargets with action='schedule' and matchId", async () => {
+      const lineup = makeDecidedLineup(12);
+      mockDb.execute
+        .mockResolvedValueOnce([lineup])
+        .mockResolvedValueOnce([makeMatch(100), makeMatch(101)]);
+      mockResolveTargets.mockResolvedValue([]);
+
+      await service.checkSchedulingReminders();
+
+      expect(mockResolveTargets).toHaveBeenCalledWith(
+        expect.anything(),
+        LINEUP_ID,
+        'schedule',
+        100,
+      );
+      expect(mockResolveTargets).toHaveBeenCalledWith(
+        expect.anything(),
+        LINEUP_ID,
+        'schedule',
+        101,
       );
     });
 
@@ -293,13 +370,15 @@ describe('LineupReminderService', () => {
       await service.checkSchedulingReminders();
 
       expect(mockNotificationService.create).not.toHaveBeenCalled();
+      expect(mockResolveTargets).not.toHaveBeenCalled();
     });
 
     it('skips when dedup indicates already sent', async () => {
       const lineup = makeDecidedLineup(20);
       mockDb.execute
         .mockResolvedValueOnce([lineup])
-        .mockResolvedValueOnce([makeSchedulingNonVoter(15)]);
+        .mockResolvedValueOnce([makeMatch(100)]);
+      mockResolveTargets.mockResolvedValueOnce([15]);
       mockDedupService.checkAndMarkSent.mockResolvedValueOnce(true);
 
       await service.checkSchedulingReminders();
@@ -314,6 +393,17 @@ describe('LineupReminderService', () => {
 
       expect(mockNotificationService.create).not.toHaveBeenCalled();
     });
+
+    it('checkSchedulingReminders wraps execution in cronJobService.executeWithTracking', async () => {
+      mockDb.execute.mockResolvedValueOnce([]);
+
+      await service.checkSchedulingReminders();
+
+      expect(mockCronJobService.executeWithTracking).toHaveBeenCalledWith(
+        'LineupReminderService_checkSchedulingReminders',
+        expect.any(Function),
+      );
+    });
   });
 
   // -----------------------------------------------------------------------
@@ -322,9 +412,8 @@ describe('LineupReminderService', () => {
   describe('notification type consistency', () => {
     it('all vote reminders use type community_lineup', async () => {
       const lineup = makeVotingLineup(12);
-      mockDb.execute
-        .mockResolvedValueOnce([lineup])
-        .mockResolvedValueOnce([makeNonVoter(1)]);
+      mockDb.execute.mockResolvedValueOnce([lineup]);
+      mockResolveTargets.mockResolvedValueOnce([1]);
 
       await service.checkVoteReminders();
 
@@ -337,12 +426,196 @@ describe('LineupReminderService', () => {
       const lineup = makeDecidedLineup(12);
       mockDb.execute
         .mockResolvedValueOnce([lineup])
-        .mockResolvedValueOnce([makeSchedulingNonVoter(1)]);
+        .mockResolvedValueOnce([{ lineupId: LINEUP_ID, matchId: 100 }]);
+      mockResolveTargets.mockResolvedValueOnce([1]);
 
       await service.checkSchedulingReminders();
 
       expect(mockNotificationService.create).toHaveBeenCalledWith(
-        expect.objectContaining({ type: 'community_lineup' }),
+        expect.objectContaining({
+          userId: 1,
+          type: 'community_lineup',
+          payload: expect.objectContaining({
+            subtype: 'lineup_scheduling_reminder',
+            matchId: 100,
+          }),
+        }),
+      );
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // ROK-1126: Nomination reminders at 24h and 1h before building deadline
+  // -----------------------------------------------------------------------
+  describe('nomination reminders', () => {
+    function makeBuildingLineup(hoursUntilDeadline: number) {
+      const deadline = new Date(NOW.getTime() + hoursUntilDeadline * 3600_000);
+      return {
+        id: LINEUP_ID,
+        status: 'building' as const,
+        phaseDeadline: deadline,
+      };
+    }
+
+    it('sends 24h reminder when <= 24h remain', async () => {
+      const lineup = makeBuildingLineup(20);
+      mockDb.execute.mockResolvedValueOnce([lineup]);
+      mockResolveTargets.mockResolvedValueOnce([1, 2]);
+
+      await service.checkNominationReminders();
+
+      expect(mockNotificationService.create).toHaveBeenCalledTimes(2);
+      expect(mockNotificationService.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'community_lineup',
+          payload: expect.objectContaining({
+            subtype: 'lineup_nominate_reminder',
+            lineupId: LINEUP_ID,
+          }),
+        }),
+      );
+    });
+
+    it('sends 1h reminder when <= 1h remains', async () => {
+      const lineup = makeBuildingLineup(0.5);
+      mockDb.execute.mockResolvedValueOnce([lineup]);
+      mockResolveTargets.mockResolvedValueOnce([3]);
+
+      await service.checkNominationReminders();
+
+      expect(mockNotificationService.create).toHaveBeenCalledTimes(1);
+      expect(mockDedupService.checkAndMarkSent).toHaveBeenCalledWith(
+        `lineup-nominate-remind:${LINEUP_ID}:3:1h`,
+        expect.anything(),
+      );
+    });
+
+    it('uses dedup key lineup-nominate-remind:{lineupId}:{userId}:{window}', async () => {
+      const lineup = makeBuildingLineup(20);
+      mockDb.execute.mockResolvedValueOnce([lineup]);
+      mockResolveTargets.mockResolvedValueOnce([7]);
+
+      await service.checkNominationReminders();
+
+      expect(mockDedupService.checkAndMarkSent).toHaveBeenCalledWith(
+        `lineup-nominate-remind:${LINEUP_ID}:7:24h`,
+        expect.anything(),
+      );
+    });
+
+    it("delegates recipient resolution to resolveLineupReminderTargets with action='nominate'", async () => {
+      const lineup = makeBuildingLineup(12);
+      mockDb.execute.mockResolvedValueOnce([lineup]);
+      mockResolveTargets.mockResolvedValueOnce([]);
+
+      await service.checkNominationReminders();
+
+      expect(mockResolveTargets).toHaveBeenCalledWith(
+        expect.anything(),
+        LINEUP_ID,
+        'nominate',
+      );
+    });
+
+    it('only fires on building-status lineups (filtered at the query level)', async () => {
+      // Helper-only: assert that checkNominationReminders pulls building-only
+      // rows. We capture the SQL fragment string the service issues for its
+      // building-lineups query and require it to mention `status = 'building'`
+      // and `phase_deadline IS NOT NULL` so we don't accidentally include
+      // voting / decided rows.
+      const captured: string[] = [];
+      mockDb.execute.mockImplementationOnce((q: unknown) => {
+        // Drizzle's `sql` template returns an SQL token object; stringify it.
+        captured.push(JSON.stringify(q));
+        return Promise.resolve([]);
+      });
+
+      await service.checkNominationReminders();
+
+      expect(captured.length).toBeGreaterThan(0);
+      const blob = captured.join(' ');
+      expect(blob).toMatch(/building/);
+      expect(blob).toMatch(/phase_deadline/);
+    });
+
+    it('skips when phaseDeadline is null', async () => {
+      // Building-lineup query already filters phase_deadline IS NOT NULL,
+      // so an empty result here is the equivalent end-state.
+      mockDb.execute.mockResolvedValueOnce([]);
+
+      await service.checkNominationReminders();
+
+      expect(mockNotificationService.create).not.toHaveBeenCalled();
+    });
+
+    it('skips when window is outside the 0–24h band', async () => {
+      const tooEarly = makeBuildingLineup(48); // 48h remaining
+      mockDb.execute.mockResolvedValueOnce([tooEarly]);
+
+      await service.checkNominationReminders();
+
+      expect(mockNotificationService.create).not.toHaveBeenCalled();
+      // helper not consulted because the window is not actionable
+      expect(mockResolveTargets).not.toHaveBeenCalled();
+    });
+
+    it('skips when phase_deadline has already passed', async () => {
+      const expired = makeBuildingLineup(-1); // 1h ago
+      mockDb.execute.mockResolvedValueOnce([expired]);
+
+      await service.checkNominationReminders();
+
+      expect(mockNotificationService.create).not.toHaveBeenCalled();
+      expect(mockResolveTargets).not.toHaveBeenCalled();
+    });
+
+    it('skips when dedup indicates reminder already sent', async () => {
+      const lineup = makeBuildingLineup(20);
+      mockDb.execute.mockResolvedValueOnce([lineup]);
+      mockResolveTargets.mockResolvedValueOnce([8]);
+      mockDedupService.checkAndMarkSent.mockResolvedValueOnce(true);
+
+      await service.checkNominationReminders();
+
+      expect(mockNotificationService.create).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when no building lineups exist', async () => {
+      mockDb.execute.mockResolvedValueOnce([]);
+
+      await service.checkNominationReminders();
+
+      expect(mockNotificationService.create).not.toHaveBeenCalled();
+    });
+
+    it('uses subtype lineup_nominate_reminder in notification payload', async () => {
+      const lineup = makeBuildingLineup(20);
+      mockDb.execute.mockResolvedValueOnce([lineup]);
+      mockResolveTargets.mockResolvedValueOnce([9]);
+
+      await service.checkNominationReminders();
+
+      expect(mockNotificationService.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'community_lineup',
+          title: expect.any(String),
+          message: expect.any(String),
+          payload: expect.objectContaining({
+            subtype: 'lineup_nominate_reminder',
+            lineupId: LINEUP_ID,
+          }),
+        }),
+      );
+    });
+
+    it('checkNominationReminders wraps execution in cronJobService.executeWithTracking', async () => {
+      mockDb.execute.mockResolvedValueOnce([]);
+
+      await service.checkNominationReminders();
+
+      expect(mockCronJobService.executeWithTracking).toHaveBeenCalledWith(
+        'LineupReminderService_checkNominationReminders',
+        expect.any(Function),
       );
     });
   });

--- a/api/src/lineups/lineup-reminder.service.spec.ts
+++ b/api/src/lineups/lineup-reminder.service.spec.ts
@@ -10,7 +10,6 @@
  * `resolveLineupReminderTargets` helper.
  */
 import { Test, TestingModule } from '@nestjs/testing';
-import { SchedulerRegistry } from '@nestjs/schedule';
 import { LineupReminderService } from './lineup-reminder.service';
 import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
 import { NotificationService } from '../notifications/notification.service';
@@ -23,8 +22,7 @@ jest.mock('./lineup-reminder-target.helpers', () => ({
   resolveLineupReminderTargets: jest.fn().mockResolvedValue([]),
 }));
 import { resolveLineupReminderTargets } from './lineup-reminder-target.helpers';
-const mockResolveTargets =
-  resolveLineupReminderTargets as unknown as jest.Mock;
+const mockResolveTargets = resolveLineupReminderTargets as unknown as jest.Mock;
 
 // ---------------------------------------------------------------------------
 // Shared mocks
@@ -111,14 +109,6 @@ function makeDecidedLineup(hoursUntilDeadline: number) {
     status: 'decided' as const,
     phaseDeadline: deadline,
   };
-}
-
-function makeNonVoter(id: number) {
-  return { id, userId: id, displayName: `Player${id}`, discordId: `d-${id}` };
-}
-
-function makeSchedulingNonVoter(id: number) {
-  return { id, userId: id, displayName: `Player${id}`, matchId: 100 };
 }
 
 // ---------------------------------------------------------------------------

--- a/api/src/lineups/lineup-reminder.service.ts
+++ b/api/src/lineups/lineup-reminder.service.ts
@@ -33,8 +33,8 @@ import { resolveLineupReminderTargets } from './lineup-reminder-target.helpers';
 interface ReminderLineup {
   id: number;
   status: string;
-  phaseDeadline: Date | null;
-  votingDeadline?: Date | null;
+  phaseDeadline: Date | string | null;
+  votingDeadline?: Date | string | null;
 }
 
 interface SchedulingMatchRef {
@@ -43,6 +43,18 @@ interface SchedulingMatchRef {
 }
 
 const MS_PER_HOUR = 3600_000;
+
+/**
+ * `phase_deadline` is `timestamp without time zone`. postgres-js returns
+ * it as a naïve string; `new Date()` would parse in local TZ. We INSERT
+ * JS Dates as UTC, so re-parse with an explicit UTC suffix.
+ */
+function parseTimestampUtc(value: Date | string): Date {
+  if (value instanceof Date) return value;
+  const s = String(value);
+  if (s.endsWith('Z') || /[+-]\d{2}:?\d{2}$/.test(s)) return new Date(s);
+  return new Date(s.replace(' ', 'T') + 'Z');
+}
 
 @Injectable()
 export class LineupReminderService {
@@ -291,11 +303,11 @@ export class LineupReminderService {
 
   // ─── Utilities ───────────────────────────────────────────────
 
-  private hoursUntil(deadline: Date): number {
-    return (deadline.getTime() - Date.now()) / MS_PER_HOUR;
+  private hoursUntil(deadline: Date | string): number {
+    return (parseTimestampUtc(deadline).getTime() - Date.now()) / MS_PER_HOUR;
   }
 
-  private classifyWindow(deadline: Date): '24h' | '1h' | null {
+  private classifyWindow(deadline: Date | string): '24h' | '1h' | null {
     const hoursLeft = this.hoursUntil(deadline);
     if (hoursLeft <= 0 || hoursLeft > 24) return null;
     return hoursLeft <= 1 ? '1h' : '24h';

--- a/api/src/lineups/lineup-reminder.service.ts
+++ b/api/src/lineups/lineup-reminder.service.ts
@@ -1,8 +1,14 @@
 /**
- * Cron-driven reminder service for Community Lineup (ROK-932, ROK-1117).
- * Sends vote reminders (24h + 1h before voting deadline), scheduling
- * reminders (24h + 1h before decided phase end), and tiebreaker reminders
- * (24h + 1h before round deadline).
+ * Cron-driven reminder service for Community Lineup
+ * (ROK-932 / ROK-1117 / ROK-1126).
+ *
+ * Sends nomination reminders (24h + 1h before building deadline),
+ * vote reminders (24h + 1h before voting deadline), scheduling
+ * reminders (24h + 1h before decided phase end), and tiebreaker
+ * reminders (24h + 1h before round deadline). Recipient resolution
+ * for nominate / vote / schedule is delegated to
+ * `resolveLineupReminderTargets`, which applies the public/private +
+ * already-participated filter.
  */
 import { Inject, Injectable, Logger } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
@@ -22,8 +28,8 @@ import {
   buildTiebreakerReminderMessage,
   type ActiveTiebreakerRow,
 } from './lineup-tiebreaker-reminder.helpers';
+import { resolveLineupReminderTargets } from './lineup-reminder-target.helpers';
 
-/** Shape of a lineup returned from reminder queries. */
 interface ReminderLineup {
   id: number;
   status: string;
@@ -31,19 +37,8 @@ interface ReminderLineup {
   votingDeadline?: Date | null;
 }
 
-/** Shape of a non-voter returned from reminder queries. */
-interface NonVoter {
-  id: number;
-  userId: number;
-  displayName: string;
-  discordId?: string;
-}
-
-/** Shape of a scheduling non-voter returned from queries. */
-interface SchedulingNonVoter {
-  id: number;
-  userId: number;
-  displayName: string;
+interface SchedulingMatchRef {
+  lineupId: number;
   matchId: number;
 }
 
@@ -62,28 +57,40 @@ export class LineupReminderService {
     private readonly cronJobService: CronJobService,
   ) {}
 
-  /** Check and send vote reminders for active voting lineups. */
+  /** Send vote reminders for active voting lineups (24h + 1h windows). */
+  @Cron(CronExpression.EVERY_5_MINUTES, {
+    name: 'LineupReminderService_checkVoteReminders',
+  })
   async checkVoteReminders(): Promise<void> {
-    const lineups = await this.getVotingLineups();
-    for (const lineup of lineups) {
-      await this.processVoteReminder(lineup);
-    }
+    await this.cronJobService.executeWithTracking(
+      'LineupReminderService_checkVoteReminders',
+      () => this.runVoteReminders(),
+    );
   }
 
-  /** Check and send scheduling reminders for active decided lineups. */
+  /** Send scheduling reminders for active decided lineups (24h + 1h windows). */
+  @Cron(CronExpression.EVERY_5_MINUTES, {
+    name: 'LineupReminderService_checkSchedulingReminders',
+  })
   async checkSchedulingReminders(): Promise<void> {
-    const lineups = await this.getDecidedLineups();
-    for (const lineup of lineups) {
-      await this.processSchedulingReminder(lineup);
-    }
+    await this.cronJobService.executeWithTracking(
+      'LineupReminderService_checkSchedulingReminders',
+      () => this.runSchedulingReminders(),
+    );
   }
 
-  /**
-   * Check and send tiebreaker reminders for active tiebreakers
-   * approaching their round deadline (ROK-1117). Targets users who
-   * have not yet engaged with this tiebreaker (vetoed or voted on
-   * every active-round matchup).
-   */
+  /** Send nomination reminders for active building lineups (ROK-1126). */
+  @Cron(CronExpression.EVERY_5_MINUTES, {
+    name: 'LineupReminderService_checkNominationReminders',
+  })
+  async checkNominationReminders(): Promise<void> {
+    await this.cronJobService.executeWithTracking(
+      'LineupReminderService_checkNominationReminders',
+      () => this.runNominationReminders(),
+    );
+  }
+
+  /** Send tiebreaker reminders for active tiebreakers approaching round deadline. */
   @Cron(CronExpression.EVERY_5_MINUTES, {
     name: 'LineupReminderService_checkTiebreakerReminders',
   })
@@ -94,7 +101,29 @@ export class LineupReminderService {
     );
   }
 
-  /** Inner body — wrapped by `executeWithTracking` for cron-jobs admin visibility. */
+  // ─── Inner runners (wrapped by executeWithTracking) ──────────
+
+  private async runVoteReminders(): Promise<void> {
+    const lineups = await this.getVotingLineups();
+    for (const lineup of lineups) {
+      await this.processVoteReminder(lineup);
+    }
+  }
+
+  private async runSchedulingReminders(): Promise<void> {
+    const lineups = await this.getDecidedLineups();
+    for (const lineup of lineups) {
+      await this.processSchedulingReminder(lineup);
+    }
+  }
+
+  private async runNominationReminders(): Promise<void> {
+    const lineups = await this.getBuildingLineups();
+    for (const lineup of lineups) {
+      await this.processNominationReminder(lineup);
+    }
+  }
+
   private async runTiebreakerReminders(): Promise<void> {
     const tiebreakers = await findActiveTiebreakersWithDeadline(this.db);
     for (const tb of tiebreakers) {
@@ -109,89 +138,59 @@ export class LineupReminderService {
     }
   }
 
-  // ─── Private: vote reminders ──────────────────────────────
+  // ─── Per-lineup processors ───────────────────────────────────
 
-  /** Process vote reminders for a single lineup. */
   private async processVoteReminder(lineup: ReminderLineup): Promise<void> {
     const deadline = lineup.phaseDeadline ?? lineup.votingDeadline;
     if (!deadline) return;
-
-    const hoursLeft = this.hoursUntil(deadline);
-    if (hoursLeft > 24 || hoursLeft <= 0) return;
-
-    const window = hoursLeft <= 1 ? '1h' : '24h';
-    const nonVoters = await this.getVoteNonVoters(lineup.id);
-
-    for (const voter of nonVoters) {
-      await this.sendVoteReminder(lineup.id, voter, window);
+    const window = this.classifyWindow(deadline);
+    if (!window) return;
+    const userIds = await resolveLineupReminderTargets(
+      this.db,
+      lineup.id,
+      'vote',
+    );
+    for (const userId of userIds) {
+      await this.sendVoteReminder(lineup.id, userId, window);
     }
   }
 
-  /** Send a single vote reminder DM. */
-  private async sendVoteReminder(
-    lineupId: number,
-    voter: NonVoter,
-    window: string,
-  ): Promise<void> {
-    const key = `lineup-reminder-${window}:${lineupId}:${voter.userId}`;
-    if (await this.dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
-
-    const urgency =
-      window === '1h'
-        ? 'Last chance to vote -- voting closes in 1 hour'
-        : "You haven't voted yet -- voting closes in 24 hours";
-
-    await this.notificationService.create({
-      userId: voter.userId,
-      type: 'community_lineup',
-      title: 'Vote Reminder',
-      message: urgency,
-      payload: { subtype: 'lineup_vote_reminder', lineupId },
-    });
-  }
-
-  // ─── Private: scheduling reminders ────────────────────────
-
-  /** Process scheduling reminders for a single lineup. */
   private async processSchedulingReminder(
     lineup: ReminderLineup,
   ): Promise<void> {
     if (!lineup.phaseDeadline) return;
-
-    const hoursLeft = this.hoursUntil(lineup.phaseDeadline);
-    if (hoursLeft > 24 || hoursLeft <= 0) return;
-
-    const window = hoursLeft <= 1 ? '1h' : '24h';
-    const nonVoters = await this.getSchedulingNonVoters(lineup.id);
-
-    for (const voter of nonVoters) {
-      await this.sendSchedulingReminder(voter, window);
+    const window = this.classifyWindow(lineup.phaseDeadline);
+    if (!window) return;
+    const matches = await this.getSchedulingMatches(lineup.id);
+    for (const match of matches) {
+      const userIds = await resolveLineupReminderTargets(
+        this.db,
+        lineup.id,
+        'schedule',
+        match.matchId,
+      );
+      for (const userId of userIds) {
+        await this.sendSchedulingReminder(match.matchId, userId, window);
+      }
     }
   }
 
-  /** Send a single scheduling reminder DM. */
-  private async sendSchedulingReminder(
-    voter: SchedulingNonVoter,
-    window: string,
+  private async processNominationReminder(
+    lineup: ReminderLineup,
   ): Promise<void> {
-    const key = `lineup-sched-remind:${voter.matchId}:${voter.userId}:${window}`;
-    if (await this.dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
-
-    await this.notificationService.create({
-      userId: voter.userId,
-      type: 'community_lineup',
-      title: 'Scheduling Reminder',
-      message: 'Your match is waiting -- pick a time!',
-      payload: {
-        subtype: 'lineup_scheduling_reminder',
-        matchId: voter.matchId,
-      },
-    });
+    if (!lineup.phaseDeadline) return;
+    const window = this.classifyWindow(lineup.phaseDeadline);
+    if (!window) return;
+    const userIds = await resolveLineupReminderTargets(
+      this.db,
+      lineup.id,
+      'nominate',
+    );
+    for (const userId of userIds) {
+      await this.sendNominationReminder(lineup.id, userId, window);
+    }
   }
 
-  // ─── Private: tiebreaker reminders (ROK-1117) ─────────────
-
-  /** Process a single active tiebreaker for reminder dispatch. */
   private async processTiebreakerReminder(
     tb: ActiveTiebreakerRow,
   ): Promise<void> {
@@ -203,7 +202,64 @@ export class LineupReminderService {
     }
   }
 
-  /** Send a single tiebreaker reminder DM. */
+  // ─── DM dispatch ─────────────────────────────────────────────
+
+  private async sendVoteReminder(
+    lineupId: number,
+    userId: number,
+    window: '24h' | '1h',
+  ): Promise<void> {
+    const key = `lineup-reminder-${window}:${lineupId}:${userId}`;
+    if (await this.dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
+    const message =
+      window === '1h'
+        ? 'Last chance to vote -- voting closes in 1 hour'
+        : "You haven't voted yet -- voting closes in 24 hours";
+    await this.notificationService.create({
+      userId,
+      type: 'community_lineup',
+      title: 'Vote Reminder',
+      message,
+      payload: { subtype: 'lineup_vote_reminder', lineupId },
+    });
+  }
+
+  private async sendSchedulingReminder(
+    matchId: number,
+    userId: number,
+    window: '24h' | '1h',
+  ): Promise<void> {
+    const key = `lineup-sched-remind:${matchId}:${userId}:${window}`;
+    if (await this.dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
+    await this.notificationService.create({
+      userId,
+      type: 'community_lineup',
+      title: 'Scheduling Reminder',
+      message: 'Your match is waiting -- pick a time!',
+      payload: { subtype: 'lineup_scheduling_reminder', matchId },
+    });
+  }
+
+  private async sendNominationReminder(
+    lineupId: number,
+    userId: number,
+    window: '24h' | '1h',
+  ): Promise<void> {
+    const key = `lineup-nominate-remind:${lineupId}:${userId}:${window}`;
+    if (await this.dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
+    const message =
+      window === '1h'
+        ? 'Last chance to nominate -- the building phase closes in 1 hour'
+        : 'Nominations are closing in 24 hours -- add your picks before the cut';
+    await this.notificationService.create({
+      userId,
+      type: 'community_lineup',
+      title: 'Nomination Reminder',
+      message,
+      payload: { subtype: 'lineup_nominate_reminder', lineupId },
+    });
+  }
+
   private async sendTiebreakerReminder(
     tb: ActiveTiebreakerRow,
     userId: number,
@@ -233,16 +289,20 @@ export class LineupReminderService {
     });
   }
 
-  // ─── Private: utilities ───────────────────────────────────
+  // ─── Utilities ───────────────────────────────────────────────
 
-  /** Calculate hours remaining until a deadline. */
   private hoursUntil(deadline: Date): number {
     return (deadline.getTime() - Date.now()) / MS_PER_HOUR;
   }
 
-  // ─── Private: DB queries ──────────────────────────────────
+  private classifyWindow(deadline: Date): '24h' | '1h' | null {
+    const hoursLeft = this.hoursUntil(deadline);
+    if (hoursLeft <= 0 || hoursLeft > 24) return null;
+    return hoursLeft <= 1 ? '1h' : '24h';
+  }
 
-  /** Get active lineups in voting status. */
+  // ─── DB queries ──────────────────────────────────────────────
+
   private async getVotingLineups(): Promise<ReminderLineup[]> {
     return (await this.db.execute(sql`
       SELECT id, status, phase_deadline AS "phaseDeadline",
@@ -252,7 +312,6 @@ export class LineupReminderService {
     `)) as unknown as ReminderLineup[];
   }
 
-  /** Get active community lineups in decided status (excludes standalone polls). */
   private async getDecidedLineups(): Promise<ReminderLineup[]> {
     return (await this.db.execute(sql`
       SELECT id, status, phase_deadline AS "phaseDeadline"
@@ -262,41 +321,23 @@ export class LineupReminderService {
     `)) as unknown as ReminderLineup[];
   }
 
-  /** Get users who have not yet voted for a lineup. */
-  private async getVoteNonVoters(lineupId: number): Promise<NonVoter[]> {
+  private async getBuildingLineups(): Promise<ReminderLineup[]> {
     return (await this.db.execute(sql`
-      SELECT u.id, u.id AS "userId",
-             COALESCE(u.display_name, u.username) AS "displayName",
-             u.discord_id AS "discordId"
-      FROM users u
-      WHERE u.discord_id IS NOT NULL
-        AND u.id NOT IN (
-          SELECT user_id FROM community_lineup_votes WHERE lineup_id = ${lineupId}
-        )
-    `)) as unknown as NonVoter[];
+      SELECT id, status, phase_deadline AS "phaseDeadline"
+      FROM community_lineups
+      WHERE status = 'building'
+        AND phase_deadline IS NOT NULL
+    `)) as unknown as ReminderLineup[];
   }
 
-  /** Get match members who have not voted on scheduling slots. */
-  private async getSchedulingNonVoters(
+  private async getSchedulingMatches(
     lineupId: number,
-  ): Promise<SchedulingNonVoter[]> {
+  ): Promise<SchedulingMatchRef[]> {
     return (await this.db.execute(sql`
-      SELECT u.id, u.id AS "userId",
-             COALESCE(u.display_name, u.username) AS "displayName",
-             lmm.match_id AS "matchId"
-      FROM community_lineup_match_members lmm
-      JOIN community_lineup_matches lm ON lm.id = lmm.match_id
-      JOIN users u ON u.id = lmm.user_id
-      WHERE lm.lineup_id = ${lineupId}
-        AND lm.status = 'scheduling'
-        AND NOT EXISTS (
-          SELECT 1
-          FROM community_lineup_schedule_votes csv
-          JOIN community_lineup_schedule_slots css
-            ON css.id = csv.slot_id
-          WHERE css.match_id = lmm.match_id
-            AND csv.user_id = lmm.user_id
-        )
-    `)) as unknown as SchedulingNonVoter[];
+      SELECT lineup_id AS "lineupId", id AS "matchId"
+      FROM community_lineup_matches
+      WHERE lineup_id = ${lineupId}
+        AND status = 'scheduling'
+    `)) as unknown as SchedulingMatchRef[];
   }
 }

--- a/api/src/lineups/lineup-reminder.service.ts
+++ b/api/src/lineups/lineup-reminder.service.ts
@@ -29,6 +29,11 @@ import {
   type ActiveTiebreakerRow,
 } from './lineup-tiebreaker-reminder.helpers';
 import { resolveLineupReminderTargets } from './lineup-reminder-target.helpers';
+import {
+  sendVoteReminder,
+  sendSchedulingReminder,
+  sendNominationReminder,
+} from './lineup-reminder-dispatch.helpers';
 
 interface ReminderLineup {
   id: number;
@@ -163,7 +168,7 @@ export class LineupReminderService {
       'vote',
     );
     for (const userId of userIds) {
-      await this.sendVoteReminder(lineup.id, userId, window);
+      await sendVoteReminder(this.deps(), lineup.id, userId, window);
     }
   }
 
@@ -182,7 +187,12 @@ export class LineupReminderService {
         match.matchId,
       );
       for (const userId of userIds) {
-        await this.sendSchedulingReminder(match.matchId, userId, window);
+        await sendSchedulingReminder(
+          this.deps(),
+          match.matchId,
+          userId,
+          window,
+        );
       }
     }
   }
@@ -199,7 +209,7 @@ export class LineupReminderService {
       'nominate',
     );
     for (const userId of userIds) {
-      await this.sendNominationReminder(lineup.id, userId, window);
+      await sendNominationReminder(this.deps(), lineup.id, userId, window);
     }
   }
 
@@ -216,60 +226,11 @@ export class LineupReminderService {
 
   // ─── DM dispatch ─────────────────────────────────────────────
 
-  private async sendVoteReminder(
-    lineupId: number,
-    userId: number,
-    window: '24h' | '1h',
-  ): Promise<void> {
-    const key = `lineup-reminder-${window}:${lineupId}:${userId}`;
-    if (await this.dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
-    const message =
-      window === '1h'
-        ? 'Last chance to vote -- voting closes in 1 hour'
-        : "You haven't voted yet -- voting closes in 24 hours";
-    await this.notificationService.create({
-      userId,
-      type: 'community_lineup',
-      title: 'Vote Reminder',
-      message,
-      payload: { subtype: 'lineup_vote_reminder', lineupId },
-    });
-  }
-
-  private async sendSchedulingReminder(
-    matchId: number,
-    userId: number,
-    window: '24h' | '1h',
-  ): Promise<void> {
-    const key = `lineup-sched-remind:${matchId}:${userId}:${window}`;
-    if (await this.dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
-    await this.notificationService.create({
-      userId,
-      type: 'community_lineup',
-      title: 'Scheduling Reminder',
-      message: 'Your match is waiting -- pick a time!',
-      payload: { subtype: 'lineup_scheduling_reminder', matchId },
-    });
-  }
-
-  private async sendNominationReminder(
-    lineupId: number,
-    userId: number,
-    window: '24h' | '1h',
-  ): Promise<void> {
-    const key = `lineup-nominate-remind:${lineupId}:${userId}:${window}`;
-    if (await this.dedupService.checkAndMarkSent(key, DEDUP_TTL)) return;
-    const message =
-      window === '1h'
-        ? 'Last chance to nominate -- the building phase closes in 1 hour'
-        : 'Nominations are closing in 24 hours -- add your picks before the cut';
-    await this.notificationService.create({
-      userId,
-      type: 'community_lineup',
-      title: 'Nomination Reminder',
-      message,
-      payload: { subtype: 'lineup_nominate_reminder', lineupId },
-    });
+  private deps() {
+    return {
+      notificationService: this.notificationService,
+      dedupService: this.dedupService,
+    };
   }
 
   private async sendTiebreakerReminder(

--- a/planning-artifacts/tdd-report-ROK-1126.md
+++ b/planning-artifacts/tdd-report-ROK-1126.md
@@ -1,0 +1,119 @@
+# TDD Report — ROK-1126
+
+**Worktree:** `/Users/sdodge/Documents/Projects/Raid-Ledger--rok-1126`
+**Branch:** `rok-1126-lineup-reminders`
+**Mode:** TDD_WRITE_FAILING
+**Failure mode summary:** all new tests are RED. The two unit specs both
+fail-by-construction (helper module missing → cannot resolve import). The
+integration spec fails-by-construction (`checkNominationReminders` does not
+exist on `LineupReminderService` — TypeScript compile error in ts-jest).
+A standalone re-run with a stub helper file confirms 25 of 40 unit tests
+fail on assertion (the remaining 15 are unmodified tiebreaker tests + skip /
+no-op edge cases that legitimately remain green post-implementation).
+
+## Files
+
+| File | Status | Lines |
+|------|--------|-------|
+| `api/src/lineups/lineup-reminder-target.helpers.spec.ts` | new | 222 |
+| `api/src/lineups/lineup-reminder.integration.spec.ts` | new | 424 |
+| `api/src/lineups/lineup-reminder.service.spec.ts` | edited | +220 / -75 |
+
+## Per-AC trace
+
+| AC | Description | Spec(s) covering it | Initial state |
+|----|-------------|---------------------|---------------|
+| 1 | `checkVoteReminders` decorated `@Cron(EVERY_5_MINUTES)` + `executeWithTracking` | `lineup-reminder.service.spec.ts › vote reminders › checkVoteReminders wraps execution in cronJobService.executeWithTracking` | RED |
+| 2 | `checkSchedulingReminders` ditto | `lineup-reminder.service.spec.ts › scheduling reminders › checkSchedulingReminders wraps execution in cronJobService.executeWithTracking` | RED |
+| 3 | `checkNominationReminders` ditto, fires on building lineups | `lineup-reminder.service.spec.ts › nomination reminders › *` (10 cases: 24h, 1h, dedup key shape, helper delegation, building filter, null deadline, out-of-window, expired, dedup, subtype, executeWithTracking) | RED (fails-by-construction; method missing) |
+| 4 | `resolveLineupReminderTargets` returns correct set per (visibility, action) | `lineup-reminder-target.helpers.spec.ts` (12 cases: ReminderAction type, return type, private+nominate/vote/schedule, no invitees, all-participated, public+nominate/vote/schedule, no participants, all-nominated, missing lineup row) | RED (fails-by-construction; module missing) |
+| 5 | private + voting + 1h → invitees ∪ creator minus voters; subtype `lineup_vote_reminder`; dedup key `lineup-reminder-1h:{lineupId}:{userId}` | `lineup-reminder.integration.spec.ts › AC #5 — private voting + 1h-out deadline` | RED |
+| 5b | private + decided (scheduling) + 1h → match members minus schedule-voters | `lineup-reminder.integration.spec.ts › AC #5b — private decided (scheduling) + 1h-out deadline` | RED |
+| 6 | public + voting + 1h → only nominators ∪ voters minus already-voted | `lineup-reminder.integration.spec.ts › AC #6 — public voting + 1h-out deadline` | RED |
+| 7 | private + building + 1h → invitees ∪ creator minus existing nominators; subtype `lineup_nominate_reminder` | `lineup-reminder.integration.spec.ts › AC #7 — private building + 1h-out deadline` | RED |
+| 8 | public + building + 1h → all Discord-linked users minus nominators | `lineup-reminder.integration.spec.ts › AC #8 — public building + 1h-out deadline` | RED |
+| 9 | Notifications routed through `userNotificationPreferences` (community_lineup type) | Implicitly verified — every test asserts `type: 'community_lineup'` | RED (downstream coverage) |
+| 10 | Dedup prevents duplicate DMs across cron firings within window | `lineup-reminder.integration.spec.ts › AC #10 — dedup prevents duplicate DMs across cron firings` | RED |
+
+## Test runner output (post-stub)
+
+To validate that the assertions are *meaningful* failures (not just import errors), I temporarily wrote a no-op stub
+`api/src/lineups/lineup-reminder-target.helpers.ts` exporting `resolveLineupReminderTargets` and the `ReminderAction` type, then re-ran the service spec.
+
+```text
+Test Suites: 1 failed, 1 total
+Tests:       25 failed, 15 passed, 40 total
+```
+
+The 15 passing are the 10 unmodified tiebreaker tests + 5 short-circuit
+edge cases (no lineups → no-op, null deadline → skip, dedup-true → skip)
+whose semantics survive the rewrite.
+
+The 25 failures cover every new behavior: `@Cron` wiring,
+`executeWithTracking`, helper delegation with correct args, dedup key
+shapes, building-status filter, all 10 nomination tests.
+
+The stub file was deleted before commit.
+
+## Confirmed RED runs
+
+```text
+$ cd api && npx jest --testPathPatterns=lineup-reminder-target.helpers --no-coverage
+FAIL src/lineups/lineup-reminder-target.helpers.spec.ts
+  ● Test suite failed to run
+
+    Cannot find module './lineup-reminder-target.helpers' from
+    'lineups/lineup-reminder-target.helpers.spec.ts'
+
+Test Suites: 1 failed, 1 total
+Tests:       0 total
+
+$ cd api && npx jest --testPathPatterns=lineup-reminder.service.spec --no-coverage
+FAIL src/lineups/lineup-reminder.service.spec.ts
+  ● Test suite failed to run
+
+    Cannot find module './lineup-reminder-target.helpers' from
+    'lineups/lineup-reminder.service.spec.ts'
+
+Test Suites: 1 failed, 1 total
+Tests:       0 total
+```
+
+Integration spec fails to compile (ts-jest):
+
+```text
+src/lineups/lineup-reminder.integration.spec.ts(268,29): error TS2339:
+  Property 'checkNominationReminders' does not exist on type 'LineupReminderService'.
+src/lineups/lineup-reminder.integration.spec.ts(310,29): error TS2339:
+  Property 'checkNominationReminders' does not exist on type 'LineupReminderService'.
+src/lineups/lineup-reminder.integration.spec.ts(420,35): error TS2339:
+  Property 'checkNominationReminders' does not exist on type 'LineupReminderService'.
+```
+
+## Notes for the dev agent
+
+- **Helper signature is fixed** by the unit spec. Mock pattern: tests
+  queue 3 `db.execute` results in order: (1) lineup row, (2) candidate
+  user list, (3) participants-to-subtract. The dev's helper internals
+  may differ — only the public signature and final filter logic are
+  pinned. The "candidate set" query for public + vote may instead use
+  a single union; the test still passes as long as the result excludes
+  already-voted users.
+- **Dedup key for nominate** is `lineup-nominate-remind:{lineupId}:{userId}:{window}` (window = `'24h'` or `'1h'`).
+- **Scheduling restructure:** the existing `getSchedulingNonVoters` SQL
+  used a single query joining match members with `NOT EXISTS` schedule
+  votes. The spec now expects the service to first fetch
+  `(lineupId, matchId)` pairs for scheduling-status matches, then call
+  `resolveLineupReminderTargets(db, lineupId, 'schedule', matchId)` per
+  match — so the helper does the per-match user resolution.
+- **`@Cron` decorators** don't actually fire in the unit test (no
+  `ScheduleModule.forRoot()` in the test module). Tests call
+  `service.checkVoteReminders()` etc. directly. The
+  `executeWithTracking` mock implementation calls its `fn` argument
+  immediately, so the inner `runX` body still runs.
+- The integration spec's AC #8 asserts `expect.arrayContaining(...)`
+  rather than equality with the new users only, because the seeded
+  admin user from `truncateAllTables` also has a discord_id and
+  participates in the public-branch fan-out. Don't tighten this to
+  exact-set equality without removing the admin from the candidate
+  pool first.


### PR DESCRIPTION
## Summary

- Wires the orphaned `LineupReminderService.checkVoteReminders` and `checkSchedulingReminders` to a 5-minute `@Cron(EVERY_5_MINUTES)` + `executeWithTracking` (matches the established pattern from `checkTiebreakerReminders` / `StandalonePollReminderService`).
- Adds a new `checkNominationReminders` cron for the building phase — DMs at 24h and 1h before `phase_deadline`.
- Replaces the old per-method `getXNonVoters` queries with a single `resolveLineupReminderTargets(db, lineupId, action, matchId?)` helper that branches on `community_lineups.visibility`:
  - **Private:** invitees ∪ {creator} minus already-participated, intersected with match members for `schedule`.
  - **Public:** action-specific candidate set (all Discord-linked / nominators ∪ voters / match members) minus already-participated.
- Always gates recipients on `users.discord_id IS NOT NULL`, including the private-lineup creator (caught by Codex review).
- Registers the 3 new crons in `CORE_JOB_METADATA` for the admin panel.

## Linear

ROK-1126

## Test plan

- [x] 16 unit tests for `resolveLineupReminderTargets` (visibility branches × actions, edge cases — including the new "schedule scoped to match members" and "creator without discord_id excluded" cases)
- [x] 40 service unit tests (cron wiring, dedup keys, dispatch via helper)
- [x] 7 integration tests (real Postgres) — private/public × building/voting/scheduling × dedup
- [x] `./scripts/validate-ci.sh --full` PASS (845/845 integration after CORE_JOB_METADATA fix)
- [x] Live smoke in DEMO_MODE: created private + building lineup with 50min deadline + 2 invitees → 21:35:00 UTC cron fired and dispatched 3 `lineup_nominate_reminder` DMs to creator + invitees; 21:40:00 UTC tick correctly deduped (count stayed at 3).
- [x] Codex review: 1 real bug fixed (private + schedule scoping), 1 edge-case fix (creator without discord_id), 1 false positive dismissed (public vote audience narrowing — operator-approved per spec AC #6).

## Operator-approved interpretive choices (recorded in spec)

1. Public + building → all Discord-linked users get the nomination reminder.
2. Private → skip recipients who already participated (de-noise).
3. Filter applies to all three reminder methods (vote + sched + nominate).