### PR TITLE
chore(config): active-state doc + /sprint-planning rewrite + /status-report global mode

### DIFF
--- a/.claude/skills/sprint-planning/SKILL.md
+++ b/.claude/skills/sprint-planning/SKILL.md
@@ -1,40 +1,174 @@
 ---
 name: sprint-planning
-description: Plan the next sprint by reviewing open issues, WIP, and recent progress
+description: "Strategic-discussion surface for Raid-Ledger. Reads the Active State Linear doc + current-sprint.md + live signals (Linear, git, PRs, env lock), synthesizes where we are, proposes 1-3 candidate next moves with rationale, recommends one, and asks for what's needed from the operator to act. Use to resume after a session break, brief a fresh agent on next strategic action, or do cycle-level planning. Pass an optional focus argument (e.g. 'after 1250 lands', 'test infra', 'ROK-1253')."
 disable-model-invocation: true
-argument-hint: "[milestone or focus area]"
-allowed-tools: "Bash(gh *), Bash(git *), Read, Grep, Glob"
+argument-hint: "[focus area or story id]"
+allowed-tools: "Bash(git *), Bash(gh *), Bash(cat *), Read, Grep, Glob, mcp__linear__get_document, mcp__linear__list_issues, mcp__linear__get_issue"
 ---
 
-# Sprint Planning
+# Sprint Planning — Strategic Discussion Surface
 
-Help plan the next sprint for the Raid-Ledger project.
+**Purpose:** the operator invokes this when they want to discuss the next strategic move — at the start of a fresh session, after a break, or at a cycle boundary. The skill reads everything that captures cross-session context, layers in live signals, and proposes options. **It does not act.** It ends by asking for go / redirect / hold.
 
-## Steps
+This is the **read-side** companion to `/status-report`'s Global mode (which is the **write-side**).
 
-1. **Check current work in progress:**
-   - Run `git status` to see uncommitted changes
-   - Run `git log --oneline -20` for recent commit history
-   - Run `git branch -a` to see active branches
+## What this skill is and isn't
 
-2. **Review open GitHub issues:**
-   - Run `gh issue list --limit 30` to see open issues
-   - Run `gh issue list --label "bug" --limit 10` for open bugs
-   - Run `gh pr list` for open pull requests
+- ✅ Reads the Active State Linear doc, `current-sprint.md`, Linear stories, git, gh PRs, env lock.
+- ✅ Synthesizes across those into a 1-page brief and proposes options.
+- ✅ Recommends ONE next move with rationale.
+- ✅ Asks for what info is needed from operator before acting.
+- ❌ Does not write code, ship PRs, file stories, or update the docs.
+- ❌ Does not auto-pick winners or assume operator intent.
 
-3. **Assess current state:**
-   - Identify partially completed work from branches and WIP
-   - Note any blocking issues or dependencies
-   - Review recent velocity from commit history
+If the operator confirms the recommendation, hand off to a different skill (`/build`, `/dispatch`, `/fix-batch`, or direct agent work). This skill ends at "go / redirect / hold."
 
-4. **Propose sprint plan:**
-   - Prioritize bugs and blockers first
-   - Group related features together
-   - Suggest a realistic scope based on recent velocity
-   - If `$ARGUMENTS` was provided, focus the sprint around that milestone or area
+---
 
