### PR TITLE
chore: combined dependabot merge — #733-#741 (excl. #738)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -461,7 +461,7 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report-shard-${{ strategy.job-index }}
           path: playwright-report/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -571,7 +571,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -23,7 +23,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Log in to Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -49,4 +49,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/api/package.json
+++ b/api/package.json
@@ -55,7 +55,7 @@
     "graphology-communities-louvain": "^2.0.2",
     "graphology-types": "^0.24.8",
     "helmet": "^8.1.0",
-    "ioredis": "^5.9.2",
+    "ioredis": "^5.10.1",
     "passport": "^0.7.0",
     "passport-discord": "^0.1.4",
     "passport-jwt": "^4.0.1",

--- a/api/package.json
+++ b/api/package.json
@@ -41,7 +41,7 @@
     "@nestjs/throttler": "^6.5.0",
     "@nestjs/websockets": "^11.1.19",
     "@raid-ledger/contract": "*",
-    "@sentry/nestjs": "^10.38.0",
+    "@sentry/nestjs": "^10.51.0",
     "bcrypt": "^6.0.0",
     "bullmq": "^5.68.0",
     "chrono-node": "^2.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -54,7 +54,7 @@
                 "graphology-communities-louvain": "^2.0.2",
                 "graphology-types": "^0.24.8",
                 "helmet": "^8.1.0",
-                "ioredis": "^5.9.2",
+                "ioredis": "^5.10.1",
                 "passport": "^0.7.0",
                 "passport-discord": "^0.1.4",
                 "passport-jwt": "^4.0.1",
@@ -114,6 +114,36 @@
                 "eslint": {
                     "optional": true
                 }
+            }
+        },
+        "api/node_modules/@ioredis/commands": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@ioredis/commands/-/commands-1.5.1.tgz",
+            "integrity": "sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==",
+            "license": "MIT"
+        },
+        "api/node_modules/ioredis": {
+            "version": "5.10.1",
+            "resolved": "https://registry.npmjs.org/ioredis/-/ioredis-5.10.1.tgz",
+            "integrity": "sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==",
+            "license": "MIT",
+            "dependencies": {
+                "@ioredis/commands": "1.5.1",
+                "cluster-key-slot": "^1.1.0",
+                "debug": "^4.3.4",
+                "denque": "^2.1.0",
+                "lodash.defaults": "^4.2.0",
+                "lodash.isarguments": "^3.1.0",
+                "redis-errors": "^1.2.0",
+                "redis-parser": "^3.0.0",
+                "standard-as-callback": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=12.22.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/ioredis"
             }
         },
         "node_modules/@acemir/cssom": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21578,9 +21578,9 @@
             }
         },
         "node_modules/zustand": {
-            "version": "5.0.11",
-            "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.11.tgz",
-            "integrity": "sha512-fdZY+dk7zn/vbWNCYmzZULHRrss0jx5pPFiOuMZ/5HJN6Yv3u+1Wswy/4MpZEkEGhtNH+pwxZB8OKgUBPzYAGg==",
+            "version": "5.0.12",
+            "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.12.tgz",
+            "integrity": "sha512-i77ae3aZq4dhMlRhJVCYgMLKuSiZAaUPAct2AksxQ+gOtimhGMdXljRT21P5BNpeT4kXlLIckvkPM029OljD7g==",
             "license": "MIT",
             "engines": {
                 "node": ">=12.20.0"
@@ -21673,7 +21673,7 @@
                 "recharts": "^3.7.0",
                 "socket.io-client": "^4.8.3",
                 "sonner": "^2.0.7",
-                "zustand": "^5.0.11"
+                "zustand": "^5.0.12"
             },
             "devDependencies": {
                 "@eslint/js": "^10.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
                 "@nestjs/throttler": "^6.5.0",
                 "@nestjs/websockets": "^11.1.19",
                 "@raid-ledger/contract": "*",
-                "@sentry/nestjs": "^10.38.0",
+                "@sentry/nestjs": "^10.51.0",
                 "bcrypt": "^6.0.0",
                 "bullmq": "^5.68.0",
                 "chrono-node": "^2.9.0",
@@ -272,23 +272,6 @@
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.1.0"
-            }
-        },
-        "node_modules/@apm-js-collab/code-transformer": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.8.2.tgz",
-            "integrity": "sha512-YRjJjNq5KFSjDUoqu5pFUWrrsvGOxl6c3bu+uMFc9HNNptZ2rNU/TI2nLw4jnhQNtka972Ee2m3uqbvDQtPeCA==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@apm-js-collab/tracing-hooks": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.3.1.tgz",
-            "integrity": "sha512-Vu1CbmPURlN5fTboVuKMoJjbO5qcq9fA5YXpskx3dXe/zTBvjODFoerw+69rVBlRLrJpwPqSDqEuJDEKIrTldw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@apm-js-collab/code-transformer": "^0.8.0",
-                "debug": "^4.4.1",
-                "module-details-from-path": "^1.0.4"
             }
         },
         "node_modules/@asamuzakjp/css-color": {
@@ -2343,6 +2326,108 @@
                 "@noble/hashes": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/@fastify/otel": {
+            "version": "0.18.0",
+            "resolved": "https://registry.npmjs.org/@fastify/otel/-/otel-0.18.0.tgz",
+            "integrity": "sha512-3TASCATfw+ctICSb4ymrv7iCm0qJ0N9CarB+CZ7zIJ7KqNbwI5JjyDL1/sxoC0ccTO1Zyd1iQ+oqncPg5FJXaA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fastify"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/fastify"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@opentelemetry/core": "^2.0.0",
+                "@opentelemetry/instrumentation": "^0.212.0",
+                "@opentelemetry/semantic-conventions": "^1.28.0",
+                "minimatch": "^10.2.4"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.9.0"
+            }
+        },
+        "node_modules/@fastify/otel/node_modules/@opentelemetry/api-logs": {
+            "version": "0.212.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.212.0.tgz",
+            "integrity": "sha512-TEEVrLbNROUkYY51sBJGk7lO/OLjuepch8+hmpM6ffMJQ2z/KVCjdHuCFX6fJj8OkJP2zckPjrJzQtXU3IAsFg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            },
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
+        "node_modules/@fastify/otel/node_modules/@opentelemetry/instrumentation": {
+            "version": "0.212.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.212.0.tgz",
+            "integrity": "sha512-IyXmpNnifNouMOe0I/gX7ENfv2ZCNdYTF0FpCsoBcpbIHzk81Ww9rQTYTnvghszCg7qGrIhNvWC8dhEifgX9Jg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@opentelemetry/api-logs": "0.212.0",
+                "import-in-the-middle": "^2.0.6",
+                "require-in-the-middle": "^8.0.0"
+            },
+            "engines": {
+                "node": "^18.19.0 || >=20.6.0"
+            },
+            "peerDependencies": {
+                "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@fastify/otel/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/@fastify/otel/node_modules/brace-expansion": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+            "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/@fastify/otel/node_modules/import-in-the-middle": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
+            "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "acorn": "^8.15.0",
+                "acorn-import-attributes": "^1.9.5",
+                "cjs-module-lexer": "^2.2.0",
+                "module-details-from-path": "^1.0.4"
+            }
+        },
+        "node_modules/@fastify/otel/node_modules/minimatch": {
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "brace-expansion": "^5.0.5"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/@grpc/grpc-js": {
@@ -4609,18 +4694,18 @@
             "license": "MIT"
         },
         "node_modules/@opentelemetry/api": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
