### PR TITLE
fix(integration-tests): cascade-wipe assertion survives sequence reuse

### DIFF
--- a/api/src/admin/demo-test-reset.integration.spec.ts
+++ b/api/src/admin/demo-test-reset.integration.spec.ts
@@ -6,7 +6,7 @@
  * sessions, preserve admin + non-demo data, and re-run the demo
  * installer so demo users/games/events come back.
  */
-import { eq, inArray } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { getTestApp, type TestApp } from '../common/testing/test-app';
 import {
   truncateAllTables,
@@ -148,10 +148,17 @@ function describeReset() {
     }, 240_000);
 
     it('cascade-wipes signups when events are wiped', async () => {
+      // Identify the test event by title, NOT id — TRUNCATE … RESTART
+      // IDENTITY resets the events sequence, so the demo installer
+      // recreates events whose ids collide with our pre-reset event.id.
+      // Demo signups for those new events would then masquerade as
+      // orphans of our wiped row. Same gotcha noted in the orphan-events
+      // test above.
+      const orphanTitle = 'wipe-signups-test';
       const [event] = await testApp.db
         .insert(schema.events)
         .values({
-          title: 'wipe-signups-test',
+          title: orphanTitle,
           duration: [
             new Date(Date.now() + 60_000),
             new Date(Date.now() + 120_000),
@@ -171,11 +178,21 @@ function describeReset() {
         .post('/admin/test/reset-to-seed')
         .set('Authorization', `Bearer ${adminToken}`);
       expect(res.status).toBe(200);
+      // Cascade is observable in the wipe counts: at least our one
+      // signup must be reported as deleted.
+      expect(res.body.deleted.signups).toBeGreaterThanOrEqual(1);
 
+      // Cross-check: no signups remain that join back to an event with
+      // our test title. Inner-join survives sequence reuse because the
+      // demo installer never uses this title.
       const orphanSignups = await testApp.db
         .select({ id: schema.eventSignups.id })
         .from(schema.eventSignups)
-        .where(inArray(schema.eventSignups.eventId, [event.id]));
+        .innerJoin(
+          schema.events,
+          eq(schema.events.id, schema.eventSignups.eventId),
+        )
+        .where(eq(schema.events.title, orphanTitle));
       expect(orphanSignups).toHaveLength(0);
     }, 120_000);
   });


### PR DESCRIPTION
## Summary

Hotfix for a test bug currently failing on main and blocking #730.

`admin/demo-test-reset.integration.spec.ts:179` — `cascade-wipes signups when events are wiped` was matching post-reset signups by integer `eventId`. But `reset-to-seed` runs `TRUNCATE … RESTART IDENTITY CASCADE`, so the demo installer recreates events whose ids collide with the pre-reset `event.id`. Demo signups for those new events then masqueraded as orphans of the wiped row.

The cascade was actually working — only the assertion was wrong.

## Fix

Replace the `eventId` match with an inner join through `events.title` (`'wipe-signups-test'`), a unique marker the demo installer never uses. Also assert `res.body.deleted.signups >= 1` so the cascade is observable from the API response.

The other test in the same file (`wipes orphan events…`, lines 70-72) already documents this exact gotcha — this brings the cascade test in line.

## Evidence

Failure was real and recurring on main, flipping shards under `--randomize`:

| Run | SHA | Failed shard |
|---|---|---|
| 25292699873 | 66a26812 | (2/3, 2) |
| 25291697358 | b5912e29 | (2/3, 1), (2/3, 3) |
| 25289759945 | f3ec212b | (1/3, 2), (1/3, 3) |

Same exact assertion: `Expected length: 0, Received length: 12` (12 demo signups whose `eventId` happened to collide with the pre-reset id).

## Test plan

- [x] Spec passes in isolation locally
- [x] Spec passes locally with `--randomize` (seed 1627652568)
- [x] Typecheck clean
- [x] Lint clean (only pre-existing function-length warnings)
- [ ] CI green
- [ ] Confirms #730 unblocks once main is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)