### PR TITLE
fix: phaseDeadline integration spec — fail-fast on POST drift

### DIFF
--- a/api/src/lineups/lineup-phase-scheduling.integration.spec.ts
+++ b/api/src/lineups/lineup-phase-scheduling.integration.spec.ts
@@ -48,6 +48,31 @@ function describePhaseScheduling() {
       .send({ title: 'Phase Scheduling Test', ...durations });
   }
 
+  /**
+   * Create a lineup and assert POST succeeded with a real row id. Use this
+   * for any test whose subsequent assertions depend on the lineup existing.
+   *
+   * Background: a flake reported during the ROK-1250 stability loop showed
+   * `GET /lineups/banner` returning 200 with body `{}` — supertest's empty-
+   * body fallback (`superagent/lib/node/response.js:60`). The 4 banner-style
+   * tests below previously fired POST without checking the result, so an
+   * upstream POST failure (auth glitch / contention) surfaced as a
+   * misleading "phaseDeadline missing" assertion. Asserting POST here
+   * surfaces the real cause on the next reproduction.
+   */
+  async function createLineupOrFail(
+    token: string,
+    durations: Parameters<typeof createLineupWithDurations>[1] = {},
+  ): Promise<{ id: number; phaseDeadline: string | null }> {
+    const res = await createLineupWithDurations(token, durations);
+    if (res.status !== 201 || typeof res.body?.id !== 'number') {
+      throw new Error(
+        `createLineupOrFail: expected 201 with body.id, got status=${res.status} body=${JSON.stringify(res.body)}`,
+      );
+    }
+    return { id: res.body.id, phaseDeadline: res.body.phaseDeadline ?? null };
+  }
+
   // ── POST /lineups with duration params ──────────────────────
 
   function describePOSTWithDurations() {
@@ -98,10 +123,9 @@ function describePhaseScheduling() {
 
   function describeGETByIdPhaseDeadline() {
     it('should include phaseDeadline in lineup detail', async () => {
-      const createRes = await createLineupWithDurations(adminToken, {
+      const { id: lineupId } = await createLineupOrFail(adminToken, {
         buildingDurationHours: 24,
       });
-      const lineupId = createRes.body.id as number;
 
       const res = await testApp.request
         .get(`/lineups/${lineupId}`)
@@ -125,7 +149,7 @@ function describePhaseScheduling() {
 
   function describeGETBannerPhaseDeadline() {
     it('should include phaseDeadline in banner response', async () => {
-      await createLineupWithDurations(adminToken, {
+      await createLineupOrFail(adminToken, {
         buildingDurationHours: 24,
       });
 
@@ -147,13 +171,12 @@ function describePhaseScheduling() {
 
   function describePATCHForceAdvance() {
     it('should update phaseDeadline when force-advancing building to voting', async () => {
-      const createRes = await createLineupWithDurations(adminToken, {
-        buildingDurationHours: 24,
-        votingDurationHours: 48,
-        decidedDurationHours: 24,
-      });
-      const lineupId = createRes.body.id as number;
-      const originalDeadline = createRes.body.phaseDeadline;
+      const { id: lineupId, phaseDeadline: originalDeadline } =
+        await createLineupOrFail(adminToken, {
+          buildingDurationHours: 24,
+          votingDurationHours: 48,
+          decidedDurationHours: 24,
+        });
 
       // Force-advance to voting
       const res = await testApp.request
@@ -175,12 +198,11 @@ function describePhaseScheduling() {
     });
 
     it('should clear phaseDeadline when transitioning to archived', async () => {
-      const createRes = await createLineupWithDurations(adminToken, {
+      const { id: lineupId } = await createLineupOrFail(adminToken, {
         buildingDurationHours: 24,
         votingDurationHours: 48,
         decidedDurationHours: 24,
       });
-      const lineupId = createRes.body.id as number;
 
       // Walk through all transitions to archived
       await testApp.request
@@ -252,10 +274,9 @@ function describePhaseScheduling() {
 
   function describeReverseTransitions() {
     it('should allow reverting voting back to building', async () => {
-      const createRes = await createLineupWithDurations(adminToken, {
+      const { id: lineupId } = await createLineupOrFail(adminToken, {
         buildingDurationHours: 24,
       });
-      const lineupId = createRes.body.id as number;
 
       // Advance to voting
       await testApp.request
@@ -275,12 +296,11 @@ function describePhaseScheduling() {
     });
 
     it('should allow reverting archived back to decided', async () => {
-      const createRes = await createLineupWithDurations(adminToken, {
+      const { id: lineupId } = await createLineupOrFail(adminToken, {
         buildingDurationHours: 24,
         votingDurationHours: 48,
         decidedDurationHours: 24,
       });
-      const lineupId = createRes.body.id as number;
 
       await testApp.request
         .patch(`/lineups/${lineupId}/status`)
@@ -306,10 +326,9 @@ function describePhaseScheduling() {
     });
 
     it('should reject skipping phases (building to decided)', async () => {
-      const createRes = await createLineupWithDurations(adminToken, {
+      const { id: lineupId } = await createLineupOrFail(adminToken, {
         buildingDurationHours: 24,
       });
-      const lineupId = createRes.body.id as number;
 
       const res = await testApp.request
         .patch(`/lineups/${lineupId}/status`)


### PR DESCRIPTION
## Summary

The `GET /lineups/banner includes phaseDeadline` integration test was flaking in ROK-1250's 30-run stability loop (`/tmp/rok-1250-runs/run-2.log`) with a confusing error:

```
expect(received).toHaveProperty(path)
Expected path: "phaseDeadline"
Received path: []
Received value: {}
```

That `Received value: {}` is supertest's empty-body fallback (`superagent/lib/node/response.js:60` returns `{}` when both `_body` and `res.body` are `undefined`). The test:

```ts
await createLineupWithDurations(adminToken, { buildingDurationHours: 24 });
const res = await testApp.request.get('/lineups/banner')...
expect(res.status).toBe(200);
expect(res.body).toHaveProperty('phaseDeadline');  // ← reported failure
```

never checked the POST response, so a silent upstream failure (auth glitch under contention, etc.) showed up as a phaseDeadline assertion failure on the GET — not the actual cause.

## Fix

Add `createLineupOrFail` helper that awaits POST and throws with `status=… body=…` if it isn't `201 + body.id`. Refactor the 6 tests in the file that previously relied on an unchecked POST to use the new helper. Production code untouched.

## Reproduction

The flake reproduces locally when multiple jest integration processes contend for Docker (e.g. rok-1250 worktree running `MAX_RUNS=30 /tmp/rok-1250-loop.sh` simultaneously). My initial 30-run loop hit 2 failures (runs 5 and 6) under that condition, mirroring ROK-1250 run-2.

## Validation

- 20 sequential runs of `lineup-phase-scheduling.integration.spec.ts` under deliberate parallel-jest contention: all pass (`/tmp/rok-1217-validate.log`).
- Single-run smoke locally: 13/13 pass.
- Lint: no new errors (5 pre-existing warnings unchanged).

## Caveats / what this does and doesn't fix

- The test is now more robust *and* more diagnostic — when the upstream failure recurs, the error message will say `status=… body=…` instead of pointing at phaseDeadline.
- This does NOT root-cause the original POST-side instability. The hypothesis is that under Docker contention either (a) auth middleware briefly trips, or (b) supertest receives an empty/truncated body for the GET. Both surface as `body={}`. ROK-1250 is the proper home for finishing that hunt.
- No production code change. Contract, controllers, services untouched.

Refs: [ROK-1217](https://linear.app/roknua-projects/issue/ROK-1217), [ROK-1250](https://linear.app/roknua-projects/issue/ROK-1250)

## Test plan

- [x] `npx jest --config ./jest.integration.config.js --runInBand lineup-phase-scheduling.integration.spec.ts` — 20/20 pass under contention
- [x] `npx eslint src/lineups/lineup-phase-scheduling.integration.spec.ts` — 0 errors
- [ ] CI integration shards green

🤖 Generated with [Claude Code](https://claude.com/claude-code)