-            "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz",
+            "integrity": "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=8.0.0"
             }
         },
         "node_modules/@opentelemetry/api-logs": {
-            "version": "0.211.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.211.0.tgz",
-            "integrity": "sha512-swFdZq8MCdmdR22jTVGQDhwqDzcI4M10nhjXkLr1EsIzXgZBqm4ZlmmcWsg3TSNf+3mzgOiqveXmBLZuDi2Lgg==",
+            "version": "0.214.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
+            "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/api": "^1.3.0"
@@ -4629,22 +4714,10 @@
                 "node": ">=8.0.0"
             }
         },
-        "node_modules/@opentelemetry/context-async-hooks": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.5.1.tgz",
-            "integrity": "sha512-MHbu8XxCHcBn6RwvCt2Vpn1WnLMNECfNKYB14LI5XypcgH4IE0/DiVifVR9tAkwPMyLXN8dOoPJfya3IryLQVw==",
-            "license": "Apache-2.0",
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": ">=1.0.0 <1.10.0"
-            }
-        },
         "node_modules/@opentelemetry/core": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.1.tgz",
-            "integrity": "sha512-Dwlc+3HAZqpgTYq0MUyZABjFkcrKTePwuiFVLjahGD8cx3enqihmpAmdgNFO1R4m/sIe5afjJrA25Prqy4NXlA==",
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
+            "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -4657,13 +4730,13 @@
             }
         },
         "node_modules/@opentelemetry/instrumentation": {
-            "version": "0.211.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.211.0.tgz",
-            "integrity": "sha512-h0nrZEC/zvI994nhg7EgQ8URIHt0uDTwN90r3qQUdZORS455bbx+YebnGeEuFghUT0HlJSrLF4iHw67f+odY+Q==",
+            "version": "0.214.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
+            "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/api-logs": "0.211.0",
-                "import-in-the-middle": "^2.0.0",
+                "@opentelemetry/api-logs": "0.214.0",
+                "import-in-the-middle": "^3.0.0",
                 "require-in-the-middle": "^8.0.0"
             },
             "engines": {
@@ -4674,13 +4747,13 @@
             }
         },
         "node_modules/@opentelemetry/instrumentation-amqplib": {
-            "version": "0.58.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.58.0.tgz",
-            "integrity": "sha512-fjpQtH18J6GxzUZ+cwNhWUpb71u+DzT7rFkg5pLssDGaEber91Y2WNGdpVpwGivfEluMlNMZumzjEqfg8DeKXQ==",
+            "version": "0.61.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-amqplib/-/instrumentation-amqplib-0.61.0.tgz",
+            "integrity": "sha512-mCKoyTGfRNisge4br0NpOFSy2Z1NnEW8hbCJdUDdJFHrPqVzc4IIBPA/vX0U+LUcQqrQvJX+HMIU0dbDRe0i0Q==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/core": "^2.0.0",
-                "@opentelemetry/instrumentation": "^0.211.0",
+                "@opentelemetry/instrumentation": "^0.214.0",
                 "@opentelemetry/semantic-conventions": "^1.33.0"
             },
             "engines": {
@@ -4691,13 +4764,13 @@
             }
         },
         "node_modules/@opentelemetry/instrumentation-connect": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.54.0.tgz",
-            "integrity": "sha512-43RmbhUhqt3uuPnc16cX6NsxEASEtn8z/cYV8Zpt6EP4p2h9s4FNuJ4Q9BbEQ2C0YlCCB/2crO1ruVz/hWt8fA==",
+            "version": "0.57.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-connect/-/instrumentation-connect-0.57.0.tgz",
+            "integrity": "sha512-FMEBChnI4FLN5TE9DHwfH7QpNir1JzXno1uz/TAucVdLCyrG0jTrKIcNHt/i30A0M2AunNBCkcd8Ei26dIPKdg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/core": "^2.0.0",
-                "@opentelemetry/instrumentation": "^0.211.0",
+                "@opentelemetry/instrumentation": "^0.214.0",
                 "@opentelemetry/semantic-conventions": "^1.27.0",
                 "@types/connect": "3.4.38"
             },
@@ -4709,29 +4782,12 @@
             }
         },
         "node_modules/@opentelemetry/instrumentation-dataloader": {
-            "version": "0.28.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.28.0.tgz",
-            "integrity": "sha512-ExXGBp0sUj8yhm6Znhf9jmuOaGDsYfDES3gswZnKr4MCqoBWQdEFn6EoDdt5u+RdbxQER+t43FoUihEfTSqsjA==",
+            "version": "0.31.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.31.0.tgz",
+            "integrity": "sha512-f654tZFQXS5YeLDNb9KySrwtg7SnqZN119FauD7acBoTzuLduaiGTNz88ixcVSOOMGZ+EjJu/RFtx5klObC95g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/instrumentation": "^0.211.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.3.0"
-            }
-        },
-        "node_modules/@opentelemetry/instrumentation-express": {
-            "version": "0.59.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-express/-/instrumentation-express-0.59.0.tgz",
-            "integrity": "sha512-pMKV/qnHiW/Q6pmbKkxt0eIhuNEtvJ7sUAyee192HErlr+a1Jx+FZ3WjfmzhQL1geewyGEiPGkmjjAgNY8TgDA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "^2.0.0",
-                "@opentelemetry/instrumentation": "^0.211.0",
-                "@opentelemetry/semantic-conventions": "^1.27.0"
+                "@opentelemetry/instrumentation": "^0.214.0"
             },
             "engines": {
                 "node": "^18.19.0 || >=20.6.0"
@@ -4741,13 +4797,13 @@
             }
         },
         "node_modules/@opentelemetry/instrumentation-fs": {
-            "version": "0.30.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.30.0.tgz",
-            "integrity": "sha512-n3Cf8YhG7reaj5dncGlRIU7iT40bxPOjsBEA5Bc1a1g6e9Qvb+JFJ7SEiMlPbUw4PBmxE3h40ltE8LZ3zVt6OA==",
+            "version": "0.33.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-fs/-/instrumentation-fs-0.33.0.tgz",
+            "integrity": "sha512-sCZWXGalQ01wr3tAhSR9ucqFJ0phidpAle6/17HVjD6gN8FLmZMK/8sKxdXYHy3PbnlV1P4zeiSVFNKpbFMNLA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/core": "^2.0.0",
-                "@opentelemetry/instrumentation": "^0.211.0"
+                "@opentelemetry/instrumentation": "^0.214.0"
             },
             "engines": {
                 "node": "^18.19.0 || >=20.6.0"
@@ -4757,12 +4813,12 @@
             }
         },
         "node_modules/@opentelemetry/instrumentation-generic-pool": {
-            "version": "0.54.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.54.0.tgz",
-            "integrity": "sha512-8dXMBzzmEdXfH/wjuRvcJnUFeWzZHUnExkmFJ2uPfa31wmpyBCMxO59yr8f/OXXgSogNgi/uPo9KW9H7LMIZ+g==",
+            "version": "0.57.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-generic-pool/-/instrumentation-generic-pool-0.57.0.tgz",
+            "integrity": "sha512-orhmlaK+ZIW9hKU+nHTbXrCSXZcH83AescTqmpamHRobRmYSQwRbD0a1odc0yAzuzOtxYiHiXAnpnIpaSSY7Ow==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/instrumentation": "^0.211.0"
+                "@opentelemetry/instrumentation": "^0.214.0"
             },
             "engines": {
                 "node": "^18.19.0 || >=20.6.0"
@@ -4772,12 +4828,12 @@
             }
         },
         "node_modules/@opentelemetry/instrumentation-graphql": {
-            "version": "0.58.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.58.0.tgz",
-            "integrity": "sha512-+yWVVY7fxOs3j2RixCbvue8vUuJ1inHxN2q1sduqDB0Wnkr4vOzVKRYl/Zy7B31/dcPS72D9lo/kltdOTBM3bQ==",
+            "version": "0.62.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-graphql/-/instrumentation-graphql-0.62.0.tgz",
+            "integrity": "sha512-3YNuLVPUxafXkH1jBAbGsKNsP3XVzcFDhCDCE3OqBwCwShlqQbLMRMFh1T/d5jaVZiGVmSsfof+ICKD2iOV8xg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/instrumentation": "^0.211.0"
+                "@opentelemetry/instrumentation": "^0.214.0"
             },
             "engines": {
                 "node": "^18.19.0 || >=20.6.0"
@@ -4787,13 +4843,13 @@
             }
         },
         "node_modules/@opentelemetry/instrumentation-hapi": {
-            "version": "0.57.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.57.0.tgz",
-            "integrity": "sha512-Os4THbvls8cTQTVA8ApLfZZztuuqGEeqog0XUnyRW7QVF0d/vOVBEcBCk1pazPFmllXGEdNbbat8e2fYIWdFbw==",
+            "version": "0.60.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-hapi/-/instrumentation-hapi-0.60.0.tgz",
+            "integrity": "sha512-aNljZKYrEa7obLAxd1bCEDxF7kzCLGXTuTJZ8lMR9rIVEjmuKBXN1gfqpm/OB//Zc2zP4iIve1jBp7sr3mQV6w==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/core": "^2.0.0",
-                "@opentelemetry/instrumentation": "^0.211.0",
+                "@opentelemetry/instrumentation": "^0.214.0",
                 "@opentelemetry/semantic-conventions": "^1.27.0"
             },
             "engines": {
@@ -4804,13 +4860,13 @@
             }
         },
         "node_modules/@opentelemetry/instrumentation-http": {
-            "version": "0.211.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.211.0.tgz",
-            "integrity": "sha512-n0IaQ6oVll9PP84SjbOCwDjaJasWRHi6BLsbMLiT6tNj7QbVOkuA5sk/EfZczwI0j5uTKl1awQPivO/ldVtsqA==",
+            "version": "0.214.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-http/-/instrumentation-http-0.214.0.tgz",
+            "integrity": "sha512-FlkDhZDRjDJDcO2LcSCtjRpkal1NJ8y0fBqBhTvfAR3JSYY2jAIj1kSS5IjmEBt4c3aWv+u/lqLuoCDrrKCSKg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "2.5.0",
-                "@opentelemetry/instrumentation": "0.211.0",
+                "@opentelemetry/core": "2.6.1",
+                "@opentelemetry/instrumentation": "0.214.0",
                 "@opentelemetry/semantic-conventions": "^1.29.0",
                 "forwarded-parse": "2.1.2"
             },
