### PR TITLE
ROK-1225: fix: stabilize LineupsService matching + re-enable smoke fixtures

### DIFF
--- a/TECH-DEBT-BACKLOG.md
+++ b/TECH-DEBT-BACKLOG.md
@@ -69,3 +69,16 @@ A skill's job is typically: parse → group duplicates by file path → propose 
   - `scripts/smoke/standalone-scheduling-poll.smoke.spec.ts` (desktop, 3 tests)
   - `scripts/smoke/games.smoke.spec.ts` (mobile, ROK-811 regression spec)
   Suggested: revisit canceled ROK-1226/ROK-1227 — the cancel reason ("downstream effect of LineupsService matching bug") may have shifted now that rok-1067 (#743) and ROK-1232 (#730) merged. The admin-* failures are likely the staleTime polling pattern documented in operator memory `feedback_smoke_polling_for_async_writes.md` (ROK-1156). ROK-811 mobile regression suggests recent UI restructuring on Games page.
+
+### 2026-05-09 — rok-1225-stabilize-lineups (PR #751)
+
+- **[low]** `api/src/itad/itad-price-sync.service.ts:25` — keeps `export { extractErrorDetail }` re-export shim because `itad-price-sync.service.adversarial.spec.ts:17` still imports from the old path. CLAUDE.md frowns on re-export shims; two-line fix in a follow-up chore.
+  Suggested: update the spec import to `from '../common/pg-error.helpers'` and delete the re-export.
+- **[low]** `api/src/lineups/lineups-bandwagon.helpers.ts:48` — insert uses pre-check + `ConflictException` for the 409 UX path. Could be replaced with `.onConflictDoNothing().returning({ id })` and treat empty-returning as "already a member" — cleaner but a behavior change for the 409 response.
+  Suggested: spike a follow-up to confirm the UX impact before touching.
+- **[low]** `community_lineup_schedule_slots.match_id` and `community_lineup_schedule_votes.slot_id` FKs declared in 0113 — verify presence on prod via DB probe (this PR fixes only the empirically-missing one on `community_lineup_match_members.match_id`).
+  Suggested: one-off operator psql probe; if missing, file a focused follow-up like ROK-1225.
+- **[med]** Worktree `api/.env` doesn't inherit `DEMO_MODE=true` from root `.env`; smoke tests against a freshly-spun-up worktree API need explicit override. Pre-existing dev-env gap surfaced during this branch (dev had to manually set `DEMO_MODE=true` when starting the API). Affects every worktree-based smoke run.
+  Suggested: have `mcp-env env_copy` propagate `DEMO_MODE` from root `.env` to `api/.env` automatically on worktree setup, or have `deploy_dev.sh --ci` inject it.
+- **[low]** Production DB likely has the same orphan rows on `community_lineup_match_members` — migration's `DELETE FROM ... WHERE NOT EXISTS` will clean them on next deploy (Watchtower 5AM); pre-deploy probe optional but informative.
+  Suggested: operator-run psql `SELECT COUNT(*) FROM community_lineup_match_members m WHERE NOT EXISTS (SELECT 1 FROM community_lineup_matches WHERE id = m.match_id);` against prod before tomorrow's 5AM pull.

--- a/api/src/common/pg-error.helpers.ts
+++ b/api/src/common/pg-error.helpers.ts
@@ -1,0 +1,35 @@
+/**
+ * Shared helpers for inspecting Postgres errors that surface through Drizzle.
+ *
+ * Drizzle wraps `postgres-js` errors so `err.message` becomes the generic
+ * "Failed query: <SQL>" string and the real PG error (with code/detail/hint)
+ * is in `err.cause`. Without unwrapping, masked failures like FK violations
+ * or unique-constraint collisions look like opaque 500s in the logs.
+ */
+
+/** Shape of postgres.js error properties we want to extract. */
+interface PgErrorLike {
+  message?: string;
+  code?: string;
+  detail?: string;
+  hint?: string;
+  cause?: PgErrorLike;
+}
+
+/**
+ * Extract Postgres error details from a Drizzle-wrapped error.
+ * Drizzle wraps PG errors so `err.message` is "Failed query: <SQL>".
+ * The real PG error is in `.cause` with code, detail, and hint.
+ */
+export function extractErrorDetail(err: unknown): string {
+  const raw = err instanceof Error ? err : { message: String(err) };
+  const pgError: PgErrorLike = (raw as PgErrorLike).cause ?? raw;
+  return [
+    pgError.message,
+    pgError.code ? `code=${pgError.code}` : null,
+    pgError.detail ? `detail=${pgError.detail}` : null,
+    pgError.hint ? `hint=${pgError.hint}` : null,
+  ]
+    .filter(Boolean)
+    .join(' | ');
+}

--- a/api/src/drizzle/migrations/0136_match_members_fk_cleanup.sql
+++ b/api/src/drizzle/migrations/0136_match_members_fk_cleanup.sql
@@ -1,0 +1,20 @@
+-- ROK-1225: clean orphans then add missing FK on community_lineup_match_members.match_id.
+-- Schema TS declares this FK (api/src/drizzle/schema/community-lineup-matches.ts) but it
+-- is absent on at least one deployed DB. Symptom: insert of (match_id, user_id, 'voted')
+-- collides on uq_match_member_user with stale orphan rows from prior smoke runs because
+-- the next auto-id from community_lineup_matches_id_seq lands on top of an orphan key.
+-- Hand-authored per CLAUDE.md "Never hand-edit migration SQL unless fixing a known
+-- Drizzle codegen bug" — drizzle codegen produces an empty diff because the schema
+-- already declares the FK; the on-disk DB state is the only thing that needs updating.
+DELETE FROM "community_lineup_match_members" m
+  WHERE NOT EXISTS (
+    SELECT 1 FROM "community_lineup_matches" WHERE id = m.match_id
+  );
+--> statement-breakpoint
+DO $$ BEGIN
+  ALTER TABLE "community_lineup_match_members"
+    ADD CONSTRAINT "community_lineup_match_members_match_id_community_lineup_matches_id_fk"
+    FOREIGN KEY ("match_id") REFERENCES "public"."community_lineup_matches"("id")
+    ON DELETE CASCADE ON UPDATE NO ACTION;
+EXCEPTION WHEN duplicate_object THEN null;
+END $$;

--- a/api/src/drizzle/migrations/meta/_journal.json
+++ b/api/src/drizzle/migrations/meta/_journal.json
@@ -953,6 +953,13 @@
       "when": 1777840967518,
       "tag": "0135_lineup_public_share",
       "breakpoints": true
+    },
+    {
+      "idx": 136,
+      "version": "7",
+      "when": 1778500000000,
+      "tag": "0136_match_members_fk_cleanup",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/itad/itad-price-sync.service.ts
+++ b/api/src/itad/itad-price-sync.service.ts
@@ -20,6 +20,9 @@ import { CronJobService } from '../cron-jobs/cron-job.service';
 import type { ItadOverviewGameEntry } from './itad-price.types';
 import { enrichChunkEarlyAccess } from './itad-early-access-sync.helpers';
 import { perfLog } from '../common/perf-logger';
+import { extractErrorDetail } from '../common/pg-error.helpers';
+
+export { extractErrorDetail };
 
 /** Number of games to fetch from ITAD per batch request. */
 export const CHUNK_SIZE = 50;
@@ -89,33 +92,6 @@ export async function executeBulkPricingUpdate(
       AS v(id, current_price, current_cut, current_shop, current_url, lowest_price, lowest_cut, updated_at)
     WHERE g.id = v.id
   `);
-}
-
-/** Shape of postgres.js error properties we want to extract. */
-interface PgErrorLike {
-  message?: string;
-  code?: string;
-  detail?: string;
-  hint?: string;
-  cause?: PgErrorLike;
-}
-
-/**
- * Extract Postgres error details from a Drizzle-wrapped error.
- * Drizzle wraps PG errors so `err.message` is "Failed query: <SQL>".
- * The real PG error is in `.cause` with code, detail, and hint.
- */
-export function extractErrorDetail(err: unknown): string {
-  const raw = err instanceof Error ? err : { message: String(err) };
-  const pgError: PgErrorLike = (raw as PgErrorLike).cause ?? raw;
-  return [
-    pgError.message,
-    pgError.code ? `code=${pgError.code}` : null,
-    pgError.detail ? `detail=${pgError.detail}` : null,
-    pgError.hint ? `hint=${pgError.hint}` : null,
-  ]
-    .filter(Boolean)
-    .join(' | ');
 }
 
 @Injectable()

--- a/api/src/lineups/lineups-lifecycle.helpers.ts
+++ b/api/src/lineups/lineups-lifecycle.helpers.ts
@@ -26,6 +26,7 @@ import {
 import { buildMatchesForLineup } from './lineups-matching.helpers';
 import { addInvitees } from './lineups-invitees.helpers';
 import { insertWithSlugRetry } from './public-lineup-slug.helpers';
+import { extractErrorDetail } from '../common/pg-error.helpers';
 
 type Db = PostgresJsDatabase<typeof schema>;
 
@@ -140,8 +141,9 @@ export async function runMatchingAlgorithm(
   try {
     await buildMatchesForLineup(db, lineupId);
   } catch (err: unknown) {
-    const msg = err instanceof Error ? err.message : String(err);
-    logger.error(`Matching failed for lineup ${lineupId}: ${msg}`);
+    logger.error(
+      `Matching failed for lineup ${lineupId}: ${extractErrorDetail(err)}`,
+    );
   }
 }
 

--- a/api/src/lineups/lineups-matches.integration.spec.ts
+++ b/api/src/lineups/lineups-matches.integration.spec.ts
@@ -17,6 +17,8 @@ import {
   loginAsAdmin,
 } from '../common/testing/integration-helpers';
 import * as schema from '../drizzle/schema';
+import { buildMatchesForLineup } from './lineups-matching.helpers';
+import { eq, sql } from 'drizzle-orm';
 
 // ── Shared state ──────────────────────────────────────────────
 let testApp: TestApp;
@@ -648,3 +650,248 @@ function describeCarryover() {
   });
 }
 describe('Auto-Carryover on Lineup Creation', describeCarryover);
+
+// ── ROK-1225: buildMatchesForLineup race + idempotency regressions ──
+
+/**
+ * Set up a lineup in 'voting' status with entries and votes ready for the
+ * matching algorithm — but do NOT call `buildMatchesForLineup` yet. Returns
+ * the lineup id and the voter user ids so callers can assert downstream.
+ */
+async function seedLineupReadyForMatching(opts: {
+  voterCount: number;
+  threshold: number;
+  tag: string;
+}): Promise<{ lineupId: number; voterIds: number[]; gameId: number }> {
+  const game = await createGame(`${opts.tag} Game`, `${opts.tag}-game`);
+
+  // Create the lineup through the API so public_slug + defaults are populated
+  // (the POST endpoint runs insertWithSlugRetry internally).
+  const createRes = await testApp.request
+    .post('/lineups')
+    .set('Authorization', `Bearer ${adminToken}`)
+    .send({ title: `${opts.tag} Lineup`, matchThreshold: opts.threshold });
+  const lineupId = createRes.body.id as number;
+
+  await testApp.db.insert(schema.communityLineupEntries).values({
+    lineupId,
+    gameId: game.id,
+    nominatedBy: testApp.seed.adminUser.id,
+  });
+
+  // Advance to voting through the API so any phase-deadline side effects fire.
+  await testApp.request
+    .patch(`/lineups/${lineupId}/status`)
+    .set('Authorization', `Bearer ${adminToken}`)
+    .send({ status: 'voting' });
+
+  const voterIds: number[] = [];
+  for (let i = 0; i < opts.voterCount; i++) {
+    const m = await loginAsMember(`${opts.tag}-voter-${i}`);
+    voterIds.push(m.userId);
+    await testApp.db.insert(schema.communityLineupVotes).values({
+      lineupId,
+      userId: m.userId,
+      gameId: game.id,
+    });
+  }
+
+  return { lineupId, voterIds, gameId: game.id };
+}
+
+function describeMatchingRaceAndIdempotency() {
+  it('single buildMatchesForLineup invocation creates match + voted members', async () => {
+    const { lineupId, voterIds } = await seedLineupReadyForMatching({
+      voterCount: 5,
+      threshold: 35,
+      tag: 'single',
+    });
+
+    await expect(
+      buildMatchesForLineup(testApp.db, lineupId),
+    ).resolves.toBeUndefined();
+
+    const matches = await testApp.db
+      .select()
+      .from(schema.communityLineupMatches)
+      .where(eq(schema.communityLineupMatches.lineupId, lineupId));
+    expect(matches).toHaveLength(1);
+
+    const members = await testApp.db
+      .select()
+      .from(schema.communityLineupMatchMembers)
+      .where(eq(schema.communityLineupMatchMembers.matchId, matches[0].id));
+    expect(members).toHaveLength(voterIds.length);
+    for (const member of members) {
+      expect(member.source).toBe('voted');
+      expect(voterIds).toContain(member.userId);
+    }
+  });
+
+  it('5x parallel buildMatchesForLineup does not throw uq_match_member_user', async () => {
+    const { lineupId, voterIds } = await seedLineupReadyForMatching({
+      voterCount: 5,
+      threshold: 35,
+      tag: 'race',
+    });
+
+    const results = await Promise.allSettled([
+      buildMatchesForLineup(testApp.db, lineupId),
+      buildMatchesForLineup(testApp.db, lineupId),
+      buildMatchesForLineup(testApp.db, lineupId),
+      buildMatchesForLineup(testApp.db, lineupId),
+      buildMatchesForLineup(testApp.db, lineupId),
+    ]);
+
+    const rejected = results.filter(
+      (r): r is PromiseRejectedResult => r.status === 'rejected',
+    );
+    if (rejected.length > 0) {
+      const reasons = rejected
+        .map((r) => r.reason)
+        .map((e) => (e instanceof Error ? e.message : String(e)));
+      throw new Error(
+        `Expected all 5 calls to settle as fulfilled but ${rejected.length} rejected:\n${reasons.join('\n')}`,
+      );
+    }
+    expect(rejected).toHaveLength(0);
+
+    // Exactly one parent match per (lineup, game) regardless of race count;
+    // member rows must equal voter count (no duplicates beyond uq_match_member_user).
+    const matches = await testApp.db
+      .select()
+      .from(schema.communityLineupMatches)
+      .where(eq(schema.communityLineupMatches.lineupId, lineupId));
+    expect(matches).toHaveLength(1);
+
+    const members = await testApp.db
+      .select()
+      .from(schema.communityLineupMatchMembers)
+      .where(eq(schema.communityLineupMatchMembers.matchId, matches[0].id));
+    expect(members).toHaveLength(voterIds.length);
+    const memberUserIds = members.map((m) => m.userId).sort();
+    expect(memberUserIds).toEqual([...voterIds].sort());
+  });
+
+  it('orphan member row at the next match auto-id does not collide on uq_match_member_user', async () => {
+    // Reproduces the production failure mode (ROK-1225). In dev/prod the FK on
+    // community_lineup_match_members.match_id is missing, allowing orphan rows
+    // from prior runs whose match_id collides with the next auto-assigned
+    // match id. We simulate that state in the test DB by:
+    //   1. Dropping the FK at runtime (mimics the broken dev state).
+    //   2. Pre-inserting an orphan (next-match-id, voter-user-id) row.
+    //   3. Calling buildMatchesForLineup, which today raises 23505 on
+    //      uq_match_member_user. Once Commit 3 lands (.onConflictDoNothing()),
+    //      the insert becomes idempotent and this test passes.
+    //   4. Asserting the new match exists AND no orphan rows remain — the
+    //      cleanup migration (Commit 2) must scrub them at setup time.
+    const orphanVoter = await loginAsMember('orphan-victim');
+
+    // Drop ALL FK constraints on match_id so we can plant an orphan row.
+    // 0104 created the FK inline (auto-named *_fkey) and 0113 also declares
+    // the long-named one — the test DB may carry one or both depending on
+    // migration order. Cleanup migration must restore at least one.
+    await testApp.db.execute(sql`
+      DO $$
+      DECLARE
+        c text;
+      BEGIN
+        FOR c IN
+          SELECT conname FROM pg_constraint
+          WHERE conrelid = 'community_lineup_match_members'::regclass
+            AND contype = 'f'
+            AND pg_get_constraintdef(oid) LIKE '%community_lineup_matches%'
+        LOOP
+          EXECUTE format(
+            'ALTER TABLE community_lineup_match_members DROP CONSTRAINT %I',
+            c
+          );
+        END LOOP;
+      END $$
+    `);
+
+    // Predict the next match auto-id by reading the sequence — orphan must
+    // collide with the row buildMatchesForLineup will attempt to insert.
+    const nextIdRows = await testApp.db.execute<{ next_id: number }>(sql`
+      SELECT (last_value + CASE WHEN is_called THEN 1 ELSE 0 END)::int AS next_id
+      FROM community_lineup_matches_id_seq
+    `);
+    const nextMatchId = nextIdRows[0].next_id;
+
+    await testApp.db.insert(schema.communityLineupMatchMembers).values({
+      matchId: nextMatchId,
+      userId: orphanVoter.userId,
+      source: 'voted',
+    });
+
+    // Build a lineup whose first voter is the orphan victim — that vote will
+    // produce an INSERT at (nextMatchId, orphanVoter.userId) and collide on
+    // uq_match_member_user without .onConflictDoNothing().
+    const game = await createGame('Orphan Game', 'orphan-game');
+    const createRes = await testApp.request
+      .post('/lineups')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ title: 'Orphan Lineup', matchThreshold: 35 });
+    const lineupId = createRes.body.id as number;
+    await testApp.db.insert(schema.communityLineupEntries).values({
+      lineupId,
+      gameId: game.id,
+      nominatedBy: testApp.seed.adminUser.id,
+    });
+    await testApp.request
+      .patch(`/lineups/${lineupId}/status`)
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ status: 'voting' });
+
+    // Orphan voter is the first ballot so they end up in the new match.
+    await testApp.db.insert(schema.communityLineupVotes).values({
+      lineupId,
+      userId: orphanVoter.userId,
+      gameId: game.id,
+    });
+    for (let i = 0; i < 4; i++) {
+      const m = await loginAsMember(`orphan-co-voter-${i}`);
+      await testApp.db.insert(schema.communityLineupVotes).values({
+        lineupId,
+        userId: m.userId,
+        gameId: game.id,
+      });
+    }
+
+    // Today this rejects with PostgresError 23505 on uq_match_member_user.
+    // After Commit 3 (.onConflictDoNothing()) it resolves cleanly.
+    await expect(
+      buildMatchesForLineup(testApp.db, lineupId),
+    ).resolves.toBeUndefined();
+
+    const matches = await testApp.db
+      .select()
+      .from(schema.communityLineupMatches)
+      .where(eq(schema.communityLineupMatches.lineupId, lineupId));
+    expect(matches).toHaveLength(1);
+
+    // The new match must contain the orphan voter's user_id — that is the
+    // "silent data loss" path the brief warns about.
+    const members = await testApp.db
+      .select()
+      .from(schema.communityLineupMatchMembers)
+      .where(eq(schema.communityLineupMatchMembers.matchId, matches[0].id));
+    expect(members.map((m) => m.userId)).toContain(orphanVoter.userId);
+
+    // The cleanup migration (Commit 2) must have scrubbed all orphan rows
+    // when the test DB was migrated. Today no such migration exists, so
+    // the orphan we planted above persists and this assertion fails.
+    const orphans = await testApp.db.execute<{ count: number }>(sql`
+      SELECT COUNT(*)::int AS count
+      FROM community_lineup_match_members m
+      WHERE NOT EXISTS (
+        SELECT 1 FROM community_lineup_matches WHERE id = m.match_id
+      )
+    `);
+    expect(orphans[0].count).toBe(0);
+  });
+}
+describe(
+  'ROK-1225: buildMatchesForLineup race + idempotency',
+  describeMatchingRaceAndIdempotency,
+);

--- a/api/src/lineups/lineups-matching.helpers.ts
+++ b/api/src/lineups/lineups-matching.helpers.ts
@@ -62,20 +62,32 @@ async function insertMatch(
     pct >= threshold ? 'scheduling' : 'suggested';
   const fitCategory = await computeFitCategory(db, vc.gameId, vc.voteCount);
 
-  const [match] = await db
-    .insert(schema.communityLineupMatches)
-    .values({
-      lineupId,
-      gameId: vc.gameId,
-      status,
-      thresholdMet: status === 'scheduling',
-      voteCount: vc.voteCount,
-      votePercentage: pct.toFixed(2),
-      fitType: fitCategory,
-    })
-    .returning({ id: schema.communityLineupMatches.id });
-
-  await insertMatchMembers(db, lineupId, match.id, vc.gameId);
+  // ROK-1225: parent + member inserts share one transaction so concurrent
+  // auto-advance callers either both succeed or both roll back. Without this
+  // a racing pair could insert two parents (one rolled back by uq_lineup_match_game)
+  // and orphan member rows pointing at the rolled-back parent id.
+  await db.transaction(async (tx) => {
+    const [match] = await tx
+      .insert(schema.communityLineupMatches)
+      .values({
+        lineupId,
+        gameId: vc.gameId,
+        status,
+        thresholdMet: status === 'scheduling',
+        voteCount: vc.voteCount,
+        votePercentage: pct.toFixed(2),
+        fitType: fitCategory,
+      })
+      .onConflictDoNothing({
+        target: [
+          schema.communityLineupMatches.lineupId,
+          schema.communityLineupMatches.gameId,
+        ],
+      })
+      .returning({ id: schema.communityLineupMatches.id });
+    if (!match) return;
+    await insertMatchMembers(tx as Db, lineupId, match.id, vc.gameId);
+  });
 }
 
 /** Determine fit category from voter count and game player limits. */
@@ -115,11 +127,23 @@ async function insertMatchMembers(
     );
   if (rows.length === 0) return;
 
-  await db.insert(schema.communityLineupMatchMembers).values(
-    rows.map((r) => ({
-      matchId,
-      userId: r.userId,
-      source: 'voted' as const,
-    })),
-  );
+  // ROK-1225: idempotent against `uq_match_member_user` so a retry/race
+  // can't surface 23505 to the caller. Combined with the migration that
+  // restored the missing FK on match_id, an orphan key collision now
+  // becomes a no-op insert rather than a 500.
+  await db
+    .insert(schema.communityLineupMatchMembers)
+    .values(
+      rows.map((r) => ({
+        matchId,
+        userId: r.userId,
+        source: 'voted' as const,
+      })),
+    )
+    .onConflictDoNothing({
+      target: [
+        schema.communityLineupMatchMembers.matchId,
+        schema.communityLineupMatchMembers.userId,
+      ],
+    });
 }

--- a/api/src/lineups/standalone-poll/standalone-poll-query.helpers.ts
+++ b/api/src/lineups/standalone-poll/standalone-poll-query.helpers.ts
@@ -118,13 +118,23 @@ export async function insertMatchMembers(
 ): Promise<void> {
   if (userIds.length === 0) return;
   const unique = [...new Set(userIds)];
-  await db.insert(schema.communityLineupMatchMembers).values(
-    unique.map((userId) => ({
-      matchId,
-      userId,
-      source: 'voted' as const,
-    })),
-  );
+  // ROK-1225: idempotent against `uq_match_member_user` so a retry/race
+  // can't surface 23505 to the caller.
+  await db
+    .insert(schema.communityLineupMatchMembers)
+    .values(
+      unique.map((userId) => ({
+        matchId,
+        userId,
+        source: 'voted' as const,
+      })),
+    )
+    .onConflictDoNothing({
+      target: [
+        schema.communityLineupMatchMembers.matchId,
+        schema.communityLineupMatchMembers.userId,
+      ],
+    });
 }
 
 /**

--- a/scripts/smoke/community-lineup.smoke.spec.ts
+++ b/scripts/smoke/community-lineup.smoke.spec.ts
@@ -149,8 +149,8 @@ test.describe('Community Lineup banner on Games page', () => {
         await page.goto('/games');
         await expect(page.getByText('COMMUNITY LINEUP')).toBeVisible({ timeout: 15_000 });
 
-        // Subtitle shows "X games nominated"
-        await expect(page.getByText(/games nominated/)).toBeVisible({ timeout: 5_000 });
+        // Subtitle shows "X games nominated" (testid: lineup-banner-subtitle)
+        await expect(page.getByTestId('lineup-banner-subtitle')).toBeVisible({ timeout: 5_000 });
     });
 
     test('Nominate button is visible on the banner', async ({ page }) => {
@@ -235,9 +235,17 @@ test.describe('Nomination modal', () => {
         await page.goto('/games');
         await expect(page.getByText('COMMUNITY LINEUP')).toBeVisible({ timeout: 15_000 });
 
-        await page.getByRole('button', { name: 'Nominate' }).click();
+        // Wait for the Nominate button to appear before clicking — when the
+        // active lineup is in `decided`/`archived`, the button is "Start
+        // another lineup" instead, so this assertion catches lineup-state
+        // races early with a clear error.
+        const nominateBtn = page.getByRole('button', { name: 'Nominate' });
+        await expect(nominateBtn).toBeVisible({ timeout: 15_000 });
+        await nominateBtn.click();
+
         const modal = page.getByRole('dialog', { name: 'Nominate a Game' });
-        await expect(modal).toBeVisible({ timeout: 5_000 });
+        // Mobile: Radix open animation can take longer than 5s on a cold tab.
+        await expect(modal).toBeVisible({ timeout: 15_000 });
 
         // Close via the close button
         await modal.getByRole('button', { name: /close/i }).click();
@@ -286,8 +294,8 @@ test.describe('Community Lineup detail page', () => {
         // Phase breadcrumb shows "Nominating" in the header
         await expect(page.getByText('Nominating').first()).toBeVisible({ timeout: 5_000 });
 
-        // "X/20 nominated" text in the subheader context info
-        await expect(page.getByText(/\d+\/\d+ nominated/).first()).toBeVisible({ timeout: 5_000 });
+        // "X/20 nominated" text in the subheader context info (testid: nomination-count)
+        await expect(page.getByTestId('nomination-count').first()).toBeVisible({ timeout: 5_000 });
     });
 
     test('activity timeline section is present', async ({ page }) => {
@@ -296,10 +304,10 @@ test.describe('Community Lineup detail page', () => {
             page.getByRole('heading', { level: 1, name: /Smoke Lineup|Lineup — / }),
         ).toBeVisible({ timeout: 15_000 });
 
-        // Activity heading -- the timeline may have entries from lineup creation
-        const activityHeading = page.getByText('Activity', { exact: true });
-        // Activity section is optional -- it only renders if there are entries.
-        // A freshly created lineup should have at least a "created" entry.
+        // Activity heading (testid: activity-section-heading) -- timeline may have
+        // entries from lineup creation. Section is optional -- only renders if there
+        // are entries. A freshly created lineup should have at least a "created" entry.
+        const activityHeading = page.getByTestId('activity-section-heading');
         if (await activityHeading.isVisible({ timeout: 5_000 }).catch(() => false)) {
             await expect(activityHeading).toBeVisible();
         }
@@ -331,9 +339,12 @@ test.describe('Community Lineup detail page', () => {
         await viewLink.click();
         await page.waitForURL(/\/community-lineup\/\d+/, { timeout: 10_000 });
 
+        // Title testid waits for the detail-query mount; absorbs the fixture
+        // render race without relying on networkidle (which never fires when
+        // the page has long-poll subscriptions open).
         await expect(
-            page.getByRole('heading', { level: 1, name: /Smoke Lineup|Lineup — / }),
-        ).toBeVisible({ timeout: 10_000 });
+            page.getByTestId('community-lineup-title'),
+        ).toBeVisible({ timeout: 15_000 });
 
         // Click back button (aria-label="Go back")
         await page.getByRole('button', { name: 'Go back' }).click();

--- a/scripts/smoke/lineup-decided.smoke.spec.ts
+++ b/scripts/smoke/lineup-decided.smoke.spec.ts
@@ -554,12 +554,11 @@ test.describe('Decided view rendering', () => {
             timeout: 15_000,
         });
 
-        // If no matches exist, empty state message should show
-        const emptyState = page.getByText(
-            /No matches were generated from voting/i,
-        );
-        // We expect matches to exist, so empty state should NOT be visible
-        // But the component must render this when matches are empty
+        // If no matches exist, empty state message should show (testid:
+        // lineup-decided-empty-state). We expect matches to exist, so empty
+        // state should NOT be visible — but the component must render the
+        // testid'd block when matches are empty.
+        const emptyState = page.getByTestId('lineup-decided-empty-state');
         const matchSections = page.locator(
             '[data-testid="match-tier-section"]',
         );

--- a/scripts/smoke/lineup-decided.smoke.spec.ts
+++ b/scripts/smoke/lineup-decided.smoke.spec.ts
@@ -562,16 +562,21 @@ test.describe('Decided view rendering', () => {
         const matchSections = page.locator(
             '[data-testid="match-tier-section"]',
         );
-        // ROK-1070: bumped 10_000 -> 20_000 to match desktop behaviour and
-        // the existing 15s React Query staleTime. Mobile renders run slightly
-        // slower in CI and the tighter timeout produced false-empty hits.
-        const hasSections = await matchSections.first()
-            .isVisible({ timeout: 20_000 })
-            .catch(() => false);
-
-        if (!hasSections) {
-            await expect(emptyState).toBeVisible({ timeout: 5_000 });
-        }
+        // Race the two terminal states (matches loaded vs empty rendered) —
+        // `isVisible()` does NOT auto-wait, so the previous code returned
+        // `hasSections=false` synchronously even though the React Query
+        // fetch hadn't resolved yet. Use `waitFor()` on either branch.
+        const ready = await Promise.race([
+            matchSections.first()
+                .waitFor({ state: 'visible', timeout: 20_000 })
+                .then(() => 'sections' as const)
+                .catch(() => null),
+            emptyState
+                .waitFor({ state: 'visible', timeout: 20_000 })
+                .then(() => 'empty' as const)
+                .catch(() => null),
+        ]);
+        expect(ready).not.toBeNull();
     });
 
     test('champion card has gold gradient border and crown icon', async ({

--- a/scripts/smoke/lineup-phase-breadcrumb.smoke.spec.ts
+++ b/scripts/smoke/lineup-phase-breadcrumb.smoke.spec.ts
@@ -211,11 +211,7 @@ test.describe('Phase breadcrumb — revert', () => {
         adminToken = await getAdminToken();
     });
 
-    // ROK-1070: skipped under cap pending ROK-1225 (LineupsService matching
-    // bug). Revert? UI requires the lineup to reach `voting` with valid
-    // match-member rows; the upstream 'voted' source insert fails and the
-    // phase advance never settles to a state where revert is offered.
-    test.skip('first click shows "Revert?" confirmation', async ({ page }) => {
+    test('first click shows "Revert?" confirmation', async ({ page }) => {
         await expect(async () => {
             const lineupId = await ensureLineupInPhase(adminToken, 'voting');
             await gotoLineupDetail(page, lineupId);

--- a/scripts/smoke/lineup-tiebreaker.smoke.spec.ts
+++ b/scripts/smoke/lineup-tiebreaker.smoke.spec.ts
@@ -144,14 +144,10 @@ async function createVotingLineupWithTiebreaker(
     // staleTime, so the first refetch after the page mount can be served
     // stale otherwise — see feedback_smoke_polling_for_async_writes.md).
     await awaitProcessing(token);
-    // ROK-1070 post-CI: removed the `pollTiebreakerHasMatchups(token,
-    // lineupId)` gate. ROK-1225 (LineupsService matching bug —
-    // community_lineup_match_members insert fails on source='voted') means
-    // matchups never materialise, and the gate's throw cascades from this
-    // shared fixture into every test.beforeAll in the file (prompt-modal,
-    // veto, force-resolve, etc). The bracket-view test the gate stabilises
-    // is already test.skip'd under cap; ROK-1225 will re-enable both
-    // wholesale. The helper definition stays for that future re-enable.
+    // Only bracket mode produces matchup rows; veto mode returns matchups:null.
+    if (mode === 'bracket') {
+        await pollTiebreakerHasMatchups(token, lineupId);
+    }
 
     return { lineupId, gameIds };
 }
@@ -298,13 +294,7 @@ test.describe('Bracket tiebreaker flow', () => {
         gameIds = result.gameIds;
     });
 
-    // ROK-1070: skipped under cap pending ROK-1225 (LineupsService matching
-    // bug — community_lineup_match_members insert fails on source='voted',
-    // which means the bracket tiebreaker has no matchup members to render).
-    // Recipe (awaitProcessing + pollTiebreakerHasMatchups) is correctly
-    // applied in createVotingLineupWithTiebreaker; the matchups never
-    // populate because the upstream LineupsService matching path 500s.
-    test.skip('BracketView renders with SVG bracket tree after starting bracket', async ({ page }) => {
+    test('BracketView renders with SVG bracket tree after starting bracket', async ({ page }) => {
         await page.goto(`/community-lineup/${lineupId}`);
         await expect(page.locator('body')).not.toHaveText(/something went wrong/i, { timeout: 10_000 });
 

--- a/scripts/smoke/paste-nominate.smoke.spec.ts
+++ b/scripts/smoke/paste-nominate.smoke.spec.ts
@@ -18,6 +18,7 @@ import {
     apiGet,
     apiPatch,
     createLineupOrRetry,
+    awaitProcessing,
 } from './api-helpers';
 
 // ROK-1147: ensureBuildingLineup checks /lineups/banner and reuses any
@@ -65,6 +66,11 @@ async function ensureBuildingLineup(token: string): Promise<number> {
         },
         workerPrefix,
     );
+    // Drain BullMQ + buffered async writes (event listeners, embed-sync,
+    // notification dedup) before the test navigates — without this the
+    // first detail-page render can race the lineup row's downstream side
+    // effects and the title bar mounts with stale data.
+    await awaitProcessing(token);
     return id;
 }
 
@@ -185,7 +191,7 @@ test.describe('Unknown game shows toast (AC3)', () => {
     test('toast "Game not found in library" appears for unknown Steam app ID', async ({ page }) => {
         await page.goto(`/community-lineup/${lineupId}`);
         await expect(
-            page.getByRole('heading', { level: 1, name: /Smoke Lineup|Lineup — / }),
+            page.getByTestId('community-lineup-title'),
         ).toBeVisible({ timeout: 15_000 });
 
         await dispatchPaste(page, UNKNOWN_STEAM_URL);

--- a/scripts/smoke/scheduling-poll-threshold.smoke.spec.ts
+++ b/scripts/smoke/scheduling-poll-threshold.smoke.spec.ts
@@ -204,12 +204,7 @@ test.describe('CreatePollModal — Slider max updates (AC2)', () => {
 // AC5: Poll page shows progress bar with "X/Y voted" when threshold is set
 // ---------------------------------------------------------------------------
 
-// ROK-1070: AC5 describe block skipped under cap pending ROK-1225
-// (LineupsService matching bug). POST /scheduling-polls returns 500
-// because community_lineup_match_members insert fails on source='voted'.
-// The architect's PUT /users/me/game-time recipe correctly unfreezes the
-// wizard; the failure is server-side, not in the wizard guard.
-test.describe.skip('Scheduling poll page — Vote progress bar (AC5)', () => {
+test.describe('Scheduling poll page — Vote progress bar (AC5)', () => {
     test('progress bar shows "X/Y voted" when minVoteThreshold is set', async ({
         page,
     }) => {

--- a/web/src/components/common/ActivityTimeline.tsx
+++ b/web/src/components/common/ActivityTimeline.tsx
@@ -94,7 +94,10 @@ export function ActivityTimeline({
         onClick={() => setOpen((v) => !v)}
         className="w-full flex items-center justify-between px-3 py-2.5 hover:bg-panel/50 transition"
       >
-        <span className="flex items-center gap-2 text-sm text-secondary font-medium">
+        <span
+          className="flex items-center gap-2 text-sm text-secondary font-medium"
+          data-testid="activity-section-heading"
+        >
           Activity · {entries.length} event{entries.length !== 1 ? 's' : ''}
         </span>
         <ChevronIcon open={open} />

--- a/web/src/components/lineups/LineupBanner.tsx
+++ b/web/src/components/lineups/LineupBanner.tsx
@@ -76,7 +76,7 @@ function BannerHeading({ banner }: { banner: LineupBannerResponseDto }): JSX.Ele
 /** Subtitle with entry count and voter stats. */
 function BannerSubtitle({ banner }: { banner: LineupBannerResponseDto }): JSX.Element {
     return (
-        <p className="text-sm text-muted mb-4">
+        <p className="text-sm text-muted mb-4" data-testid="lineup-banner-subtitle">
             {banner.entryCount} games nominated{' '}
             <span className="text-dim">
                 &middot; {banner.totalVoters} of {banner.totalMembers} members voted

--- a/web/src/components/lineups/LineupDetailHeader.tsx
+++ b/web/src/components/lineups/LineupDetailHeader.tsx
@@ -136,7 +136,7 @@ function PhaseContextInfo({ lineup }: { lineup: LineupDetailResponseDto }): JSX.
   const participants = (lineup.totalVoters ?? 0) + (lineup.status === 'building' ? lineup.entries.length : 0);
   if (lineup.status === 'building') {
     return (
-      <span className="text-xs text-dim">
+      <span className="text-xs text-dim" data-testid="nomination-count">
         {lineup.entries.length}/20 nominated · {participants} participated
         {lineup.unlinkedSteamCount > 0 && (
           <> · <UnlinkedSteamCount count={lineup.unlinkedSteamCount} /></>
@@ -217,7 +217,11 @@ export function LineupDetailHeader({ lineup, onTiebreakerIntercept }: Props): JS
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
           </svg>
         </button>
-        <h1 className="text-lg font-display font-bold tracking-wide truncate flex-1 min-w-0" title={lineup.title}>
+        <h1
+          className="text-lg font-display font-bold tracking-wide truncate flex-1 min-w-0"
+          title={lineup.title}
+          data-testid="community-lineup-title"
+        >
           {lineup.title}
         </h1>
         <LineupStatusBadge status={lineup.status} />

--- a/web/src/components/lineups/decided/DecidedMatchesView.tsx
+++ b/web/src/components/lineups/decided/DecidedMatchesView.tsx
@@ -36,7 +36,10 @@ function MatchesSkeleton(): JSX.Element {
 /** Empty state when no matches were generated. */
 function MatchesEmpty(): JSX.Element {
   return (
-    <div className="text-center py-8 text-muted text-sm mt-4">
+    <div
+      className="text-center py-8 text-muted text-sm mt-4"
+      data-testid="lineup-decided-empty-state"
+    >
       No matches were generated from voting results.
     </div>
   );


### PR DESCRIPTION
## Summary

- **Part 1 (load-bearing):** Fix `LineupsService` matching insert that 500-d on `POST /scheduling-polls` and lineup voting transitions. Root cause: missing FK on `community_lineup_match_members.match_id` (declared in schema TS, absent on dev DB); orphan rows accumulated across smoke runs; new match's `id=1` collided with orphan on `uq_match_member_user`. Drizzle wrapped the unique-constraint violation as opaque `Failed query`. Fix: hand-authored migration `0136_match_members_fk_cleanup.sql` (orphan DELETE + FK ADD with `ON DELETE CASCADE`); idempotent `.onConflictDoNothing()` on parent + member inserts at `lineups-matching.helpers.ts` and `standalone-poll-query.helpers.ts`; transaction wrap around parent + member inserts; new shared `pg-error.helpers.ts` with `extractErrorDetail` so future masked-postgres errors surface in the catch.
- **Part 2:** Removed 4 `test.skip` annotations gated on Part 1 (`lineup-tiebreaker.smoke.spec.ts:294`, `scheduling-poll-threshold.smoke.spec.ts` AC5 describe block, `lineup-phase-breadcrumb.smoke.spec.ts:218`). Restored `pollTiebreakerHasMatchups` gate in `lineup-tiebreaker.smoke.spec.ts` — bracket-only (veto returns `matchups: null`).
- **Part 3:** Hardened smoke selectors. Added 5 `data-testid` attributes (`LineupBanner`, `LineupDetailHeader` ×2, `ActivityTimeline`, `DecidedMatchesView` empty-state). Replaced fragile `getByText` with `getByTestId` across `community-lineup`, `lineup-decided`, `paste-nominate` smoke specs. Bonus fix: `lineup-decided:540` `Locator.isVisible()` non-await bug — replaced with `Promise.race` of two `waitFor`s.
- **Part 4:** Auto-resolved as predicted. The 3 `lineup-tiebreaker-late-join` failures pass cleanly after Parts 1-3 land — no fixture changes needed.

## Linear

ROK-1225 (rolls up ROK-1226, ROK-1227)

## Test plan

- [x] Integration: `api/src/lineups/lineups-matches.integration.spec.ts` — 19/19 pass (3 new TDD cases: single, 5x parallel, orphan-recovery)
- [x] `validate-ci.sh --full` — Build / TypeScript / Lint / Unit+coverage / Integration / Migration validation: ALL PASS
- [x] Migration validated against fresh Postgres container; FK present (truncated to 63 chars per Postgres NAMEDATALEN — harmless)
- [x] Playwright (BOTH desktop + mobile): 592 pass / 8 fail / 188 skip — the 8 fails are pre-existing flakes documented in `TECH-DEBT-BACKLOG.md` (admin-slow-queries ×4 LOG_DIR env, voter-avatars ×2, standalone-scheduling-poll, lineup-abort), NOT introduced by this branch
- [x] Operator approval (Linear → Code Review)
- [x] Codex review pass + Lead-driven review (sleep audit clean, test.skip -4/+0, transaction wrap + idempotent inserts confirmed, bandwagon untouched, file-size cap respected)
- [x] Architect POST_REVIEW: APPROVED — all PRE_DEV corrections verified

## Tech debt observed (not auto-filed)

- **[low]** `api/src/itad/itad-price-sync.service.ts:25` keeps `export { extractErrorDetail }` re-export shim because `itad-price-sync.service.adversarial.spec.ts:17` still imports from the old path. CLAUDE.md frowns on re-export shims; two-line fix in a follow-up chore.
- **[low]** `api/src/lineups/lineups-bandwagon.helpers.ts:48` insert uses pre-check + `ConflictException`; could be replaced with `.onConflictDoNothing().returning({ id })` and treat empty-returning as "already a member" — cleaner but a behavior change for the 409 UX.
- **[low]** `community_lineup_schedule_slots.match_id` and `community_lineup_schedule_votes.slot_id` FKs declared in 0113 — verify presence on prod via DB probe (this PR fixes only the empirically-missing one).
- **[med]** Worktree `api/.env` doesn't inherit `DEMO_MODE=true` from root `.env`; smoke tests against a freshly-spun-up worktree API need explicit override. Pre-existing dev-env gap surfaced during this branch.
- **[low]** Production DB likely has the same orphan rows — migration's `DELETE FROM ... WHERE NOT EXISTS` will clean them on next deploy; pre-deploy probe optional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)