### PR TITLE
chore(tooling): cross-worktree env lock + queue (mcp-env)

### DIFF
--- a/.claude/skills/operator-testing/SKILL.md
+++ b/.claude/skills/operator-testing/SKILL.md
@@ -2,7 +2,7 @@
 name: operator-testing
 description: Deploy the current branch to the local dev environment for hands-on testing. Operator-invoked — overrides whatever is currently deployed.
 disable-model-invocation: true
-allowed-tools: "Bash(./scripts/deploy_dev.sh*), Bash(git*)"
+allowed-tools: "Bash(./scripts/deploy_dev.sh*), Bash(./scripts/env-lock.sh*), Bash(git*)"
 ---
 
 # Operator Testing
@@ -15,14 +15,16 @@ Aliases: `/opt` (same skill).
 
 This skill is **operator-invoked and always overrides** whatever branch is currently deployed. The operator knows what they want to test — when they type `/opt`, take the env. The "don't steal a deployed branch" rule applies to *autonomous agent deploys*, not to this skill.
 
+The `--operator` flag (passed to `deploy_dev.sh` below) makes this concrete: it preempts any agent currently holding the env-lease, displaces them to the front of the queue (so they get the env back when you're done), and surfaces a "⚡ Preempted X" line in the deploy output so you can see who you bumped.
+
 ## Steps
 
 1. Confirm current branch: `git branch --show-current`.
-2. (Optional, informational) Run `./scripts/deploy_dev.sh --status` so the report tells the operator what's being replaced. Don't gate on it — just inform.
-3. Deploy:
-   - With contract/schema changes since the last deploy: `./scripts/deploy_dev.sh --ci --rebuild`
-   - Otherwise: `./scripts/deploy_dev.sh --ci`
-4. Report the API and Web URLs from the script output (default `:3000` and `:5173`/`:5174`) plus the branch now deployed.
+2. (Optional, informational) Run `./scripts/deploy_dev.sh --status` so the report tells the operator what's being replaced and who currently holds the env-lease. Don't gate on it — just inform.
+3. Deploy with `--operator` to preempt:
+   - With contract/schema changes since the last deploy: `./scripts/deploy_dev.sh --ci --operator --rebuild`
+   - Otherwise: `./scripts/deploy_dev.sh --ci --operator`
+4. Report the API and Web URLs from the script output (default `:3000` and `:5173`/`:5174`) plus the branch now deployed. If a preemption occurred, mention which branch was bumped — the operator may want to know.
 5. If the operator wants a fresh DB: pass `--fresh` (warn that it wipes data).
 6. If the operator wants a different branch: switch with `--branch <name>` first.
 

--- a/.claude/skills/opt/SKILL.md
+++ b/.claude/skills/opt/SKILL.md
@@ -2,7 +2,7 @@
 name: opt
 description: Alias for /operator-testing — deploy the current branch to local dev for hands-on testing. Operator-invoked, always overrides whatever is currently deployed.
 disable-model-invocation: true
-allowed-tools: "Bash(./scripts/deploy_dev.sh*), Bash(git*)"
+allowed-tools: "Bash(./scripts/deploy_dev.sh*), Bash(./scripts/env-lock.sh*), Bash(git*)"
 ---
 
 # /opt — alias for /operator-testing

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ implementation-artifacts/
 scripts/*
 !scripts/deploy_prod.sh
 !scripts/deploy_dev.sh
+!scripts/env-lock.sh
 !scripts/fix-migration-order.sh
 !scripts/reconcile-migrations.mjs
 !scripts/validate-ci.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,11 @@ Three custom MCP servers provide tools for environment management, story trackin
 |------|----------|
 | `mcp__mcp-env__env_check` | Check .env files: existence, missing vars, worktree status. Use BEFORE `deploy_dev.sh` or when builds fail due to missing env vars. |
 | `mcp__mcp-env__env_copy` | Copy .env files from main repo to worktree. Use when setting up worktrees. |
-| `mcp__mcp-env__env_service_status` | Check Docker containers, ports, API health. Use to verify local dev environment is running. |
+| `mcp__mcp-env__env_service_status` | Check Docker containers, ports, API health, AND env-lease state (who holds it, who's queued). Use to verify local dev environment is running. |
+| `mcp__mcp-env__env_lock_status` | Show env-lease holder + queue. Use BEFORE acquiring or any work that needs `:3000`/`:5173`. |
+| `mcp__mcp-env__env_lock_acquire` | Acquire the env lease (or get queued). Pass `purpose`, optional `priority: "operator"` to preempt. Auto-defaults branch + worktree. |
+| `mcp__mcp-env__env_lock_release` | Release the env lease (or remove yourself from the queue). Always call when you're done. |
+| `mcp__mcp-env__env_lock_force_release` | Operator-only override to clear a stuck lease. Ask the operator first. |
 | `mcp__mcp-env__story_status` | Check delivery status of stories (git branches + PRs). Use when resuming in-flight work to reconcile state against origin. |
 
 ### `mcp-discord` — Discord UI Testing (`tools/mcp-discord/`)
@@ -87,6 +91,23 @@ This rule exists because parallel agents kept seeing these commits, assuming "no
 - **Ports:** API on `:3000`, Web on `:5173` (Vite may increment to `:5174` if `:5173` is in use — CORS allows both)
 - **DEMO_MODE=true** in root `.env` enables auth bypass with prefilled credentials
 - **Docker volume gotcha (handled automatically):** The deploy script uses `docker start` by name first, falling back to `docker compose` from the main repo's compose file. This prevents worktrees from creating separate volumes with wrong directory prefixes.
+
+### Env coordination across agents (STRICT)
+
+The local dev env (Docker DB, API `:3000`, Vite `:5173`) is a single shared resource. Multiple agents/worktrees cannot run it simultaneously — `deploy_dev.sh` will refuse to start if another worktree holds the lease.
+
+State lives at `~/.raid-ledger/env-lock.json` (outside any worktree). The lease auto-expires when the holder's PID is dead OR when no heartbeat has arrived within the TTL (default 60min for MCP-acquired, 240min for `deploy_dev.sh`-acquired).
+
+**Before any work that needs the env (smoke tests, browser testing, deploy):**
+
+1. `mcp__mcp-env__env_lock_status` — see who holds it and who's queued. (`env_service_status` also includes lease state in its summary.)
+2. `mcp__mcp-env__env_lock_acquire({ purpose: "<what you'll do>" })` — if `acquired: false`, you've been queued. Either come back later (call `env_lock_acquire` again — it's idempotent), or pick non-env work in the meantime. Auto-defaults `branch` via git and `worktree` to the MCP server's cwd.
+3. Run `./scripts/deploy_dev.sh --ci --rebuild` (or pass `--wait-for-env <minutes>` to block instead of erroring if it's still held). The script re-acquires under your branch+worktree (idempotent if you already hold the lease) and registers its own PID for liveness tracking.
+4. When done, call `mcp__mcp-env__env_lock_release` so the next queued agent can take it. `./scripts/deploy_dev.sh --down` also releases.
+
+**Never bypass:** do not start the API/web manually to "skip the lock." If you find a stale lease (holder PID dead, no progress for >TTL), it auto-clears on the next `acquire`. If something is genuinely stuck, ask the operator before calling `env_lock_force_release`.
+
+**Operator priority (`/opt`):** `/opt` (and `deploy_dev.sh --operator`) always preempts — it cuts the queue, displaces the current holder to the **front** of the queue with `preempted: true`, and takes the env immediately. If you were preempted, you'll see `preempted: true` on your queue entry; you'll get the env back when the operator releases, ahead of any normal-priority waiters. Don't fight it; let the operator test, then resume.
 
 ## Code Size Limits (STRICT — enforced by ESLint)
 

--- a/scripts/deploy_dev.sh
+++ b/scripts/deploy_dev.sh
@@ -425,6 +425,18 @@ show_status() {
     else
         echo "  No dev processes tracked"
     fi
+    echo ""
+
+    echo -e "${BLUE}Env Lease:${NC}"
+    "$MAIN_REPO/scripts/env-lock.sh" status 2>/dev/null | jq -r '
+        if .holder == null then "  free"
+        else "  held by \(.holder.branch) @ \(.holder.worktree) (\(.holder.purpose), pid \(.holder.pid), priority \(.holder.priority))"
+        end,
+        if (.queue | length) > 0
+        then "  queue: " + ([.queue[] | .branch + (if .preempted then "*" else "" end)] | join(", "))
+        else empty end,
+        if .stale_cleared then "  (stale lease auto-cleared: \(.stale_cleared.reason))" else empty end
+    ' || echo "  (env-lock.sh not available)"
 }
 
 show_logs() {
@@ -446,6 +458,10 @@ stop_dev() {
     print_success "Database and Redis stopped"
 
     rm -rf "$LOG_DIR" "$PID_FILE"
+
+    # Release the cross-worktree env lease so the next agent can take it.
+    # Always non-fatal — if we never held it, this is a no-op.
+    "$MAIN_REPO/scripts/env-lock.sh" release "$(get_current_branch)" "$PROJECT_DIR" >/dev/null 2>&1 || true
 }
 
 reset_password() {
@@ -514,6 +530,35 @@ create_safety_backup() {
 start_dev() {
     local rebuild=$1
     local fresh=$2
+
+    # ---- Cross-worktree lease check (env-lock.sh) ------------------------------
+    # The local dev env is a single shared resource. Acquire a lease before
+    # starting; refuse if another worktree already holds it (or wait, if asked).
+    # `/opt` and operator-driven invocations set --operator (or
+    # RAID_LEDGER_OPERATOR=1) to preempt — see env-lock.sh for details.
+    local lease_branch lease_priority="normal" lease_cmd="acquire"
+    lease_branch=$(get_current_branch)
+    if [ "$ARG_OPERATOR" = "true" ] || [ "${RAID_LEDGER_OPERATOR:-}" = "1" ]; then
+        lease_priority="operator"
+    fi
+    local lease_args=("$lease_branch" "$PROJECT_DIR" "deploy_dev.sh" --pid $$ --ttl-minutes 240 --priority "$lease_priority")
+    if [ -n "$ARG_WAIT_FOR_ENV_MINUTES" ]; then
+        lease_cmd="wait"
+        lease_args+=(--timeout-seconds $((ARG_WAIT_FOR_ENV_MINUTES * 60)))
+    fi
+    local lease_out
+    lease_out=$(mktemp -t deploy-dev-lease.XXXXXX)
+    if ! "$MAIN_REPO/scripts/env-lock.sh" "$lease_cmd" "${lease_args[@]}" >"$lease_out" 2>&1; then
+        print_error "Local dev env is held by another worktree. See lease state below; pass --wait-for-env <min> to block, or --operator to preempt."
+        "$MAIN_REPO/scripts/env-lock.sh" status | jq . >&2 || cat "$lease_out" >&2
+        rm -f "$lease_out"
+        exit 2
+    fi
+    # If we preempted, surface it loudly so the operator sees who got bumped.
+    # `|| true` because this is cosmetic — never abort the deploy on a parse error.
+    jq -r 'if .preempted_holder then "⚡ Preempted \(.preempted_holder.branch) (now at front of queue)" else empty end' \
+        "$lease_out" 2>/dev/null || true
+    rm -f "$lease_out"
 
     # Stop conflicting Docker app containers
     stop_docker_app
@@ -652,6 +697,8 @@ ARG_FRESH=false
 ARG_BRANCH=""
 ARG_ACTION=""
 ARG_AI=false
+ARG_OPERATOR=false
+ARG_WAIT_FOR_ENV_MINUTES=""
 
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -697,6 +744,24 @@ while [ $# -gt 0 ]; do
             ARG_AI=true
             shift
             ;;
+        --operator)
+            # Cross-worktree env lease: cut the line, preempt any current holder.
+            # Used by /opt skill and operator-driven workflows.
+            ARG_OPERATOR=true
+            shift
+            ;;
+        --wait-for-env)
+            if [ -z "${2:-}" ]; then
+                print_error "Missing minutes. Usage: $0 --wait-for-env <minutes>"
+                exit 1
+            fi
+            if ! [[ "$2" =~ ^[1-9][0-9]*$ ]]; then
+                print_error "Invalid --wait-for-env value: '$2' (must be a positive integer of minutes)"
+                exit 1
+            fi
+            ARG_WAIT_FOR_ENV_MINUTES="$2"
+            shift 2
+            ;;
         --help|-h)
             echo "Usage: $0 [OPTIONS]"
             echo ""
@@ -708,8 +773,10 @@ while [ $# -gt 0 ]; do
             echo "  --reset-password  Reset admin password without losing data"
             echo "  --ai              Start Ollama container (--profile ai)"
             echo "  --ci              Non-interactive mode (skip prompts, for agents)"
+            echo "  --operator        Preempt any current env-lease holder (cuts the line; for /opt)"
+            echo "  --wait-for-env M  If env is held, block up to M minutes for it to free instead of erroring"
             echo "  --down            Stop native processes + DB/Redis containers"
-            echo "  --status          Show process/container status"
+            echo "  --status          Show process/container status (incl. env lease)"
             echo "  --logs            Tail API and web logs"
             echo "  --help            Show this help message"
             echo ""

--- a/scripts/env-lock.sh
+++ b/scripts/env-lock.sh
@@ -1,0 +1,504 @@
+#!/bin/bash
+# =============================================================================
+# env-lock.sh - Cross-worktree lease for the local dev environment
+# =============================================================================
+# Coordinates which agent / worktree owns the local dev env (Docker DB,
+# API :3000, Vite :5173). Multiple agents in parallel cannot run the env
+# simultaneously; this script is the chokepoint that enforces a lease.
+#
+# State lives at ~/.raid-ledger/env-lock.json (outside any worktree, so all
+# worktrees share it). Atomicity: a sidecar mkdir mutex + atomic JSON writes.
+#
+# Usage:
+#   env-lock.sh status
+#   env-lock.sh acquire <branch> <worktree> <purpose> [--pid N] [--ttl-minutes N] [--priority normal|operator]
+#   env-lock.sh release <branch> <worktree>
+#   env-lock.sh heartbeat <branch> <worktree>
+#   env-lock.sh wait <branch> <worktree> <purpose> [--timeout-seconds N] [--pid N] [--ttl-minutes N] [--priority ...]
+#   env-lock.sh force-release
+#
+# Subcommands always print a JSON result on stdout. Exit codes:
+#   0  - operation succeeded (or env was free / lock acquired)
+#   1  - acquire failed because env is held by someone else (caller enqueued)
+#   64 - bad usage
+#   124 - wait timed out
+# =============================================================================
+
+set -e
+
+STATE_DIR="${RAID_LEDGER_STATE_DIR:-$HOME/.raid-ledger}"
+STATE_FILE="$STATE_DIR/env-lock.json"
+MUTEX_DIR="$STATE_DIR/.lock-mutex"
+# Mutex contention is brief (a few jq invocations); 30 seconds is a generous
+# upper bound that won't collide with any normal operation. We poll at 100ms,
+# so 300 iterations × 100ms = 30s real time. Counted in iterations, not
+# seconds, to keep the math correct (an earlier version mistakenly compared
+# iteration count to seconds and timed out at ~0.5s).
+MUTEX_MAX_ITERATIONS=300
+MUTEX_POLL_SLEEP=0.1
+
+# -----------------------------------------------------------------------------
+# Bootstrap: ensure state dir + initial empty state exist.
+# -----------------------------------------------------------------------------
+init_state() {
+    mkdir -p "$STATE_DIR"
+    if [ ! -f "$STATE_FILE" ]; then
+        echo '{"holder": null, "queue": []}' > "$STATE_FILE"
+    fi
+}
+
+# -----------------------------------------------------------------------------
+# Mutex: mkdir is atomic per POSIX. Held only for the JSON read-modify-write
+# critical section (~ms), never across long operations.
+# -----------------------------------------------------------------------------
+mutex_lock() {
+    # Pure spin-with-timeout. NEVER auto-clobber a held mutex — even after a
+    # long wait, another instance may still be in the middle of its critical
+    # section. Lost-update races would corrupt the lease state for every agent
+    # at once. If the mutex is genuinely stuck (crashed prior invocation),
+    # operators can clear it with: `rmdir ~/.raid-ledger/.lock-mutex`.
+    local iterations=0
+    while ! mkdir "$MUTEX_DIR" 2>/dev/null; do
+        iterations=$((iterations + 1))
+        if [ "$iterations" -ge "$MUTEX_MAX_ITERATIONS" ]; then
+            echo "{\"error\": \"mutex_stuck\", \"hint\": \"check $MUTEX_DIR — if no env-lock.sh is running, rmdir it manually\"}" >&2
+            exit 70
+        fi
+        sleep "$MUTEX_POLL_SLEEP"
+    done
+}
+
+mutex_unlock() {
+    rmdir "$MUTEX_DIR" 2>/dev/null || true
+}
+
+# Always release the mutex on exit (errors, signals, normal return).
+trap 'mutex_unlock' EXIT
+
+# -----------------------------------------------------------------------------
+# State I/O: read whole JSON, write atomically via mktemp + mv.
+# -----------------------------------------------------------------------------
+read_state() {
+    cat "$STATE_FILE"
+}
+
+write_state() {
+    local new_state="$1"
+    local tmp
+    tmp=$(mktemp "$STATE_DIR/.env-lock.XXXXXX")
+    echo "$new_state" > "$tmp"
+    mv "$tmp" "$STATE_FILE"
+}
+
+# -----------------------------------------------------------------------------
+# Liveness: a holder is stale if its PID is dead OR its heartbeat is older
+# than ttl_minutes. PID 0 / empty means "no PID tracking" — TTL only.
+# Checks run inside jq using `now` + `fromdateiso8601` for portability.
+# -----------------------------------------------------------------------------
+is_pid_alive() {
+    local pid="$1"
+    [ -z "$pid" ] && return 0          # no PID tracking → treat as alive
+    [ "$pid" = "0" ] && return 0
+    # `ps -p` is preferred over `kill -0`: on macOS, signaling another user's
+    # process (e.g. PID 1 / launchd) returns EPERM, which kill -0 cannot
+    # distinguish from ESRCH. ps just checks process-table presence.
+    ps -p "$pid" >/dev/null 2>&1
+}
+
+# Returns "alive" or "stale:<reason>" based on the current holder.
+holder_liveness() {
+    local state="$1"
+    local pid
+    pid=$(echo "$state" | jq -r '.holder.pid // empty')
+    if [ -n "$pid" ] && [ "$pid" != "0" ]; then
+        if ! is_pid_alive "$pid"; then
+            echo "stale:pid_dead"
+            return
+        fi
+    fi
+    local stale_by_time
+    stale_by_time=$(echo "$state" | jq -r '
+        if .holder == null then "no_holder"
+        else
+            (.holder.ttl_minutes // 60) as $ttl
+            | (.holder.heartbeat_at // .holder.acquired_at) as $hb
+            | if (now - ($hb | fromdateiso8601)) > ($ttl * 60)
+              then "stale_ttl"
+              else "alive"
+              end
+        end')
+    case "$stale_by_time" in
+        no_holder) echo "no_holder" ;;
+        stale_ttl) echo "stale:heartbeat_ttl" ;;
+        alive)     echo "alive" ;;
+    esac
+}
+
+# Clear the holder if dead/stale; mutate state in place. Returns the cleanup
+# reason (empty if no clearing happened).
+auto_expire() {
+    local state="$1"
+    local liveness
+    liveness=$(holder_liveness "$state")
+    case "$liveness" in
+        stale:*)
+            local reason="${liveness#stale:}"
+            STATE_OUT=$(echo "$state" | jq '.holder = null')
+            EXPIRED_REASON="$reason"
+            ;;
+        *)
+            STATE_OUT="$state"
+            EXPIRED_REASON=""
+            ;;
+    esac
+}
+
+# -----------------------------------------------------------------------------
+# Identity helpers.
+# -----------------------------------------------------------------------------
+now_iso() {
+    date -u +"%Y-%m-%dT%H:%M:%SZ"
+}
+
+# True if (branch, worktree) matches the current holder.
+is_holder_self() {
+    local state="$1" branch="$2" worktree="$3"
+    echo "$state" | jq -e --arg b "$branch" --arg w "$worktree" \
+        '.holder != null and .holder.branch == $b and .holder.worktree == $w' >/dev/null
+}
+
+# True if (branch, worktree) is already in the queue.
+is_in_queue() {
+    local state="$1" branch="$2" worktree="$3"
+    echo "$state" | jq -e --arg b "$branch" --arg w "$worktree" \
+        '[.queue[] | select(.branch == $b and .worktree == $w)] | length > 0' >/dev/null
+}
+
+# -----------------------------------------------------------------------------
+# Subcommand: status
+# -----------------------------------------------------------------------------
+cmd_status() {
+    init_state
+    mutex_lock
+    local state
+    state=$(read_state)
+    auto_expire "$state"
+    if [ -n "$EXPIRED_REASON" ]; then
+        write_state "$STATE_OUT"
+    fi
+    mutex_unlock
+    # Annotate output with `free` boolean and optional stale_cleared reason.
+    echo "$STATE_OUT" | jq --arg reason "$EXPIRED_REASON" '
+        . + {
+            free: (.holder == null),
+            stale_cleared: (if $reason == "" then null else { reason: $reason } end)
+        }'
+}
+
+# -----------------------------------------------------------------------------
+# Subcommand: acquire
+# -----------------------------------------------------------------------------
+cmd_acquire() {
+    # Validate positional args BEFORE `shift 3` — under `set -e`, `shift N`
+    # silently aborts when fewer than N args are present, swallowing our
+    # own error messages.
+    if [ $# -lt 3 ] || [ -z "${1:-}" ] || [ -z "${2:-}" ] || [ -z "${3:-}" ]; then
+        echo '{"error": "missing_required_args", "expected": "<branch> <worktree> <purpose>"}' >&2
+        exit 64
+    fi
+    local branch="$1" worktree="$2" purpose="$3"
+    shift 3
+    local pid="" ttl_minutes=60 priority="normal"
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --pid)         pid="$2"; shift 2 ;;
+            --ttl-minutes) ttl_minutes="$2"; shift 2 ;;
+            --priority)    priority="$2"; shift 2 ;;
+            *) echo "{\"error\": \"unknown_flag\", \"flag\": \"$1\"}" >&2; exit 64 ;;
+        esac
+    done
+    case "$priority" in
+        normal|operator) ;;
+        *) echo "{\"error\": \"bad_priority\", \"value\": \"$priority\"}" >&2; exit 64 ;;
+    esac
+
+    init_state
+    mutex_lock
+    local state
+    state=$(read_state)
+    auto_expire "$state"
+    state="$STATE_OUT"
+
+    local now
+    now=$(now_iso)
+    local new_holder
+    new_holder=$(build_holder_fragment "$branch" "$worktree" "$purpose" "$pid" "$ttl_minutes" "$priority" "$now")
+
+    if is_holder_self "$state" "$branch" "$worktree"; then
+        acquire_refresh_self "$state" "$new_holder"
+        return 0
+    fi
+
+    if echo "$state" | jq -e '.holder == null' >/dev/null; then
+        acquire_take_free "$state" "$new_holder"
+        return 0
+    fi
+
+    if [ "$priority" = "operator" ]; then
+        acquire_preempt "$state" "$new_holder" "$now"
+        return 0
+    fi
+
+    acquire_enqueue "$state" "$branch" "$worktree" "$purpose" "$pid" "$priority" "$now"
+    exit 1
+}
+
+# Build a JSON fragment representing the proposed new holder. Reused across
+# all acquire branches so the shape stays consistent.
+build_holder_fragment() {
+    local branch="$1" worktree="$2" purpose="$3" pid="$4" ttl="$5" priority="$6" now="$7"
+    jq -n \
+        --arg b "$branch" --arg w "$worktree" --arg p "$purpose" \
+        --arg pid "$pid" --argjson ttl "$ttl" \
+        --arg priority "$priority" --arg now "$now" \
+        '{
+            branch: $b, worktree: $w, purpose: $p,
+            pid: ($pid | if . == "" then 0 else (tonumber? // 0) end),
+            priority: $priority,
+            acquired_at: $now,
+            heartbeat_at: $now,
+            ttl_minutes: $ttl,
+            preempted_from: null
+        }'
+}
+
+# Idempotent re-acquire by the current holder: refresh PID/purpose/ttl/heartbeat
+# but preserve the original acquired_at and any preempted_from marker.
+acquire_refresh_self() {
+    local state="$1" new_holder="$2"
+    state=$(echo "$state" | jq --argjson h "$new_holder" '
+        .holder = ($h + { acquired_at: .holder.acquired_at, preempted_from: .holder.preempted_from })
+    ')
+    write_state "$state"
+    mutex_unlock
+    emit_acquire_result "$state" true "" 0
+}
+
+# Free env: install ourselves as holder, dequeue ourselves if we were waiting.
+acquire_take_free() {
+    local state="$1" new_holder="$2"
+    state=$(echo "$state" | jq --argjson h "$new_holder" \
+        '.holder = $h | .queue = [.queue[] | select(.branch != $h.branch or .worktree != $h.worktree)]')
+    write_state "$state"
+    mutex_unlock
+    emit_acquire_result "$state" true "" 0
+}
+
+# Operator preempt: push the current holder to the FRONT of the queue with
+# preempted:true, then install ourselves as holder with preempted_from set
+# so the displaced agent can see why they were bumped.
+acquire_preempt() {
+    local state="$1" new_holder="$2" now="$3"
+    local preempted_holder
+    preempted_holder=$(echo "$state" | jq -c '.holder')
+    state=$(echo "$state" | jq --argjson h "$new_holder" --arg now "$now" '
+        . as $orig
+        | .queue = (
+            [{
+                branch: $orig.holder.branch,
+                worktree: $orig.holder.worktree,
+                pid: $orig.holder.pid,
+                purpose: $orig.holder.purpose,
+                priority: $orig.holder.priority,
+                enqueued_at: $now,
+                preempted: true
+            }]
+            + ($orig.queue | map(select(.branch != $h.branch or .worktree != $h.worktree)))
+        )
+        | .holder = ($h + {
+            preempted_from: {
+                branch: $orig.holder.branch,
+                worktree: $orig.holder.worktree,
+                purpose: $orig.holder.purpose
+            }
+          })
+    ')
+    write_state "$state"
+    mutex_unlock
+    emit_acquire_result "$state" true "$preempted_holder" 0
+}
+
+# Normal priority, held by another: append to queue if not already there.
+# Caller exits 1 after we return.
+acquire_enqueue() {
+    local state="$1" branch="$2" worktree="$3" purpose="$4" pid="$5" priority="$6" now="$7"
+    if ! is_in_queue "$state" "$branch" "$worktree"; then
+        state=$(echo "$state" | jq \
+            --arg b "$branch" --arg w "$worktree" --arg p "$purpose" \
+            --arg pid "$pid" --arg priority "$priority" --arg now "$now" '
+            .queue += [{
+                branch: $b, worktree: $w,
+                pid: ($pid | if . == "" then 0 else (tonumber? // 0) end),
+                purpose: $p, priority: $priority,
+                enqueued_at: $now, preempted: false
+            }]')
+        write_state "$state"
+    fi
+    mutex_unlock
+    emit_acquire_result "$state" false "" 1
+}
+
+# Print structured JSON for an acquire result. Args: state, acquired (true|false),
+# preempted_holder_json (or empty), exit_code.
+emit_acquire_result() {
+    local state="$1" acquired="$2" preempted="$3"
+    local pos
+    pos=$(echo "$state" | jq --arg b "$BRANCH_FOR_RESULT" --arg w "$WORKTREE_FOR_RESULT" \
+        '[.queue[] | .branch + "@" + .worktree] | index($b + "@" + $w) // null')
+    echo "$state" | jq \
+        --argjson acquired "$acquired" \
+        --argjson preempted "${preempted:-null}" \
+        --argjson pos "$pos" '
+        . + {
+            acquired: $acquired,
+            preempted_holder: $preempted,
+            my_position: ($pos // null)
+        }'
+}
+
+# -----------------------------------------------------------------------------
+# Subcommand: release
+# -----------------------------------------------------------------------------
+cmd_release() {
+    local branch="$1" worktree="$2"
+    if [ -z "$branch" ] || [ -z "$worktree" ]; then
+        echo '{"error": "missing_required_args"}' >&2
+        exit 64
+    fi
+    init_state
+    mutex_lock
+    local state was_holder=false
+    state=$(read_state)
+    if is_holder_self "$state" "$branch" "$worktree"; then
+        was_holder=true
+        state=$(echo "$state" | jq '.holder = null')
+    fi
+    # Always also remove from queue (covers "I was queued and now I'm leaving").
+    state=$(echo "$state" | jq --arg b "$branch" --arg w "$worktree" \
+        '.queue = [.queue[] | select(.branch != $b or .worktree != $w)]')
+    write_state "$state"
+    mutex_unlock
+    echo "$state" | jq --argjson wh "$was_holder" \
+        '. + { released: true, was_holder: $wh }'
+}
+
+# -----------------------------------------------------------------------------
+# Subcommand: heartbeat
+# -----------------------------------------------------------------------------
+cmd_heartbeat() {
+    local branch="$1" worktree="$2"
+    if [ -z "$branch" ] || [ -z "$worktree" ]; then
+        echo '{"error": "missing_required_args"}' >&2
+        exit 64
+    fi
+    init_state
+    mutex_lock
+    local state refreshed=false now
+    now=$(now_iso)
+    state=$(read_state)
+    if is_holder_self "$state" "$branch" "$worktree"; then
+        refreshed=true
+        state=$(echo "$state" | jq --arg now "$now" '.holder.heartbeat_at = $now')
+        write_state "$state"
+    fi
+    mutex_unlock
+    echo "$state" | jq --argjson r "$refreshed" '. + { refreshed: $r }'
+}
+
+# -----------------------------------------------------------------------------
+# Subcommand: force-release
+# -----------------------------------------------------------------------------
+cmd_force_release() {
+    init_state
+    mutex_lock
+    local state cleared
+    state=$(read_state)
+    cleared=$(echo "$state" | jq -c '.holder')
+    state=$(echo "$state" | jq '.holder = null')
+    write_state "$state"
+    mutex_unlock
+    echo "$state" | jq --argjson c "$cleared" '. + { cleared_holder: $c }'
+}
+
+# -----------------------------------------------------------------------------
+# Subcommand: wait
+# -----------------------------------------------------------------------------
+cmd_wait() {
+    # Validate before shift — see cmd_acquire for the same rationale.
+    if [ $# -lt 3 ] || [ -z "${1:-}" ] || [ -z "${2:-}" ] || [ -z "${3:-}" ]; then
+        echo '{"error": "missing_required_args", "expected": "<branch> <worktree> <purpose>"}' >&2
+        exit 64
+    fi
+    local branch="$1" worktree="$2" purpose="$3"
+    shift 3
+    local timeout_seconds=1800
+    local extra_args=()
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --timeout-seconds) timeout_seconds="$2"; shift 2 ;;
+            *) extra_args+=("$1"); shift ;;
+        esac
+    done
+    local out_file
+    out_file=$(mktemp -t env-lock-wait.XXXXXX)
+    # Caller may also Ctrl-C — clean up the temp file on exit.
+    trap 'rm -f "$out_file"' RETURN
+
+    local elapsed=0 poll_seconds=2 acquire_status
+    while [ "$elapsed" -lt "$timeout_seconds" ]; do
+        # `set -e` means we have to capture the status without letting non-0 abort us.
+        set +e
+        "$0" acquire "$branch" "$worktree" "$purpose" "${extra_args[@]}" >"$out_file" 2>&1
+        acquire_status=$?
+        set -e
+        case "$acquire_status" in
+            0)   cat "$out_file"; return 0 ;;
+            1)   ;;  # busy + enqueued, keep polling
+            *)   # bad usage / unexpected error — bubble it up immediately
+                 cat "$out_file" >&2
+                 exit "$acquire_status"
+                 ;;
+        esac
+        sleep "$poll_seconds"
+        elapsed=$((elapsed + poll_seconds))
+    done
+    echo "{\"error\": \"timeout\", \"timeout_seconds\": $timeout_seconds}" >&2
+    exit 124
+}
+
+# -----------------------------------------------------------------------------
+# Dispatch
+# -----------------------------------------------------------------------------
+SUBCOMMAND="${1:-}"
+shift || true
+
+# These are referenced by emit_acquire_result for queue position lookup.
+BRANCH_FOR_RESULT="${1:-}"
+WORKTREE_FOR_RESULT="${2:-}"
+
+case "$SUBCOMMAND" in
+    status)        cmd_status ;;
+    acquire)       cmd_acquire "$@" ;;
+    release)       cmd_release "$@" ;;
+    heartbeat)     cmd_heartbeat "$@" ;;
+    wait)          cmd_wait "$@" ;;
+    force-release) cmd_force_release ;;
+    -h|--help|help|"")
+        sed -n '2,28p' "$0"
+        exit 0
+        ;;
+    *)
+        echo "{\"error\": \"unknown_subcommand\", \"value\": \"$SUBCOMMAND\"}" >&2
+        exit 64
+        ;;
+esac

--- a/tools/mcp-env/src/index.ts
+++ b/tools/mcp-env/src/index.ts
@@ -3,6 +3,7 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { z } from 'zod';
 import * as envCheck from './tools/env-check.js';
 import * as envCopy from './tools/env-copy.js';
+import * as envLock from './tools/env-lock.js';
 import * as mcpHealth from './tools/mcp-health.js';
 import * as serviceStatus from './tools/service-status.js';
 import * as storyStatus from './tools/story-status.js';
@@ -68,6 +69,64 @@ server.tool(
   {},
   async () => {
     const result = await mcpHealth.execute();
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+    };
+  },
+);
+
+server.tool(
+  envLock.STATUS_TOOL_NAME,
+  envLock.STATUS_TOOL_DESCRIPTION,
+  {},
+  async () => {
+    const result = await envLock.executeStatus();
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+    };
+  },
+);
+
+server.tool(
+  envLock.ACQUIRE_TOOL_NAME,
+  envLock.ACQUIRE_TOOL_DESCRIPTION,
+  {
+    branch: z.string().optional(),
+    worktree: z.string().optional(),
+    purpose: z.string(),
+    pid: z.number().int().nonnegative().optional(),
+    ttl_minutes: z.number().int().positive().optional(),
+    priority: z.enum(['normal', 'operator']).optional(),
+  },
+  async (params) => {
+    const result = await envLock.executeAcquire(params);
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+    };
+  },
+);
+
+server.tool(
+  envLock.RELEASE_TOOL_NAME,
+  envLock.RELEASE_TOOL_DESCRIPTION,
+  {
+    branch: z.string().optional(),
+    worktree: z.string().optional(),
+  },
+  async (params) => {
+    const result = await envLock.executeRelease(params);
+    return {
+      content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
+    };
+  },
+);
+
+server.tool(
+  envLock.FORCE_RELEASE_TOOL_NAME,
+  envLock.FORCE_RELEASE_TOOL_DESCRIPTION,
+  {},
+  async () => {
+    const result = await envLock.executeForceRelease();
     return {
       content: [{ type: 'text', text: JSON.stringify(result, null, 2) }],
     };

--- a/tools/mcp-env/src/tools/env-lock.test.ts
+++ b/tools/mcp-env/src/tools/env-lock.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock config so PROJECT_DIR / MAIN_REPO are deterministic and the script path
+// resolves predictably.
+vi.mock('../config.js', () => ({
+  PROJECT_DIR: '/fake/project',
+  MAIN_REPO: '/fake/main',
+  IS_WORKTREE: false,
+}));
+
+// Mock the shell() utility — it's the boundary between the TS wrapper and the
+// bash script, so tests verify command shape + JSON parsing without ever
+// running env-lock.sh.
+const mockShell = vi.fn();
+vi.mock('../shell.js', () => ({
+  shell: (...args: unknown[]) => mockShell(...args),
+}));
+
+// Import after mocks are registered.
+import {
+  executeStatus,
+  executeAcquire,
+  executeRelease,
+  executeForceRelease,
+  STATUS_TOOL_NAME,
+  ACQUIRE_TOOL_NAME,
+  RELEASE_TOOL_NAME,
+  FORCE_RELEASE_TOOL_NAME,
+} from './env-lock.js';
+
+beforeEach(() => {
+  mockShell.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Queue a single shell() response with stdout=<JSON of given object>. */
+function queueShellJson(response: object): void {
+  mockShell.mockResolvedValueOnce({
+    stdout: JSON.stringify(response),
+    stderr: '',
+    exitCode: 0,
+  });
+}
+
+/** Queue a plain string as the next shell() stdout (used for `git branch --show-current`). */
+function queueShellRaw(stdout: string): void {
+  mockShell.mockResolvedValueOnce({ stdout, stderr: '', exitCode: 0 });
+}
+
+/** Pull the command string from a recorded shell() call. */
+function lastCommand(): string {
+  const calls = mockShell.mock.calls;
+  return calls[calls.length - 1]?.[0] as string;
+}
+
+// ---------------------------------------------------------------------------
+// Tool name + description constants
+// ---------------------------------------------------------------------------
+
+describe('env-lock tool registration constants', () => {
+  it('exports stable tool names', () => {
+    expect(STATUS_TOOL_NAME).toBe('env_lock_status');
+    expect(ACQUIRE_TOOL_NAME).toBe('env_lock_acquire');
+    expect(RELEASE_TOOL_NAME).toBe('env_lock_release');
+    expect(FORCE_RELEASE_TOOL_NAME).toBe('env_lock_force_release');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// status
+// ---------------------------------------------------------------------------
+
+describe('executeStatus', () => {
+  it('returns the parsed JSON when env is free', async () => {
+    queueShellJson({ holder: null, queue: [], free: true, stale_cleared: null });
+
+    const result = await executeStatus();
+
+    expect(result).toEqual({ holder: null, queue: [], free: true, stale_cleared: null });
+    expect(lastCommand()).toMatch(/bash '\/fake\/main\/scripts\/env-lock\.sh' status/);
+  });
+
+  it('returns parsed holder info when env is held', async () => {
+    queueShellJson({
+      holder: { branch: 'rok-1248', purpose: 'smoke', pid: 123, priority: 'normal' },
+      queue: [],
+      free: false,
+      stale_cleared: null,
+    });
+
+    const result = (await executeStatus()) as { holder: { branch: string }; free: boolean };
+
+    expect(result.holder.branch).toBe('rok-1248');
+    expect(result.free).toBe(false);
+  });
+
+  it('returns an error envelope when stdout is not JSON', async () => {
+    mockShell.mockResolvedValueOnce({ stdout: 'oops not json', stderr: '', exitCode: 1 });
+
+    const result = (await executeStatus()) as { error: string; raw: string };
+
+    expect(result.error).toMatch(/non-JSON/);
+    expect(result.raw).toBe('oops not json');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// acquire
+// ---------------------------------------------------------------------------
+
+describe('executeAcquire', () => {
+  it('builds the correct command for an explicit branch + worktree + pid', async () => {
+    queueShellJson({ acquired: true, holder: { branch: 'b' }, queue: [] });
+
+    await executeAcquire({
+      branch: 'b',
+      worktree: '/wt',
+      purpose: 'unit-test',
+      pid: 4321,
+      ttl_minutes: 30,
+      priority: 'normal',
+    });
+
+    const cmd = lastCommand();
+    expect(cmd).toContain("acquire 'b' '/wt' 'unit-test'");
+    expect(cmd).toContain('--pid 4321');
+    expect(cmd).toContain('--ttl-minutes 30');
+    expect(cmd).toContain('--priority normal');
+  });
+
+  it('omits --pid when no pid is provided', async () => {
+    queueShellJson({ acquired: true, holder: {}, queue: [] });
+
+    await executeAcquire({ branch: 'b', worktree: '/wt', purpose: 'p' });
+
+    expect(lastCommand()).not.toContain('--pid');
+  });
+
+  it('auto-defaults branch via git and worktree via cwd', async () => {
+    queueShellRaw('detected-branch'); // git branch --show-current
+    queueShellJson({ acquired: true, holder: {}, queue: [] }); // acquire
+
+    await executeAcquire({ purpose: 'auto-detect' });
+
+    const calls = mockShell.mock.calls;
+    expect(calls[0]?.[0]).toMatch(/git -C '.*' branch --show-current/);
+    expect(calls[1]?.[0]).toContain("'detected-branch'");
+    expect(calls[1]?.[0]).toContain(`'${process.cwd()}'`);
+  });
+
+  it('falls back to "unknown" branch when git output is empty', async () => {
+    queueShellRaw(''); // git returns nothing (detached HEAD)
+    queueShellJson({ acquired: true, holder: {}, queue: [] });
+
+    await executeAcquire({ purpose: 'detached' });
+
+    expect(mockShell.mock.calls[1]?.[0]).toContain("'unknown'");
+  });
+
+  it('passes --priority operator through to the script', async () => {
+    queueShellJson({
+      acquired: true,
+      holder: { branch: 'opt-runner' },
+      queue: [{ branch: 'displaced', preempted: true }],
+      preempted_holder: { branch: 'displaced' },
+    });
+
+    const result = (await executeAcquire({
+      branch: 'opt-runner',
+      worktree: '/wt',
+      purpose: 'operator-test',
+      priority: 'operator',
+    })) as { acquired: boolean; preempted_holder: { branch: string } };
+
+    expect(lastCommand()).toContain('--priority operator');
+    expect(result.acquired).toBe(true);
+    expect(result.preempted_holder.branch).toBe('displaced');
+  });
+
+  it('returns acquired:false with my_position when env is held', async () => {
+    queueShellJson({
+      acquired: false,
+      holder: { branch: 'someone-else' },
+      queue: [{ branch: 'me' }],
+      my_position: 0,
+    });
+
+    const result = (await executeAcquire({
+      branch: 'me',
+      worktree: '/wt',
+      purpose: 'queued',
+    })) as { acquired: boolean; my_position: number };
+
+    expect(result.acquired).toBe(false);
+    expect(result.my_position).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// release
+// ---------------------------------------------------------------------------
+
+describe('executeRelease', () => {
+  it('passes branch and worktree through, returns parsed JSON', async () => {
+    queueShellJson({ released: true, was_holder: true, holder: null, queue: [] });
+
+    const result = (await executeRelease({ branch: 'b', worktree: '/wt' })) as {
+      released: boolean;
+      was_holder: boolean;
+    };
+
+    expect(lastCommand()).toContain("release 'b' '/wt'");
+    expect(result.released).toBe(true);
+    expect(result.was_holder).toBe(true);
+  });
+
+  it('reports was_holder:false when caller was only queued', async () => {
+    queueShellJson({ released: true, was_holder: false, holder: { branch: 'other' }, queue: [] });
+
+    const result = (await executeRelease({ branch: 'queued-one', worktree: '/wt' })) as {
+      was_holder: boolean;
+    };
+
+    expect(result.was_holder).toBe(false);
+  });
+
+  it('auto-defaults branch + worktree when omitted', async () => {
+    queueShellRaw('current-branch');
+    queueShellJson({ released: true, was_holder: true, holder: null, queue: [] });
+
+    await executeRelease({});
+
+    expect(mockShell.mock.calls[1]?.[0]).toContain("'current-branch'");
+    expect(mockShell.mock.calls[1]?.[0]).toContain(`'${process.cwd()}'`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// force-release
+// ---------------------------------------------------------------------------
+
+describe('executeForceRelease', () => {
+  it('shells force-release and returns the cleared holder', async () => {
+    queueShellJson({ cleared_holder: { branch: 'stuck' }, holder: null, queue: [] });
+
+    const result = (await executeForceRelease()) as { cleared_holder: { branch: string } };
+
+    expect(lastCommand()).toMatch(/force-release$/);
+    expect(result.cleared_holder.branch).toBe('stuck');
+  });
+
+  it('handles force-release when env was already free (cleared_holder:null)', async () => {
+    queueShellJson({ cleared_holder: null, holder: null, queue: [] });
+
+    const result = (await executeForceRelease()) as { cleared_holder: null };
+
+    expect(result.cleared_holder).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Quoting / argument safety
+// ---------------------------------------------------------------------------
+
+describe('shell argument quoting', () => {
+  it('escapes single quotes in branch / worktree / purpose', async () => {
+    queueShellJson({ acquired: true, holder: {}, queue: [] });
+
+    await executeAcquire({
+      branch: "weird'branch",
+      worktree: "/path/with'quote",
+      purpose: "purpose'with-quote",
+    });
+
+    const cmd = lastCommand();
+    // single quote should be replaced with the standard '\'' shell escape
+    expect(cmd).toContain("'weird'\\''branch'");
+    expect(cmd).toContain("'/path/with'\\''quote'");
+    expect(cmd).toContain("'purpose'\\''with-quote'");
+  });
+
+  it('safely quotes worktree paths in detectBranch (no command substitution)', async () => {
+    // A malicious worktree path with $() must not be expanded by the shell.
+    queueShellRaw('detected-branch'); // git command result
+    queueShellJson({ acquired: true, holder: {}, queue: [] });
+
+    await executeAcquire({
+      worktree: '/tmp/$(rm -rf /)evil',
+      purpose: 'inject-test',
+    });
+
+    const gitCmd = mockShell.mock.calls[0]?.[0] as string;
+    // Single-quoted: $(...) is treated as literal text, not a substitution.
+    expect(gitCmd).toContain("git -C '/tmp/$(rm -rf /)evil'");
+    expect(gitCmd).not.toMatch(/git -C "/);
+  });
+});

--- a/tools/mcp-env/src/tools/env-lock.ts
+++ b/tools/mcp-env/src/tools/env-lock.ts
@@ -1,0 +1,147 @@
+import { resolve } from 'node:path';
+import { MAIN_REPO, PROJECT_DIR } from '../config.js';
+import { shell } from '../shell.js';
+
+// =============================================================================
+// MCP wrappers around scripts/env-lock.sh — the bash script owns the logic;
+// these tools just shell out and parse the JSON it emits.
+// =============================================================================
+
+const SCRIPT_PATH = resolve(MAIN_REPO ?? PROJECT_DIR, 'scripts', 'env-lock.sh');
+
+/** Shape of the JSON the bash script always emits on stdout (subset varies by command). */
+type LockState = {
+  holder: HolderRecord | null;
+  queue: QueueEntry[];
+  free?: boolean;
+  stale_cleared?: { reason: string } | null;
+};
+
+interface HolderRecord {
+  branch: string;
+  worktree: string;
+  purpose: string;
+  pid: number;
+  priority: 'normal' | 'operator';
+  acquired_at: string;
+  heartbeat_at: string;
+  ttl_minutes: number;
+  preempted_from: { branch: string; worktree: string; purpose: string } | null;
+}
+
+interface QueueEntry {
+  branch: string;
+  worktree: string;
+  pid: number;
+  purpose: string;
+  priority: 'normal' | 'operator';
+  enqueued_at: string;
+  preempted: boolean;
+}
+
+/**
+ * Quote a shell argument safely. Single-quote wrapping with `'\''` for embedded
+ * single quotes is the only escape form that's both shell-safe AND immune to
+ * variable expansion (`$`, backticks). Double-quote escaping is NOT sufficient
+ * — double-quoted strings still expand `$VAR`, `$(...)`, and backticks.
+ */
+function q(s: string): string {
+  return `'${s.replace(/'/g, "'\\''")}'`;
+}
+
+/** Auto-detect branch via `git branch --show-current` in a given worktree. */
+async function detectBranch(worktree: string): Promise<string> {
+  const result = await shell(`git -C ${q(worktree)} branch --show-current`, 5_000);
+  return result.stdout.trim() || 'unknown';
+}
+
+/** Parse JSON; on parse failure return an error envelope so MCP doesn't crash. */
+function parseJson<T>(stdout: string, command: string): T | { error: string; raw: string } {
+  try {
+    return JSON.parse(stdout) as T;
+  } catch {
+    return { error: `env-lock.sh ${command} returned non-JSON`, raw: stdout };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// env_lock_status
+// ---------------------------------------------------------------------------
+
+export const STATUS_TOOL_NAME = 'env_lock_status';
+export const STATUS_TOOL_DESCRIPTION =
+  'Show who holds the local dev env lease (Docker DB, API :3000, Vite :5173) and who is queued. ' +
+  'Use before acquiring or before any work that needs the env.';
+
+export async function executeStatus(): Promise<LockState | { error: string; raw: string }> {
+  const result = await shell(`bash ${q(SCRIPT_PATH)} status`);
+  return parseJson<LockState>(result.stdout, 'status');
+}
+
+// ---------------------------------------------------------------------------
+// env_lock_acquire
+// ---------------------------------------------------------------------------
+
+export const ACQUIRE_TOOL_NAME = 'env_lock_acquire';
+export const ACQUIRE_TOOL_DESCRIPTION =
+  'Acquire the local dev env lease. Returns acquired:true on success or acquired:false (with queue position) ' +
+  "if held by another agent. priority:'operator' preempts the current holder, displacing them to the front " +
+  'of the queue with preempted:true. Auto-defaults branch via git and worktree to the MCP server cwd.';
+
+export interface AcquireParams {
+  branch?: string;
+  worktree?: string;
+  purpose: string;
+  pid?: number;
+  ttl_minutes?: number;
+  priority?: 'normal' | 'operator';
+}
+
+export async function executeAcquire(params: AcquireParams): Promise<unknown> {
+  const worktree = params.worktree ?? process.cwd();
+  const branch = params.branch ?? (await detectBranch(worktree));
+  const ttl = params.ttl_minutes ?? 60;
+  const priority = params.priority ?? 'normal';
+  const pidPart = params.pid !== undefined ? ` --pid ${params.pid}` : '';
+  const cmd =
+    `bash ${q(SCRIPT_PATH)} acquire ${q(branch)} ${q(worktree)} ${q(params.purpose)}` +
+    `${pidPart} --ttl-minutes ${ttl} --priority ${priority}`;
+  const result = await shell(cmd);
+  return parseJson(result.stdout, 'acquire');
+}
+
+// ---------------------------------------------------------------------------
+// env_lock_release
+// ---------------------------------------------------------------------------
+
+export const RELEASE_TOOL_NAME = 'env_lock_release';
+export const RELEASE_TOOL_DESCRIPTION =
+  'Release the local dev env lease (or remove yourself from the queue). Auto-defaults branch ' +
+  'via git and worktree to the MCP server cwd. Always call this when you are done with env-needing work.';
+
+export interface ReleaseParams {
+  branch?: string;
+  worktree?: string;
+}
+
+export async function executeRelease(params: ReleaseParams): Promise<unknown> {
+  const worktree = params.worktree ?? process.cwd();
+  const branch = params.branch ?? (await detectBranch(worktree));
+  const cmd = `bash ${q(SCRIPT_PATH)} release ${q(branch)} ${q(worktree)}`;
+  const result = await shell(cmd);
+  return parseJson(result.stdout, 'release');
+}
+
+// ---------------------------------------------------------------------------
+// env_lock_force_release
+// ---------------------------------------------------------------------------
+
+export const FORCE_RELEASE_TOOL_NAME = 'env_lock_force_release';
+export const FORCE_RELEASE_TOOL_DESCRIPTION =
+  'Operator-only override: clear the current env lease unconditionally. Use ONLY when a lease is ' +
+  "genuinely stuck and auto-expiry isn't clearing it. Ask the operator before calling.";
+
+export async function executeForceRelease(): Promise<unknown> {
+  const result = await shell(`bash ${q(SCRIPT_PATH)} force-release`);
+  return parseJson(result.stdout, 'force-release');
+}

--- a/tools/mcp-env/src/tools/service-status.ts
+++ b/tools/mcp-env/src/tools/service-status.ts
@@ -1,8 +1,9 @@
 import { shell } from '../shell.js';
+import { executeStatus as executeLockStatus } from './env-lock.js';
 
 export const TOOL_NAME = 'env_service_status';
 export const TOOL_DESCRIPTION =
-  'Check Docker containers, ports, and API health for the local dev environment.';
+  'Check Docker containers, ports, API health, AND who holds the env lease (lock + queue) for the local dev environment.';
 
 /** Health check result for an HTTP endpoint. */
 interface HealthCheck {
@@ -22,9 +23,19 @@ interface ServiceStatus {
   details?: string;
 }
 
+/** Lock status as surfaced inline in env_service_status. */
+interface LockSummary {
+  free: boolean;
+  holder_branch: string | null;
+  holder_purpose: string | null;
+  queue_length: number;
+  error?: string;
+}
+
 /** Full response from env_service_status. */
 interface ServiceStatusResult {
   services: ServiceStatus[];
+  lock: LockSummary;
   summary: string;
 }
 
@@ -107,20 +118,64 @@ async function checkWebService(): Promise<ServiceStatus> {
   };
 }
 
-/** Build summary string from service statuses. */
-function buildServiceSummary(services: ServiceStatus[]): string {
+/** Build summary string from service statuses + lock state. */
+function buildServiceSummary(services: ServiceStatus[], lock: LockSummary): string {
   const running = services.filter((s) => s.status === 'running').length;
   const other = services.length - running;
-  return `${services.length} services: ${running} running, ${other} stopped/unknown`;
+  let lockClause: string;
+  if (lock.error) {
+    lockClause = `env lock state UNKNOWN (${lock.error})`;
+  } else if (lock.free) {
+    lockClause = 'env free';
+  } else {
+    lockClause = `env held by ${lock.holder_branch} (${lock.holder_purpose}${
+      lock.queue_length > 0 ? `, ${lock.queue_length} in queue` : ''
+    })`;
+  }
+  return `${services.length} services: ${running} running, ${other} stopped/unknown — ${lockClause}`;
+}
+
+/** Pull the lock state and reduce it to the inline summary shape. */
+async function fetchLockSummary(): Promise<LockSummary> {
+  const lockState = (await executeLockStatus()) as
+    | {
+        holder?: { branch: string; purpose: string } | null;
+        queue?: unknown[];
+        free?: boolean;
+      }
+    | { error: string; raw: string };
+
+  // env-lock.sh failed or returned non-JSON — surface that loudly instead of
+  // silently reporting "free" (which would lie to every agent that calls us).
+  if ('error' in lockState && typeof lockState.error === 'string') {
+    return {
+      free: false,
+      holder_branch: null,
+      holder_purpose: null,
+      queue_length: 0,
+      error: lockState.error,
+    };
+  }
+
+  const queueLength = Array.isArray(lockState.queue) ? lockState.queue.length : 0;
+  return {
+    free: lockState.free ?? lockState.holder == null,
+    holder_branch: lockState.holder?.branch ?? null,
+    holder_purpose: lockState.holder?.purpose ?? null,
+    queue_length: queueLength,
+  };
 }
 
 /** Execute the env_service_status tool. */
 export async function execute(): Promise<ServiceStatusResult> {
-  const services = await Promise.all([
-    checkDockerService('postgres', 'raid-ledger-db', 5432),
-    checkDockerService('redis', 'raid-ledger-redis', 6379),
-    checkApiService(),
-    checkWebService(),
+  const [services, lock] = await Promise.all([
+    Promise.all([
+      checkDockerService('postgres', 'raid-ledger-db', 5432),
+      checkDockerService('redis', 'raid-ledger-redis', 6379),
+      checkApiService(),
+      checkWebService(),
+    ]),
+    fetchLockSummary(),
   ]);
-  return { services, summary: buildServiceSummary(services) };
+  return { services, lock, summary: buildServiceSummary(services, lock) };
 }


### PR DESCRIPTION
## Summary

Turns the soft "don't steal the dev env" rule into an enforced lease, so multiple parallel agents across worktrees can coordinate without operator mediation.

- **`scripts/env-lock.sh`** (new, bash) — `acquire`/`release`/`heartbeat`/`status`/`wait`/`force-release`. POSIX `mkdir` mutex + atomic JSON writes at `~/.raid-ledger/env-lock.json` (shared across worktrees). Self-healing via PID-liveness + TTL — stale leases auto-clear.
- **MCP tools** (`tools/mcp-env/`) — `env_lock_status`, `env_lock_acquire`, `env_lock_release`, `env_lock_force_release`. `env_service_status` now folds lease state into its summary, so existing callers see it for free.
- **`scripts/deploy_dev.sh`** — gates `start_dev` on lease acquire, releases on `--down`, shows lease in `--status`. New flags: `--operator` (preempts current holder, used by `/opt`) and `--wait-for-env <minutes>` (block instead of error).
- **`/opt` + `/operator-testing` skills** — invoke `deploy_dev.sh` with `--operator` so they provably preempt. Displaced agent goes to front of the queue with `preempted: true` and reclaims the env when the operator releases.

Designed against `/Users/sdodge/.claude/plans/sorted-leaping-hopcroft.md` and reviewed via `/devedup-rl:review` before push — addressed: critical shell-injection in `detectBranch` (now uses single-quote escaping), silent `shift 3 + set -e` aborts in `cmd_acquire`/`cmd_wait`, racy mutex auto-clobber (now hard-errors after 30s real-time), `cmd_wait` swallowing non-busy errors, `--wait-for-env` numeric validation, predictable `/tmp` paths (now `mktemp`), `jq` cosmetic line that could abort the deploy under `set -e`, and `service-status` falsely reporting "free" on lock parse failure.

## Test plan

- [x] `bash -n scripts/env-lock.sh` + `bash -n scripts/deploy_dev.sh` clean
- [x] `npm test -w tools/mcp-env` → **69/69 passing** (17 new env-lock tests, including injection-safety regression)
- [x] Live-tested all `env-lock.sh` subcommands against a temp `RAID_LEDGER_STATE_DIR`: free→acquire, enqueue when held, idempotent re-enqueue, release, stale-PID auto-expire, operator preempt with displaced-holder front-of-queue, post-release reclaim, force-release, heartbeat timestamp updates, wait timeout (124), wait error-routing (bad flag → 64, not 124), bad-args validation (clear 64 message)
- [x] `deploy_dev.sh --status` correctly shows free vs held with branch + queue
- [x] MCP TS wrapper round-trips JSON correctly via `tsx`
- [ ] Two simultaneous worktrees: one acquires, the other gets queued + can `--wait-for-env` past it (manual operator verification)
- [ ] `/opt` from one session preempts another's hold; displaced session sees `preempted: true` in status (manual operator verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)