@@ -4822,9 +4878,9 @@
             }
         },
         "node_modules/@opentelemetry/instrumentation-http/node_modules/@opentelemetry/core": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.5.0.tgz",
-            "integrity": "sha512-ka4H8OM6+DlUhSAZpONu0cPBtPPTQKxbxVzC4CzVx5+K4JnroJVBtDzLAMx4/3CDTJXRvVFhpFjtl4SaiTNoyQ==",
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.6.1.tgz",
+            "integrity": "sha512-8xHSGWpJP9wBxgBpnqGL0R3PbdWQndL1Qp50qrg71+B28zK5OQmUgcDKLJgzyAAV38t4tOyLMGDD60LneR5W8g==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -4837,12 +4893,12 @@
             }
         },
         "node_modules/@opentelemetry/instrumentation-ioredis": {
-            "version": "0.59.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.59.0.tgz",
-            "integrity": "sha512-875UxzBHWkW+P4Y45SoFM2AR8f8TzBMD8eO7QXGCyFSCUMP5s9vtt/BS8b/r2kqLyaRPK6mLbdnZznK3XzQWvw==",
+            "version": "0.62.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-ioredis/-/instrumentation-ioredis-0.62.0.tgz",
+            "integrity": "sha512-ZYt//zcPve8qklaZX+5Z4MkU7UpEkFRrxsf2cnaKYBitqDnsCN69CPAuuMOX6NYdW2rG9sFy7V/QWtBlP5XiNQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/instrumentation": "^0.211.0",
+                "@opentelemetry/instrumentation": "^0.214.0",
                 "@opentelemetry/redis-common": "^0.38.2",
                 "@opentelemetry/semantic-conventions": "^1.33.0"
             },
