### PR TITLE
chore: TypeScript 6.0.3 + compat fixes (supersedes #738)

### DIFF
--- a/api/jest.config.js
+++ b/api/jest.config.js
@@ -8,11 +8,13 @@ module.exports = {
             'ts-jest',
             {
                 tsconfig: {
+                    rootDir: '.',
                     module: 'commonjs',
                     moduleResolution: 'node16',
                     esModuleInterop: true,
                     allowSyntheticDefaultImports: true,
                     resolvePackageJsonExports: false,
+                    ignoreDeprecations: '6.0',
                 },
             },
         ],

--- a/api/jest.integration.config.js
+++ b/api/jest.integration.config.js
@@ -8,11 +8,13 @@ module.exports = {
       'ts-jest',
       {
         tsconfig: {
+          rootDir: '.',
           module: 'commonjs',
           moduleResolution: 'node16',
           esModuleInterop: true,
           allowSyntheticDefaultImports: true,
           resolvePackageJsonExports: false,
+          ignoreDeprecations: '6.0',
         },
       },
     ],

--- a/api/package.json
+++ b/api/package.json
@@ -92,7 +92,7 @@
     "ts-jest": "^29.4.9",
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
-    "typescript": "^5.7.3",
+    "typescript": "^6.0.3",
     "typescript-eslint": "^8.59.1"
   }
 }

--- a/api/scripts/debug-db.ts
+++ b/api/scripts/debug-db.ts
@@ -16,7 +16,7 @@ async function check() {
         const migrations = await client`SELECT * FROM "__drizzle_migrations"`;
         migrations.forEach(m => console.log(JSON.stringify(m)));
     } catch (e) {
-        console.log('Migration table error (likely missing):', e.message);
+        console.log('Migration table error (likely missing):', e instanceof Error ? e.message : e);
     }
 
     process.exit(0);

