### PR TITLE
fix: batch (ROK-1261 ThemeParticles clip + ROK-1262 idempotent tiebreaker dismiss)

### DIFF
--- a/TECH-DEBT-BACKLOG.md
+++ b/TECH-DEBT-BACKLOG.md
@@ -46,29 +46,6 @@ A skill's job is typically: parse → group duplicates by file path → propose 
   Suggested: phased migration (separate PRs for backfill vs `SET NOT NULL`) or DB-side default that the new app code overwrites.
 - **[low]** `nginx/monolith.conf.template:75-84` and `nginx/default.conf:52-61` — The existing ROK-393 `/i/:code` crawler block also lacks `proxy_set_header X-Real-IP` / `X-Forwarded-For`, so the invite-OG endpoint's rate-limit buckets all crawlers under the upstream IP too. Same class of bug as the ROK-1067 finding (fixed for `/p/lineup/:slug` in this PR); the invite block was the precedent and inherited the gap.
   Suggested: mirror the four `proxy_set_header` lines in the `/i/:code` location block.
-- **[med]** `api/src/discord-bot/utils/push-content.spec.ts:123` — host-TZ-dependent test. Asserts `withoutTz` (no override) renders `Mar 17` for a 22:00 UTC event, which only holds in non-North-American timezones. Passes under CI's `TZ=UTC` default, fails on any host with `TZ=America/Los_Angeles` (PDT) or similar. Latent flake — never bites in CI but hides if a developer's `npm test` is part of a pre-push gate. Identical file on origin/main; broken since ROK-918 (#492).
-  Suggested: explicitly mock the timezone in the test, or always pass an explicit timezone arg to `buildEventPushContent` rather than testing the implicit-TZ branch.
-  **[FIXED IN BATCH 2026-05-05](#2026-05-05--batch20260505-pr-pending)** — commit bc08ef02 patched the test to use Pacific vs Tokyo (both explicit) instead of relying on default TZ.
-
-### 2026-05-05 — batch/2026-05-05 (PR pending — ROK-1155 + ROK-1069)
-
-- **[high]** `api/src/events/events-dashboard.dashboard.integration.spec.ts` (and rotating siblings) — **cross-suite pollution flake re-surfaced post-ROK-1232**. Run 1 of `validate-ci.sh --full --ci` failed two events-dashboard tests with `loginAsAdmin → 401`; run 2 immediately after passed all 77 suites / 855 tests. Isolated single-file run also passes. Failing suite rotates per run — same signature ROK-1058 documented. ROK-1232 (PR #730, merged 2026-05-06) was the canonical hardening story; the fix reduces but does not eliminate the flake. Not introduced by ROK-1155 or ROK-1069 (neither touches integration test infra; ROK-1155 only changes coverage thresholds on `jest.config.js`, ROK-1069 only adds DEMO_MODE-gated `/admin/test/lineup/*` endpoints unused by integration tests).
-  Suggested: re-open ROK-1058 / file follow-up to ROK-1232 with the specific 2026-05-05 reproduction (events-dashboard auth-401 in full-suite run, isolated pass). May need queue-state reset between auth-touching suites or shared admin-token cache flush.
-- **[high]** Pre-existing Playwright smoke failures observed during batch validation (full `npx playwright test` on this branch, both projects). Not introduced by ROK-1155 or ROK-1069 — same failures occur with our 2 stories backed out (the stories' new admin/test/lineup controller is unused by these specs, and coverage threshold config is a non-runtime change). 21 failing tests across these areas:
-  - `scripts/smoke/admin-slow-queries-log.smoke.spec.ts` (desktop + mobile)
-  - `scripts/smoke/admin-discord.smoke.spec.ts` (mobile)
-  - `scripts/smoke/admin-general.smoke.spec.ts` (mobile)
-  - `scripts/smoke/admin-operations.smoke.spec.ts` (mobile)
-  - `scripts/smoke/lineup-decided.smoke.spec.ts` (desktop + mobile) — covered by canceled ROK-1226
-  - `scripts/smoke/lineup-tiebreaker.smoke.spec.ts` (desktop) — covered by canceled ROK-1226
-  - `scripts/smoke/lineup-tiebreaker-late-join.smoke.spec.ts` (desktop) — covered by canceled ROK-1227
-  - `scripts/smoke/navigation.smoke.spec.ts` (desktop, 2 tests)
-  - `scripts/smoke/onboarding.smoke.spec.ts` (desktop)
-  - `scripts/smoke/paste-nominate.smoke.spec.ts` (desktop)
-  - `scripts/smoke/scheduling-poll.smoke.spec.ts` (desktop + mobile)
-  - `scripts/smoke/standalone-scheduling-poll.smoke.spec.ts` (desktop, 3 tests)
-  - `scripts/smoke/games.smoke.spec.ts` (mobile, ROK-811 regression spec)
-  Suggested: revisit canceled ROK-1226/ROK-1227 — the cancel reason ("downstream effect of LineupsService matching bug") may have shifted now that rok-1067 (#743) and ROK-1232 (#730) merged. The admin-* failures are likely the staleTime polling pattern documented in operator memory `feedback_smoke_polling_for_async_writes.md` (ROK-1156). ROK-811 mobile regression suggests recent UI restructuring on Games page.
 
 ### 2026-05-09 — rok-1225-stabilize-lineups (PR #751)
 
@@ -78,15 +55,11 @@ A skill's job is typically: parse → group duplicates by file path → propose 
   Suggested: spike a follow-up to confirm the UX impact before touching.
 - **[low]** `community_lineup_schedule_slots.match_id` and `community_lineup_schedule_votes.slot_id` FKs declared in 0113 — verify presence on prod via DB probe (this PR fixes only the empirically-missing one on `community_lineup_match_members.match_id`).
   Suggested: one-off operator psql probe; if missing, file a focused follow-up like ROK-1225.
-- **[med]** Worktree `api/.env` doesn't inherit `DEMO_MODE=true` from root `.env`; smoke tests against a freshly-spun-up worktree API need explicit override. Pre-existing dev-env gap surfaced during this branch (dev had to manually set `DEMO_MODE=true` when starting the API). Affects every worktree-based smoke run.
-  Suggested: have `mcp-env env_copy` propagate `DEMO_MODE` from root `.env` to `api/.env` automatically on worktree setup, or have `deploy_dev.sh --ci` inject it.
 - **[low]** Production DB likely has the same orphan rows on `community_lineup_match_members` — migration's `DELETE FROM ... WHERE NOT EXISTS` will clean them on next deploy (Watchtower 5AM); pre-deploy probe optional but informative.
   Suggested: operator-run psql `SELECT COUNT(*) FROM community_lineup_match_members m WHERE NOT EXISTS (SELECT 1 FROM community_lineup_matches WHERE id = m.match_id);` against prod before tomorrow's 5AM pull.
 
 ### 2026-05-09 — rok-1247-smoke-api-polling
 
-- **[high]** `scripts/smoke/admin-slow-queries-log.smoke.spec.ts` × 4 tests (D + M, both `:90` and `:118`) — bucket-c app bug, NOT a staleTime poll issue. `POST /admin/test/seed-slow-queries-log` returns `{success:true, logFilePath:"/data/logs/slow-queries.log"}` but immediately `GET /admin/logs` returns `{files:[], total:0}`. Confirmed via direct curl in worktree env. Likely permissions on `/data/logs/` (LOG_DIR not writable by API user) or path mismatch between seed and listing endpoints. Spec ROK-1247 misclassified this file as "canonical, no migration needed."
-  Suggested: file a focused bug story — investigate `LOG_DIR` resolution in seed vs listing endpoints, verify writeability, check `.dockerignore` for `/data/logs`.
 - **[med]** `scripts/smoke/scheduling-poll.smoke.spec.ts:904` voter-avatars (D, 1 test) — migration's `pollSchedulingPollHasSlot({ withVote: true })` resolves on **any** slot vote, but the test asserts `[data-testid="schedule-slot"][data-voted="true"]` which is current-user-scoped. Vote-toggle flow may end with admin's vote toggled off; pre-existing flakiness uncovered by the migration.
   Suggested: redesign the test — either tighten the poll to current-user vote (poll for `data.slots.some(s => s.votes?.some(v => v.userId === adminUserId))`), or assert on the lower-bound `[data-testid="schedule-slot"]` having ANY avatar group.
 - **[med]** `scripts/smoke/standalone-scheduling-poll.smoke.spec.ts:217` AC9 (D, 1 test) — migration's `pollPollPageHasMatch` resolves but post-navigation the `<h1>Scheduling Poll</h1>` never renders. Page snapshot shows layout chrome + Discord join banner only. Possible navigation race or the page chrome renders before the match query resolves.
@@ -100,8 +73,6 @@ A skill's job is typically: parse → group duplicates by file path → propose 
 
 ### 2026-05-09 — rok-1209-confirmation-pattern (PR pending)
 
-- **[high]** `api/src/cron-jobs/cron-job.integration.spec.ts:404` — **same rotating-suite cross-pollution flake** documented above (2026-05-05 entry). Run 1 of `validate-ci.sh --full` against the post-rebase ROK-1209 branch failed two tests (`pause and resume › should resume a paused cron job via admin API`, `schedule update › should update cron expression and persist`) with `Expected: 200, Received: 401`. Isolated single-file run passes 19/19 in 6s. Failing suite rotated from events-dashboard (2026-05-05) → cron-jobs (today) — same signature, same root cause, ROK-1058 / ROK-1232-follow-up territory. Not caused by ROK-1209 (web-only, no api/auth changes in the diff).
-  Suggested: bundle into the existing ROK-1058 reopen / ROK-1232 follow-up story rather than a new ticket. Today's data point reinforces "rotates per run" pattern — a fix needs to address the cross-suite admin-auth state pollution, not whichever suite happens to land first in run order.
 - **[med]** `scripts/smoke/lineup-confirmation-pills.smoke.spec.ts` — smoke harness has no non-admin fixture user, so all four ROK-1209 smoke tests run with admin-as-creator → `organizer` persona. This means invitee-not-acted, invitee-acted (waiting-tone hero flip), and the per-row ✓ on `LeaderboardRow` for someone-other-than-you cases are NOT exercised at the browser level. Vitest unit tests for `useLineupHero`, `getLineupPersona`, `hasUserActedInPhase`, `getLineupHeroCopy`, and each phase component cover the invitee personas exhaustively, so AC coverage is maintained — but a real persona × phase × phaseState matrix run in a real browser would catch any DOM-level regression vitest's jsdom misses (e.g., IntersectionObserver-driven mobile compact, real CSS sticky behavior under invitee data).
   Suggested: add a smoke-fixture endpoint (e.g., `POST /admin/test/seed-fixture-user` returning `{ userId, jwt }`) plus a `getInviteeToken()` helper in `scripts/smoke/api-helpers.ts`, then add a separate `lineup-confirmation-pills-invitee.smoke.spec.ts` that runs the same matrix from the invitee side. Sized as a small follow-up; not blocking ROK-1209 ship.
 

--- a/api/src/lineups/tiebreaker/tiebreaker-dismiss.helpers.ts
+++ b/api/src/lineups/tiebreaker/tiebreaker-dismiss.helpers.ts
@@ -1,0 +1,39 @@
+/**
+ * Tiebreaker dismiss helpers (ROK-1262).
+ *
+ * Extracted so `tiebreaker.service.ts` stays under its 300-line cap while
+ * the idempotent dismiss behavior (no tiebreaker row + ties → auto-pick
+ * winner) lives close to the related detect logic.
+ */
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { eq } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from '../../drizzle/schema';
+import { detectTies } from './tiebreaker-detect.helpers';
+
+type Db = PostgresJsDatabase<typeof schema>;
+
+/**
+ * Resolve the winner for a "dismiss with no tiebreaker row" path.
+ * Validates the lineup is in voting first (matches `findAndValidateLineup`
+ * semantics), then picks the lowest-gameId tied entry — matches
+ * `deriveTopVotedGame`'s deterministic tiebreaker (`a.gameId - b.gameId`).
+ * Throws 404 if the lineup is missing, 400 if not voting or no ties.
+ */
+export async function pickDismissWinner(
+  db: Db,
+  lineupId: number,
+): Promise<number> {
+  const [lineup] = await db
+    .select()
+    .from(schema.communityLineups)
+    .where(eq(schema.communityLineups.id, lineupId))
+    .limit(1);
+  if (!lineup) throw new NotFoundException('Lineup not found');
+  if (lineup.status !== 'voting') {
+    throw new BadRequestException('Lineup must be in voting status');
+  }
+  const ties = await detectTies(db, lineupId);
+  if (!ties) throw new BadRequestException('No ties to dismiss');
+  return Math.min(...ties.tiedGameIds);
+}

--- a/api/src/lineups/tiebreaker/tiebreaker-dismiss.integration.spec.ts
+++ b/api/src/lineups/tiebreaker/tiebreaker-dismiss.integration.spec.ts
@@ -1,0 +1,231 @@
+/**
+ * ROK-1262 — Tiebreaker dismiss idempotency (integration).
+ *
+ * Regression: `POST /lineups/:id/tiebreaker/dismiss` used to 404 when no
+ * tiebreaker row existed, but the TiebreakerPromptModal opens precisely in
+ * that "ties detected, no row yet" state. The dismiss endpoint is now
+ * idempotent and transitions to `decided` with the lowest-gameId tied entry.
+ *
+ * Cases:
+ *   1. Pending/active tiebreaker exists → 200, row dismissed, lineup decided
+ *      (regression of existing happy path).
+ *   2. No tiebreaker row, voting + ties → 200, lineup `decided`, `decidedGameId`
+ *      = min gameId of tied set (NEW — the bug).
+ *   3. No tiebreaker row, voting, no ties → 400 'No ties to dismiss'.
+ *   4. Lineup not in voting → 400 from `findAndValidateLineup`.
+ */
+import { eq } from 'drizzle-orm';
+import { getTestApp, type TestApp } from '../../common/testing/test-app';
+import {
+  truncateAllTables,
+  loginAsAdmin,
+} from '../../common/testing/integration-helpers';
+import * as schema from '../../drizzle/schema';
+import { generatePublicSlug } from '../public-lineup-slug.helpers';
+import { TiebreakerService } from './tiebreaker.service';
+import { DiscordBotClientService } from '../../discord-bot/discord-bot-client.service';
+
+interface TiedLineupSetup {
+  lineupId: number;
+  gameAId: number;
+  gameBId: number;
+  voterAId: number;
+  voterBId: number;
+}
+
+function describeTiebreakerDismiss() {
+  let testApp: TestApp;
+  let adminToken: string;
+  let tiebreakerService: TiebreakerService;
+  let sendEmbedSpy: jest.SpyInstance;
+
+  beforeAll(async () => {
+    testApp = await getTestApp();
+    adminToken = await loginAsAdmin(testApp.request, testApp.seed);
+    tiebreakerService = testApp.app.get(TiebreakerService);
+  });
+
+  beforeEach(() => {
+    // start() fires a notification dispatch in the regression case; stub the
+    // bot client so we don't depend on Discord being reachable.
+    sendEmbedSpy = jest
+      .spyOn(testApp.app.get(DiscordBotClientService), 'sendEmbed')
+      .mockResolvedValue({ id: 'mock-msg-tb-dismiss' } as never);
+  });
+
+  afterEach(async () => {
+    sendEmbedSpy.mockRestore();
+    testApp.seed = await truncateAllTables(testApp.db);
+    adminToken = await loginAsAdmin(testApp.request, testApp.seed);
+  });
+
+  async function createMember(tag: string): Promise<number> {
+    const [user] = await testApp.db
+      .insert(schema.users)
+      .values({
+        discordId: `discord:dismiss-${tag}`,
+        username: `mem-dismiss-${tag}`,
+        role: 'member',
+      })
+      .returning();
+    return user.id;
+  }
+
+  async function createGame(name: string): Promise<number> {
+    const [g] = await testApp.db
+      .insert(schema.games)
+      .values({
+        name,
+        slug: `${name.toLowerCase()}-${Date.now()}-${Math.random()}`,
+      })
+      .returning();
+    return g.id;
+  }
+
+  /** Voting lineup with two tied games (one vote each from distinct voters). */
+  async function setupVotingLineupWithTies(): Promise<TiedLineupSetup> {
+    const voterAId = await createMember('vA');
+    const voterBId = await createMember('vB');
+    const gameAId = await createGame('TBDismissA');
+    const gameBId = await createGame('TBDismissB');
+
+    const [lineup] = await testApp.db
+      .insert(schema.communityLineups)
+      .values({
+        title: 'ROK-1262 dismiss',
+        status: 'voting',
+        visibility: 'public',
+        createdBy: testApp.seed.adminUser.id,
+        publicSlug: generatePublicSlug(),
+      })
+      .returning();
+
+    await testApp.db.insert(schema.communityLineupEntries).values([
+      { lineupId: lineup.id, gameId: gameAId, nominatedBy: voterAId },
+      { lineupId: lineup.id, gameId: gameBId, nominatedBy: voterBId },
+    ]);
+    await testApp.db.insert(schema.communityLineupVotes).values([
+      { lineupId: lineup.id, gameId: gameAId, userId: voterAId },
+      { lineupId: lineup.id, gameId: gameBId, userId: voterBId },
+    ]);
+
+    return { lineupId: lineup.id, gameAId, gameBId, voterAId, voterBId };
+  }
+
+  async function getLineup(lineupId: number) {
+    const [row] = await testApp.db
+      .select()
+      .from(schema.communityLineups)
+      .where(eq(schema.communityLineups.id, lineupId))
+      .limit(1);
+    return row;
+  }
+
+  // ── Case 1: regression of existing path ──────────────────────────────
+
+  it('dismisses when a pending/active tiebreaker row exists (regression)', async () => {
+    const { lineupId } = await setupVotingLineupWithTies();
+    await tiebreakerService.start(lineupId, {
+      mode: 'veto',
+      roundDurationHours: 24,
+    });
+
+    const res = await testApp.request
+      .post(`/lineups/${lineupId}/tiebreaker/dismiss`)
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+    const [tb] = await testApp.db
+      .select()
+      .from(schema.communityLineupTiebreakers)
+      .where(eq(schema.communityLineupTiebreakers.lineupId, lineupId));
+    expect(tb.status).toBe('dismissed');
+    const lineup = await getLineup(lineupId);
+    expect(lineup.status).toBe('decided');
+    expect(lineup.activeTiebreakerId).toBeNull();
+  });
+
+  // ── Case 2: the bug — no row, ties present ───────────────────────────
+
+  it('dismisses with no tiebreaker row + ties → 200, decidedGameId = min tied gameId (ROK-1262)', async () => {
+    const { lineupId, gameAId, gameBId } = await setupVotingLineupWithTies();
+    // Sanity: no tiebreaker row yet — this is the exact state the modal opens in.
+    const tbsBefore = await testApp.db
+      .select()
+      .from(schema.communityLineupTiebreakers)
+      .where(eq(schema.communityLineupTiebreakers.lineupId, lineupId));
+    expect(tbsBefore).toHaveLength(0);
+
+    const res = await testApp.request
+      .post(`/lineups/${lineupId}/tiebreaker/dismiss`)
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+
+    const lineup = await getLineup(lineupId);
+    expect(lineup.status).toBe('decided');
+    expect(lineup.decidedGameId).toBe(Math.min(gameAId, gameBId));
+  });
+
+  // ── Case 3: no row + no ties → clear 400 ─────────────────────────────
+
+  it('returns 400 when voting lineup has no ties to dismiss', async () => {
+    const voterId = await createMember('soloVoter');
+    const gameId = await createGame('TBDismissSolo');
+    const [lineup] = await testApp.db
+      .insert(schema.communityLineups)
+      .values({
+        title: 'ROK-1262 no-ties',
+        status: 'voting',
+        visibility: 'public',
+        createdBy: testApp.seed.adminUser.id,
+        publicSlug: generatePublicSlug(),
+      })
+      .returning();
+    await testApp.db.insert(schema.communityLineupEntries).values({
+      lineupId: lineup.id,
+      gameId,
+      nominatedBy: voterId,
+    });
+    await testApp.db.insert(schema.communityLineupVotes).values({
+      lineupId: lineup.id,
+      gameId,
+      userId: voterId,
+    });
+
+    const res = await testApp.request
+      .post(`/lineups/${lineup.id}/tiebreaker/dismiss`)
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(400);
+    expect(String(res.body.message)).toMatch(/no ties/i);
+  });
+
+  // ── Case 4: not voting → 400 ─────────────────────────────────────────
+
+  it('returns 400 when lineup is not in voting status', async () => {
+    const [lineup] = await testApp.db
+      .insert(schema.communityLineups)
+      .values({
+        title: 'ROK-1262 not-voting',
+        status: 'building',
+        visibility: 'public',
+        createdBy: testApp.seed.adminUser.id,
+        publicSlug: generatePublicSlug(),
+      })
+      .returning();
+
+    const res = await testApp.request
+      .post(`/lineups/${lineup.id}/tiebreaker/dismiss`)
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(400);
+    expect(String(res.body.message)).toMatch(/voting/i);
+  });
+}
+
+describe(
+  'Regression: ROK-1262 dismiss with no tiebreaker row (integration)',
+  describeTiebreakerDismiss,
+);

--- a/api/src/lineups/tiebreaker/tiebreaker.service.ts
+++ b/api/src/lineups/tiebreaker/tiebreaker.service.ts
@@ -24,6 +24,7 @@ import { LineupNotificationService } from '../lineup-notification.service';
 import { LineupsGateway } from '../lineups.gateway';
 import { dispatchTiebreakerOpen } from './tiebreaker-dispatch.helpers';
 import { detectTies } from './tiebreaker-detect.helpers';
+import { pickDismissWinner } from './tiebreaker-dismiss.helpers';
 import { runMatchingAlgorithm } from '../lineups-lifecycle.helpers';
 import {
   findPendingOrActiveTiebreaker,
@@ -123,14 +124,18 @@ export class TiebreakerService {
     );
   }
 
-  /** Dismiss tiebreaker — proceed to decided without resolution. */
+  /**
+   * Dismiss tiebreaker — proceed to decided. Idempotent (ROK-1262): when
+   * the modal is shown but no tiebreaker row exists yet, fall back to the
+   * lowest-gameId tied entry — see `pickDismissWinner`.
+   */
   async dismiss(lineupId: number): Promise<void> {
     const [tb] = await findPendingOrActiveTiebreaker(this.db, lineupId);
-    if (!tb) throw new NotFoundException('No tiebreaker found');
-
-    await this.updateTiebreakerStatus(tb.id, 'dismissed');
+    if (tb) await this.updateTiebreakerStatus(tb.id, 'dismissed');
     await this.clearActiveTiebreaker(lineupId);
-    await this.transitionToDecided(lineupId);
+    if (tb) return this.transitionToDecided(lineupId);
+    const winnerId = await pickDismissWinner(this.db, lineupId);
+    await this.transitionToDecided(lineupId, winnerId);
   }
 
   /** Reset/clear any active tiebreaker without changing lineup phase. */

--- a/scripts/smoke/lineup-tiebreaker.smoke.spec.ts
+++ b/scripts/smoke/lineup-tiebreaker.smoke.spec.ts
@@ -504,6 +504,59 @@ test.describe('Dismiss tiebreaker', () => {
         await expect(page.locator('[data-testid="bracket-view"]')).not.toBeVisible();
         await expect(page.locator('[data-testid="veto-view"]')).not.toBeVisible();
     });
+
+    test('dismisses with no tiebreaker row via UI (ROK-1262 regression)', async ({ page }) => {
+        test.skip(test.info().project.name === 'mobile', 'Breadcrumb overflows on mobile viewport');
+
+        // Regression: the TiebreakerPromptModal opens when ties are detected
+        // BEFORE any tiebreaker row exists. Clicking Dismiss must transition
+        // the lineup to decided (previously it was a silent 404).
+        await archiveActiveLineup(adminToken);
+
+        const gameIds = await fetchGameIds(adminToken, 4);
+        const { id: noRowLineupId } = await createLineupOrRetry(
+            adminToken,
+            {
+                title: lineupTitle,
+                buildingDurationHours: 720,
+                votingDurationHours: 720,
+                decidedDurationHours: 720,
+                matchThreshold: 10,
+            },
+            workerPrefix,
+        );
+
+        for (const gid of gameIds) {
+            await apiPost(adminToken, `/lineups/${noRowLineupId}/nominate`, { gameId: gid });
+        }
+        await apiPatch(adminToken, `/lineups/${noRowLineupId}/status`, { status: 'voting' });
+        // Equal votes on two games → ties, no tiebreaker row started.
+        await apiPost(adminToken, `/lineups/${noRowLineupId}/vote`, { gameId: gameIds[0] });
+        await apiPost(adminToken, `/lineups/${noRowLineupId}/vote`, { gameId: gameIds[1] });
+        await awaitProcessing(adminToken);
+
+        await page.goto(`/community-lineup/${noRowLineupId}`);
+        await expect(page.locator('body')).not.toHaveText(/something went wrong/i, { timeout: 10_000 });
+
+        // Trigger TIEBREAKER_REQUIRED → prompt modal via the breadcrumb advance.
+        const advanceBtn = page.getByRole('button', { name: 'Scheduling' });
+        await expect(advanceBtn).toBeVisible({ timeout: 10_000 });
+        await advanceBtn.click();
+        const confirmBtn = page.getByRole('button', { name: /advance/i });
+        await expect(confirmBtn).toBeVisible({ timeout: 5_000 });
+        await confirmBtn.click();
+
+        const modal = page.locator('[data-testid="tiebreaker-prompt-modal"]');
+        await expect(modal).toBeVisible({ timeout: 15_000 });
+
+        // Click Dismiss inside the modal — this used to silently 404.
+        const dismissBtn = modal.getByRole('button', { name: /dismiss|proceed without/i });
+        await dismissBtn.click();
+
+        // Modal closes and the page re-renders into the decided view.
+        await expect(modal).not.toBeVisible({ timeout: 10_000 });
+        await expect(page.getByText("THIS WEEK'S PODIUM")).toBeVisible({ timeout: 15_000 });
+    });
 });
 
 // ---------------------------------------------------------------------------

--- a/web/src/components/ui/ThemeParticles.test.tsx
+++ b/web/src/components/ui/ThemeParticles.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Regression: ROK-1261 — ThemeParticles canvas must be clipped to the
+ * document's content height so bright streaks/particles never render in
+ * the empty zone below the footer when page content is shorter than the
+ * viewport.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { render } from '@testing-library/react';
+
+// Force the resolved theme to one with a CONFIGS entry ('arctic'), otherwise
+// ThemeParticles short-circuits to null on themes without an ambient config.
+vi.mock('../../stores/theme-store', () => ({
+    useThemeStore: (selector: (s: { resolved: { id: string } }) => unknown) =>
+        selector({ resolved: { id: 'arctic' } }),
+}));
+
+import { ThemeParticles } from './ThemeParticles';
+
+function setDimensions(viewportH: number, documentH: number) {
+    vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(viewportH);
+    vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1280);
+    vi.spyOn(document.documentElement, 'scrollHeight', 'get').mockReturnValue(documentH);
+}
+
+function stubCanvasContext() {
+    // jsdom does not implement 2D canvas. Return a minimal stub so setupCanvas
+    // proceeds and sizes the bitmap; the regression we care about is purely
+    // about width/height attributes, not drawing.
+    const ctx = new Proxy({}, {
+        get: () => () => undefined,
+    }) as unknown as CanvasRenderingContext2D;
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(ctx);
+}
+
+describe('Regression: ROK-1261 — ThemeParticles canvas clip', () => {
+    beforeEach(() => {
+        stubCanvasContext();
+        // Default matchMedia mock returns matches: false for reduced-motion so
+        // the animation effect runs and sizes the canvas.
+        window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+            matches: false,
+            media: query,
+            onchange: null,
+            addListener: vi.fn(),
+            removeListener: vi.fn(),
+            addEventListener: vi.fn(),
+            removeEventListener: vi.fn(),
+            dispatchEvent: vi.fn(),
+        })) as unknown as typeof window.matchMedia;
+    });
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('caps canvas height to document height when content is shorter than viewport', () => {
+        // Viewport is 900px tall but page content is only 600px — without the
+        // fix, particles would draw in the empty 600-900 zone below the footer.
+        setDimensions(900, 600);
+
+        const { container } = render(<ThemeParticles />);
+        const canvas = container.querySelector('canvas') as HTMLCanvasElement | null;
+        expect(canvas).not.toBeNull();
+        expect(canvas!.height).toBe(600);
+        expect(canvas!.height).toBeLessThanOrEqual(document.documentElement.scrollHeight);
+    });
+
+    it('uses viewport height when document is taller (long-content page)', () => {
+        // Long-content page — canvas should still cover the visible viewport
+        // on first paint; particles drawing above scrollHeight is fine because
+        // they remain inside the viewport bitmap.
+        setDimensions(900, 3000);
+
+        const { container } = render(<ThemeParticles />);
+        const canvas = container.querySelector('canvas') as HTMLCanvasElement | null;
+        expect(canvas).not.toBeNull();
+        expect(canvas!.height).toBe(900);
+    });
+
+    it('sets canvas CSS height to match the bitmap height (prevents stretch)', () => {
+        // Without an explicit CSS height the prior `inset: 0` rule stretched the
+        // canvas to the full viewport regardless of its bitmap, re-introducing
+        // the streaks below content. Verify the inline style is set in px.
+        setDimensions(900, 500);
+
+        const { container } = render(<ThemeParticles />);
+        const canvas = container.querySelector('canvas') as HTMLCanvasElement | null;
+        expect(canvas).not.toBeNull();
+        expect(canvas!.style.height).toBe('500px');
+    });
+
+    it('does not pin the canvas bottom to the viewport (would re-stretch via CSS)', () => {
+        // With `inset: 0` (top:0; right:0; bottom:0; left:0) the canvas always
+        // fills the viewport regardless of its bitmap height. The fix removes
+        // the bottom anchor and drives height from the bitmap instead.
+        setDimensions(900, 400);
+
+        const { container } = render(<ThemeParticles />);
+        const canvas = container.querySelector('canvas') as HTMLCanvasElement | null;
+        expect(canvas).not.toBeNull();
+        expect(canvas!.style.bottom).toBe('');
+    });
+});