@@ -4854,12 +4910,12 @@
             }
         },
         "node_modules/@opentelemetry/instrumentation-kafkajs": {
-            "version": "0.20.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.20.0.tgz",
-            "integrity": "sha512-yJXOuWZROzj7WmYCUiyT27tIfqBrVtl1/TwVbQyWPz7rL0r1Lu7kWjD0PiVeTCIL6CrIZ7M2s8eBxsTAOxbNvw==",
+            "version": "0.23.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.23.0.tgz",
+            "integrity": "sha512-4K+nVo+zI+aDz0Z85SObwbdixIbzS9moIuKJaYsdlzcHYnKOPtB7ya8r8Ezivy/GVIBHiKJVq4tv+BEkgOMLaQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/instrumentation": "^0.211.0",
+                "@opentelemetry/instrumentation": "^0.214.0",
                 "@opentelemetry/semantic-conventions": "^1.30.0"
             },
             "engines": {
@@ -4870,12 +4926,12 @@
             }
         },
         "node_modules/@opentelemetry/instrumentation-knex": {
-            "version": "0.55.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.55.0.tgz",
-            "integrity": "sha512-FtTL5DUx5Ka/8VK6P1VwnlUXPa3nrb7REvm5ddLUIeXXq4tb9pKd+/ThB1xM/IjefkRSN3z8a5t7epYw1JLBJQ==",
+            "version": "0.58.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-knex/-/instrumentation-knex-0.58.0.tgz",
+            "integrity": "sha512-Hc/o8fSsaWxZ8r1Yw4rNDLwTpUopTf4X32y4W6UhlHmW8Wizz8wfhgOKIelSeqFVTKBBPIDUOsQWuIMxBmu8Bw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/instrumentation": "^0.211.0",
+                "@opentelemetry/instrumentation": "^0.214.0",
                 "@opentelemetry/semantic-conventions": "^1.33.1"
             },
             "engines": {
@@ -4886,13 +4942,13 @@
             }
         },
         "node_modules/@opentelemetry/instrumentation-koa": {
-            "version": "0.59.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.59.0.tgz",
-            "integrity": "sha512-K9o2skADV20Skdu5tG2bogPKiSpXh4KxfLjz6FuqIVvDJNibwSdu5UvyyBzRVp1rQMV6UmoIk6d3PyPtJbaGSg==",
+            "version": "0.62.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-koa/-/instrumentation-koa-0.62.0.tgz",
+            "integrity": "sha512-uVip0VuGUQXZ+vFxkKxAUNq8qNl+VFlyHDh/U6IQ8COOEDfbEchdaHnpFrMYF3psZRUuoSIgb7xOeXj00RdwDA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/core": "^2.0.0",
-                "@opentelemetry/instrumentation": "^0.211.0",
+                "@opentelemetry/instrumentation": "^0.214.0",
                 "@opentelemetry/semantic-conventions": "^1.36.0"
             },
             "engines": {
@@ -4903,12 +4959,12 @@
             }
         },
         "node_modules/@opentelemetry/instrumentation-lru-memoizer": {
-            "version": "0.55.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.55.0.tgz",
-            "integrity": "sha512-FDBfT7yDGcspN0Cxbu/k8A0Pp1Jhv/m7BMTzXGpcb8ENl3tDj/51U65R5lWzUH15GaZA15HQ5A5wtafklxYj7g==",
+            "version": "0.58.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-lru-memoizer/-/instrumentation-lru-memoizer-0.58.0.tgz",
+            "integrity": "sha512-6grM3TdMyHzlGY1cUA+mwoPueB1F3dYKgKtZIH6jOFXqfHAByyLTc+6PFjGM9tKh52CFBJaDwodNlL/Td39z7Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/instrumentation": "^0.211.0"
+                "@opentelemetry/instrumentation": "^0.214.0"
             },
             "engines": {
                 "node": "^18.19.0 || >=20.6.0"
@@ -4918,12 +4974,12 @@
             }
         },
         "node_modules/@opentelemetry/instrumentation-mongodb": {
-            "version": "0.64.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.64.0.tgz",
-            "integrity": "sha512-pFlCJjweTqVp7B220mCvCld1c1eYKZfQt1p3bxSbcReypKLJTwat+wbL2YZoX9jPi5X2O8tTKFEOahO5ehQGsA==",
+            "version": "0.67.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongodb/-/instrumentation-mongodb-0.67.0.tgz",
+            "integrity": "sha512-1WJp5N1lYfHq2IhECOTewFs5Tf2NfUOwQRqs/rZdXKTezArMlucxgzAaqcgp3A3YREXopXTpXHsxZTGHjNhMdQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/instrumentation": "^0.211.0",
+                "@opentelemetry/instrumentation": "^0.214.0",
                 "@opentelemetry/semantic-conventions": "^1.33.0"
             },
             "engines": {
@@ -4934,13 +4990,13 @@
             }
         },
         "node_modules/@opentelemetry/instrumentation-mongoose": {
-            "version": "0.57.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.57.0.tgz",
-            "integrity": "sha512-MthiekrU/BAJc5JZoZeJmo0OTX6ycJMiP6sMOSRTkvz5BrPMYDqaJos0OgsLPL/HpcgHP7eo5pduETuLguOqcg==",
+            "version": "0.60.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mongoose/-/instrumentation-mongoose-0.60.0.tgz",
+            "integrity": "sha512-8BahAZpKsOoc+lrZGb7Ofn4g3z8qtp5IxDfvAVpKXsEheQN7ONMH5djT5ihy6yf8yyeQJGS0gXFfpEAEeEHqQg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/core": "^2.0.0",
-                "@opentelemetry/instrumentation": "^0.211.0",
+                "@opentelemetry/instrumentation": "^0.214.0",
                 "@opentelemetry/semantic-conventions": "^1.33.0"
             },
             "engines": {
@@ -4951,12 +5007,12 @@
             }
         },
         "node_modules/@opentelemetry/instrumentation-mysql": {
-            "version": "0.57.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.57.0.tgz",
-            "integrity": "sha512-HFS/+FcZ6Q7piM7Il7CzQ4VHhJvGMJWjx7EgCkP5AnTntSN5rb5Xi3TkYJHBKeR27A0QqPlGaCITi93fUDs++Q==",
+            "version": "0.60.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql/-/instrumentation-mysql-0.60.0.tgz",
+            "integrity": "sha512-08pO8GFPEIz2zquKDGteBZDNmwketdgH8hTe9rVYgW9kCJXq1Psj3wPQGx+VaX4ZJKCfPeoLMYup9+cxHvZyVQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/instrumentation": "^0.211.0",
+                "@opentelemetry/instrumentation": "^0.214.0",
                 "@opentelemetry/semantic-conventions": "^1.33.0",
                 "@types/mysql": "2.15.27"
             },
@@ -4968,12 +5024,12 @@
             }
         },
         "node_modules/@opentelemetry/instrumentation-mysql2": {
-            "version": "0.57.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.57.0.tgz",
-            "integrity": "sha512-nHSrYAwF7+aV1E1V9yOOP9TchOodb6fjn4gFvdrdQXiRE7cMuffyLLbCZlZd4wsspBzVwOXX8mpURdRserAhNA==",
+            "version": "0.60.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.60.0.tgz",
+            "integrity": "sha512-m/5d3bxQALllCzezYDk/6vajh0tj5OijMMvOZGr+qN1NMXm1dzMNwyJ0gNZW7Fo3YFRyj/jJMxIw+W7d525dlw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/instrumentation": "^0.211.0",
+                "@opentelemetry/instrumentation": "^0.214.0",
                 "@opentelemetry/semantic-conventions": "^1.33.0",
                 "@opentelemetry/sql-common": "^0.41.2"
             },
@@ -4985,12 +5041,12 @@
             }
         },
         "node_modules/@opentelemetry/instrumentation-nestjs-core": {
-            "version": "0.57.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.57.0.tgz",
-            "integrity": "sha512-mzTjjethjuk70o/vWUeV12QwMG9EAFJpkn13/q8zi++sNosf2hoGXTplIdbs81U8S3PJ4GxHKsBjM0bj1CGZ0g==",
+            "version": "0.60.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-nestjs-core/-/instrumentation-nestjs-core-0.60.0.tgz",
+            "integrity": "sha512-BZqFAoD+frnwjpb0/T4kEEQMhl2YykZch4n2MMLKAVTzTehTBBV2hZxvFF629ipS+WOGBKjCjz1dycU9QNIckQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/instrumentation": "^0.211.0",
+                "@opentelemetry/instrumentation": "^0.214.0",
                 "@opentelemetry/semantic-conventions": "^1.30.0"
             },
             "engines": {
@@ -5001,13 +5057,13 @@
             }
         },
         "node_modules/@opentelemetry/instrumentation-pg": {
-            "version": "0.63.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.63.0.tgz",
-            "integrity": "sha512-dKm/ODNN3GgIQVlbD6ZPxwRc3kleLf95hrRWXM+l8wYo+vSeXtEpQPT53afEf6VFWDVzJK55VGn8KMLtSve/cg==",
+            "version": "0.66.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-pg/-/instrumentation-pg-0.66.0.tgz",
+            "integrity": "sha512-KxfLGXBb7k2ueaPJfq2GXBDXBly8P+SpR/4Mj410hhNgmQF3sCqwXvUBQxZQkDAmsdBAoenM+yV1LhtsMRamcA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/core": "^2.0.0",
-                "@opentelemetry/instrumentation": "^0.211.0",
+                "@opentelemetry/instrumentation": "^0.214.0",
                 "@opentelemetry/semantic-conventions": "^1.34.0",
                 "@opentelemetry/sql-common": "^0.41.2",
                 "@types/pg": "8.15.6",
@@ -5021,12 +5077,12 @@
             }
         },
         "node_modules/@opentelemetry/instrumentation-redis": {
-            "version": "0.59.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.59.0.tgz",
-            "integrity": "sha512-JKv1KDDYA2chJ1PC3pLP+Q9ISMQk6h5ey+99mB57/ARk0vQPGZTTEb4h4/JlcEpy7AYT8HIGv7X6l+br03Neeg==",
+            "version": "0.62.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-redis/-/instrumentation-redis-0.62.0.tgz",
+            "integrity": "sha512-y3pPpot7WzR/8JtHcYlTYsyY8g+pbFhAqbwAuG5bLPnR6v6pt1rQc0DpH0OlGP/9CZbWBP+Zhwp9yFoygf/ZXQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/instrumentation": "^0.211.0",
+                "@opentelemetry/instrumentation": "^0.214.0",
                 "@opentelemetry/redis-common": "^0.38.2",
                 "@opentelemetry/semantic-conventions": "^1.27.0"
             },