--- a/api/scripts/manual-migrate-0009.ts
+++ b/api/scripts/manual-migrate-0009.ts
@@ -28,21 +28,21 @@ async function migrate() {
             await client`ALTER TABLE "availability" ADD CONSTRAINT "availability_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;`;
             console.log('Added user FK.');
         } catch (e) {
-            console.log('User FK likely exists or error:', e.message);
+            console.log('User FK likely exists or error:', e instanceof Error ? e.message : e);
         }
 
         try {
             await client`ALTER TABLE "availability" ADD CONSTRAINT "availability_game_id_game_registry_id_fk" FOREIGN KEY ("game_id") REFERENCES "public"."game_registry"("id") ON DELETE no action ON UPDATE no action;`;
             console.log('Added game FK.');
         } catch (e) {
-            console.log('Game FK likely exists or error:', e.message);
+            console.log('Game FK likely exists or error:', e instanceof Error ? e.message : e);
         }
 
         try {
             await client`ALTER TABLE "availability" ADD CONSTRAINT "availability_source_event_id_events_id_fk" FOREIGN KEY ("source_event_id") REFERENCES "public"."events"("id") ON DELETE no action ON UPDATE no action;`;
             console.log('Added event FK.');
         } catch (e) {
-            console.log('Event FK likely exists or error:', e.message);
+            console.log('Event FK likely exists or error:', e instanceof Error ? e.message : e);
         }
 
     } catch (e) {

--- a/api/src/admin/slash-command-test.service.ts
+++ b/api/src/admin/slash-command-test.service.ts
@@ -19,7 +19,7 @@ import { BindingsCommand } from '../discord-bot/commands/bindings.command';
 import { InviteCommand } from '../discord-bot/commands/invite.command';
 import { PlayingCommand } from '../discord-bot/commands/playing.command';
 
-type HandlerClass = new (...args: unknown[]) => CommandInteractionHandler;
+type HandlerClass = new (...args: any[]) => CommandInteractionHandler;
 
 /** Map command names to their NestJS provider classes. */
 const HANDLER_MAP: Record<string, HandlerClass> = {

--- a/api/src/plugins/discord/discord-auth.helpers.ts
+++ b/api/src/plugins/discord/discord-auth.helpers.ts
@@ -146,7 +146,10 @@ export async function exchangeCodeForToken(
   redirectUri: string,
   clientId: string,
   clientSecret: string,
-  discordFetch: typeof fetch,
+  discordFetch: (
+    url: string | URL,
+    init?: RequestInit,
+  ) => Promise<globalThis.Response>,
 ): Promise<{ access_token: string }> {
   const tokenResponse = await discordFetch(
     'https://discord.com/api/oauth2/token',
@@ -171,7 +174,10 @@ export async function exchangeCodeForToken(
 /** Fetch Discord user profile with access token. */
 export async function fetchDiscordProfile(
   accessToken: string,
-  discordFetch: typeof fetch,
+  discordFetch: (
+    url: string | URL,
+    init?: RequestInit,
+  ) => Promise<globalThis.Response>,
 ): Promise<{ id: string; username: string; avatar?: string }> {
   const userResponse = await discordFetch('https://discord.com/api/users/@me', {
     headers: {

--- a/api/tsconfig.build.json
+++ b/api/tsconfig.build.json
@@ -1,4 +1,11 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "test", "dist", "**/*spec.ts"]
+  "exclude": [
+    "node_modules",
+    "test",
+    "dist",
+    "**/*.spec*.ts",
+    "**/*.test-fixtures.ts",
+    "src/common/testing/**"
+  ]
 }

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -13,7 +13,6 @@
     "target": "ES2022",
     "sourceMap": true,
     "outDir": "./dist",
-    "baseUrl": "./",
     "incremental": true,
     "skipLibCheck": true,
     "strictNullChecks": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -91,7 +91,7 @@
                 "ts-jest": "^29.4.9",
                 "ts-node": "^10.9.2",
                 "tsconfig-paths": "^4.2.0",
-                "typescript": "^5.7.3",
+                "typescript": "^6.0.3",
                 "typescript-eslint": "^8.59.1"
             }
         },
@@ -144,6 +144,20 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/ioredis"
+            }
+        },
+        "api/node_modules/typescript": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
             }
         },
         "node_modules/@acemir/cssom": {
@@ -21633,8 +21647,22 @@
                 "zod": "^3.22.4"
             },
             "devDependencies": {
-                "typescript": "^5.0.0",
+                "typescript": "^6.0.3",
                 "zod": "^3.22.4"
+            }
+        },
+        "packages/contract/node_modules/typescript": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
             }
         },
         "tools/mcp-discord": {
@@ -21647,7 +21675,7 @@
                 "tsx": "^4.19.3"
             },
             "devDependencies": {
-                "typescript": "^5.7.3",
+                "typescript": "^6.0.3",
                 "vitest": "^4.1.5"
             }
         },
@@ -21663,6 +21691,20 @@
                 "url": "https://dotenvx.com"
             }
         },
+        "tools/mcp-discord/node_modules/typescript": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
+            }
+        },
         "tools/mcp-env": {
             "name": "@raid-ledger/mcp-env",
             "version": "0.1.0",
@@ -21672,8 +21714,22 @@
                 "zod": "^3.24.2"
             },
             "devDependencies": {
-                "typescript": "^5.7.3",
+                "typescript": "^6.0.3",
                 "vitest": "^4.1.5"
+            }
+        },
+        "tools/mcp-env/node_modules/typescript": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
             }
         },
         "web": {
@@ -21716,7 +21772,7 @@
                 "jsdom": "^28.0.0",
                 "msw": "^2.14.2",
                 "tailwindcss": "^4.1.18",
-                "typescript": "~5.9.3",
+                "typescript": "^6.0.3",
                 "typescript-eslint": "^8.59.1",
                 "vite": "^7.2.4",
                 "vitest": "^4.1.5",
@@ -21742,6 +21798,20 @@
                 "eslint": {
                     "optional": true
                 }
+            }
+        },
+        "web/node_modules/typescript": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
             }
         }
     }

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -16,7 +16,7 @@
         "lint": "echo 'lint passed'"
     },
     "devDependencies": {
-        "typescript": "^5.0.0",
+        "typescript": "^6.0.3",
         "zod": "^3.22.4"
     },
     "dependencies": {

--- a/packages/contract/tsconfig.json
+++ b/packages/contract/tsconfig.json
@@ -10,7 +10,7 @@
         "target": "ES2021",
         "sourceMap": true,
         "outDir": "./dist",
-        "baseUrl": "./",
+        "rootDir": "./src",
         "incremental": true,
         "skipLibCheck": true,
         "strict": true

--- a/tools/mcp-discord/package.json
+++ b/tools/mcp-discord/package.json
@@ -20,7 +20,7 @@
     "tsx": "^4.19.3"
   },
   "devDependencies": {
-    "typescript": "^5.7.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.5"
   }
 }