-5. **Present the plan** as a clear, prioritized task list with:
-   - Priority level (P0/P1/P2)
-   - Estimated complexity (S/M/L)
-   - Dependencies between tasks
-   - Suggested order of execution
+## Step 1: Capture the focus
+
+`$ARGUMENTS` may be empty or carry a focus hint. Examples and how they bias the discussion:
+
+| Argument | Bias |
+|---|---|
+| _empty_ | Open question — "given everything, what's next?" |
+| `ROK-XXXX` | Center the proposal on that story (resume / unblock / sequence) |
+| `test infra` / `lineup` / `discord` | Filter candidate moves to that area |
+| `after X lands` | Forward-look — what becomes the next move once X is shipped |
+| `cycle planning` | Cycle-level mode — produce wave plan instead of single-move recommendation |
+
+If the argument is genuinely ambiguous, ask one clarifying question before running Step 2.
+
+---
+
+## Step 2: Read the canonical state docs
+
+Run these in parallel:
+
+1. **Active State Linear doc** — `mcp__linear__get_document` with slug `7a4ddc5652c9`. This is the primary input — Strategic section has decisions and next-up rationale; Derived has current state.
+2. **`planning-artifacts/current-sprint.md`** — `Read`. Cycle theme, waves, conflict map, deferred list.
+
+If either is missing or malformed, surface as a BLOCKER and stop — synthesizing without these is guesswork.
+
+---
+
+## Step 3: Drift check against live signals
+
+The Active State doc's Derived section may be stale if `/status-report` hasn't run on `main` recently. Run these in parallel to catch drift:
+
+```
+git log --oneline origin/main -10
+gh pr list --state open --json number,title,headRefName,createdAt
+git worktree list
+cat ~/.raid-ledger/env-lock.json
+mcp__linear__list_issues  (state="In Progress")
+mcp__linear__list_issues  (state="Code Review")
+```
+
+Compare to the doc's Derived section. If significant drift (>1 day stale, or a story-status mismatch, or an env-lock holder change), **flag it** and recommend running `/status-report` from `main` to refresh. Continue with current reality, not the stale doc.
+
+---
+
+## Step 4: Synthesize and propose
+
+Build the output in this exact structure. **No extra prose before or after.**
+
+```
+═══ STRATEGIC PLANNING ═══
+Focus: <$ARGUMENTS or "open question">
+
+CURRENT STATE
+- In flight: <1-2 sentences naming each in-flight story + phase>
+- Last 3 strategic decisions: <one-liner each, dated, from Strategic / Recent decisions>
+- Env lock: <holder + branch, or "free">
+- Recently shipped (3): <one-liner each>
+- Doc freshness: <"current" | "stale, last derived: <date> — recommend /status-report on main">
+
+CANDIDATE MOVES
+1. <name>
+   - Why: <single-sentence rationale>
+   - Gates / unblocks: <what depends on this, what this depends on>
+   - Effort: <S / M / L> (S=hours, M=1-2 days, L=multi-day)
+   - Risk: <one-liner — or "low">
+
+2. <name>
+   - Why: ...
+   - Gates / unblocks: ...
+   - Effort: ...
+   - Risk: ...
+
+3. <name>
+   - ... (omit if only 1-2 candidates make sense)
+
+RECOMMENDED: #<N> — <one-sentence why this over the others>
+
+NEEDED FROM YOU
+- <specific decision, info, or approval required to act>
+- <one item per line, max 3>
+
+(go / redirect / hold)
+```
+
+### Rules for each block
+
+- **CURRENT STATE** — facts only, no recommendations. Pull "Last 3 strategic decisions" from the doc's Strategic / Recent decisions section, newest first. If fewer than 3 decisions exist, list what's there.
+- **CANDIDATE MOVES** — 1-3 entries. Don't pad with options that aren't real. Each option must be concretely actionable (no "consider exploring X").
+- **RECOMMENDED** — pick ONE. The rationale must reference something from CURRENT STATE — not invented.
+- **NEEDED FROM YOU** — only the items that genuinely need operator input. If no clarification is needed, write `- nothing — say "go" to proceed`.
+- **End at `(go / redirect / hold)`**. No farewell, no "let me know if". Stop printing text.
+
+### When focus is `cycle planning`
+
+Use this alternative output instead of the single-move recommendation:
+
+```
+═══ CYCLE PLANNING ═══
+
+CYCLE CONTEXT
+- Current cycle: <theme + dates>
+- Stories closed this cycle: <count + ROK list>
+- Stories still open: <count + ROK list>
+- Carry-over candidates: <stories that won't close in time>
+
+PROPOSED NEXT-CYCLE WAVES
+- Wave 1 (urgent / parallel-safe): ROK-... | ROK-... | ROK-...
+- Wave 2 (parallel-safe, lower priority): ...
+- Wave 3 (sequential / gated): ...
+- Deferred: ROK-... (reason)
+
+CONFLICT MAP
+- ROK-A and ROK-B both touch <files> — sequence or rollup
+- ...
+
+CAPACITY
+- Recommended max parallel: <N> (per memory `feedback_build_always_uses_teams.md`)
+- Slot allocation suggestion: ...
+
+NEEDED FROM YOU
+- <decisions required before committing the plan to current-sprint.md>
+
+(approve / redirect / hold)
+```
+
+Only enter cycle-planning mode when the operator explicitly passes that argument or asks for cycle-level planning. Default behavior is single-move recommendation.
+
+---
+
+## Step 5: Stop
+
+This skill ends with the operator's choice. Do not act on the recommendation in the same turn — `/build`, `/dispatch`, `/fix-batch`, or direct work picks up from there.
+
+If the operator says "go", proceed by handing off to whichever execution skill matches the recommended move, OR by directly working on it if it's a small Lead-direct task (per memory `feedback_lead_does_small_fixes.md`).
+
+If the operator redirects, restart at Step 1 with the new focus.
+
+If the operator says "hold" or asks for more analysis, expand on the specific candidate they asked about — don't re-print the full template.
+
+---
+
+## Halts
+
+- Active State doc inaccessible (Linear MCP error, doc missing) → BLOCKER, stop. The skill cannot synthesize without it.
+- `current-sprint.md` missing → BLOCKER, stop. Same reason.
+- All sources fresh and aligned but no candidate moves are credible (e.g. everything is in flight, nothing is queued, no follow-ups) → output the CURRENT STATE block, then write `CANDIDATE MOVES: none — work in flight is sufficient. Re-invoke when a slot opens.` Skip RECOMMENDED.
+- Operator interrupts mid-synthesis → stop cleanly; the read steps are idempotent and re-running is cheap.