@@ -5038,12 +5094,12 @@
             }
         },
         "node_modules/@opentelemetry/instrumentation-tedious": {
-            "version": "0.30.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.30.0.tgz",
-            "integrity": "sha512-bZy9Q8jFdycKQ2pAsyuHYUHNmCxCOGdG6eg1Mn75RvQDccq832sU5OWOBnc12EFUELI6icJkhR7+EQKMBam2GA==",
+            "version": "0.33.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-tedious/-/instrumentation-tedious-0.33.0.tgz",
+            "integrity": "sha512-Q6WQwAD01MMTub31GlejoiFACYNw26J426wyjvU7by7fDIr2nZXNW4vhTGs7i7F0TnXBO3xN688g1tdUgYwJ5w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/instrumentation": "^0.211.0",
+                "@opentelemetry/instrumentation": "^0.214.0",
                 "@opentelemetry/semantic-conventions": "^1.33.0",
                 "@types/tedious": "^4.0.14"
             },
@@ -5054,39 +5110,22 @@
                 "@opentelemetry/api": "^1.3.0"
             }
         },
-        "node_modules/@opentelemetry/instrumentation-undici": {
-            "version": "0.21.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-undici/-/instrumentation-undici-0.21.0.tgz",
-            "integrity": "sha512-gok0LPUOTz2FQ1YJMZzaHcOzDFyT64XJ8M9rNkugk923/p6lDGms/cRW1cqgqp6N6qcd6K6YdVHwPEhnx9BWbw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@opentelemetry/core": "^2.0.0",
-                "@opentelemetry/instrumentation": "^0.211.0",
-                "@opentelemetry/semantic-conventions": "^1.24.0"
-            },
-            "engines": {
-                "node": "^18.19.0 || >=20.6.0"
-            },
-            "peerDependencies": {
-                "@opentelemetry/api": "^1.7.0"
-            }
-        },
         "node_modules/@opentelemetry/redis-common": {
-            "version": "0.38.2",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.2.tgz",
-            "integrity": "sha512-1BCcU93iwSRZvDAgwUxC/DV4T/406SkMfxGqu5ojc3AvNI+I9GhV7v0J1HljsczuuhcnFLYqD5VmwVXfCGHzxA==",
+            "version": "0.38.3",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/redis-common/-/redis-common-0.38.3.tgz",
+            "integrity": "sha512-VCghU1JYs/4gP6Gqf/xro9MEsZ7LrMv2uONVsaESKL38ZOB9BqnI98FfS23wjMnHlpuE+TTaWSoAVNpTwYXzjw==",
             "license": "Apache-2.0",
             "engines": {
                 "node": "^18.19.0 || >=20.6.0"
             }
         },
         "node_modules/@opentelemetry/resources": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.5.1.tgz",