--- a/tools/mcp-env/package.json
+++ b/tools/mcp-env/package.json
@@ -18,7 +18,7 @@
     "zod": "^3.24.2"
   },
   "devDependencies": {
-    "typescript": "^5.7.3",
+    "typescript": "^6.0.3",
     "vitest": "^4.1.5"
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -49,7 +49,7 @@
     "jsdom": "^28.0.0",
     "msw": "^2.14.2",
     "tailwindcss": "^4.1.18",
-    "typescript": "~5.9.3",
+    "typescript": "~6.0.3",
     "typescript-eslint": "^8.59.1",
     "vite": "^7.2.4",
     "vitest": "^4.1.5",


### PR DESCRIPTION
## Summary

Bumps TypeScript 5.9.3 → 6.0.3 (the bump from #738) and adds the compat fixes that make CI pass. Closes #738 in favor of this PR.

## tsconfig changes

- `packages/contract/tsconfig.json` — add explicit `rootDir: ./src`, drop unused `baseUrl` (TS6 deprecation; no `paths` in this config so baseUrl was a no-op).
- `api/tsconfig.json` — drop unused `baseUrl`.
- `api/tsconfig.build.json` — broaden test-file excludes from `**/*spec.ts` to also catch `**/*.spec*.ts`, `**/*.test-fixtures.ts`, and `src/common/testing/**`. TS6 surfaced that `*.spec-helpers.ts`, `*.test-fixtures.ts`, and `src/common/testing/**` were leaking jest globals into production builds because the old pattern only matched `*.spec.ts`.

## Code changes

- `api/scripts/{debug-db,manual-migrate-0009}.ts` — narrow `catch (e)` errors via `e instanceof Error` (TS6 strictens implicit unknown in catch).
- `api/src/admin/slash-command-test.service.ts` — `HandlerClass` uses `any[]` for constructor args. TS6 enforces stricter contravariance on `(...args: unknown[])`, so concrete command constructors no longer match. This mirrors NestJS's own `Type<T>` pattern.
- `api/src/plugins/discord/discord-auth.helpers.ts` — replace `discordFetch: typeof fetch` with a narrow signature and qualify `Response` as `globalThis.Response`. The file imports express's `Response` type at module scope, which previously shadowed the fetch one.

## Jest

- `api/jest.config.js` — ts-jest inline tsconfig now sets `rootDir: '.'` (TS6 needs explicit rootDir) and adds `ignoreDeprecations: '6.0'` so the existing `commonjs` + `node16` combo keeps working without TS6 deprecation noise.

## Test plan

- [x] `npm install` (TS 6.0.3 active locally)
- [x] `npm run build -w packages/contract`
- [x] `npm run build -w api`
- [x] `npm run build -w web`
- [x] `npx tsc --noEmit -p api/tsconfig.json`
- [x] `npx tsc --noEmit -p web/tsconfig.json`
- [x] `npm run lint -w api` — 0 errors
- [x] `npm run lint -w web` — 0 errors
- [x] `npm run test -w api` — 5836/5837 (1 pre-existing local-TZ-only failure on `discord-bot/utils/push-content.spec.ts`; CI runs UTC and passes)
- [x] `npx vitest run` (web) — 3132/3132
- [ ] GitHub CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)