--- a/.claude/skills/status-report/SKILL.md
+++ b/.claude/skills/status-report/SKILL.md
@@ -1,13 +1,24 @@
 ---
 name: status-report
-description: "Print a consistent, scannable status report for the current agent's work — story ID, phase, what's done, what's next, blockers. Use when the operator asks for a status update across multiple parallel agent windows ('status', 'where are we', 'what's the state', 'update'). When invoked during Reviewing, also drives the work forward without asking: if any AC is undelivered → implements it; if ACs are delivered but e2e wasn't run → runs the appropriate suite. Goal: maximize what's verified before the operator looks at the window."
+description: "Print a consistent, scannable status report. On a story branch (matches `rok-\\d+`): per-agent snapshot — story ID, phase, what's done, what's next, blockers; during Reviewing also drives the work forward (implements undelivered ACs, runs missing e2e). On `main` (no story branch): global mode — reconciles the 'Raid Ledger — Active State' Linear doc by re-deriving env lock, in-flight stories, recently shipped, open follow-ups, and known stale state. Use when the operator asks for a status update ('status', 'where are we', 'what's the state', 'update', 'sync state')."
 ---
 
-# Status Report — Per-Agent State Snapshot
+# Status Report — Per-Agent Snapshot or Global State Sync
 
-**Goal:** The operator runs 10+ agent windows in parallel and forgets which window is which. This skill produces a 10-second-readable snapshot of THIS agent's work so they can identify the window and decide whether to interact.
+**Two modes**, dispatched by branch:
 
-Output **MUST** match the template exactly — same fields, same order, same labels — every invocation. Consistency is the entire point. If a field has no content, write `none`. Never substitute "no progress yet" or other prose for missing fields.
+1. **Story-branch mode** (`rok-\d+` in branch name) — per-agent snapshot. The operator runs 10+ agent windows in parallel and forgets which window is which; this skill produces a 10-second-readable snapshot of THIS agent's work so they can identify the window and decide whether to interact. Output MUST match the template exactly — same fields, same order, same labels — every invocation. Consistency is the entire point. If a field has no content, write `none`. Never substitute "no progress yet" or other prose for missing fields.
+
+2. **Global mode** (`main` or any branch with no `rok-\d+`) — reconcile the cross-session "Active State" Linear doc. Reads current doc, re-derives env lock + in-flight + recently shipped + open follow-ups + known stale state from authoritative sources, overwrites the Derived section, preserves Strategic and Conventions sections verbatim, prints a brief 3-line summary.
+
+---
+
+## Step 0: Branch-mode dispatch (run first)
+
+Run `git branch --show-current`. Pick the path:
+
+- Branch matches `rok-\d+` → **Story-branch mode**: continue with Steps 1–4 below.
+- Branch is `main` (or any branch with no `rok-\d+`) → **Global mode**: jump to the "Global mode" section near the end of this file. Do **not** run Steps 1–4.
 
 ---
 