-            "integrity": "sha512-BViBCdE/GuXRlp9k7nS1w6wJvY5fnFX5XvuEtWsTAOQFIO89Eru7lGW3WbfbxtCuZ/GbrJfAziXG0w0dpxL7eQ==",
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.7.1.tgz",
+            "integrity": "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "2.5.1",
+                "@opentelemetry/core": "2.7.1",
                 "@opentelemetry/semantic-conventions": "^1.29.0"
             },
             "engines": {
@@ -5097,13 +5136,13 @@
             }
         },
         "node_modules/@opentelemetry/sdk-trace-base": {
-            "version": "2.5.1",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.5.1.tgz",
-            "integrity": "sha512-iZH3Gw8cxQn0gjpOjJMmKLd9GIaNh/E3v3ST67vyzLSxHBs14HsG4dy7jMYyC5WXGdBVEcM7U/XTF5hCQxjDMw==",
+            "version": "2.7.1",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.7.1.tgz",
+            "integrity": "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@opentelemetry/core": "2.5.1",
-                "@opentelemetry/resources": "2.5.1",
+                "@opentelemetry/core": "2.7.1",
+                "@opentelemetry/resources": "2.7.1",
                 "@opentelemetry/semantic-conventions": "^1.29.0"
             },
             "engines": {
@@ -5114,9 +5153,9 @@
             }
         },
         "node_modules/@opentelemetry/semantic-conventions": {
-            "version": "1.39.0",
-            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.39.0.tgz",
-            "integrity": "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==",
+            "version": "1.40.0",
+            "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.40.0.tgz",
+            "integrity": "sha512-cifvXDhcqMwwTlTK04GBNeIe7yyo28Mfby85QXFe1Yk8nmi36Ab/5UQwptOx84SsoGNRg+EVSjwzfSZMy6pmlw==",
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=14"
@@ -5198,9 +5237,9 @@
             }
         },
         "node_modules/@prisma/instrumentation": {
-            "version": "7.2.0",
-            "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-7.2.0.tgz",
-            "integrity": "sha512-Rh9Z4x5kEj1OdARd7U18AtVrnL6rmLSI0qYShaB4W7Wx5BKbgzndWF+QnuzMb7GLfVdlT5aYCXoPQVYuYtVu0g==",
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-7.6.0.tgz",
+            "integrity": "sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@opentelemetry/instrumentation": "^0.207.0"
@@ -5236,6 +5275,18 @@
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.3.0"
+            }
+        },
+        "node_modules/@prisma/instrumentation/node_modules/import-in-the-middle": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
+            "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "acorn": "^8.15.0",
+                "acorn-import-attributes": "^1.9.5",
+                "cjs-module-lexer": "^2.2.0",
+                "module-details-from-path": "^1.0.4"
             }
         },
         "node_modules/@protobufjs/aspromise": {
@@ -5782,15 +5833,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/@sentry-internal/browser-utils/node_modules/@sentry/core": {
-            "version": "10.51.0",
-            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.51.0.tgz",
-            "integrity": "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/@sentry-internal/feedback": {
             "version": "10.51.0",
             "resolved": "https://registry.npmjs.org/@sentry-internal/feedback/-/feedback-10.51.0.tgz",
@@ -5799,15 +5841,6 @@
             "dependencies": {
                 "@sentry/core": "10.51.0"
             },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@sentry-internal/feedback/node_modules/@sentry/core": {
-            "version": "10.51.0",
-            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.51.0.tgz",
-            "integrity": "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w==",
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             }
@@ -5838,24 +5871,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/@sentry-internal/replay-canvas/node_modules/@sentry/core": {
-            "version": "10.51.0",
-            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.51.0.tgz",
-            "integrity": "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@sentry-internal/replay/node_modules/@sentry/core": {
-            "version": "10.51.0",
-            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.51.0.tgz",
-            "integrity": "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/@sentry/babel-plugin-component-annotate": {
             "version": "4.9.1",
             "resolved": "https://registry.npmjs.org/@sentry/babel-plugin-component-annotate/-/babel-plugin-component-annotate-4.9.1.tgz",
@@ -5878,15 +5893,6 @@
                 "@sentry-internal/replay-canvas": "10.51.0",
                 "@sentry/core": "10.51.0"
             },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@sentry/browser/node_modules/@sentry/core": {
-            "version": "10.51.0",
-            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.51.0.tgz",
-            "integrity": "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w==",
-            "license": "MIT",
             "engines": {
                 "node": ">=18"
             }
@@ -6211,27 +6217,27 @@
             }
         },
         "node_modules/@sentry/core": {
-            "version": "10.38.0",
-            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.38.0.tgz",
-            "integrity": "sha512-1pubWDZE5y5HZEPMAZERP4fVl2NH3Ihp1A+vMoVkb3Qc66Diqj1WierAnStlZP7tCx0TBa0dK85GTW/ZFYyB9g==",
+            "version": "10.51.0",
+            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.51.0.tgz",
+            "integrity": "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w==",
             "license": "MIT",
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@sentry/nestjs": {
-            "version": "10.38.0",
-            "resolved": "https://registry.npmjs.org/@sentry/nestjs/-/nestjs-10.38.0.tgz",
-            "integrity": "sha512-K+dMs0JzCrwAnOV7M1uSbGzm3KvvdkTvRKNyyOcBOPY9IeVoffPQxz+KNtMsXEIeI7UA35T8riFN8zCNxdqH+A==",
+            "version": "10.51.0",
+            "resolved": "https://registry.npmjs.org/@sentry/nestjs/-/nestjs-10.51.0.tgz",
+            "integrity": "sha512-4k5G9XZQH28zt1YyLjeJCgQ5kstAxpiW1UH0+VuYQr39VQmXVfRaZwJ7VfoWYyvz3LOB+HezOLL0D5jcG3nDpg==",
             "license": "MIT",
             "dependencies": {
-                "@opentelemetry/api": "^1.9.0",
-                "@opentelemetry/core": "^2.5.0",
-                "@opentelemetry/instrumentation": "^0.211.0",
-                "@opentelemetry/instrumentation-nestjs-core": "0.57.0",
-                "@opentelemetry/semantic-conventions": "^1.39.0",
-                "@sentry/core": "10.38.0",
-                "@sentry/node": "10.38.0"
+                "@opentelemetry/api": "^1.9.1",
+                "@opentelemetry/core": "^2.6.1",
+                "@opentelemetry/instrumentation": "^0.214.0",
+                "@opentelemetry/instrumentation-nestjs-core": "0.60.0",
+                "@opentelemetry/semantic-conventions": "^1.40.0",
+                "@sentry/core": "10.51.0",
+                "@sentry/node": "10.51.0"
             },
             "engines": {
                 "node": ">=18"
@@ -6242,113 +6248,102 @@
             }
         },
         "node_modules/@sentry/node": {
-            "version": "10.38.0",
-            "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.38.0.tgz",
-            "integrity": "sha512-wriyDtWDAoatn8EhOj0U4PJR1WufiijTsCGALqakOHbFiadtBJANLe6aSkXoXT4tegw59cz1wY4NlzHjYksaPw==",
+            "version": "10.51.0",
+            "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.51.0.tgz",
+            "integrity": "sha512-2yZLRZwS1dKG8/4eOTpGSo/gO/EgmT9aPj6lAzUkRa7bZCTTdW4BraaHU0leX5T94909Qfhbr3W5AVTfDOCKiQ==",
             "license": "MIT",
             "dependencies": {
-                "@opentelemetry/api": "^1.9.0",
-                "@opentelemetry/context-async-hooks": "^2.5.0",
-                "@opentelemetry/core": "^2.5.0",
-                "@opentelemetry/instrumentation": "^0.211.0",
-                "@opentelemetry/instrumentation-amqplib": "0.58.0",
-                "@opentelemetry/instrumentation-connect": "0.54.0",
-                "@opentelemetry/instrumentation-dataloader": "0.28.0",
-                "@opentelemetry/instrumentation-express": "0.59.0",
-                "@opentelemetry/instrumentation-fs": "0.30.0",
-                "@opentelemetry/instrumentation-generic-pool": "0.54.0",
-                "@opentelemetry/instrumentation-graphql": "0.58.0",
-                "@opentelemetry/instrumentation-hapi": "0.57.0",
-                "@opentelemetry/instrumentation-http": "0.211.0",
-                "@opentelemetry/instrumentation-ioredis": "0.59.0",
-                "@opentelemetry/instrumentation-kafkajs": "0.20.0",
-                "@opentelemetry/instrumentation-knex": "0.55.0",
-                "@opentelemetry/instrumentation-koa": "0.59.0",
-                "@opentelemetry/instrumentation-lru-memoizer": "0.55.0",
-                "@opentelemetry/instrumentation-mongodb": "0.64.0",
-                "@opentelemetry/instrumentation-mongoose": "0.57.0",
-                "@opentelemetry/instrumentation-mysql": "0.57.0",
-                "@opentelemetry/instrumentation-mysql2": "0.57.0",
-                "@opentelemetry/instrumentation-pg": "0.63.0",
-                "@opentelemetry/instrumentation-redis": "0.59.0",
-                "@opentelemetry/instrumentation-tedious": "0.30.0",
-                "@opentelemetry/instrumentation-undici": "0.21.0",
-                "@opentelemetry/resources": "^2.5.0",
-                "@opentelemetry/sdk-trace-base": "^2.5.0",
-                "@opentelemetry/semantic-conventions": "^1.39.0",
-                "@prisma/instrumentation": "7.2.0",
-                "@sentry/core": "10.38.0",
-                "@sentry/node-core": "10.38.0",
-                "@sentry/opentelemetry": "10.38.0",
-                "import-in-the-middle": "^2.0.6",
-                "minimatch": "^9.0.0"
+                "@fastify/otel": "0.18.0",
+                "@opentelemetry/api": "^1.9.1",
+                "@opentelemetry/core": "^2.6.1",
+                "@opentelemetry/instrumentation": "^0.214.0",
+                "@opentelemetry/instrumentation-amqplib": "0.61.0",
+                "@opentelemetry/instrumentation-connect": "0.57.0",
+                "@opentelemetry/instrumentation-dataloader": "0.31.0",
+                "@opentelemetry/instrumentation-fs": "0.33.0",
+                "@opentelemetry/instrumentation-generic-pool": "0.57.0",
+                "@opentelemetry/instrumentation-graphql": "0.62.0",
+                "@opentelemetry/instrumentation-hapi": "0.60.0",
+                "@opentelemetry/instrumentation-http": "0.214.0",
+                "@opentelemetry/instrumentation-ioredis": "0.62.0",
+                "@opentelemetry/instrumentation-kafkajs": "0.23.0",
+                "@opentelemetry/instrumentation-knex": "0.58.0",
+                "@opentelemetry/instrumentation-koa": "0.62.0",
+                "@opentelemetry/instrumentation-lru-memoizer": "0.58.0",
+                "@opentelemetry/instrumentation-mongodb": "0.67.0",
+                "@opentelemetry/instrumentation-mongoose": "0.60.0",
+                "@opentelemetry/instrumentation-mysql": "0.60.0",
+                "@opentelemetry/instrumentation-mysql2": "0.60.0",
+                "@opentelemetry/instrumentation-pg": "0.66.0",
+                "@opentelemetry/instrumentation-redis": "0.62.0",
+                "@opentelemetry/instrumentation-tedious": "0.33.0",
+                "@opentelemetry/sdk-trace-base": "^2.6.1",
+                "@opentelemetry/semantic-conventions": "^1.40.0",
+                "@prisma/instrumentation": "7.6.0",
+                "@sentry/core": "10.51.0",
+                "@sentry/node-core": "10.51.0",
+                "@sentry/opentelemetry": "10.51.0",
+                "import-in-the-middle": "^3.0.0"
             },
             "engines": {
                 "node": ">=18"
             }
         },
         "node_modules/@sentry/node-core": {
-            "version": "10.38.0",
-            "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.38.0.tgz",
-            "integrity": "sha512-ErXtpedrY1HghgwM6AliilZPcUCoNNP1NThdO4YpeMq04wMX9/GMmFCu46TnCcg6b7IFIOSr2S4yD086PxLlHQ==",
+            "version": "10.51.0",
+            "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.51.0.tgz",
+            "integrity": "sha512-VP9DMEzBEuauABrfDHYz/pRYa74M09uRJLz0ls3yel3sKhYHMyCB29ZxbKcciUhD4d33dwgi8DbaPZV2H/wnfQ==",
             "license": "MIT",
             "dependencies": {
-                "@apm-js-collab/tracing-hooks": "^0.3.1",
-                "@sentry/core": "10.38.0",
-                "@sentry/opentelemetry": "10.38.0",
-                "import-in-the-middle": "^2.0.6"
+                "@sentry/core": "10.51.0",
+                "@sentry/opentelemetry": "10.51.0",
+                "import-in-the-middle": "^3.0.0"
             },
             "engines": {
                 "node": ">=18"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.9.0",
-                "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0",
                 "@opentelemetry/core": "^1.30.1 || ^2.1.0",
+                "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
                 "@opentelemetry/instrumentation": ">=0.57.1 <1",
-                "@opentelemetry/resources": "^1.30.1 || ^2.1.0",
                 "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
                 "@opentelemetry/semantic-conventions": "^1.39.0"
-            }
-        },
-        "node_modules/@sentry/node/node_modules/brace-expansion": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
-            "license": "MIT",
-            "dependencies": {
-                "balanced-match": "^1.0.0"
-            }
-        },
-        "node_modules/@sentry/node/node_modules/minimatch": {
-            "version": "9.0.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
-            "license": "ISC",
-            "dependencies": {
-                "brace-expansion": "^2.0.1"
             },
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
+            "peerDependenciesMeta": {
+                "@opentelemetry/api": {
+                    "optional": true
+                },
+                "@opentelemetry/core": {
+                    "optional": true
+                },
+                "@opentelemetry/exporter-trace-otlp-http": {
+                    "optional": true
+                },
+                "@opentelemetry/instrumentation": {
+                    "optional": true
+                },
+                "@opentelemetry/sdk-trace-base": {
+                    "optional": true
+                },
+                "@opentelemetry/semantic-conventions": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@sentry/opentelemetry": {
-            "version": "10.38.0",
-            "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.38.0.tgz",
-            "integrity": "sha512-YPVhWfYmC7nD3EJqEHGtjp4fp5LwtAbE5rt9egQ4hqJlYFvr8YEz9sdoqSZxO0cZzgs2v97HFl/nmWAXe52G2Q==",
+            "version": "10.51.0",
+            "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.51.0.tgz",
+            "integrity": "sha512-Qc7AlCE4uhB+SvHLqah4RgR1WdY7wmmr/hx9g/prDP9R1ocshmUEMrZK9qjuwaklW7/fmkFCXI8ETxo5L1bHIA==",
             "license": "MIT",
             "dependencies": {
-                "@sentry/core": "10.38.0"
+                "@sentry/core": "10.51.0"
             },
             "engines": {
                 "node": ">=18"
             },
             "peerDependencies": {
                 "@opentelemetry/api": "^1.9.0",
-                "@opentelemetry/context-async-hooks": "^1.30.1 || ^2.1.0",
                 "@opentelemetry/core": "^1.30.1 || ^2.1.0",
                 "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
                 "@opentelemetry/semantic-conventions": "^1.39.0"
@@ -6368,15 +6363,6 @@
             },
             "peerDependencies": {
                 "react": "^16.14.0 || 17.x || 18.x || 19.x"
-            }
-        },
-        "node_modules/@sentry/react/node_modules/@sentry/core": {
-            "version": "10.51.0",
-            "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.51.0.tgz",
-            "integrity": "sha512-Y45V/YXvVLEXmOdkbD1oG1gkRWFi9guCEGg3PlIlIpRjAbZUrvLGgjRJIc1E7XpSzmOnWbs5BbUxMv4PDaPj2w==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/@sentry/vite-plugin": {
@@ -9333,6 +9319,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/bare-events": {
@@ -13274,15 +13261,18 @@
             }
         },
         "node_modules/import-in-the-middle": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-2.0.6.tgz",
-            "integrity": "sha512-3vZV3jX0XRFW3EJDTwzWoZa+RH1b8eTTx6YOCjglrLyPuepwoBti1k3L2dKwdCUrnVEfc5CuRuGstaC/uQJJaw==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.0.1.tgz",
+            "integrity": "sha512-pYkiyXVL2Mf3pozdlDGV6NAObxQx13Ae8knZk1UJRJ6uRW/ZRmTGHlQYtrsSl7ubuE5F8CD1z+s1n4RHNuTtuA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "acorn": "^8.15.0",
                 "acorn-import-attributes": "^1.9.5",
                 "cjs-module-lexer": "^2.2.0",
                 "module-details-from-path": "^1.0.4"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/import-local": {
@@ -16761,9 +16751,9 @@
             }
         },
         "node_modules/pg-protocol": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.11.0.tgz",
