### PR TITLE
fix(test-infra): reset 4 module singletons in truncateAllTables

### DIFF
--- a/api/src/common/swr-cache.ts
+++ b/api/src/common/swr-cache.ts
@@ -31,6 +31,24 @@ export interface MemoryCacheEntry<T> {
 /** In-flight refresh tracker — prevents duplicate concurrent refreshes per key */
 const inFlightRefreshes = new Map<string, Promise<unknown>>();
 
+/** @internal Exposed for testing only — clears the in-flight refresh tracker. */
+export function _resetInFlightRefreshes(): void {
+  inFlightRefreshes.clear();
+}
+
+/** @internal Exposed for testing only — current in-flight tracker size. */
+export function _inFlightRefreshesSize(): number {
+  return inFlightRefreshes.size;
+}
+
+/** @internal Exposed for testing only — record a fake in-flight entry. */
+export function _setInFlightRefresh(
+  key: string,
+  promise: Promise<unknown>,
+): void {
+  inFlightRefreshes.set(key, promise);
+}
+
 /**
  * Options for in-memory SWR cache get.
  */

--- a/api/src/common/testing/cross-suite-state.integration.spec.ts
+++ b/api/src/common/testing/cross-suite-state.integration.spec.ts
@@ -19,19 +19,20 @@ import {
   setCachedAuthUser,
 } from '../../auth/auth-user-cache';
 import { TokenBlocklistService } from '../../auth/token-blocklist.service';
+import { _isKeyCached, getEncryptionKey } from '../../settings/encryption.util';
+import {
+  _cooldownsSize,
+  setCooldown,
+} from '../../discord-bot/listeners/signup-interaction.helpers';
+import {
+  _recentlyProcessedSize,
+  _setRecentlyProcessed,
+} from '../../discord-bot/listeners/event-link.dedup';
+import { _inFlightRefreshesSize, _setInFlightRefresh } from '../swr-cache';
 
-function describeCrossSuiteState() {
-  let testApp: TestApp;
-
-  beforeAll(async () => {
-    testApp = await getTestApp();
-  });
-
-  afterEach(async () => {
-    testApp.seed = await truncateAllTables(testApp.db);
-  });
-
+function describeOriginalResets(testAppRef: { current: TestApp }) {
   it('clears jwt_block:* keys so a fresh admin token is accepted after truncate', async () => {
+    const testApp = testAppRef.current;
     const blocklist = testApp.app.get(TokenBlocklistService);
     // Simulate an earlier suite blocking the currently-seeded admin.
     await blocklist.blockUser(testApp.seed.adminUser.id);
@@ -58,6 +59,7 @@ function describeCrossSuiteState() {
   });
 
   it('clears the auth-user cache so stale role/discordId data does not leak', async () => {
+    const testApp = testAppRef.current;
     const staleId = 999_999;
     setCachedAuthUser(staleId, { role: 'member', discordId: 'stale' });
     expect(getCachedAuthUser(staleId)).not.toBeNull();
@@ -68,5 +70,68 @@ function describeCrossSuiteState() {
   });
 }
 
-describe('Cross-suite state reset (integration)', () =>
-  describeCrossSuiteState());
+// ROK-1245: 4 module-scoped singletons that survive `app.close()` and
+// retained references to prior apps' DI containers across spec files.
+// The SWR `inFlightRefreshes` map was the dominant carrier — promises
+// closed over the previous file's NestJS service instances.
+function describeModuleSingletonResets(testAppRef: { current: TestApp }) {
+  it('clears the encryption key cache so a JWT_SECRET rotation between suites is honored', async () => {
+    const testApp = testAppRef.current;
+    getEncryptionKey();
+    expect(_isKeyCached()).toBe(true);
+
+    testApp.seed = await truncateAllTables(testApp.db);
+
+    expect(_isKeyCached()).toBe(false);
+  });
+
+  it('clears Discord signup-interaction cooldowns so a cooldown from one suite does not suppress the next', async () => {
+    const testApp = testAppRef.current;
+    setCooldown('event:1:user:42', Date.now());
+    expect(_cooldownsSize()).toBeGreaterThan(0);
+
+    testApp.seed = await truncateAllTables(testApp.db);
+
+    expect(_cooldownsSize()).toBe(0);
+  });
+
+  it("clears event-link unfurl dedup map so a prior suite's unfurl does not block the next", async () => {
+    const testApp = testAppRef.current;
+    _setRecentlyProcessed('msg:42:event:1', Date.now());
+    expect(_recentlyProcessedSize()).toBeGreaterThan(0);
+
+    testApp.seed = await truncateAllTables(testApp.db);
+
+    expect(_recentlyProcessedSize()).toBe(0);
+  });
+
+  it("clears SWR in-flight refresh tracker so a prior suite's pending promise cannot deliver to the next", async () => {
+    const testApp = testAppRef.current;
+    _setInFlightRefresh(
+      'blizzard:realm:us-tichondrius',
+      Promise.resolve('stale'),
+    );
+    expect(_inFlightRefreshesSize()).toBeGreaterThan(0);
+
+    testApp.seed = await truncateAllTables(testApp.db);
+
+    expect(_inFlightRefreshesSize()).toBe(0);
+  });
+}
+
+describe('Cross-suite state reset (integration)', () => {
+  const testAppRef: { current: TestApp } = {
+    current: null as unknown as TestApp,
+  };
+
+  beforeAll(async () => {
+    testAppRef.current = await getTestApp();
+  });
+
+  afterEach(async () => {
+    testAppRef.current.seed = await truncateAllTables(testAppRef.current.db);
+  });
+
+  describeOriginalResets(testAppRef);
+  describeModuleSingletonResets(testAppRef);
+});

--- a/api/src/common/testing/integration-helpers.ts
+++ b/api/src/common/testing/integration-helpers.ts
@@ -16,6 +16,10 @@ import * as schema from '../../drizzle/schema';
 import { clearAuthUserCache } from '../../auth/auth-user-cache';
 import { ALL_QUEUE_NAMES } from '../../queue/queue-registry';
 import { SettingsService } from '../../settings/settings.service';
+import { _resetKeyCache } from '../../settings/encryption.util';
+import { _resetCooldowns } from '../../discord-bot/listeners/signup-interaction.helpers';
+import { _resetRecentlyProcessed } from '../../discord-bot/listeners/event-link.dedup';
+import { _resetInFlightRefreshes } from '../swr-cache';
 import { INSTANCE_KEY, type TestApp } from './test-app';
 
 const obliterateLogger = new Logger('truncateAllTables.obliterate');
@@ -131,6 +135,7 @@ export async function truncateAllTables(
   clearAuthUserCache();
   clearMockRedisByPrefix(MOCK_REDIS_TEARDOWN_PREFIXES);
   clearSettingsServiceCache();
+  resetModuleSingletons();
   await obliterateAllQueues();
 
   // Re-seed baseline data
@@ -198,6 +203,23 @@ function clearMockRedisByPrefix(prefixes: readonly string[]): void {
   for (const key of [...store.keys()]) {
     if (prefixes.some((p) => key.startsWith(p))) store.delete(key);
   }
+}
+
+/**
+ * Reset module-scoped singletons that survive `app.close()` and would
+ * otherwise retain state — including references to the previous file's
+ * NestJS DI container — across spec files within a Jest worker. The SWR
+ * `inFlightRefreshes` tracker is the dominant carrier: pending promises
+ * close over the previous file's service instances via the `fetcher`
+ * closure, blocking GC of the entire prior app graph. The Discord
+ * cooldown / unfurl dedup maps and the encryption key cache are silent
+ * but cheap to reset alongside.
+ */
+function resetModuleSingletons(): void {
+  _resetKeyCache();
+  _resetCooldowns();
+  _resetRecentlyProcessed();
+  _resetInFlightRefreshes();
 }
 
 /**

--- a/api/src/discord-bot/listeners/event-link.dedup.ts
+++ b/api/src/discord-bot/listeners/event-link.dedup.ts
@@ -1,0 +1,46 @@
+/**
+ * Module-scoped dedup tracker for event-link unfurls — prevents duplicate
+ * unfurls when dev-mode HMR creates multiple `EventLinkListener` instances
+ * pointing at surviving Discord Client objects. Entries auto-expire after
+ * 30 seconds via an `unref()`'d interval.
+ *
+ * Extracted from `event-link.listener.ts` (ROK-1245) so the listener stays
+ * under the 300-line ESLint cap and so the integration suite can reset the
+ * Map between spec files via `_resetRecentlyProcessed()`.
+ */
+
+const recentlyProcessed = new Map<string, number>();
+
+const EXPIRY_MS = 30_000;
+
+setInterval(() => {
+  const now = Date.now();
+  for (const [id, ts] of recentlyProcessed) {
+    if (now - ts > EXPIRY_MS) recentlyProcessed.delete(id);
+  }
+}, EXPIRY_MS).unref();
+
+/** True when the given message id was processed within the expiry window. */
+export function hasRecentlyProcessed(id: string): boolean {
+  return recentlyProcessed.has(id);
+}
+
+/** Record that the given message id has just been processed. */
+export function markRecentlyProcessed(id: string): void {
+  recentlyProcessed.set(id, Date.now());
+}
+
+/** @internal Exposed for testing only — clears the dedup map. */
+export function _resetRecentlyProcessed(): void {
+  recentlyProcessed.clear();
+}
+
+/** @internal Exposed for testing only — record an entry directly. */
+export function _setRecentlyProcessed(id: string, ts: number): void {
+  recentlyProcessed.set(id, ts);
+}
+
+/** @internal Exposed for testing only — current dedup map size. */
+export function _recentlyProcessedSize(): number {
+  return recentlyProcessed.size;
+}

--- a/api/src/discord-bot/listeners/event-link.listener.ts
+++ b/api/src/discord-bot/listeners/event-link.listener.ts
@@ -23,21 +23,12 @@ import { SettingsService } from '../../settings/settings.service';
 import { EventsService } from '../../events/events.service';
 import { PugsService } from '../../events/pugs.service';
 import { DISCORD_BOT_EVENTS, EMBED_STATES } from '../discord-bot.constants';
+import {
+  hasRecentlyProcessed,
+  markRecentlyProcessed,
+} from './event-link.dedup';
 
 const MAX_UNFURLS_PER_MESSAGE = 3;
-
-/**
- * Module-scoped dedup set — prevents duplicate unfurls when dev-mode HMR
- * creates multiple EventLinkListener instances pointing at surviving Client objects.
- * Entries auto-expire after 30 seconds.
- */
-const recentlyProcessed = new Map<string, number>();
-setInterval(() => {
-  const now = Date.now();
-  for (const [id, ts] of recentlyProcessed) {
-    if (now - ts > 30_000) recentlyProcessed.delete(id);
-  }
-}, 30_000).unref();
 
 /**
  * Listener that auto-unfurls Raid Ledger event links posted in Discord channels (ROK-380).
@@ -82,8 +73,8 @@ export class EventLinkListener {
 
   private async handleMessage(message: Message): Promise<void> {
     if (message.author.bot) return;
-    if (recentlyProcessed.has(message.id)) return;
-    recentlyProcessed.set(message.id, Date.now());
+    if (hasRecentlyProcessed(message.id)) return;
+    markRecentlyProcessed(message.id);
     if (!message.guild) return;
     if (!isGuildTextChannel(message.channel.type)) return;
     const clientUrl = resolveClientUrl();

--- a/api/src/discord-bot/listeners/signup-interaction.helpers.ts
+++ b/api/src/discord-bot/listeners/signup-interaction.helpers.ts
@@ -42,6 +42,17 @@ export function setCooldown(key: string, ts: number): void {
   interactionCooldowns.set(key, ts);
 }
 
+/** @internal Exposed for testing only — clears the cooldown map. */
+export function _resetCooldowns(): void {
+  interactionCooldowns.clear();
+  lastCleanup = 0;
+}
+
+/** @internal Exposed for testing only — current cooldown map size. */
+export function _cooldownsSize(): number {
+  return interactionCooldowns.size;
+}
+
 /**
  * Check if an error is a Discord API interaction race condition.
  * Code 40060 = already acknowledged, 10062 = expired token.

--- a/api/src/settings/encryption.util.ts
+++ b/api/src/settings/encryption.util.ts
@@ -68,6 +68,11 @@ export function _resetKeyCache(): void {
   cachedKeySecret = null;
 }
 
+/** @internal Exposed for testing only — true when a key is cached. */
+export function _isKeyCached(): boolean {
+  return cachedKey !== null;
+}
+
 /**
  * Encrypts a string value using AES-256-GCM with a specific key.
  * Returns format: iv:authTag:encryptedData (all hex encoded)


### PR DESCRIPTION
## Summary

Cross-suite pollution flake (rotating-suite 401 on `loginAsAdmin`, documented in `TECH-DEBT-BACKLOG.md` 2026-05-05 entry) is partially caused by 4 module-scoped singletons that survive `app.close()` but weren't reset by `truncateAllTables`. This PR adds reset hooks and a regression spec; an empirical validation revealed a second cause (ROK-1091 / `socket hang up`) that needs a follow-up story.

## What changed

| File | Change |
|---|---|
| `api/src/settings/encryption.util.ts` | Added `_isKeyCached()` getter (`_resetKeyCache()` already existed) |
| `api/src/discord-bot/listeners/signup-interaction.helpers.ts` | Added `_resetCooldowns()` + `_cooldownsSize()` |
| `api/src/discord-bot/listeners/event-link.dedup.ts` | **NEW** — extracted dedup map + `setInterval` from listener so the listener stays under 300-line cap |
| `api/src/discord-bot/listeners/event-link.listener.ts` | Replaced inline dedup with imports from `event-link.dedup` |
| `api/src/common/swr-cache.ts` | Added `_resetInFlightRefreshes()` + size getter + test setter |
| `api/src/common/testing/integration-helpers.ts` | New `resetModuleSingletons()` helper, called in `truncateAllTables` |
| `api/src/common/testing/cross-suite-state.integration.spec.ts` | 4 new TDD tests proving the leak (red→green) |

The SWR `inFlightRefreshes` Map is the highest-impact of the four — pending promises closed over the previous file's NestJS DI container via fetcher closures, retaining the entire prior app graph and blocking GC.

## Why this is correct hygiene

- Each `_reset*` is a one-liner that clears a Map / nulls a cache.
- The 4 new TDD tests in `cross-suite-state.integration.spec.ts` go red without the wiring, green with it.
- The `cross-suite-state` regression spec (originally added for ROK-1059's `jwt_block:` leak) is the canonical place for these assertions.

## Empirical validation (5x sequential `npm run test:integration`)

| Run | Result | Cause |
|---|---|---|
| 1 | INVALID | Lead error — extracted `event-link.dedup.ts` mid-run, cache contamination |
| 2 | 1 failure (`backup`) | `Cannot read .filename of undefined` — likely 401-shaped pollution |
| 3 | 9 failures (`notification-dedup`) | Testcontainers `Timed out waiting for container ports` — Docker resource exhaustion (system-level, not state pollution) |
| 4 | 1 failure (`lineups-auto-advance`) | `socket hang up` — **matches ROK-1091 ECONNRESET pattern explicitly predicted by `jest.integration.config.js:25-33`** |
| 5 | killed | (in-flight when bg job stopped after run 4 produced enough signal) |

**Honest finding: this fix is necessary but not sufficient.** The rotating-suite flake survived. The dominant carrier on this hardware is `socket hang up` / embed-sync ECONNRESET, which `jest.integration.config.js:25-33` already predicted as residual from ROK-1232. That comment said: *"recommend the dev verify ROK-1091 still reproduces after the new reset hook lands; if so, file a follow-up."* This run is the "if so" — needs a separate story. (Operator will file.)

A clean single-shot run of `validate-ci.sh --full --ci` after the fix passes 77/77 suites / 859/859 tests, so this PR doesn't regress the green-path baseline.

## Test plan

- [x] `validate-ci.sh --full --ci` passes (build + tsc + lint + unit + integration)
- [x] `cross-suite-state.integration.spec.ts` — 6 tests (2 original + 4 new), all green
- [x] Single full integration run: 77/77 suites, 859/859 tests, 315s
- [ ] CI to confirm GitHub matrix passes
- [ ] After merge, file follow-up story for ROK-1091 / `socket hang up` class

## Notes

- No production-code behavior change. The 3 new exports per touched module are `_`-prefixed and `@internal` — only used by `integration-helpers.ts` (test-time) and `cross-suite-state.integration.spec.ts`.
- `event-link.listener.ts` extraction is incidental — needed to stay under the 300-line cap after my additions. The dedup behavior is unchanged (same Map, same `setInterval(30_000).unref()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)