@@ -243,5 +254,105 @@ No driving today. Do not invent it.
 ### Halts that override every phase
 
 - Operator has explicitly asked in *this conversation* for a passive snapshot ("just give me the status, don't do anything") → skip Step 4 entirely.
-- Branch is `main` or a release branch (no `rok-\d+` in branch name) → skip; the skill is meant for in-flight story branches.
 - No story is associated (`Story: no story — ...`) → skip; without ACs, "drive forward" has no target.
+
+(Note: `main` no longer halts — Step 0 routes main-branch invocations to Global mode below.)
+
+---
+
+## Global mode — reconcile the Active State Linear doc
+
+Trigger: Step 0 routed here because branch is `main` (or any branch with no `rok-\d+`).
+
+**Goal:** keep the cross-session "Raid Ledger — Active State" Linear doc current by re-deriving the auto-managed sections from authoritative sources, while preserving operator/agent-authored strategic context untouched.
+
+**Doc reference (stable):** see memory `reference_active_state_doc.md`.
+- URL: `https://linear.app/roknua-projects/document/raid-ledger-active-state-7a4ddc5652c9`
+- Doc ID for `mcp__linear__save_document`: `bbacd5ae-0c99-4eaf-bbd7-24e7eb90ffce`
+- Slug: `7a4ddc5652c9`
+
+### Step G1: Read the current doc
+
+`mcp__linear__get_document` with the slug above. Capture the full content. **Identify three section anchors** by markdown heading:
+- `## Derived (auto-overwritten by ...)` — to be replaced
+- `## Strategic (operator + agent updates ...)` — preserve verbatim
+- `## Conventions` — preserve verbatim
+
+If any anchor is missing or out of order, **stop and surface a BLOCKER** (`active state doc structure broken: <which anchor>`). Do not write a malformed doc.
+
+### Step G2: Re-derive each Derived bucket
+
+Run these in parallel where possible. Each bucket maps to a labelled subsection in the new Derived block.
+
+| Bucket | Source command(s) | Notes |
+|---|---|---|
+| **Env lock** | `cat ~/.raid-ledger/env-lock.json` | If `holder: null` and queue empty, write "Holder: `null` / Queue: empty". Otherwise list holder branch + purpose + acquired_at, then queued branches in order. |
+| **In flight** | `gh pr list --state open --json number,title,headRefName,createdAt` AND `mcp__linear__list_issues` for statuses `In Progress`, `Code Review` AND `git worktree list` | Cross-reference: a worktree on a non-main commit + an active Linear story = "in flight." Include architectural verdict if it's been recorded in Strategic (helpful for resumption). |
+| **Recently shipped** | `git log --oneline --since="7 days ago" origin/main` AND `gh pr list --state merged --search "merged:>=$(date -u -v-7d +%Y-%m-%d)" --json number,title,headRefName` | Match commits to PRs to story IDs. Newest first. Cap at ~10 entries. |
+| **Open follow-ups (last 7 days)** | `mcp__linear__list_issues --createdAt -P7D` filtered to states `Backlog`, `Todo` | Skip stories already in flight (covered above). Brief why-it-matters one-liner per entry. |
+| **Known stale state** | Cross-reference `git worktree list` against `git log --oneline origin/main` | Worktrees on commits that aren't on main AND whose corresponding story is shipped → flag as cleanable. Worktrees on commits that aren't on main AND whose story is in flight → not stale, skip. |
+
+If any source command fails (network, auth, missing file), surface the failure as a BLOCKER in the print summary AND skip that bucket (write the literal text `(unavailable — <one-line reason>)`). Do not invent values.
+
+### Step G3: Construct the new Derived section
+
+Use this exact layout:
+
+```markdown
+## Derived (auto-overwritten by `/status-report` on `main`)
+
+### Env lock
+- Holder: <holder block or `null`>
+- Queue: <queue block or `empty`>
+
+### In flight
+- **<ROK-XXXX>** — <title>. Status: <Linear status>. Branch <branch> in worktree <worktree>. <PR or "No PR yet">. <one-line architectural note if relevant>.
+
+### Recently shipped (last 7 days, newest first)
+- `<sha>` PR #<n> — <ROK-XXXX> <title>
+
+### Open follow-ups filed last 7 days
+- **<ROK-XXXX>** (<status> / <priority>) — <one-line why-it-matters>
+
+### Known stale state
+- <description, OR "none">
+```
+
+If a subsection has no content, write `- none` rather than omitting the subsection — readers should see the structure even when the bucket is empty.
+
+### Step G4: Write back
+
+Reassemble the full doc:
+
+```
+<header up to and including the two intro blockquotes>
+---
+<new ## Derived section from Step G3>
+---
+<preserved ## Strategic section from Step G1, byte-for-byte>
+---
+<preserved ## Conventions section from Step G1, byte-for-byte>
+```
+
+The horizontal rules (`---`) between sections are part of the layout; preserve them. Update the `**Last derived update:**` date at the top to today's ISO-8601 date (UTC).
+
+Call `mcp__linear__save_document` with `id: bbacd5ae-0c99-4eaf-bbd7-24e7eb90ffce` and the reassembled content.
+
+### Step G5: Print a 3-line summary
+
+Output **exactly** this format (no template, no addenda — global mode has its own minimal output):
+
+```
+═══ ACTIVE STATE SYNCED ═══
+Doc:      https://linear.app/roknua-projects/document/raid-ledger-active-state-7a4ddc5652c9
+Derived:  <N> in-flight | <M> shipped 7d | <K> follow-ups | <S> stale items
+Note:     <one-line — anything that warranted attention, or "no anomalies">
+```
+
+The `Note:` line is for things the operator should see at a glance — e.g. "ROK-1250 in flight 24h+ without PR", "env lock held by ROK-XXXX since <time>", "stale --rok-XXXX worktree can be removed". One sentence max. If nothing is notable, write `no anomalies`.
+
+### Halts specific to Global mode
+
+- Doc structure broken (Step G1 anchor check failed) → print BLOCKER and stop without writing.
+- `mcp__linear__save_document` returns an error → print BLOCKER `doc save failed: <error>`. The next invocation will re-derive and retry.
+- Operator explicitly says "don't update the doc" in this conversation → run Steps G1–G3, print Step G5's summary with `Note: doc-write skipped per operator request`, but skip Step G4 entirely.