-            "integrity": "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g==",
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+            "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
             "license": "MIT"
         },
         "node_modules/pg-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17439,9 +17439,9 @@
             }
         },
         "node_modules/react-router": {
-            "version": "7.13.0",
-            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
-            "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
+            "version": "7.14.2",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
+            "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
             "license": "MIT",
             "dependencies": {
                 "cookie": "^1.0.1",
@@ -17461,12 +17461,12 @@
             }
         },
         "node_modules/react-router-dom": {
-            "version": "7.13.0",
-            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.0.tgz",
-            "integrity": "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g==",
+            "version": "7.14.2",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz",
+            "integrity": "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==",
             "license": "MIT",
             "dependencies": {
-                "react-router": "7.13.0"
+                "react-router": "7.14.2"
             },
             "engines": {
                 "node": ">=20.0.0"
@@ -21669,7 +21669,7 @@
                 "react-big-calendar": "^1.19.4",
                 "react-dom": "^19.2.5",
                 "react-force-graph-2d": "^1.29.1",
-                "react-router-dom": "^7.13.0",
+                "react-router-dom": "^7.14.2",
                 "recharts": "^3.7.0",
                 "socket.io-client": "^4.8.3",
                 "sonner": "^2.0.7",

--- a/tools/test-bot/package-lock.json
+++ b/tools/test-bot/package-lock.json
@@ -11,7 +11,7 @@
         "@discordjs/voice": "^0.19.2",
         "discord.js": "^14.26.4",
         "dotenv": "^17.4.2",
-        "sodium-native": "^4.3.1"
+        "sodium-native": "^5.1.0"
       },
       "devDependencies": {
         "tsx": "^4.19.3",
@@ -990,6 +990,20 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/bare-addon-resolve": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/bare-addon-resolve/-/bare-addon-resolve-1.10.0.tgz",
@@ -1006,6 +1020,59 @@
         "bare-url": {
           "optional": true
         }
+      }
+    },
+    "node_modules/bare-ansi-escapes": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/bare-ansi-escapes/-/bare-ansi-escapes-2.2.3.tgz",
+      "integrity": "sha512-02ES4/E2RbrtZSnHJ9LntBhYkLA6lPpSEeP8iqS3MccBIVhVBlEmruF1I7HZqx5Q8aiTeYfQVeqmrU9YO2yYoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-stream": "^2.6.5"
+      },
+      "peerDependencies": {
+        "bare-buffer": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-buffer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-assert": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/bare-assert/-/bare-assert-1.2.0.tgz",
+      "integrity": "sha512-c6uvgvTJBspTDxtVnPgrBKmLgcpW3Fp72NVKDLg6oT4QjQbhGtvrkHMhGYMK1sh4vjBHOBmuUalyt9hSzV37fQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-inspect": "^3.1.2"
+      }
+    },
+    "node_modules/bare-events": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.8.2.tgz",
+      "integrity": "sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "bare-abort-controller": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-inspect": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/bare-inspect/-/bare-inspect-3.1.4.tgz",
+      "integrity": "sha512-jfW5KRA84o3REpI6Vr4nbvMn+hqVAw8GU1mMdRwUsY5yJovQamxYeKGVKGqdzs+8ZbG4jRzGUXP/3Ji/DnqfPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-ansi-escapes": "^2.1.0",
+        "bare-type": "^1.0.0"
+      },
+      "engines": {
+        "bare": ">=1.18.0"
       }
     },
     "node_modules/bare-module-resolve": {
@@ -1030,6 +1097,41 @@
       "resolved": "https://registry.npmjs.org/bare-semver/-/bare-semver-1.0.2.tgz",
       "integrity": "sha512-ESVaN2nzWhcI5tf3Zzcq9aqCZ676VWzqw07eEZ0qxAcEOAFYBa0pWq8sK34OQeHLY3JsfKXZS9mDyzyxGjeLzA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/bare-stream": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.1.tgz",
+      "integrity": "sha512-Vp0cnjYyrEC4whYTymQ+YZi6pBpfiICZO3cfRG8sy67ZNWe951urv1x4eW1BKNngw3U+3fPYb5JQvHbCtxH7Ow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "streamx": "^2.25.0",
+        "teex": "^1.0.1"
+      },
+      "peerDependencies": {
+        "bare-abort-controller": "*",
+        "bare-buffer": "*",
+        "bare-events": "*"
+      },
+      "peerDependenciesMeta": {
+        "bare-abort-controller": {
+          "optional": true
+        },
+        "bare-buffer": {
+          "optional": true
+        },
+        "bare-events": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/bare-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/bare-type/-/bare-type-1.1.0.tgz",
+      "integrity": "sha512-LdtnnEEYldOc87Dr4GpsKnStStZk3zfgoEMXy8yvEZkXrcCv9RtYDrUYWFsBQHtaB0s1EUWmcvS6XmEZYIj3Bw==",
+      "license": "Apache-2.0",
+      "engines": {
+        "bare": ">=1.2.0"
+      }
     },
     "node_modules/discord-api-types": {
       "version": "0.38.42",
@@ -1121,10 +1223,25 @@
         "@esbuild/win32-x64": "0.27.4"
       }
     },