--- a/web/src/components/ui/ThemeParticles.tsx
+++ b/web/src/components/ui/ThemeParticles.tsx
@@ -14,13 +14,27 @@ import { CONFIGS } from './theme-particles.config';
 import { spawnParticle, placePanelEdgeParticle, queryPanelElements } from './theme-particles.helpers';
 import { tick, createTickState } from './theme-particles.tick';
 
+/**
+ * Effective drawable height: capped at the document's content height so
+ * particles never render in empty space below the footer when content is
+ * shorter than the viewport (ROK-1261). Falls back to viewport height when
+ * the document is taller (long-content pages) so particles still cover the
+ * visible viewport on first paint before scroll.
+ */
+function computeCanvasHeight() {
+    const docH = document.documentElement.scrollHeight;
+    const viewH = window.innerHeight;
+    return docH > 0 ? Math.min(viewH, docH) : viewH;
+}
+
 function setupCanvas(canvas: HTMLCanvasElement) {
     const ctx = canvas.getContext('2d');
     if (!ctx) return null;
     const w = window.innerWidth;
-    const h = window.innerHeight;
+    const h = computeCanvasHeight();
     canvas.width = w;
     canvas.height = h;
+    canvas.style.height = `${h}px`;
     return { ctx, w, h };
 }
 
