### PR TITLE
ROK-1119: vote-feedback toast on community lineup voting

### DIFF
--- a/web/src/components/lineups/LineupVoteBanner.test.tsx
+++ b/web/src/components/lineups/LineupVoteBanner.test.tsx
@@ -98,7 +98,8 @@ describe('LineupVoteBanner — VotingBanner vote feedback (ROK-1119)', () => {
         expect(opts).toBeDefined();
         expect(typeof opts.onSuccess).toBe('function');
 
-        opts.onSuccess?.({} as never, vars, undefined);
+        // Server returns the updated lineup with the vote now recorded
+        opts.onSuccess?.({ myVotes: [GAME_ID] } as never, vars, undefined);
 
         expect(toast.success).toHaveBeenCalledTimes(1);
         expect(vi.mocked(toast.success).mock.calls[0][0]).toMatch(/vote recorded/i);
@@ -119,7 +120,8 @@ describe('LineupVoteBanner — VotingBanner vote feedback (ROK-1119)', () => {
         expect(vars).toEqual({ lineupId: LINEUP_ID, gameId: GAME_ID });
         expect(typeof opts.onSuccess).toBe('function');
 
-        opts.onSuccess?.({} as never, vars, undefined);
+        // Server returns the updated lineup with the vote no longer present
+        opts.onSuccess?.({ myVotes: [] } as never, vars, undefined);
 
         expect(toast.success).toHaveBeenCalledTimes(1);
         expect(vi.mocked(toast.success).mock.calls[0][0]).toMatch(/vote removed/i);

--- a/web/src/components/lineups/LineupVoteBanner.test.tsx
+++ b/web/src/components/lineups/LineupVoteBanner.test.tsx
@@ -1,0 +1,147 @@
+/**
+ * Tests for LineupVoteBanner — VotingBanner sub-component (ROK-1119).
+ *
+ * The VotingBanner is the in-page CTA that appears on a game's detail page
+ * when the game is up for vote on the active community lineup. ROK-1119
+ * requires explicit feedback (success / error toast) after the vote
+ * mutation resolves, so users know their vote landed.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../../test/render-helpers';
+
+// Hooks: mock so we control the data shapes the banner consumes.
+vi.mock('../../hooks/use-lineups', () => ({
+    useLineupBanner: vi.fn(),
+    useLineupDetail: vi.fn(),
+    useToggleVote: vi.fn(),
+}));
+
+vi.mock('../../hooks/use-tiebreaker', () => ({
+    useTiebreakerDetail: vi.fn(),
+}));
+
+// Toast: mock to spy on success / error.
+vi.mock('../../lib/toast', () => ({
+    toast: {
+        success: vi.fn(),
+        error: vi.fn(),
+    },
+}));
+
+import { LineupVoteBanner } from './LineupVoteBanner';
+import {
+    useLineupBanner,
+    useLineupDetail,
+    useToggleVote,
+} from '../../hooks/use-lineups';
+import { useTiebreakerDetail } from '../../hooks/use-tiebreaker';
+import { toast } from '../../lib/toast';
+
+const mockUseLineupBanner = vi.mocked(useLineupBanner);
+const mockUseLineupDetail = vi.mocked(useLineupDetail);
+const mockUseToggleVote = vi.mocked(useToggleVote);
+const mockUseTiebreakerDetail = vi.mocked(useTiebreakerDetail);
+
+const mockMutate = vi.fn();
+
+const GAME_ID = 42;
+const LINEUP_ID = 7;
+
+function setupVotingBanner({ hasVoted = false }: { hasVoted?: boolean } = {}) {
+    mockUseLineupBanner.mockReturnValue({
+        data: {
+            id: LINEUP_ID,
+            status: 'voting',
+            tiebreakerActive: false,
+            entries: [
+                { gameId: GAME_ID, gameName: 'Lethal Company' },
+            ],
+        },
+    } as unknown as ReturnType<typeof useLineupBanner>);
+
+    mockUseLineupDetail.mockReturnValue({
+        data: {
+            id: LINEUP_ID,
+            myVotes: hasVoted ? [GAME_ID] : [],
+        },
+    } as unknown as ReturnType<typeof useLineupDetail>);
+
+    mockUseTiebreakerDetail.mockReturnValue({
+        data: null,
+    } as unknown as ReturnType<typeof useTiebreakerDetail>);
+
+    mockUseToggleVote.mockReturnValue({
+        mutate: mockMutate,
+        isPending: false,
+    } as unknown as ReturnType<typeof useToggleVote>);
+}
+
+describe('LineupVoteBanner — VotingBanner vote feedback (ROK-1119)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockMutate.mockReset();
+    });
+
+    it('shows a success toast after a new vote is recorded', async () => {
+        const user = userEvent.setup();
+        setupVotingBanner({ hasVoted: false });
+
+        renderWithProviders(<LineupVoteBanner gameId={GAME_ID} />);
+
+        await user.click(screen.getByRole('button', { name: /vote/i }));
+
+        expect(mockMutate).toHaveBeenCalledTimes(1);
+        const [vars, opts] = mockMutate.mock.calls[0];
+        expect(vars).toEqual({ lineupId: LINEUP_ID, gameId: GAME_ID });
+        expect(opts).toBeDefined();
+        expect(typeof opts.onSuccess).toBe('function');
+
+        opts.onSuccess?.({} as never, vars, undefined);
+
+        expect(toast.success).toHaveBeenCalledTimes(1);
+        expect(vi.mocked(toast.success).mock.calls[0][0]).toMatch(/vote recorded/i);
+        expect(toast.error).not.toHaveBeenCalled();
+    });
+
+    it('shows a success toast after an existing vote is removed', async () => {
+        const user = userEvent.setup();
+        setupVotingBanner({ hasVoted: true });
+
+        renderWithProviders(<LineupVoteBanner gameId={GAME_ID} />);
+
+        // When hasVoted=true the button label is "✓ Voted" — click it to unvote
+        await user.click(screen.getByRole('button', { name: /voted/i }));
+
+        expect(mockMutate).toHaveBeenCalledTimes(1);
+        const [vars, opts] = mockMutate.mock.calls[0];
+        expect(vars).toEqual({ lineupId: LINEUP_ID, gameId: GAME_ID });
+        expect(typeof opts.onSuccess).toBe('function');
+
+        opts.onSuccess?.({} as never, vars, undefined);
+
+        expect(toast.success).toHaveBeenCalledTimes(1);
+        expect(vi.mocked(toast.success).mock.calls[0][0]).toMatch(/vote removed/i);
+        expect(toast.error).not.toHaveBeenCalled();
+    });
+
+    it('shows an error toast when the vote mutation fails', async () => {
+        const user = userEvent.setup();
+        setupVotingBanner({ hasVoted: false });
+
+        renderWithProviders(<LineupVoteBanner gameId={GAME_ID} />);
+
+        await user.click(screen.getByRole('button', { name: /vote/i }));
+
+        expect(mockMutate).toHaveBeenCalledTimes(1);
+        const [, opts] = mockMutate.mock.calls[0];
+        expect(typeof opts.onError).toBe('function');
+
+        opts.onError?.(new Error('Voting closed'), { lineupId: LINEUP_ID, gameId: GAME_ID } as never, undefined);
+
+        expect(toast.error).toHaveBeenCalledTimes(1);
+        expect(vi.mocked(toast.error).mock.calls[0][0]).toBe('Voting closed');
+        expect(toast.success).not.toHaveBeenCalled();
+    });
+});

--- a/web/src/components/lineups/LineupVoteBanner.tsx
+++ b/web/src/components/lineups/LineupVoteBanner.tsx
@@ -107,7 +107,10 @@ function VotingBanner({ lineupId, gameId, gameName }: {
     voteMutation.mutate(
       { lineupId, gameId },
       {
-        onSuccess: () => toast.success(hasVoted ? 'Vote removed' : 'Vote recorded'),
+        onSuccess: (data) => {
+          const stillVoted = data.myVotes?.includes(gameId) ?? false;
+          toast.success(stillVoted ? 'Vote recorded' : 'Vote removed');
+        },
         onError: (err) => toast.error(err instanceof Error ? err.message : 'Vote failed'),
       },
     );

--- a/web/src/components/lineups/LineupVoteBanner.tsx
+++ b/web/src/components/lineups/LineupVoteBanner.tsx
@@ -6,6 +6,7 @@ import type { JSX } from 'react';
 import { Link } from 'react-router-dom';
 import { useLineupBanner, useLineupDetail, useToggleVote } from '../../hooks/use-lineups';
 import { useTiebreakerDetail } from '../../hooks/use-tiebreaker';
+import { toast } from '../../lib/toast';
 
 interface Props {
   gameId: number;
@@ -103,7 +104,13 @@ function VotingBanner({ lineupId, gameId, gameName }: {
   const isVoting = voteMutation.isPending;
 
   const handleVote = () => {
-    voteMutation.mutate({ lineupId, gameId });
+    voteMutation.mutate(
+      { lineupId, gameId },
+      {
+        onSuccess: () => toast.success(hasVoted ? 'Vote removed' : 'Vote recorded'),
+        onError: (err) => toast.error(err instanceof Error ? err.message : 'Vote failed'),
+      },
+    );
   };
 
   return (

--- a/web/src/components/lineups/VotingLeaderboard.test.tsx
+++ b/web/src/components/lineups/VotingLeaderboard.test.tsx
@@ -1,5 +1,5 @@
 /**
- * Tests for VotingLeaderboard component (ROK-936).
+ * Tests for VotingLeaderboard component (ROK-936, ROK-1119).
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
@@ -13,8 +13,17 @@ vi.mock('../../hooks/use-lineups', () => ({
   useToggleVote: vi.fn(),
 }));
 
+// Mock toast so we can spy on success/error calls (ROK-1119)
+vi.mock('../../lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
 import { VotingLeaderboard } from './VotingLeaderboard';
 import { useToggleVote } from '../../hooks/use-lineups';
+import { toast } from '../../lib/toast';
 
 const mockMutate = vi.fn();
 const mockUseToggleVote = vi.mocked(useToggleVote);
@@ -157,5 +166,83 @@ describe('VotingLeaderboard — voting', () => {
     await user.click(dButton);
     expect(mockMutate).not.toHaveBeenCalled();
     unmount();
+  });
+});
+
+/**
+ * ROK-1119 — vote feedback toasts.
+ *
+ * After toggling a vote in the leaderboard, the user must get explicit
+ * confirmation: a success toast on add ("Vote recorded"), a success toast
+ * on remove ("Vote removed"), and the existing error toast must keep firing.
+ *
+ * The mutation's `mutate` is mocked, so we drive the result by invoking
+ * the options callbacks (onSuccess / onError) passed to mutate directly.
+ */
+describe('VotingLeaderboard — vote feedback (ROK-1119)', () => {
+  beforeEach(() => {
+    mockMutate.mockReset();
+    vi.mocked(toast.success).mockReset();
+    vi.mocked(toast.error).mockReset();
+    mockUseToggleVote.mockReturnValue({ mutate: mockMutate, isPending: false } as never);
+  });
+
+  it('shows a success toast when a new vote is recorded', async () => {
+    const user = userEvent.setup();
+    renderLeaderboard({ myVotes: [] });
+
+    const toggleButtons = screen.getAllByTestId('vote-toggle');
+    await user.click(toggleButtons[0]);
+
+    // Component should have called mutate with onSuccess option
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+    const [, opts] = mockMutate.mock.calls[0];
+    expect(opts).toBeDefined();
+    expect(typeof opts.onSuccess).toBe('function');
+
+    // Simulate the server returning success — the component should toast.success
+    opts.onSuccess?.({} as never, { lineupId: 1, gameId: 42 } as never, undefined);
+
+    expect(toast.success).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(toast.success).mock.calls[0][0]).toMatch(/vote recorded/i);
+  });
+
+  it('shows a success toast when an existing vote is removed', async () => {
+    const user = userEvent.setup();
+    // gameId=42 is already in myVotes, so clicking it removes the vote
+    renderLeaderboard({ myVotes: [42] });
+
+    const toggleButtons = screen.getAllByTestId('vote-toggle');
+    // First row (Lethal Company, gameId=42) is the voted one
+    await user.click(toggleButtons[0]);
+
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+    const [vars, opts] = mockMutate.mock.calls[0];
+    expect(vars).toEqual({ lineupId: 1, gameId: 42 });
+    expect(typeof opts.onSuccess).toBe('function');
+
+    // Simulate the toggle-off success — component should toast.success removal
+    opts.onSuccess?.({} as never, vars, undefined);
+
+    expect(toast.success).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(toast.success).mock.calls[0][0]).toMatch(/vote removed/i);
+  });
+
+  it('still fires the existing error toast when the mutation fails (regression)', async () => {
+    const user = userEvent.setup();
+    renderLeaderboard({ myVotes: [] });
+
+    const toggleButtons = screen.getAllByTestId('vote-toggle');
+    await user.click(toggleButtons[0]);
+
+    const [, opts] = mockMutate.mock.calls[0];
+    expect(typeof opts.onError).toBe('function');
+
+    opts.onError?.(new Error('Voting closed'), { lineupId: 1, gameId: 42 } as never, undefined);
+
+    expect(toast.error).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(toast.error).mock.calls[0][0]).toBe('Voting closed');
+    // Should NOT also fire success on error
+    expect(toast.success).not.toHaveBeenCalled();
   });
 });

--- a/web/src/components/lineups/VotingLeaderboard.test.tsx
+++ b/web/src/components/lineups/VotingLeaderboard.test.tsx
@@ -201,7 +201,8 @@ describe('VotingLeaderboard — vote feedback (ROK-1119)', () => {
     expect(typeof opts.onSuccess).toBe('function');
 
     // Simulate the server returning success — the component should toast.success
-    opts.onSuccess?.({} as never, { lineupId: 1, gameId: 42 } as never, undefined);
+    // After add: server's myVotes now includes gameId 42
+    opts.onSuccess?.({ myVotes: [42] } as never, { lineupId: 1, gameId: 42 } as never, undefined);
 
     expect(toast.success).toHaveBeenCalledTimes(1);
     expect(vi.mocked(toast.success).mock.calls[0][0]).toMatch(/vote recorded/i);
@@ -221,8 +222,8 @@ describe('VotingLeaderboard — vote feedback (ROK-1119)', () => {
     expect(vars).toEqual({ lineupId: 1, gameId: 42 });
     expect(typeof opts.onSuccess).toBe('function');
 
-    // Simulate the toggle-off success — component should toast.success removal
-    opts.onSuccess?.({} as never, vars, undefined);
+    // Simulate the toggle-off success — server's myVotes no longer includes gameId 42
+    opts.onSuccess?.({ myVotes: [] } as never, vars, undefined);
 
     expect(toast.success).toHaveBeenCalledTimes(1);
     expect(vi.mocked(toast.success).mock.calls[0][0]).toMatch(/vote removed/i);

--- a/web/src/components/lineups/VotingLeaderboard.tsx
+++ b/web/src/components/lineups/VotingLeaderboard.tsx
@@ -44,12 +44,16 @@ export function VotingLeaderboard({
 
   const handleToggle = useCallback(
     (gameId: number) => {
+      const wasVoted = votedSet.has(gameId);
       toggleVote.mutate(
         { lineupId, gameId },
-        { onError: (err) => toast.error(err instanceof Error ? err.message : 'Vote failed') },
+        {
+          onSuccess: () => toast.success(wasVoted ? 'Vote removed' : 'Vote recorded'),
+          onError: (err) => toast.error(err instanceof Error ? err.message : 'Vote failed'),
+        },
       );
     },
-    [lineupId, toggleVote],
+    [lineupId, toggleVote, votedSet],
   );
 
   const atLimit = myVotes.length >= maxVotes;

--- a/web/src/components/lineups/VotingLeaderboard.tsx
+++ b/web/src/components/lineups/VotingLeaderboard.tsx
@@ -44,16 +44,18 @@ export function VotingLeaderboard({
 
   const handleToggle = useCallback(
     (gameId: number) => {
-      const wasVoted = votedSet.has(gameId);
       toggleVote.mutate(
         { lineupId, gameId },
         {
-          onSuccess: () => toast.success(wasVoted ? 'Vote removed' : 'Vote recorded'),
+          onSuccess: (data) => {
+            const stillVoted = data.myVotes?.includes(gameId) ?? false;
+            toast.success(stillVoted ? 'Vote recorded' : 'Vote removed');
+          },
           onError: (err) => toast.error(err instanceof Error ? err.message : 'Vote failed'),
         },
       );
     },
-    [lineupId, toggleVote, votedSet],
+    [lineupId, toggleVote],
   );
 
   const atLimit = myVotes.length >= maxVotes;


### PR DESCRIPTION
## Summary
- Adds `toast.success('Vote recorded' | 'Vote removed')` after vote toggles in both `VotingLeaderboard` (lineup page) and `VotingBanner` (game-detail page).
- `LineupVoteBanner.VotingBanner` previously had no callbacks at all — now also gets the `toast.error(...)` mirror from the leaderboard.
- Toast text is derived from the `LineupDetailResponseDto` returned by the mutation (`data.myVotes.includes(gameId)`), not pre-mutation client state — so cross-tab / stale-cache scenarios announce the correct action.

## Linear
ROK-1119

## Test plan
- [x] 5 new failing TDD tests added (commit 15d8ebb7) and made green by the fix
- [x] CI passes: web build + tsc + lint + full vitest (3143/3143)
- [x] Operator browser-tested both surfaces (leaderboard add/remove, banner add/remove) — toasts render correctly
- [x] Code review (Codex) — initially flagged 2 P2 stale-state findings; fix committed (97b67991) addresses both, re-smoked
- [x] Smoke tests passed (full web vitest re-run post-fix)

## DM-side note
The original AC asked about a "DM-side vote submission path." Investigation found the lineup notification DM is a `ButtonStyle.Link` deep-link to the web UI, not a Discord interaction button — fixing the two web call sites covers the DM flow.