+    "node_modules/events-universal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
+      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bare-events": "^2.7.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-fifo": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
+      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
       "license": "MIT"
     },
     "node_modules/fsevents": {
@@ -1222,12 +1339,46 @@
       }
     },
     "node_modules/sodium-native": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-4.3.3.tgz",
-      "integrity": "sha512-OnxSlN3uyY8D0EsLHpmm2HOFmKddQVvEMmsakCrXUzSd8kjjbzL413t4ZNF3n0UxSwNgwTyUvkmZHTfuCeiYSw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/sodium-native/-/sodium-native-5.1.0.tgz",
+      "integrity": "sha512-3RxgyWyJlhTsABPnJVpCI5CoTDANZTqqFrEPqr+kjfnRaBihpVtMUE3yTF40ukdoB1APXeoBNKF3MzZAIHg39g==",
       "license": "MIT",
       "dependencies": {
-        "require-addon": "^1.1.0"
+        "bare-assert": "^1.2.0",
+        "require-addon": "^1.1.0",
+        "which-runtime": "^1.2.1"
+      },
+      "engines": {
+        "bare": ">=1.16.0"
+      }
+    },
+    "node_modules/streamx": {
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+      "integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
+      "license": "MIT",
+      "dependencies": {
+        "events-universal": "^1.0.0",
+        "fast-fifo": "^1.3.2",
+        "text-decoder": "^1.1.0"
+      }
+    },
+    "node_modules/teex": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+      "license": "MIT",
+      "dependencies": {
+        "streamx": "^2.12.5"
+      }
+    },
+    "node_modules/text-decoder": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "b4a": "^1.6.4"
       }
     },
     "node_modules/ts-mixer": {
@@ -1290,6 +1441,12 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "license": "MIT"
+    },
+    "node_modules/which-runtime": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/which-runtime/-/which-runtime-1.3.2.tgz",
+      "integrity": "sha512-5kwCfWml7+b2NO7KrLMhYihjRx0teKkd3yGp1Xk5Vaf2JGdSh+rgVhEALAD9c/59dP+YwJHXoEO7e8QPy7gOkw==",
+      "license": "Apache-2.0"
     },
     "node_modules/ws": {
       "version": "8.19.0",

--- a/tools/test-bot/package.json
+++ b/tools/test-bot/package.json
@@ -14,7 +14,7 @@
     "@discordjs/voice": "^0.19.2",
     "discord.js": "^14.26.4",
     "dotenv": "^17.4.2",
-    "sodium-native": "^4.3.1"
+    "sodium-native": "^5.1.0"
   },
   "devDependencies": {
     "tsx": "^4.19.3",

--- a/web/package.json
+++ b/web/package.json
@@ -22,7 +22,7 @@
     "react-big-calendar": "^1.19.4",
     "react-dom": "^19.2.5",
     "react-force-graph-2d": "^1.29.1",
-    "react-router-dom": "^7.13.0",
+    "react-router-dom": "^7.14.2",
     "recharts": "^3.7.0",
     "socket.io-client": "^4.8.3",
     "sonner": "^2.0.7",

--- a/web/package.json
+++ b/web/package.json
@@ -26,7 +26,7 @@
     "recharts": "^3.7.0",
     "socket.io-client": "^4.8.3",
     "sonner": "^2.0.7",
-    "zustand": "^5.0.11"
+    "zustand": "^5.0.12"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",


### PR DESCRIPTION
## Summary

Combined merge of 8 open dependabot PRs to reduce CI runs from 8 to 1. Excludes #738 (TypeScript 6.0.3 major bump — has real lint + discord-smoke failures, needs separate work) and #732 (operator has parallel local in-flight fix on `fix/cascade-wipe-test-id-collision`).

### Included PRs

#### GitHub Actions
- #734 — chore(ci): bump actions/deploy-pages from 4 to 5
- #735 — chore(ci): bump actions/upload-artifact from 4 to 7
- #736 — chore(ci): bump docker/login-action from 3 to 4

#### npm dependencies
- #733 — chore(deps,test-bot): bump sodium-native from 4.3.3 to 5.1.0 in /tools/test-bot
- #737 — chore(deps): bump ioredis from 5.9.2 to 5.10.1
- #739 — chore(deps): bump react-router-dom from 7.13.0 to 7.14.2
- #740 — chore(deps): bump zustand from 5.0.11 to 5.0.12
- #741 — chore(deps): bump @sentry/nestjs from 10.38.0 to 10.51.0

## Test plan

- [x] Combined branch built locally: `npm install` (lockfile consistent)
- [x] `npm run build -w packages/contract`
- [x] `npm run build -w api`
- [x] `npm run build -w web`
- [x] `npx tsc --noEmit -p api/tsconfig.json`
- [x] `npx tsc --noEmit -p web/tsconfig.json`
- [x] `npm run lint -w api` — 0 errors
- [x] `npm run lint -w web` — 0 errors
- [x] `npm run test -w api` — 5836/5837 (1 pre-existing local-TZ-only failure on `discord-bot/utils/push-content.spec.ts` that also fails on main; CI runs in UTC and passes)
- [x] `npx vitest run` (web) — 3132/3132
- [ ] GitHub CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)