@@ -39,6 +53,16 @@ function startAnimation(
     rafRef.current = requestAnimationFrame(loop);
 }
 
+function bindResizeListeners(handler: () => void) {
+    window.addEventListener('resize', handler);
+    // Document grows/shrinks on route changes, lazy images, dynamic content —
+    // re-measure so the canvas keeps tracking the footer's bottom edge.
+    const ro = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(handler) : null;
+    ro?.observe(document.documentElement);
+    ro?.observe(document.body);
+    return () => { window.removeEventListener('resize', handler); ro?.disconnect(); };
+}
+
 function useParticleAnimation(
     themeId: string,
     canvasRef: React.RefObject<HTMLCanvasElement | null>,
@@ -53,20 +77,16 @@ function useParticleAnimation(
         const canvas = canvasRef.current;
         let { w, h } = setup;
         const { ctx } = setup;
-
         const state = createTickState();
         if (cfg.behavior === 'panel-edge') state.panelElements = queryPanelElements();
-
-        const handleResize = () => {
-            w = window.innerWidth; h = window.innerHeight;
+        const unbind = bindResizeListeners(() => {
+            w = window.innerWidth; h = computeCanvasHeight();
             canvas.width = w; canvas.height = h;
+            canvas.style.height = `${h}px`;
             if (cfg.behavior === 'panel-edge') state.panelElements = queryPanelElements();
-        };
-        window.addEventListener('resize', handleResize);
-
+        });
         startAnimation(canvas, ctx, cfg, w, h, state, themeId, rafRef);
-
-        return () => { cancelAnimationFrame(rafRef.current); window.removeEventListener('resize', handleResize); ctx.clearRect(0, 0, w, h); };
+        return () => { cancelAnimationFrame(rafRef.current); unbind(); ctx.clearRect(0, 0, w, h); };
     }, [themeId, canvasRef, rafRef]);
 }
 
