### PR TITLE
chore(test-infra): teardown hygiene — drain barrier + async flush + bootstrap-timer gate

### DIFF
--- a/api/src/common/testing/test-app.ts
+++ b/api/src/common/testing/test-app.ts
@@ -31,6 +31,7 @@ import * as path from 'path';
 import * as schema from '../../drizzle/schema';
 import { AppModule } from '../../app.module';
 import { DrizzleAsyncProvider } from '../../drizzle/drizzle.module';
+import { QueueHealthService } from '../../queue/queue-health.service';
 import { REDIS_CLIENT } from '../../redis/redis.module';
 import { truncateAllTables, type SeededData } from './integration-helpers';
 import { createRedisMock, type RedisMockHandle } from './redis-mock';
@@ -220,6 +221,18 @@ export async function getTestApp(): Promise<TestApp> {
 export async function closeTestApp(): Promise<void> {
   const instance = getInstance();
   if (!instance) return;
+
+  // ROK-1248: drain BullMQ queues before tearing down the app so worker.close()
+  // never has to await an in-flight job whose DB query would race the
+  // _appClient.end({ timeout: 5 }) cap that follows.
+  try {
+    const queueHealth = instance.app.get(QueueHealthService, { strict: false });
+    if (queueHealth) {
+      await queueHealth.awaitDrained(15_000);
+    }
+  } catch {
+    // best-effort — fall through to app.close() regardless
+  }
 
   await instance.app.close();
   if (instance._appClient) {

--- a/api/src/cron-jobs/cron-job.service.ts
+++ b/api/src/cron-jobs/cron-job.service.ts
@@ -74,6 +74,14 @@ export class CronJobService implements OnApplicationBootstrap, OnModuleDestroy {
   ) {}
 
   onApplicationBootstrap() {
+    // Skip bootstrap timers when crons are disabled (integration tests).
+    // Without this gate the 2s setTimeout fires mid-suite and races with
+    // afterEach truncates / in-flight HTTP requests, surfacing as
+    // intermittent log spam ("Failed to sync cron jobs") next to the
+    // socket hang up flake the diagnostic at
+    // planning-artifacts/test-infra-diagnostic-layer-2-2026-05-08.md
+    // calls out (§3d). Production never sets CRON_DISABLED.
+    if (process.env.CRON_DISABLED === 'true') return;
     this.bootstrapTimer = setTimeout(() => {
       this.bootstrapTimer = null;
       this.syncJobs().catch((err) =>

--- a/api/src/discord-bot/services/voice-attendance.service.ts
+++ b/api/src/discord-bot/services/voice-attendance.service.ts
@@ -71,12 +71,14 @@ export class VoiceAttendanceService implements OnModuleInit, OnModuleDestroy {
     }, FLUSH_INTERVAL_MS);
   }
 
-  onModuleDestroy(): void {
+  async onModuleDestroy(): Promise<void> {
     if (this.flushTimer) clearInterval(this.flushTimer);
     this.flushTimer = null;
-    this.flushToDb().catch((e) =>
-      this.logger.error(`Final flush failed: ${e}`),
-    );
+    try {
+      await this.flushToDb();
+    } catch (e) {
+      this.logger.error(`Final flush failed: ${e}`);
+    }
   }
 
   handleJoin(


### PR DESCRIPTION
## Summary

Three adjacent test-infra hygiene fixes layered on top of Layer 1 (commit `300c55b1`). All three are logically correct in isolation and remove demonstrable hygiene gaps. **None individually or collectively eliminate the rotating-suite `socket hang up` / ECONNRESET flake** that ROK-1248 originally targeted — see "AC2 deferred" below.

| # | Fix | File | Diagnostic ref |
|---|-----|------|----------------|
| 1 | Drain BullMQ queues before `app.close()` in `closeTestApp` | `api/src/common/testing/test-app.ts` | §3a |
| 2 | `VoiceAttendanceService.onModuleDestroy` is now async + awaits final flush | `api/src/discord-bot/services/voice-attendance.service.ts` | §3e |
| 3 | `CronJobService.onApplicationBootstrap` returns early when `CRON_DISABLED === 'true'` | `api/src/cron-jobs/cron-job.service.ts` | §3d |

Production behavior is unchanged for all three — production never sets `CRON_DISABLED`, the voice-attendance flush always ran, and the queue-drain barrier only activates when `QueueHealthService` is registered (which it is in production too, but `app.close()` already drains queues there via the SIGTERM path).

## AC2 deferred

Empirical 3x integration loop on this branch produced 2/3 failures. Both signatures are inconsistent with the §3a (BullMQ teardown) race the original story named:

- **Run 1** — `lineups-voting.integration.spec.ts`: 120s `truncateAllTables` timeout in `afterEach`, then `read ECONNRESET` on the next test. Mid-file. Pool is unresponsive.
- **Run 3** — `admin/demo-data.integration.spec.ts`: `socket hang up` on `POST /admin/settings/demo/install` (auth guards test that should 401 immediately). `CronJobService` "Failed to sync cron jobs" logged at the same timestamp — matches §3d log noise (now silenced by fix #3) but the underlying request reset is unexplained.

The §3a race is real. It is not the dominant carrier. Continuing to code-read for plausible races is the failure mode that produced ROK-1246 → ROK-1248 without ever observing the actual failure point. **The actual unblock is ROK-1249 — Layer 3 instrumentation spike** (Track A from §7 of the Layer 2 diagnostic): wrap `app.getHttpServer()`, capture pool/worker/handle state at the moment of failure, and name the carrier with evidence rather than reasoning.

## Acceptance criteria status (vs ROK-1248)

- [x] **AC1** — `closeTestApp` calls `await queueHealth.awaitDrained(15_000)` before `app.close()`, wrapped in try/catch. Verified: `api/src/common/testing/test-app.ts:225-234`.
- [ ] **AC2 — DEFERRED.** 10x sequential green did not prove out (2/3 fails). See above. Tracked in ROK-1249.
- [x] **AC3** — Layer 1 regression spec (`integration-teardown.integration.spec.ts`) passes. Verified locally (3 of 3 vectors green).
- [x] **AC4** — ROK-1245 regression assertions (`cross-suite-state.integration.spec.ts`) pass. Verified locally.

## Why ship anyway

1. The drain barrier closes a real, named race that the diagnostic traced through `BullExplorer.onApplicationShutdown` → `worker.close()` → unbounded in-flight wait vs `_appClient.end({ timeout: 5 })`. Even if it isn't the dominant carrier, the race exists and the fix is correct.
2. The async voice flush is the same defect class (fire-and-forget at teardown). No reason to wait.
3. The cron bootstrap gate silences `Failed to sync cron jobs` log noise that's been polluting integration logs for months and made the run-3 failure harder to read. Strictly log hygiene; not a flake fix.
4. None of the three changes affect production. None of the three weaken any test.

## Test plan

- [x] `npx tsc --noEmit -p api/tsconfig.json` — clean
- [x] Layer 1 regression: `integration-teardown.integration.spec.ts` — 3/3 pass
- [x] ROK-1245 regression: `cross-suite-state.integration.spec.ts` — pass
- [x] Cron-jobs integration: `cron-job.integration.spec.ts` — pass with bootstrap gate active
- [x] Voice-attendance unit: 11 spec files / 164 tests pass with async `onModuleDestroy`
- [ ] Full CI (lint, build, integration matrix, container-startup, Playwright) — runs on this PR
- [ ] **AC2 10x integration green** — explicitly NOT attempted; tracked in ROK-1249

## Follow-up

- **ROK-1249** — Layer 3 instrumentation spike (filed). Real successor.
- The CronJobService gate in this PR is log-noise cleanup, not a flake fix. Do not interpret its presence as a claim about the rotating-suite carrier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)