### PR TITLE
ROK-1232: tech-debt: integration suite teardown hardening

### DIFF
--- a/api/jest.integration.config.js
+++ b/api/jest.integration.config.js
@@ -25,7 +25,15 @@ module.exports = {
   testEnvironment: 'node',
   // Integration tests need more time due to container startup
   testTimeout: 120_000,
-  // Run sequentially — tests share a single Testcontainers instance
+  // ROK-1232: kept at 1 for the FIRST PR. The teardown hardening landed
+  // here (SettingsService cache reset, dedup Redis sweep, cron jobs
+  // stopped post-init) closes the three deterministic leak vectors the
+  // TDD repros codified, but a residual `socket hang up` flake matching
+  // ROK-1091 (embed-sync ECONNRESET) still bites at maxWorkers=2 in
+  // ~25% of local runs. The dev brief explicitly defers that cascade
+  // ("recommend the dev verify ROK-1091 still reproduces after the new
+  // reset hook lands; if so, file a follow-up") — once that lands, this
+  // can ratchet up to 2 (and CI sharding stays orthogonal).
   maxWorkers: 1,
   // ROK-1058 AC3: file-order randomization is opt-in via the CLI `--randomize`
   // flag (passed by the CI matrix). Local default stays deterministic so

--- a/api/src/common/testing/integration-helpers.ts
+++ b/api/src/common/testing/integration-helpers.ts
@@ -15,6 +15,7 @@ import type { Queue } from 'bullmq';
 import * as schema from '../../drizzle/schema';
 import { clearAuthUserCache } from '../../auth/auth-user-cache';
 import { ALL_QUEUE_NAMES } from '../../queue/queue-registry';
+import { SettingsService } from '../../settings/settings.service';
 import { INSTANCE_KEY, type TestApp } from './test-app';
 
 const obliterateLogger = new Logger('truncateAllTables.obliterate');
@@ -119,13 +120,17 @@ export async function truncateAllTables(
   }
 
   // Reset cross-suite in-memory state that can otherwise leak between files
-  // during a full integration run (ROK-1059). The mock Redis store and the
-  // auth-user cache are module-level singletons held alive by the TestApp
-  // singleton on `process`. Without clearing them here, a `jwt_block:<userId>`
-  // entry written by an earlier suite can silently invalidate tokens issued
-  // to the freshly re-seeded admin (whose new id may collide with a stale key).
+  // during a full integration run (ROK-1059, ROK-1232). The mock Redis store,
+  // the auth-user cache, and the SettingsService cache are module/instance-
+  // level singletons held alive by the TestApp singleton on `process`.
+  // Without clearing them here, a `jwt_block:<userId>` entry written by an
+  // earlier suite can silently invalidate tokens issued to the freshly
+  // re-seeded admin, a stale `community_name` (or any setting) read can
+  // bias logic in the next spec, and a `lineup-*` dedup key can silence a
+  // notification expected by spec B.
   clearAuthUserCache();
-  clearJwtBlockKeysFromMockRedis();
+  clearMockRedisByPrefix(MOCK_REDIS_TEARDOWN_PREFIXES);
+  clearSettingsServiceCache();
   await obliterateAllQueues();
 
   // Re-seed baseline data
@@ -163,18 +168,56 @@ async function obliterateAllQueues(): Promise<void> {
 }
 
 /**
- * Delete all `jwt_block:*` entries from the in-memory Redis mock backing the
- * current TestApp singleton. No-op when no TestApp is registered yet (which
- * happens during the very first truncate before the mock is created).
+ * Prefixes purged from the mock Redis store on each truncate.
+ *
+ * `jwt_block:` blocks token reuse after revocation; the dedup prefixes mirror
+ * the Playwright reset (`demo-test-reset.service.ts:flushDedupRedisCache`) so
+ * a `lineup-reminder:1:99:24h` written by spec A cannot silence a matching
+ * notification expected by spec B. ROK-1059 + ROK-1232.
  */
-function clearJwtBlockKeysFromMockRedis(): void {
+const MOCK_REDIS_TEARDOWN_PREFIXES: readonly string[] = [
+  'jwt_block:',
+  'lineup-',
+  'event-',
+  'tiebreaker-',
+  'scheduling-',
+  'standalone-poll-',
+];
+
+/**
+ * Delete every key in the in-memory Redis mock that starts with one of the
+ * given prefixes. No-op when no TestApp is registered yet (during the very
+ * first truncate, before the mock is created).
+ */
+function clearMockRedisByPrefix(prefixes: readonly string[]): void {
   const instance = (process as unknown as Record<string, TestApp | null>)[
     INSTANCE_KEY
   ];
   const store = instance?.redisMock?.store;
   if (!store) return;
   for (const key of [...store.keys()]) {
-    if (key.startsWith('jwt_block:')) store.delete(key);
+    if (prefixes.some((p) => key.startsWith(p))) store.delete(key);
+  }
+}
+
+/**
+ * Drop the in-memory `SettingsService` cache so the next read after truncate
+ * goes back to the (now-empty) DB. The service caches decrypted settings for
+ * 30 minutes; without this reset, a `community_name` (or any setting) value
+ * written by spec A still resolves in spec B even though its row was just
+ * deleted. No-op until the NestJS app has been booted. ROK-1232.
+ */
+function clearSettingsServiceCache(): void {
+  const instance = (process as unknown as Record<string, TestApp | null>)[
+    INSTANCE_KEY
+  ];
+  const app = instance?.app;
+  if (!app) return;
+  try {
+    const settings = app.get(SettingsService, { strict: false });
+    settings?.clearCache();
+  } catch {
+    // Service not yet available (very first truncate before app.init()).
   }
 }
 

--- a/api/src/common/testing/integration-helpers.ts
+++ b/api/src/common/testing/integration-helpers.ts
@@ -215,7 +215,7 @@ function clearSettingsServiceCache(): void {
   if (!app) return;
   try {
     const settings = app.get(SettingsService, { strict: false });
-    settings?.clearCache();
+    settings?.invalidateCache(true);
   } catch {
     // Service not yet available (very first truncate before app.init()).
   }

--- a/api/src/common/testing/integration-setup.ts
+++ b/api/src/common/testing/integration-setup.ts
@@ -10,6 +10,12 @@
 // Must be before the test-app import to take effect before modules are evaluated.
 process.env.THROTTLE_DISABLED = 'true';
 process.env.THROTTLE_DEFAULT_LIMIT = '999999';
+// ROK-1232: stop every `@Cron`/plugin-host cron handler from firing inside
+// the test window. `SchedulerRegistry` is still wired (plugins inject it),
+// so individual jobs are stopped after `app.init()` in `getTestApp` rather
+// than skipping `ScheduleModule.forRoot()` outright. Same shape as
+// THROTTLE_DISABLED — explicit, not piggy-backed on NODE_ENV.
+process.env.CRON_DISABLED = 'true';
 
 import { closeTestApp, getTestApp } from './test-app';
 import { truncateAllTables } from './integration-helpers';

--- a/api/src/common/testing/integration-teardown.integration.spec.ts
+++ b/api/src/common/testing/integration-teardown.integration.spec.ts
@@ -1,0 +1,137 @@
+/**
+ * ROK-1232 — failing TDD repros: integration teardown gaps.
+ *
+ * Three tests, each codifying a deterministic leak vector that survives
+ * `truncateAllTables` today and must be closed by the dev's
+ * `resetIntegrationState()` (or extended `truncateAllTables`).
+ *
+ * Vector 1: SettingsService in-memory cache survives truncate.
+ *   `settings.service.ts` caches decrypted app_settings in a Map with a
+ *   30-minute TTL. `truncateAllTables` wipes the `app_settings` table but
+ *   does NOT clear the cache; the next spec sees stale values written by
+ *   the previous spec.
+ *
+ * Vector 2: Notification dedup keys survive truncate.
+ *   The Playwright reset (`demo-test-reset.service.ts:flushDedupRedisCache`)
+ *   sweeps `lineup-*`, `event-*`, `tiebreaker-*`, `scheduling-*`,
+ *   `standalone-poll-*`. The integration teardown only sweeps `jwt_block:*`.
+ *   A dedup write in spec A silences a notification in spec B.
+ *
+ * Vector 3: Cron jobs run during the test window (ROK-1223).
+ *   `ScheduleModule.forRoot()` registers every `@Cron` decorator into the
+ *   shared `SchedulerRegistry`. Today nothing pauses or short-circuits
+ *   them in `NODE_ENV === 'test'`, so a 5-min cron handler can fire
+ *   inside a long integration suite, mutating DB state out of band.
+ *
+ * Each test is expected to FAIL on current main and pass after the dev
+ * lands the additive teardown / cron pause.
+ *
+ * Hard rule (build template): tests only — no source-code edits, no
+ * helper additions, no harness changes. Run via:
+ *   npm run test:integration -w api -- common/testing/integration-teardown
+ */
+import { SchedulerRegistry } from '@nestjs/schedule';
+import { sql } from 'drizzle-orm';
+import { getTestApp, type TestApp } from './test-app';
+import { truncateAllTables } from './integration-helpers';
+import { SettingsService } from '../../settings/settings.service';
+import { NotificationDedupService } from '../../notifications/notification-dedup.service';
+
+function describeTeardownGaps() {
+  let testApp: TestApp;
+
+  beforeAll(async () => {
+    testApp = await getTestApp();
+  });
+
+  afterEach(async () => {
+    testApp.seed = await truncateAllTables(testApp.db);
+  });
+
+  // ── Vector 1: SettingsService cache survives truncate ───────────────
+  it('clears the SettingsService in-memory cache so a fresh setting read after truncate misses', async () => {
+    const settings = testApp.app.get(SettingsService);
+
+    // Write a setting that any subsequent spec might read for an
+    // operational decision (e.g. community name on an embed).
+    await settings.set('community_name', 'rok-1232-leak-canary');
+    expect(await settings.get('community_name')).toBe('rok-1232-leak-canary');
+
+    // The canonical "between specs" reset.
+    testApp.seed = await truncateAllTables(testApp.db);
+
+    // The DB row is gone — confirm the test's SQL premise is correct.
+    const rows = await testApp.db.execute<{ count: string }>(
+      sql`SELECT COUNT(*)::text AS count FROM app_settings WHERE key = 'community_name'`,
+    );
+    expect(rows[0]?.count).toBe('0');
+
+    // The bug: cache TTL is 30 minutes, `truncateAllTables` does not clear
+    // it, so the in-memory copy still returns the previous value.
+    // Until the dev adds a cache-reset step to the teardown surface, this
+    // assertion fails — `get` returns the stale 'rok-1232-leak-canary'.
+    expect(await settings.get('community_name')).toBeNull();
+  });
+
+  // ── Vector 2: dedup Redis keys survive truncate ─────────────────────
+  it('clears notification dedup Redis keys (lineup-*/event-*/standalone-poll-*) so spec A cannot silence spec B', async () => {
+    const dedup = testApp.app.get(NotificationDedupService);
+
+    // Plant a representative key from each domain prefix the Playwright
+    // reset already sweeps. `checkAndMarkSent` returns false (= not yet
+    // sent) on first call and writes the key to Redis + DB.
+    const keys = [
+      'lineup-reminder:1:99:24h',
+      'event-reminder:42:99:1h',
+      'tiebreaker-veto:7:99',
+      'scheduling-poll:13:99',
+      'standalone-poll-reminder:55:99:24h',
+    ];
+    for (const k of keys) {
+      const alreadySent = await dedup.checkAndMarkSent(k, 3_600);
+      expect(alreadySent).toBe(false);
+    }
+
+    // Sanity: the Redis mock now holds those keys.
+    const storeBefore = testApp.redisMock.store;
+    for (const k of keys) {
+      expect(storeBefore.has(k)).toBe(true);
+    }
+
+    // The canonical reset.
+    testApp.seed = await truncateAllTables(testApp.db);
+
+    // After teardown, no dedup keys may remain. Today only `jwt_block:*`
+    // is purged, so each of these survives — every assertion below fails
+    // until the dev mirrors `flushDedupRedisCache` into the helper.
+    const storeAfter = testApp.redisMock.store;
+    const survivors = keys.filter((k) => storeAfter.has(k));
+    expect(survivors).toEqual([]);
+  });
+
+  // ── Vector 3: crons remain registered + running during tests ────────
+  it('disables registered cron jobs during integration tests so handlers cannot fire mid-spec', () => {
+    const scheduler = testApp.app.get(SchedulerRegistry);
+    const cronJobs = scheduler.getCronJobs();
+
+    // The scheduler should hold cron registrations from real services
+    // (e.g. StandalonePollReminderService_runReminders, the failure mode
+    // in ROK-1223). If the registry is empty, the test premise is wrong.
+    expect(cronJobs.size).toBeGreaterThan(0);
+
+    // Every registered cron must be inert under NODE_ENV=test. The
+    // `cron` library's CronJob exposes `isActive` — true while the
+    // internal timer is armed (between `start()` and `stop()`).
+    // ScheduleModule.forRoot() calls `start()` on every @Cron at
+    // app.init() and nothing in the harness pauses them — so this
+    // assertion fails for all 30+ jobs on main today.
+    const stillActive: string[] = [];
+    for (const [name, job] of cronJobs) {
+      const isActive = (job as unknown as { isActive?: boolean }).isActive;
+      if (isActive) stillActive.push(name);
+    }
+    expect(stillActive).toEqual([]);
+  });
+}
+
+describe('Integration teardown gaps (ROK-1232)', () => describeTeardownGaps());

--- a/api/src/common/testing/test-app.ts
+++ b/api/src/common/testing/test-app.ts
@@ -16,6 +16,7 @@
  */
 import { Test } from '@nestjs/testing';
 import { type INestApplication } from '@nestjs/common';
+import { SchedulerRegistry } from '@nestjs/schedule';
 import {
   PostgreSqlContainer,
   type StartedPostgreSqlContainer,
@@ -147,10 +148,33 @@ async function buildNestApp(
     .compile();
   const app = moduleRef.createNestApplication();
   await app.init();
+  if (process.env.CRON_DISABLED === 'true') {
+    stopAllCronJobs(app);
+  }
   const request = supertest.default(
     app.getHttpServer() as import('http').Server,
   );
   return { app, request };
+}
+
+/**
+ * Stop every cron job registered against the SchedulerRegistry by either
+ * `@Cron` decorators (mounted by `SchedulerOrchestrator.onApplicationBootstrap`)
+ * or the plugin-host `CronManagerService`. Called immediately after
+ * `app.init()` returns so handlers cannot fire inside the test window
+ * (ROK-1223 / ROK-1232). Cron handlers run on real timers and can mutate
+ * DB rows the test loop is also asserting against — e.g.
+ * `StandalonePollReminderService_runReminders` writing `notification_dedup`
+ * mid-spec. The `cron` library's `CronJob.stop()` flips `isActive` to false
+ * and clears the internal interval, so jobs stay in the registry but are
+ * inert for the lifetime of the test app.
+ */
+function stopAllCronJobs(app: INestApplication): void {
+  const scheduler = app.get(SchedulerRegistry, { strict: false });
+  if (!scheduler) return;
+  for (const [, job] of scheduler.getCronJobs()) {
+    job.stop();
+  }
 }
 
 export async function getTestApp(): Promise<TestApp> {

--- a/api/src/settings/settings.service.ts
+++ b/api/src/settings/settings.service.ts
@@ -169,6 +169,18 @@ export class SettingsService implements OnModuleInit {
     this.cacheLoadedAt = 0;
   }
 
+  /**
+   * Drop the in-memory cache entirely (entries + load timestamp).
+   * Used by integration teardown after `truncateAllTables` deletes
+   * `app_settings` rows so the next spec sees a fresh DB-backed read
+   * instead of values written by a prior spec (ROK-1232).
+   */
+  clearCache(): void {
+    this.cache.clear();
+    this.cacheLoadedAt = 0;
+    this.cacheLoadPromise = null;
+  }
+
   /** Emit cleared events for all integrations. */
   emitAllIntegrationsCleared(): void {
     this.eventEmitter.emit(SETTINGS_EVENTS.DISCORD_BOT_UPDATED, null);

--- a/api/src/settings/settings.service.ts
+++ b/api/src/settings/settings.service.ts
@@ -89,34 +89,8 @@ export class SettingsService implements OnModuleInit {
     await this.cacheLoadPromise;
   }
 
-  /** Loads all settings from DB, decrypts, and replaces the cache. */
-  private async loadCache(): Promise<void> {
-    try {
-      const rows = await this.db.select().from(appSettings);
-      const fresh = new Map<string, string>();
-      for (const row of rows) {
-        try {
-          fresh.set(row.key, decrypt(row.encryptedValue));
-        } catch {
-          this.logger.error(`Failed to decrypt setting ${row.key}`);
-        }
-      }
-      this.cache = fresh;
-      this.cacheLoadedAt = Date.now();
-      this.logger.debug(`Settings cache loaded (${fresh.size} entries)`);
-    } catch (err: unknown) {
-      this.logger.error('Background cache refresh failed', err);
-    } finally {
-      this.cacheLoadPromise = null;
-    }
-  }
-
-  /**
-   * Startup-only variant that re-throws on failure.
-   * Used by onModuleInit so a DB outage at boot crashes fast
-   * rather than leaving an empty cache that causes cascading failures.
-   */
-  private async loadCacheOrThrow(): Promise<void> {
+  /** Build a fresh decrypted-settings map from rows, swap into cache. */
+  private async refreshCacheFromDb(): Promise<void> {
     const rows = await this.db.select().from(appSettings);
     const fresh = new Map<string, string>();
     for (const row of rows) {
@@ -129,6 +103,26 @@ export class SettingsService implements OnModuleInit {
     this.cache = fresh;
     this.cacheLoadedAt = Date.now();
     this.logger.debug(`Settings cache loaded (${fresh.size} entries)`);
+  }
+
+  /** Loads all settings from DB, decrypts, and replaces the cache. */
+  private async loadCache(): Promise<void> {
+    try {
+      await this.refreshCacheFromDb();
+    } catch (err: unknown) {
+      this.logger.error('Background cache refresh failed', err);
+    } finally {
+      this.cacheLoadPromise = null;
+    }
+  }
+
+  /**
+   * Startup-only variant that re-throws on failure.
+   * Used by onModuleInit so a DB outage at boot crashes fast
+   * rather than leaving an empty cache that causes cascading failures.
+   */
+  private loadCacheOrThrow(): Promise<void> {
+    return this.refreshCacheFromDb();
   }
 
   /** Get a setting value by key (decrypted, from cache). */
@@ -164,20 +158,11 @@ export class SettingsService implements OnModuleInit {
     return this.cache.has(key);
   }
 
-  /** Force-reload cache on next access. */
-  invalidateCache(): void {
+  /** Force cache reload on next access. `full` also drops entries (ROK-1232). */
+  invalidateCache(full = false): void {
     this.cacheLoadedAt = 0;
-  }
-
-  /**
-   * Drop the in-memory cache entirely (entries + load timestamp).
-   * Used by integration teardown after `truncateAllTables` deletes
-   * `app_settings` rows so the next spec sees a fresh DB-backed read
-   * instead of values written by a prior spec (ROK-1232).
-   */
-  clearCache(): void {
-    this.cache.clear();
-    this.cacheLoadedAt = 0;
+    if (!full) return;
+    this.cache = new Map();
     this.cacheLoadPromise = null;
   }
 


### PR DESCRIPTION
## Summary
- Three additive teardown fixes wired into `truncateAllTables` + integration test bootstrap to close state leaks past the existing ROK-1058/ROK-1059 sweep:
  - **`SettingsService` 30-min in-memory cache** is now reset on truncate (the most plausible mechanism behind the random `createFutureEvent 401` flake — settings reads cached values from a prior spec).
  - **Notification dedup Redis keys** (`lineup-*`, `event-*`, `tiebreaker-*`, `scheduling-*`, `standalone-poll-*`) are flushed alongside `jwt_block:*` — mirrors the Playwright pattern in `demo-test-reset.service.ts:68 flushDedupRedisCache`.
  - **38 active CronJob timers** in `SchedulerRegistry` are stopped post-`app.init()` when `CRON_DISABLED=true` is set in the integration setup file. Same env-var shape as the existing `THROTTLE_DISABLED` precedent. Closes ROK-1223 (standalone-poll cron firing mid-test).
- New deterministic regression spec at `api/src/common/testing/integration-teardown.integration.spec.ts` codifies all three vectors. Was 3/3 FAIL on `main`; now 3/3 PASS.
- Ride-along: `SettingsService.invalidateCache(full = false)` now accepts an optional `true` for full reset; the new code path replaced a duplicated decrypt loop with a private helper. Behavioral no-op for prior callers; net -7 lines so the file stays under the 300-line ESLint cap.
- `maxWorkers: 1` held — bumping to 2 surfaced ROK-1091 (embed-sync ECONNRESET) which is explicitly out of scope per the spec. Comment in `jest.integration.config.js` documents the path forward.

## Linear
ROK-1232 — rolls up ROK-1055 / ROK-1091 / ROK-1100 / ROK-1104 / ROK-1111 / ROK-1223. Spec: `planning-artifacts/specs/ROK-1232.md` (with as-built reconciliation). Dev report: `planning-artifacts/dev-report-ROK-1232.md`. Codex review: `planning-artifacts/review-ROK-1232.md` — APPROVED, no findings.

## Test plan
- [x] TDD failing tests committed before implementation (`c21a2ac5`/`da911d09` post-rebase)
- [x] All 3 TDD repros now passing locally
- [x] Full integration suite: 848/848 PASS at `maxWorkers: 1`, twice consecutively (~290s each)
- [x] `validate-ci.sh --full` green twice consecutively (build, tsc, lint, unit + coverage, integration)
- [x] Codex review: APPROVED, zero findings
- [x] No UI changes — Playwright N/A
- [x] Operator approved in browser review
- [ ] CI: verify on this PR

## Out of scope / follow-ups
- **ROK-1091** (embed-sync ECONNRESET): drain the embed-sync queue (and adjacent user-fixture-touching queues) BEFORE truncating tables. Once landed, bump `maxWorkers` to 2 in `jest.integration.config.js` per the comment block.
- **ROK-1100 / 1104 / 1111**: cascade fixes — should resolve once the dominant SettingsService leak is closed by this PR. Verify in subsequent CI runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)