@@ -91,7 +111,7 @@ export function ThemeParticles() {
         <canvas
             ref={canvasRef}
             aria-hidden="true"
-            style={{ position: 'fixed', inset: 0, pointerEvents: 'none', zIndex: 0 }}
+            style={{ position: 'fixed', top: 0, left: 0, right: 0, pointerEvents: 'none', zIndex: 0 }}
         />
     );
 }

--- a/web/src/hooks/use-tiebreaker.ts
+++ b/web/src/hooks/use-tiebreaker.ts
@@ -11,6 +11,7 @@ import {
     castVeto,
     forceResolveTiebreaker,
 } from '../lib/api/tiebreaker-api';
+import { toast } from '../lib/toast';
 
 export const TIEBREAKER_KEY = ['tiebreaker'] as const;
 const LINEUPS_PREFIX = ['lineups'] as const;
@@ -46,6 +47,11 @@ export function useDismissTiebreaker() {
         onSuccess: () => {
             void qc.invalidateQueries({ queryKey: [...LINEUPS_PREFIX] });
             void qc.invalidateQueries({ queryKey: [...TIEBREAKER_KEY] });
+        },
+        // ROK-1262: surface errors so dismiss isn't a silent no-op when the
+        // backend rejects (e.g. no ties remain, lineup not in voting).
+        onError: (err: Error) => {
+            toast.error(err.message || 'Failed to dismiss tiebreaker');
         },
     });
 }