### PR DESCRIPTION
## Summary

Operator-config changes that wire up the new **"Raid Ledger — Active State"** Linear doc into the existing skill system. Pure markdown — no code, no migrations, no infra.

- **/sprint-planning rewritten** as the project's strategic-discussion surface. Replaces the dormant GitHub-Issues-based template with one that reads Linear + the active-state doc + `current-sprint.md` and proposes a single recommended next move (or, with `cycle planning` arg, a wave plan). Read-only by design.
- **/status-report extended** with a Step 0 branch-mode dispatch. Story-branch invocations (`rok-\d+`) keep the existing per-agent snapshot template unchanged. `main`-branch invocations now run Global mode and reconcile the active-state doc's Derived section against live state (env lock, gh PR list, git log, Linear MCP, git worktree list).

## Companion Linear doc

[Raid Ledger — Active State](https://linear.app/roknua-projects/document/raid-ledger-active-state-7a4ddc5652c9) — two sections, fixed ordering:
- **Derived** — overwritten by `/status-report` on main. Treat as ephemeral.
- **Strategic** — append-only. Hand-edited by operator and agents. Holds architectural decisions, queue rationale, open architectural questions.

## Why now

Strategic context (architecture decisions, queue reorders, "this shipped as hygiene only") was previously trapped in conversation. After a reboot it was lost. The doc + the two skill wirings give cross-session continuity:
- Read flow (`/sprint-planning`) — fresh agent reads doc, proposes next move.
- Write flow (`/status-report` on main) — keeps the Derived section current automatically.

## Test plan

- [ ] `/status-report` from a story branch — confirm the existing per-agent template still prints unchanged
- [ ] `/status-report` from `main` — confirm it reconciles the Active State doc's Derived section without disturbing Strategic / Conventions
- [ ] `/sprint-planning` (no args) — confirm it reads the doc, proposes a move, ends at `(go / redirect / hold)` without acting
- [ ] `/sprint-planning cycle planning` — confirm it switches to wave-plan output

## Notes

- No code changes — `validate-ci.sh` not run (n/a for skill markdown).
- Operator-config files per CLAUDE.md "Operator Config Files (STRICT)" rule.
- Memory pointers (`MEMORY.md`, `reference_active_state_doc.md`) live outside the repo and were updated alongside; not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)