### PR DESCRIPTION
## Summary

Fix batch shipped via `/fix-batch` pipeline.

| Story | Label | Description |
|-------|-------|-------------|
| ROK-1261 | Bug, UI/UX | Clip `ThemeParticles` canvas to document height — shooting-star streaks no longer render below the footer on short pages. |
| ROK-1262 | Bug, UI/UX | Make `POST /lineups/:id/tiebreaker/dismiss` idempotent — when the modal opens but no tiebreaker row exists yet, auto-pick the lowest-`gameId` tied entry and transition to decided (Option B from the story). Surface dismiss errors via toast instead of silently swallowing. |
| chore(config) | — | Prune triaged tech-debt entries (ROK-1266, ROK-1267); operator config ride-along. |

## Linear

- ROK-1261
- ROK-1262
- Follow-up filed: ROK-1268 (residual integration-suite socket-leak flake post-ROK-1250) — tracked, not blocking.

## What changed

### ROK-1261 — ThemeParticles canvas clip
- `web/src/components/ui/ThemeParticles.tsx` — `computeCanvasHeight()` clamps bitmap and CSS height to `min(window.innerHeight, document.documentElement.scrollHeight)`. Removed `bottom: 0` (was re-stretching via CSS). ResizeObserver on `documentElement` + `body` re-measures on dynamic content. `prefers-reduced-motion` preserved.
- `web/src/components/ui/ThemeParticles.test.tsx` (NEW) — Vitest regression suite, 4 cases (short-page, long-page, css-height-set, no-bottom-stretch). Operator-approved alternative to Playwright (acceptable per spec).

### ROK-1262 — Idempotent tiebreaker dismiss
- `api/src/lineups/tiebreaker/tiebreaker.service.ts` — `dismiss()` branched. Existing path unchanged; no-row path delegates to `pickDismissWinner`.
- `api/src/lineups/tiebreaker/tiebreaker-dismiss.helpers.ts` (NEW) — Extracted to keep service under the 300-line ESLint cap. Validates lineup exists + is in `voting`, then picks `Math.min(...ties.tiedGameIds)` — matches `deriveTopVotedGame`'s deterministic ordering.
- `api/src/lineups/tiebreaker/tiebreaker-dismiss.integration.spec.ts` (NEW) — Jest integration spec, 4 cases on real DB: pending-row regression, no-row + ties (the bug fix), no-row + no-ties (400), not-in-voting (400).
- `web/src/hooks/use-tiebreaker.ts` — `useDismissTiebreaker` `onError` → `toast.error`. No more silent failures.
- `scripts/smoke/lineup-tiebreaker.smoke.spec.ts` — extended the existing `Dismiss tiebreaker` describe with the no-tiebreaker-row UI regression.

### Operator config ride-along
- `TECH-DEBT-BACKLOG.md` — pruned 6 triaged entries (ROK-1266, ROK-1267 promoted; ROK-1247 / ROK-1225 / ROK-1209 / TZ-test reconciled per /readlogs triage on 2026-05-11).

## Known follow-ups (NOT blockers — pre-existing)

- **runStatusTransition bypass for tiebreaker-resolution paths** — `transitionToDecided` writes the lineup row + runs matching but skips `fireDecidedNotifications` and `logTransition`. Pre-existing across `forceResolve`, bracket auto-advance, and now the no-row dismiss path. Called out in commit body for ROK-1262 backend. ROK-1117 territory.
- **Residual integration-suite socket-leak flake post-ROK-1250** — tracked as **ROK-1268** (Medium). Full `test:integration` suite still flakes on a different carrier each run after the ROK-1250 fix. Our batch's specific integration spec passes 4/4 in isolation; flake is unrelated to this PR's changes.

## Test plan

- [x] `npm run build -w packages/contract` (rebuilt after rebase, per `feedback_rebuild_contract_after_rebase.md`)
- [x] `validate-ci.sh --full` — build (api + web + contract), typecheck, lint, unit tests + coverage (api + web), integration tests
- [x] Batch-specific integration: `tiebreaker-dismiss.integration.spec.ts` — 4/4 PASS in 9s on real DB
- [x] Playwright smoke (desktop + mobile)
- [x] Code review (Lead direct review — see `planning-artifacts/review-fix-batch-2026-05-11.md`): 0 critical, 0 high
- [x] Regression tests: `Regression: ROK-1261` in `ThemeParticles.test.tsx`, `Regression: ROK-1262` in both `tiebreaker-dismiss.integration.spec.ts` and `lineup-tiebreaker.smoke.spec.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
