### PR TITLE
fix: batch 2026-05-12 (ROK-1240 reminder cadence + ROK-1269 rescheduler + ROK-1266 admin logs)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,7 +111,7 @@ State lives at `~/.raid-ledger/env-lock.json` (outside any worktree). The lease 
 
 ## Code Size Limits (STRICT — enforced by ESLint)
 
-- **Max 300 lines per file** (`max-lines: warn`, skipBlankLines + skipComments) — will be upgraded to `error` once existing violations are resolved
+- **Max 300 lines per file** (`max-lines: error`, skipBlankLines + skipComments) — CI lint fails on violations. Run `npm run lint -w api` AND `npm run lint -w web` locally before pushing; `./scripts/validate-ci.sh --full` runs both. Note: line counts are after stripping blanks + comments, so the raw file may exceed 300 (e.g. `wc -l` 360 → counted 295 is fine).
 - **Max 30 lines per function** (`max-lines-per-function: warn`, skipBlankLines + skipComments) — will be upgraded to `error` once existing violations are resolved
 - **Design small from the start** — do not write large files and refactor after. Plan focused modules, extract helpers/sub-services/child components proactively.
 - Test files (`*.spec.ts`, `*.test.tsx`) have a relaxed **750-line** file limit (not 300).

--- a/api/src/admin/admin.module.ts
+++ b/api/src/admin/admin.module.ts
@@ -16,6 +16,7 @@ import { DemoTestLineupController } from './demo-test-lineup.controller';
 import { DemoTestGraceController } from './demo-test-grace.controller';
 import { DemoTestResetController } from './demo-test-reset.controller';
 import { DemoTestStandalonePollController } from './demo-test-standalone-poll.controller';
+import { DemoTestRecruitmentController } from './demo-test-recruitment.controller';
 import { SlashCommandTestController } from './slash-command-test.controller';
 import { ItadSettingsController } from './itad-settings.controller';
 import { CommunityInsightsSettingsController } from './settings-community-insights.controller';
@@ -65,6 +66,7 @@ import { AiChatTestController } from './ai-chat-test.controller';
     DemoTestGraceController,
     DemoTestResetController,
     DemoTestStandalonePollController,
+    DemoTestRecruitmentController,
     AiChatTestController,
     SlashCommandTestController,
     ItadSettingsController,

--- a/api/src/admin/demo-test-core.controller.spec.ts
+++ b/api/src/admin/demo-test-core.controller.spec.ts
@@ -29,7 +29,10 @@ function createMockService() {
 
 function createMockSlowQueries() {
   return {
-    appendDigestToLog: jest.fn().mockResolvedValue(undefined),
+    // ROK-1266: appendDigestToLog now returns boolean — true means file was
+    // actually written. The seed endpoint surfaces `false` as a 500 so smoke
+    // tests catch silent IO failures instead of seeing { files: [], total: 0 }.
+    appendDigestToLog: jest.fn().mockResolvedValue(true),
     getLogFilePath: jest
       .fn()
       .mockReturnValue('/tmp/raid-ledger-smoke/slow-queries.log'),
@@ -453,6 +456,18 @@ function seedSlowQueriesLogTests(
     await expect(
       getController().seedSlowQueriesLogForTest({ entryCount: 5 }),
     ).rejects.toThrow(/Validation failed/);
+  });
+
+  // ROK-1266 regression: previously the endpoint returned `{ success: true }`
+  // even when `appendDigestToLog` failed to write the file (LOG_DIR not
+  // writable). The smoke test then saw `success` from the seed but the
+  // listing endpoint returned `{ files: [], total: 0 }` — the file never
+  // existed. Now an IO failure surfaces as a 500.
+  it('throws InternalServerError when appendDigestToLog reports failure (ROK-1266)', async () => {
+    getMockSlowQueries().appendDigestToLog.mockResolvedValueOnce(false);
+    await expect(getController().seedSlowQueriesLogForTest({})).rejects.toThrow(
+      /Failed to write slow-query digest/,
+    );
   });
 }
 

--- a/api/src/admin/demo-test-core.controller.ts
+++ b/api/src/admin/demo-test-core.controller.ts
@@ -11,6 +11,7 @@ import {
   BadRequestException,
   ForbiddenException,
   Inject,
+  InternalServerErrorException,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { SkipThrottle } from '@nestjs/throttler';
@@ -162,10 +163,14 @@ export class DemoTestCoreController {
   /**
    * Seed a deterministic slow-query digest entry — DEMO_MODE only (ROK-1070).
    *
-   * Workaround for the admin-slow-queries-log smoke test on Mac dev where
-   * `LOG_DIR` defaults to `/data/logs/` and is unwritable. Delegates to the
-   * production `SlowQueriesService.appendDigestToLog` which already handles
-   * `mkdir -p` and best-effort error handling.
+   * Delegates to the production `SlowQueriesService.appendDigestToLog`,
+   * which performs `mkdir -p` then `appendFile` against the shared LOG_DIR
+   * resolved by `common/log-dir.ts` (writable temp dir in dev, `/data/logs`
+   * volume in prod). ROK-1266: the writer used to swallow IO errors and the
+   * endpoint reported `success: true` even when the file was never written —
+   * the listing endpoint then returned `{ files: [], total: 0 }` because no
+   * file existed at all. We now propagate the failure as a 500 so the smoke
+   * test (and any human curl) sees the real reason.
    */
   @Post('seed-slow-queries-log')
   @HttpCode(HttpStatus.OK)
@@ -176,11 +181,15 @@ export class DemoTestCoreController {
     // gate via the controller's own assertDemoMode (env + DB checks).
     await this.assertDemoMode();
     parseDemoBody(SeedSlowQueriesLogSchema, body ?? {});
-    await this.slowQueriesService.appendDigestToLog();
-    return {
-      success: true,
-      logFilePath: this.slowQueriesService.getLogFilePath(),
-    };
+    const written = await this.slowQueriesService.appendDigestToLog();
+    const logFilePath = this.slowQueriesService.getLogFilePath();
+    if (!written) {
+      throw new InternalServerErrorException(
+        `Failed to write slow-query digest to ${logFilePath}; ` +
+          `check LOG_DIR is writable by the API process`,
+      );
+    }
+    return { success: true, logFilePath };
   }
 
   /**

--- a/api/src/admin/demo-test-recruitment.controller.ts
+++ b/api/src/admin/demo-test-recruitment.controller.ts
@@ -1,0 +1,52 @@
+/**
+ * DemoTestRecruitmentController (ROK-1240).
+ *
+ * DEMO_MODE-only endpoint used by the recruitment-reminder smoke test
+ * (`tools/test-bot/src/smoke/tests/recruitment-reminder.test.ts`).
+ *
+ * Mirrors `trigger-standalone-poll-reminders` from
+ * `demo-test-standalone-poll.controller.ts`: runs the recruitment-reminder
+ * cron once on demand so smoke tests don't have to wait for the natural
+ * 15-minute schedule.
+ */
+import {
+  Controller,
+  ForbiddenException,
+  HttpCode,
+  HttpStatus,
+  Post,
+  UseGuards,
+} from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { SkipThrottle } from '@nestjs/throttler';
+import { AdminGuard } from '../auth/admin.guard';
+import { SettingsService } from '../settings/settings.service';
+import { RecruitmentReminderService } from '../notifications/recruitment-reminder.service';
+
+@Controller('admin/test')
+@SkipThrottle()
+@UseGuards(AuthGuard('jwt'), AdminGuard)
+export class DemoTestRecruitmentController {
+  constructor(
+    private readonly settingsService: SettingsService,
+    private readonly recruitmentReminderService: RecruitmentReminderService,
+  ) {}
+
+  private async assertDemoMode(): Promise<void> {
+    if (process.env.DEMO_MODE !== 'true') {
+      throw new ForbiddenException('Only available in DEMO_MODE');
+    }
+    if (!(await this.settingsService.getDemoMode())) {
+      throw new ForbiddenException('Only available in DEMO_MODE');
+    }
+  }
+
+  /** Run the recruitment-reminder cron once, on demand (DEMO_MODE only). */
+  @Post('trigger-recruitment-reminders')
+  @HttpCode(HttpStatus.OK)
+  async triggerReminders(): Promise<{ success: boolean }> {
+    await this.assertDemoMode();
+    await this.recruitmentReminderService.checkAndSendReminders();
+    return { success: true };
+  }
+}

--- a/api/src/common/log-dir.ts
+++ b/api/src/common/log-dir.ts
@@ -1,0 +1,32 @@
+import * as os from 'node:os';
+import * as path from 'node:path';
+import type { ConfigService } from '@nestjs/config';
+
+/**
+ * Production default: Docker volume-mounted, writable by the `app` user inside
+ * the allinone image. Survives container recreation.
+ */
+const PRODUCTION_DEFAULT = '/data/logs';
+
+/**
+ * Resolve the directory used for application log files (ROK-1266).
+ *
+ * Order of precedence:
+ *   1. `LOG_DIR` env var (CI sets `/tmp/raid-ledger-logs`; ops may override).
+ *   2. `/data/logs` when `NODE_ENV=production` (allinone Docker volume).
+ *   3. `<os.tmpdir()>/raid-ledger-logs` in dev/test.
+ *
+ * The dev fallback exists because the previous default (`/data/logs`) was
+ * unwritable on local Macs and the seed endpoint silently swallowed the
+ * `mkdir` failure, leaving the admin Logs panel listing endpoint reading from
+ * an empty / nonexistent path. Both the listing endpoint
+ * (`LogsService.listLogFiles`) and the writers (`SlowQueriesService.appendDigestToLog`,
+ * the hourly cron) MUST resolve to the same directory or the listing won't
+ * see what was written.
+ */
+export function resolveLogDir(configService: ConfigService): string {
+  const configured = configService.get<string>('LOG_DIR');
+  if (configured && configured.length > 0) return configured;
+  if (process.env.NODE_ENV === 'production') return PRODUCTION_DEFAULT;
+  return path.join(os.tmpdir(), 'raid-ledger-logs');
+}

--- a/api/src/cron-jobs/cron-job.constants.ts
+++ b/api/src/cron-jobs/cron-job.constants.ts
@@ -125,7 +125,7 @@ export const CORE_JOB_METADATA: Record<string, CoreJobMetadata> = {
   },
   RecruitmentReminderService_checkAndSendReminders: {
     description:
-      'DMs unsigned game followers about upcoming events every 15 minutes',
+      'DMs unsigned game followers and posts channel "spots still available" bumps every 15 minutes. Suppresses both paths for short-notice events (start - created < RECRUITMENT_SHORT_NOTICE_HOURS, default 12) — ROK-1240.',
     category: 'Notifications',
   },
   SteamSyncProcessor_scheduledSync: {

--- a/api/src/discord-bot/discord-bot.module.ts
+++ b/api/src/discord-bot/discord-bot.module.ts
@@ -79,6 +79,7 @@ import { VoiceAttendanceService } from './services/voice-attendance.service';
 import { EventAutoExtendService } from './services/event-auto-extend.service';
 import { AdHocReaperService } from './services/ad-hoc-reaper.service';
 import { PlayingCommand } from './commands/playing.command';
+import { ActivityLogModule } from '../activity-log/activity-log.module';
 
 @Module({
   imports: [
@@ -92,6 +93,7 @@ import { PlayingCommand } from './commands/playing.command';
     CronJobModule,
     ItadModule,
     GameTasteModule,
+    ActivityLogModule,
     BullModule.registerQueue({ name: EMBED_SYNC_QUEUE }),
     BullModule.registerQueue({ name: AD_HOC_GRACE_QUEUE }),
     BullModule.registerQueue({ name: DEPARTURE_GRACE_QUEUE }),

--- a/api/src/discord-bot/listeners/reschedule-response.helpers.ts
+++ b/api/src/discord-bot/listeners/reschedule-response.helpers.ts
@@ -13,6 +13,7 @@ import { SignupsService } from '../../events/signups.service';
 import { CharactersService } from '../../characters/characters.service';
 import { EmbedSyncQueueService } from '../queues/embed-sync.queue';
 import { DiscordEmojiService } from '../services/discord-emoji.service';
+import { ActivityLogService } from '../../activity-log/activity-log.service';
 import { RESCHEDULE_BUTTON_IDS } from '../discord-bot.constants';
 
 const STATE_LABELS: Record<string, string> = {
@@ -37,6 +38,7 @@ export interface RescheduleDeps {
   charactersService: CharactersService;
   embedSyncQueue: EmbedSyncQueueService;
   emojiService: DiscordEmojiService;
+  activityLog: ActivityLogService;
   logger: Logger;
 }
 
@@ -226,4 +228,29 @@ export async function safeEditReply(
     if (isDiscordInteractionError(error)) return;
     throw error;
   }
+}
+
+/**
+ * ROK-1269: log signup_reconfirmed when a user flips from pending → confirmed
+ * via the Discord reschedule DM. Skipped on no-op repeat clicks. Used by
+ * both linked and unlinked (anonymous) ack paths.
+ */
+export async function logDiscordAck(
+  deps: RescheduleDeps,
+  eventId: number,
+  wasPending: boolean,
+  updateSet: Record<string, unknown>,
+  actor: { userId: number } | { discordUserId: string },
+): Promise<void> {
+  if (!wasPending || updateSet.confirmationStatus !== 'confirmed') return;
+  const isLinked = 'userId' in actor;
+  const metadata: Record<string, unknown> = { reason: 'discord-ack' };
+  if (!isLinked) metadata.discordUserId = actor.discordUserId;
+  await deps.activityLog.log(
+    'event',
+    eventId,
+    'signup_reconfirmed',
+    isLinked ? actor.userId : null,
+    metadata,
+  );
 }

--- a/api/src/discord-bot/listeners/reschedule-response.listener.confirm.spec.ts
+++ b/api/src/discord-bot/listeners/reschedule-response.listener.confirm.spec.ts
@@ -8,6 +8,7 @@ import { MessageFlags } from 'discord.js';
 import { RESCHEDULE_BUTTON_IDS } from '../discord-bot.constants';
 import { EmbedSyncQueueService } from '../queues/embed-sync.queue';
 import { DiscordEmojiService } from '../services/discord-emoji.service';
+import { ActivityLogService } from '../../activity-log/activity-log.service';
 import {
   createDrizzleMock,
   type MockDb,
@@ -144,6 +145,10 @@ function buildRescheduleProviders() {
     { provide: CharactersService, useValue: mockCharactersService },
     { provide: EmbedSyncQueueService, useValue: mockEmbedSyncQueue },
     { provide: DiscordEmojiService, useValue: mockEmojiService },
+    {
+      provide: ActivityLogService,
+      useValue: { log: jest.fn().mockResolvedValue(undefined) },
+    },
   ];
 }
 

--- a/api/src/discord-bot/listeners/reschedule-response.listener.menus.spec.ts
+++ b/api/src/discord-bot/listeners/reschedule-response.listener.menus.spec.ts
@@ -7,6 +7,7 @@ import { DrizzleAsyncProvider } from '../../drizzle/drizzle.module';
 import { RESCHEDULE_BUTTON_IDS } from '../discord-bot.constants';
 import { EmbedSyncQueueService } from '../queues/embed-sync.queue';
 import { DiscordEmojiService } from '../services/discord-emoji.service';
+import { ActivityLogService } from '../../activity-log/activity-log.service';
 import {
   createDrizzleMock,
   type MockDb,
@@ -170,6 +171,10 @@ async function setupMenusModule() {
           getClassEmojiComponent: jest.fn().mockReturnValue(undefined),
           getRoleEmojiComponent: jest.fn().mockReturnValue(undefined),
         },
+      },
+      {
+        provide: ActivityLogService,
+        useValue: { log: jest.fn().mockResolvedValue(undefined) },
       },
     ],
   }).compile();

--- a/api/src/discord-bot/listeners/reschedule-response.listener.status.spec.ts
+++ b/api/src/discord-bot/listeners/reschedule-response.listener.status.spec.ts
@@ -7,6 +7,7 @@ import { DrizzleAsyncProvider } from '../../drizzle/drizzle.module';
 import { RESCHEDULE_BUTTON_IDS } from '../discord-bot.constants';
 import { EmbedSyncQueueService } from '../queues/embed-sync.queue';
 import { DiscordEmojiService } from '../services/discord-emoji.service';
+import { ActivityLogService } from '../../activity-log/activity-log.service';
 import {
   createDrizzleMock,
   type MockDb,
@@ -140,6 +141,10 @@ async function setupStatusModule() {
           getClassEmojiComponent: jest.fn().mockReturnValue(undefined),
           getRoleEmojiComponent: jest.fn().mockReturnValue(undefined),
         },
+      },
+      {
+        provide: ActivityLogService,
+        useValue: { log: jest.fn().mockResolvedValue(undefined) },
       },
     ],
   }).compile();

--- a/api/src/discord-bot/listeners/reschedule-response.listener.ts
+++ b/api/src/discord-bot/listeners/reschedule-response.listener.ts
@@ -19,6 +19,7 @@ import {
 import { DiscordBotClientService } from '../discord-bot-client.service';
 import { EmbedSyncQueueService } from '../queues/embed-sync.queue';
 import { DiscordEmojiService } from '../services/discord-emoji.service';
+import { ActivityLogService } from '../../activity-log/activity-log.service';
 import type { EventRow, RescheduleDeps } from './reschedule-response.helpers';
 import {
   isRescheduleAction,
@@ -56,6 +57,7 @@ export class RescheduleResponseListener {
     private readonly charactersService: CharactersService,
     private readonly embedSyncQueue: EmbedSyncQueueService,
     private readonly emojiService: DiscordEmojiService,
+    private readonly activityLog: ActivityLogService,
   ) {}
 
   private get deps(): RescheduleDeps {
@@ -65,6 +67,7 @@ export class RescheduleResponseListener {
       charactersService: this.charactersService,
       embedSyncQueue: this.embedSyncQueue,
       emojiService: this.emojiService,
+      activityLog: this.activityLog,
       logger: this.logger,
     };
   }

--- a/api/src/discord-bot/listeners/reschedule-roster.handlers.ts
+++ b/api/src/discord-bot/listeners/reschedule-roster.handlers.ts
@@ -12,6 +12,7 @@ import type {
   RescheduleDeps,
   ReconfirmOptions,
 } from './reschedule-response.helpers';
+import { logDiscordAck } from './reschedule-response.helpers';
 import { ensureRosterAssignment } from './reschedule-slot.handlers';
 
 export type { RescheduleDeps, ReconfirmOptions };
@@ -158,6 +159,7 @@ async function updateLinkedSignup(
     .where(where)
     .limit(1);
   if (!signup) return undefined;
+  const wasPending = signup.confirmationStatus === 'pending';
   await deps.db
     .update(schema.eventSignups)
     .set(updateSet)
@@ -167,6 +169,7 @@ async function updateLinkedSignup(
       characterId: options.characterId,
     });
   }
+  await logDiscordAck(deps, event.id, wasPending, updateSet, { userId });
   return signup.id;
 }
 
@@ -186,10 +189,14 @@ async function updateUnlinkedSignup(
     .where(where)
     .limit(1);
   if (!signup) return undefined;
+  const wasPending = signup.confirmationStatus === 'pending';
   await deps.db
     .update(schema.eventSignups)
     .set(updateSet)
     .where(eq(schema.eventSignups.id, signup.id));
+  await logDiscordAck(deps, event.id, wasPending, updateSet, {
+    discordUserId: interaction.user.id,
+  });
   return signup.id;
 }
 

--- a/api/src/events/event-lifecycle.helpers.spec.ts
+++ b/api/src/events/event-lifecycle.helpers.spec.ts
@@ -3,7 +3,11 @@
  */
 import { NotFoundException, ForbiddenException } from '@nestjs/common';
 import { createMockEvent } from '../common/testing/factories';
-import { deleteEvent, rescheduleEvent } from './event-lifecycle.helpers';
+import {
+  deleteEvent,
+  rescheduleEvent,
+  resetSignupConfirmations,
+} from './event-lifecycle.helpers';
 import { APP_EVENT_EVENTS } from '../discord-bot/discord-bot.constants';
 
 function createMockNotificationService() {
@@ -321,5 +325,83 @@ describe('Regression: ROK-846 — deleteEvent uses emitAsync before cascade dele
       ).resolves.toBeUndefined();
       expect(emitter.emitAsync).toHaveBeenCalledTimes(1);
     });
+  });
+});
+
+/**
+ * Build a minimal mock DB that captures the where() predicates passed to
+ * the UPDATE statement issued by resetSignupConfirmations. Returns the
+ * captured args for inspection.
+ */
+function buildResetMockDb() {
+  const updateWhereCalls: unknown[] = [];
+  const mockDb: Record<string, jest.Mock> = {};
+  for (const m of [
+    'select',
+    'from',
+    'limit',
+    'orderBy',
+    'returning',
+    'execute',
+  ]) {
+    mockDb[m] = jest.fn().mockReturnThis();
+  }
+  // delete().where() — the reminders cleanup
+  // update().set().where() — the signup reset
+  mockDb.delete = jest.fn().mockReturnValue({
+    where: jest.fn().mockResolvedValue(undefined),
+  });
+  mockDb.update = jest.fn().mockReturnValue({
+    set: jest.fn().mockReturnValue({
+      where: jest.fn().mockImplementation((...args: unknown[]) => {
+        updateWhereCalls.push(args);
+        return Promise.resolve();
+      }),
+    }),
+  });
+  return { mockDb, updateWhereCalls };
+}
+
+describe('Regression: ROK-1269 — resetSignupConfirmations excludes rescheduler', () => {
+  it('passes a where() predicate to UPDATE when reschedulerId is provided', async () => {
+    const { mockDb, updateWhereCalls } = buildResetMockDb();
+    await resetSignupConfirmations(mockDb as any, 42, 7);
+    expect(updateWhereCalls).toHaveLength(1);
+    // Drizzle's `and(...)` returns an SQL chunk; the captured arg should
+    // be a non-null object representing the combined predicate.
+    const predicate = (updateWhereCalls[0] as unknown[])[0];
+    expect(predicate).toBeDefined();
+    expect(predicate).not.toBeNull();
+  });
+
+  it('still passes a predicate when reschedulerId is null', async () => {
+    const { mockDb, updateWhereCalls } = buildResetMockDb();
+    await resetSignupConfirmations(mockDb as any, 42, null);
+    expect(updateWhereCalls).toHaveLength(1);
+    const predicate = (updateWhereCalls[0] as unknown[])[0];
+    expect(predicate).toBeDefined();
+  });
+
+  it('issues DELETE for reminders before UPDATE for signups', async () => {
+    const { mockDb } = buildResetMockDb();
+    await resetSignupConfirmations(mockDb as any, 42, 7);
+    expect(mockDb.delete).toHaveBeenCalled();
+    expect(mockDb.update).toHaveBeenCalled();
+  });
+
+  it('rescheduleEvent threads userId through to resetSignupConfirmations', async () => {
+    // Verifies the wiring: a rescheduleEvent call results in an UPDATE
+    // whose where() predicate is non-null (the userId-aware predicate).
+    const event = createMockEvent({ id: 99, title: 'X', creatorId: 1 });
+    const mockNotifSvc = createMockNotificationService();
+    // Reuse the multi-where reschedule mock to drive the full path.
+    const mockDb = buildRescheduleMockDb(event, [{ userId: 2 }]);
+    await rescheduleEvent(mockDb as any, mockNotifSvc as any, 99, 1, true, {
+      startTime: '2026-04-01T00:00:00Z',
+      endTime: '2026-04-01T02:00:00Z',
+    });
+    // At least one UPDATE issued with a where() — exact predicate shape
+    // is asserted via the integration test against a real Postgres.
+    expect(mockDb.update).toHaveBeenCalled();
   });
 });

--- a/api/src/events/event-lifecycle.helpers.ts
+++ b/api/src/events/event-lifecycle.helpers.ts
@@ -127,24 +127,33 @@ export async function cancelEvent(
   );
 }
 
-/** Resets confirmation status for active signups after reschedule. */
+/**
+ * Resets confirmation status for active signups after reschedule.
+ *
+ * The rescheduler is excluded from the reset (ROK-1269) — they chose the
+ * new time so they're implicitly committed. If `reschedulerId` is null
+ * (e.g. series-bulk reschedule with no acting user), no exclusion applies.
+ */
 export async function resetSignupConfirmations(
   db: PostgresJsDatabase<typeof schema>,
   eventId: number,
+  reschedulerId: number | null = null,
 ): Promise<void> {
   await db
     .delete(schema.eventRemindersSent)
     .where(eq(schema.eventRemindersSent.eventId, eventId));
+  const conditions = [
+    eq(schema.eventSignups.eventId, eventId),
+    ne(schema.eventSignups.status, 'declined'),
+    ne(schema.eventSignups.status, 'departed'),
+  ];
+  if (reschedulerId !== null) {
+    conditions.push(ne(schema.eventSignups.userId, reschedulerId));
+  }
   await db
     .update(schema.eventSignups)
     .set({ confirmationStatus: 'pending', status: 'signed_up' })
-    .where(
-      and(
-        eq(schema.eventSignups.eventId, eventId),
-        ne(schema.eventSignups.status, 'declined'),
-        ne(schema.eventSignups.status, 'departed'),
-      ),
-    );
+    .where(and(...conditions));
 }
 
 /** Formats a date for Discord notification display using native timestamps. */
@@ -263,7 +272,7 @@ export async function rescheduleEvent(
     .update(schema.events)
     .set({ duration: [newStart, new Date(dto.endTime)], updatedAt: new Date() })
     .where(eq(schema.events.id, eventId));
-  await resetSignupConfirmations(db, eventId);
+  await resetSignupConfirmations(db, eventId, userId);
   await notifyReschedule(
     db,
     notificationService,

--- a/api/src/events/event-series.helpers.ts
+++ b/api/src/events/event-series.helpers.ts
@@ -100,7 +100,8 @@ export async function updateSeriesEvents(
         .set(updateData)
         .where(eq(schema.events.id, evt.id));
       if (timeDelta) {
-        await resetSignupConfirmations(tx, evt.id);
+        // ROK-1269: pass acting userId so the series editor stays confirmed.
+        await resetSignupConfirmations(tx, evt.id, userId);
       }
     }
   });

--- a/api/src/events/events-dashboard.actions.integration.spec.ts
+++ b/api/src/events/events-dashboard.actions.integration.spec.ts
@@ -303,6 +303,162 @@ async function testRescheduleDoesNotResetDeclined() {
   expect(signup.status).toBe('declined');
 }
 
+// ─── ROK-1269: rescheduler stays confirmed + activity log ───────────────────
+
+/** Signs the admin (rescheduler) up for their own event before rescheduling. */
+async function signupAdmin(eventId: number) {
+  await testApp.db.insert(schema.eventSignups).values({
+    eventId,
+    userId: testApp.seed.adminUser.id,
+    status: 'signed_up',
+    confirmationStatus: 'confirmed',
+  });
+}
+
+async function testRescheduleStaysConfirmedForRescheduler() {
+  const eventId = await createFutureEvent(testApp, adminToken, {
+    title: 'Rescheduler Confirmed Raid',
+  });
+  await signupAdmin(eventId);
+  const others = await Promise.all(
+    [0, 1, 2].map((i) =>
+      createMemberAndLogin(
+        testApp,
+        `rok1269_other_${i}`,
+        `rok1269_other_${i}@test.local`,
+      ),
+    ),
+  );
+  await testApp.db.insert(schema.eventSignups).values(
+    others.map((o) => ({
+      eventId,
+      userId: o.userId,
+      status: 'signed_up' as const,
+      confirmationStatus: 'confirmed' as const,
+    })),
+  );
+  const newStart = new Date(Date.now() + 48 * 60 * 60 * 1000);
+  const newEnd = new Date(newStart.getTime() + 3 * 60 * 60 * 1000);
+  await testApp.request
+    .patch(`/events/${eventId}/reschedule`)
+    .set('Authorization', `Bearer ${adminToken}`)
+    .send({ startTime: newStart.toISOString(), endTime: newEnd.toISOString() });
+  const signups = await testApp.db
+    .select()
+    .from(schema.eventSignups)
+    .where(eq(schema.eventSignups.eventId, eventId));
+  const adminSignup = signups.find(
+    (s) => s.userId === testApp.seed.adminUser.id,
+  )!;
+  expect(adminSignup.confirmationStatus).toBe('confirmed');
+  expect(adminSignup.status).toBe('signed_up');
+  for (const o of others) {
+    const otherSignup = signups.find((s) => s.userId === o.userId)!;
+    expect(otherSignup.confirmationStatus).toBe('pending');
+    expect(otherSignup.status).toBe('signed_up');
+  }
+}
+
+async function testRescheduleSkipsNotificationForRescheduler() {
+  const eventId = await createFutureEvent(testApp, adminToken, {
+    title: 'No Self-DM Raid',
+  });
+  await signupAdmin(eventId);
+  const newStart = new Date(Date.now() + 48 * 60 * 60 * 1000);
+  const newEnd = new Date(newStart.getTime() + 3 * 60 * 60 * 1000);
+  await testApp.request
+    .patch(`/events/${eventId}/reschedule`)
+    .set('Authorization', `Bearer ${adminToken}`)
+    .send({ startTime: newStart.toISOString(), endTime: newEnd.toISOString() });
+  const reschedNotifs = await testApp.db
+    .select()
+    .from(schema.notifications)
+    .where(eq(schema.notifications.userId, testApp.seed.adminUser.id));
+  expect(
+    reschedNotifs.find((n) => n.type === 'event_rescheduled'),
+  ).toBeUndefined();
+}
+
+async function testRescheduleTentativeReschedulerStaysTentative() {
+  const eventId = await createFutureEvent(testApp, adminToken, {
+    title: 'Tentative Rescheduler Raid',
+  });
+  await testApp.db.insert(schema.eventSignups).values({
+    eventId,
+    userId: testApp.seed.adminUser.id,
+    status: 'tentative',
+    confirmationStatus: 'confirmed',
+  });
+  const newStart = new Date(Date.now() + 48 * 60 * 60 * 1000);
+  const newEnd = new Date(newStart.getTime() + 3 * 60 * 60 * 1000);
+  await testApp.request
+    .patch(`/events/${eventId}/reschedule`)
+    .set('Authorization', `Bearer ${adminToken}`)
+    .send({ startTime: newStart.toISOString(), endTime: newEnd.toISOString() });
+  const [signup] = await testApp.db
+    .select()
+    .from(schema.eventSignups)
+    .where(eq(schema.eventSignups.userId, testApp.seed.adminUser.id));
+  // tentative + confirmed preserved (UPDATE skipped because user excluded)
+  expect(signup.status).toBe('tentative');
+  expect(signup.confirmationStatus).toBe('confirmed');
+}
+
+async function testRosterUpdateLogsSignupReconfirmed() {
+  const eventId = await createFutureEvent(testApp, adminToken, {
+    title: 'Roster Reconfirm Activity Raid',
+  });
+  const { userId: memberId } = await createMemberAndLogin(
+    testApp,
+    'rok1269_member',
+    'rok1269_member@test.local',
+  );
+  // Member signs up; reschedule resets them to pending; admin then assigns
+  // them via roster update which flips back to confirmed.
+  await testApp.db.insert(schema.eventSignups).values({
+    eventId,
+    userId: memberId,
+    status: 'signed_up',
+    confirmationStatus: 'pending',
+  });
+  const [signup] = await testApp.db
+    .select()
+    .from(schema.eventSignups)
+    .where(eq(schema.eventSignups.userId, memberId));
+  const rosterRes = await testApp.request
+    .patch(`/events/${eventId}/roster`)
+    .set('Authorization', `Bearer ${adminToken}`)
+    .send({
+      assignments: [
+        {
+          userId: memberId,
+          signupId: signup.id,
+          slot: 'player',
+          position: 1,
+        },
+      ],
+    });
+  expect(rosterRes.status).toBe(200);
+  const [flipped] = await testApp.db
+    .select()
+    .from(schema.eventSignups)
+    .where(eq(schema.eventSignups.userId, memberId));
+  expect(flipped.confirmationStatus).toBe('confirmed');
+  const activity = await testApp.request.get(`/events/${eventId}/activity`);
+  expect(activity.status).toBe(200);
+  type ActivityRow = {
+    action: string;
+    actor: { id: number } | null;
+    metadata: Record<string, unknown> | null;
+  };
+  const reconfirms = (activity.body.data as ActivityRow[]).filter(
+    (e) => e.action === 'signup_reconfirmed',
+  );
+  expect(reconfirms).toHaveLength(1);
+  expect(reconfirms[0].actor?.id).toBe(memberId);
+  expect(reconfirms[0].metadata?.reason).toBe('roster-update');
+}
+
 // ─── invite member tests ────────────────────────────────────────────────────
 
 async function testInviteByDiscordId() {
@@ -479,6 +635,14 @@ describe('Events — reschedule', () => {
     testRescheduleDoesNotResetDeclined());
   it('reschedule with 12 signups completes under 200ms (ROK-1043)', () =>
     testReschedulePerfBatch());
+  it("ROK-1269: rescheduler's signup stays confirmed; others flip to pending", () =>
+    testRescheduleStaysConfirmedForRescheduler());
+  it('ROK-1269: rescheduler does not receive their own reschedule DM', () =>
+    testRescheduleSkipsNotificationForRescheduler());
+  it('ROK-1269: tentative rescheduler stays tentative + confirmed', () =>
+    testRescheduleTentativeReschedulerStaysTentative());
+  it('ROK-1269: roster update logs signup_reconfirmed per flipped attendee', () =>
+    testRosterUpdateLogsSignupReconfirmed());
 });
 
 describe('Events — invite member', () => {

--- a/api/src/events/events-dashboard.actions.integration.spec.ts
+++ b/api/src/events/events-dashboard.actions.integration.spec.ts
@@ -8,7 +8,7 @@ import {
 } from '../common/testing/integration-helpers';
 import * as bcrypt from 'bcrypt';
 import * as schema from '../drizzle/schema';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import { EventsService } from './events.service';
 
 async function createMemberAndLogin(
@@ -305,14 +305,17 @@ async function testRescheduleDoesNotResetDeclined() {
 
 // ─── ROK-1269: rescheduler stays confirmed + activity log ───────────────────
 
-/** Signs the admin (rescheduler) up for their own event before rescheduling. */
+/** Ensures the admin's auto-created signup is in signed_up + confirmed. */
 async function signupAdmin(eventId: number) {
-  await testApp.db.insert(schema.eventSignups).values({
-    eventId,
-    userId: testApp.seed.adminUser.id,
-    status: 'signed_up',
-    confirmationStatus: 'confirmed',
-  });
+  await testApp.db
+    .update(schema.eventSignups)
+    .set({ status: 'signed_up', confirmationStatus: 'confirmed' })
+    .where(
+      and(
+        eq(schema.eventSignups.eventId, eventId),
+        eq(schema.eventSignups.userId, testApp.seed.adminUser.id),
+      ),
+    );
 }
 
 async function testRescheduleStaysConfirmedForRescheduler() {
@@ -383,12 +386,15 @@ async function testRescheduleTentativeReschedulerStaysTentative() {
   const eventId = await createFutureEvent(testApp, adminToken, {
     title: 'Tentative Rescheduler Raid',
   });
-  await testApp.db.insert(schema.eventSignups).values({
-    eventId,
-    userId: testApp.seed.adminUser.id,
-    status: 'tentative',
-    confirmationStatus: 'confirmed',
-  });
+  await testApp.db
+    .update(schema.eventSignups)
+    .set({ status: 'tentative', confirmationStatus: 'confirmed' })
+    .where(
+      and(
+        eq(schema.eventSignups.eventId, eventId),
+        eq(schema.eventSignups.userId, testApp.seed.adminUser.id),
+      ),
+    );
   const newStart = new Date(Date.now() + 48 * 60 * 60 * 1000);
   const newEnd = new Date(newStart.getTime() + 3 * 60 * 60 * 1000);
   await testApp.request

--- a/api/src/events/signups-notification.helpers.ts
+++ b/api/src/events/signups-notification.helpers.ts
@@ -153,20 +153,19 @@ export async function replaceRosterAssignments(
       position: number,
     ) => Promise<void>;
   },
-) {
+): Promise<number[]> {
   await db
     .delete(schema.rosterAssignments)
     .where(eq(schema.rosterAssignments.eventId, eventId));
   await updateCharacterOverrides(db, assignments, signupByUserId);
-  if (assignments.length > 0) {
-    await insertNewAssignments(
-      db,
-      eventId,
-      assignments,
-      signupByUserId,
-      benchPromotionService,
-    );
-  }
+  if (assignments.length === 0) return [];
+  return insertNewAssignments(
+    db,
+    eventId,
+    assignments,
+    signupByUserId,
+    benchPromotionService,
+  );
 }
 
 async function updateCharacterOverrides(
@@ -198,7 +197,7 @@ async function insertNewAssignments(
       position: number,
     ) => Promise<void>;
   },
-) {
+): Promise<number[]> {
   const values = assignments.map((a) => ({
     eventId,
     signupId: a.signupId ?? signupByUserId.get(a.userId)!.id,
@@ -207,28 +206,38 @@ async function insertNewAssignments(
     isOverride: a.isOverride ? 1 : 0,
   }));
   await db.insert(schema.rosterAssignments).values(values);
-  await confirmNonBenchSignups(db, assignments, signupByUserId);
+  const reconfirmedUserIds = await confirmNonBenchSignups(
+    db,
+    assignments,
+    signupByUserId,
+  );
   for (const a of assignments) {
     if (a.slot && a.slot !== 'bench') {
       await benchPromotionService.cancelPromotion(eventId, a.slot, a.position);
     }
   }
+  return reconfirmedUserIds;
 }
 
+/**
+ * Flips matching pending signups to confirmed, returning the userIds whose
+ * status actually changed (ROK-1269 — caller emits signup_reconfirmed
+ * activity-log entries per returned userId).
+ */
 async function confirmNonBenchSignups(
   db: Tx,
   assignments: UpdateRosterDto['assignments'],
   signupByUserId: Map<number | null, typeof schema.eventSignups.$inferSelect>,
-) {
-  const ids = assignments
+): Promise<number[]> {
+  const flipped = assignments
     .filter((a) => a.slot && a.slot !== 'bench')
     .map((a) => signupByUserId.get(a.userId)!)
-    .filter((s) => s.confirmationStatus === 'pending')
-    .map((s) => s.id);
-  if (ids.length > 0) {
-    await db
-      .update(schema.eventSignups)
-      .set({ confirmationStatus: 'confirmed' })
-      .where(inArray(schema.eventSignups.id, ids));
-  }
+    .filter((s) => s.confirmationStatus === 'pending');
+  const ids = flipped.map((s) => s.id);
+  if (ids.length === 0) return [];
+  await db
+    .update(schema.eventSignups)
+    .set({ confirmationStatus: 'confirmed' })
+    .where(inArray(schema.eventSignups.id, ids));
+  return flipped.map((s) => s.userId).filter((u): u is number => u !== null);
 }

--- a/api/src/events/signups-roster.service.emit.spec.ts
+++ b/api/src/events/signups-roster.service.emit.spec.ts
@@ -13,6 +13,7 @@ import { RosterNotificationBufferService } from '../notifications/roster-notific
 import { BenchPromotionService } from './bench-promotion.service';
 import { SignupsAllocationService } from './signups-allocation.service';
 import { SIGNUP_EVENTS } from '../discord-bot/discord-bot.constants';
+import { ActivityLogService } from '../activity-log/activity-log.service';
 
 describe('SignupsRosterService — emit timing (ROK-824)', () => {
   let service: SignupsRosterService;
@@ -98,6 +99,10 @@ describe('SignupsRosterService — emit timing (ROK-824)', () => {
           },
         },
         { provide: EventEmitter2, useValue: mockEventEmitter },
+        {
+          provide: ActivityLogService,
+          useValue: { log: jest.fn().mockResolvedValue(undefined) },
+        },
       ],
     }).compile();
 

--- a/api/src/events/signups-roster.service.ts
+++ b/api/src/events/signups-roster.service.ts
@@ -21,6 +21,7 @@ import type {
 import * as cancelH from './signups-cancel.helpers';
 import * as notifH from './signups-notification.helpers';
 import * as rosterOpsH from './signups-roster-ops.helpers';
+import { ActivityLogService } from '../activity-log/activity-log.service';
 
 @Injectable()
 export class SignupsRosterService {
@@ -33,6 +34,7 @@ export class SignupsRosterService {
     private benchPromotionService: BenchPromotionService,
     private allocationService: SignupsAllocationService,
     private readonly eventEmitter: EventEmitter2,
+    private readonly activityLog: ActivityLogService,
   ) {}
 
   async cancel(eventId: number, userId: number): Promise<void> {
@@ -168,7 +170,7 @@ export class SignupsRosterService {
       eventId: number,
     ) => Promise<RosterWithAssignments>,
   ): Promise<RosterWithAssignments> {
-    const { event, signupByUserId, oldRoleBySignupId } =
+    const { event, signupByUserId, oldRoleBySignupId, reconfirmedUserIds } =
       await this.executeRosterUpdate(eventId, userId, isAdmin, dto);
     this.emit(SIGNUP_EVENTS.UPDATED, { eventId, action: 'roster_updated' });
     rosterOpsH.fireRosterNotifications(
@@ -181,7 +183,12 @@ export class SignupsRosterService {
       (eId) => notifH.fetchNotificationContext(this.notificationService, eId),
       this.logger,
     );
-    return getRosterWithAssignments(eventId);
+    return getRosterWithAssignments(eventId).then(async (roster) => {
+      // ROK-1269: emit signup_reconfirmed per attendee whose pending status
+      // got flipped to confirmed by this roster update. Done after tx commit.
+      await this.logReconfirms(eventId, reconfirmedUserIds);
+      return roster;
+    });
   }
 
   /** Run roster replacement inside a transaction for atomicity (ROK-824). */
@@ -205,7 +212,7 @@ export class SignupsRosterService {
         dto.assignments,
       );
       const oldRoleBySignupId = await notifH.captureOldAssignments(tx, eventId);
-      await notifH.replaceRosterAssignments(
+      const reconfirmedUserIds = await notifH.replaceRosterAssignments(
         tx,
         eventId,
         dto.assignments,
@@ -215,7 +222,7 @@ export class SignupsRosterService {
       this.logger.log(
         `Roster updated for event ${eventId}: ${dto.assignments.length} assignments`,
       );
-      return { event, signupByUserId, oldRoleBySignupId };
+      return { event, signupByUserId, oldRoleBySignupId, reconfirmedUserIds };
     });
   }
 
@@ -269,5 +276,22 @@ export class SignupsRosterService {
 
   private emit(eventName: string, payload: SignupEventPayload): void {
     this.eventEmitter.emit(eventName, payload);
+  }
+
+  /**
+   * ROK-1269: log a signup_reconfirmed activity entry per attendee whose
+   * pending status flipped to confirmed via this roster update. Actor is
+   * the attendee themselves; metadata.reason='roster-update' discriminates
+   * from the discord-ack path.
+   */
+  private async logReconfirms(
+    eventId: number,
+    userIds: number[],
+  ): Promise<void> {
+    for (const uid of userIds) {
+      await this.activityLog.log('event', eventId, 'signup_reconfirmed', uid, {
+        reason: 'roster-update',
+      });
+    }
   }
 }

--- a/api/src/logs/logs.service.ts
+++ b/api/src/logs/logs.service.ts
@@ -12,9 +12,7 @@ import * as readline from 'node:readline';
 import { createGzip } from 'node:zlib';
 import { Readable, PassThrough, Transform } from 'node:stream';
 import type { LogFileDto, LogService } from '@raid-ledger/contract';
-
-/** Hardcoded production log directory — Docker volume-mounted, survives container recreation. */
-const DEFAULT_LOG_DIR = '/data/logs';
+import { resolveLogDir } from '../common/log-dir';
 
 /** Maximum total archive size in bytes (~100 MB). */
 const MAX_ARCHIVE_BYTES = 100 * 1024 * 1024;
@@ -45,7 +43,7 @@ export class LogsService {
   private readonly logDir: string;
 
   constructor(private readonly configService: ConfigService) {
-    this.logDir = this.configService.get<string>('LOG_DIR') || DEFAULT_LOG_DIR;
+    this.logDir = resolveLogDir(this.configService);
   }
 
   /**

--- a/api/src/logs/logs.slow-queries-alignment.spec.ts
+++ b/api/src/logs/logs.slow-queries-alignment.spec.ts
@@ -1,0 +1,169 @@
+/**
+ * Regression: ROK-1266 — `/admin/logs` listing returns empty despite
+ * `slow-queries.log` being written.
+ *
+ * Reproduces the original bug end-to-end with real filesystem (no fs mock):
+ *   1. SlowQueriesService.appendDigestToLog → writes to LOG_DIR.
+ *   2. LogsService.listLogFiles(LOG_DIR) → MUST surface the file.
+ *
+ * The pre-fix bug was a silent path/IO mismatch:
+ *   - Both services resolved `LOG_DIR` via `configService.get('LOG_DIR') ||
+ *     '/data/logs'`. On Mac dev / non-prod containers `/data/logs` is
+ *     unwritable → the writer's `mkdir+appendFile` failed inside a try/catch
+ *     and the seed endpoint reported `success: true` regardless. The listing
+ *     endpoint then read from the same nonexistent dir and returned an empty
+ *     array. Net effect: GET /admin/logs always returned `{ files: [], total: 0 }`.
+ *
+ * Fix (ROK-1266):
+ *   - Centralise LOG_DIR resolution in `common/log-dir.ts` with a writable
+ *     dev fallback (`<tmp>/raid-ledger-logs`).
+ *   - `appendDigestToLog` now returns whether the write succeeded.
+ *   - The `/admin/test/seed-slow-queries-log` endpoint surfaces a 500 when
+ *     the writer reports failure (covered separately in
+ *     `demo-test-core.controller.spec.ts`).
+ */
+import { Test, type TestingModule } from '@nestjs/testing';
+import { ConfigService } from '@nestjs/config';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { LogsService } from './logs.service';
+import { SlowQueriesService } from '../slow-queries/slow-queries.service';
+import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
+
+/**
+ * Build a fake drizzle handle that makes `db.execute(sql)` reject — the
+ * service treats this as "extension absent" and writes an empty digest block,
+ * which is exactly what we want to assert on (we're testing the IO path, not
+ * the pg_stat_statements query).
+ */
+function fakeDb() {
+  return {
+    execute: jest
+      .fn()
+      .mockRejectedValue(new Error('pg_stat_statements absent')),
+  };
+}
+
+describe('Regression: ROK-1266 — slow-queries seed/listing alignment', () => {
+  let logDir: string;
+  let module: TestingModule;
+  let logsService: LogsService;
+  let slowQueriesService: SlowQueriesService;
+
+  beforeEach(async () => {
+    // Use a real, writable temp dir to mirror production behaviour. The
+    // original bug was that BOTH services resolved an unwritable default —
+    // pinning LOG_DIR here proves that when both resolve the same writable
+    // path, the listing surfaces the file the writer just created.
+    logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rok-1266-'));
+
+    module = await Test.createTestingModule({
+      providers: [
+        LogsService,
+        SlowQueriesService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) =>
+              key === 'LOG_DIR' ? logDir : undefined,
+            ),
+          },
+        },
+        { provide: DrizzleAsyncProvider, useValue: fakeDb() },
+      ],
+    }).compile();
+
+    logsService = module.get<LogsService>(LogsService);
+    slowQueriesService = module.get<SlowQueriesService>(SlowQueriesService);
+  });
+
+  afterEach(async () => {
+    await module.close();
+    fs.rmSync(logDir, { recursive: true, force: true });
+  });
+
+  it('writer and listing resolve to the same directory', () => {
+    // The writer's path must live inside the listing's logDir, otherwise the
+    // listing can never see what was written. This catches future regressions
+    // where one service is updated without the other.
+    const writerPath = slowQueriesService.getLogFilePath();
+    expect(path.dirname(writerPath)).toBe(path.resolve(logDir));
+  });
+
+  it('seed → listing surfaces slow-queries.log immediately (no race)', async () => {
+    // Pre-condition: dir is empty.
+    expect(logsService.listLogFiles()).toHaveLength(0);
+
+    // Seed: writer must report success when LOG_DIR is writable.
+    const written = await slowQueriesService.appendDigestToLog();
+    expect(written).toBe(true);
+
+    // Sanity: the file is on disk.
+    const expectedPath = path.join(logDir, 'slow-queries.log');
+    expect(fs.existsSync(expectedPath)).toBe(true);
+    expect(fs.statSync(expectedPath).size).toBeGreaterThan(0);
+
+    // Regression assertion: the listing endpoint MUST return the file with
+    // service='slow-queries'. Pre-fix this returned []. The append is
+    // synchronous from the writer's perspective (await fs.appendFile
+    // resolved), so a follow-up readdirSync MUST see the entry — there is
+    // no eventual-consistency race here.
+    const files = logsService.listLogFiles();
+    expect(files).toHaveLength(1);
+    expect(files[0]).toMatchObject({
+      filename: 'slow-queries.log',
+      service: 'slow-queries',
+    });
+    expect(files[0].sizeBytes).toBeGreaterThan(0);
+  });
+
+  it('listing filtered by service="slow-queries" still surfaces the file', async () => {
+    await slowQueriesService.appendDigestToLog();
+    const filtered = logsService.listLogFiles('slow-queries');
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0].service).toBe('slow-queries');
+  });
+
+  it('appendDigestToLog returns false when LOG_DIR is unwritable', async () => {
+    // Recreate the services with an unwritable LOG_DIR (a regular file's
+    // child path can never be created as a directory). This is the actual
+    // failure mode reported in production logs as "Failed to append slow-
+    // query digest to /data/logs/slow-queries.log: EACCES".
+    const unwritableParent = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'rok-1266-unwritable-'),
+    );
+    const wedgeFile = path.join(unwritableParent, 'wedge');
+    fs.writeFileSync(wedgeFile, 'block');
+    const blockedLogDir = path.join(wedgeFile, 'logs'); // mkdir under a file
+
+    const blockedModule = await Test.createTestingModule({
+      providers: [
+        SlowQueriesService,
+        {
+          provide: ConfigService,
+          useValue: {
+            get: jest.fn((key: string) =>
+              key === 'LOG_DIR' ? blockedLogDir : undefined,
+            ),
+          },
+        },
+        { provide: DrizzleAsyncProvider, useValue: fakeDb() },
+      ],
+    }).compile();
+
+    try {
+      const blockedService =
+        blockedModule.get<SlowQueriesService>(SlowQueriesService);
+      const written = await blockedService.appendDigestToLog();
+      // Pre-fix the writer would also return undefined here (no return value)
+      // and the seed endpoint would happily report success. Now it returns
+      // false and the endpoint converts that into a 500 (covered by the
+      // controller spec).
+      expect(written).toBe(false);
+    } finally {
+      await blockedModule.close();
+      fs.rmSync(unwritableParent, { recursive: true, force: true });
+    }
+  });
+});

--- a/api/src/notifications/recruitment-reminder.helpers.spec.ts
+++ b/api/src/notifications/recruitment-reminder.helpers.spec.ts
@@ -1,6 +1,11 @@
 import {
   calculateGracePeriodMs,
   isWithinGracePeriod,
+  formatRelativeTimeLabel,
+  isSameCalendarDay,
+  isShortNoticeEvent,
+  getShortNoticeThresholdHours,
+  DEFAULT_SHORT_NOTICE_THRESHOLD_HOURS,
 } from './recruitment-reminder.helpers';
 
 const HOUR = 60 * 60 * 1000;
@@ -232,30 +237,35 @@ describe('isWithinGracePeriod', () => {
     expect(isWithinGracePeriod(event)).toBe(false);
   });
 
-  it('should return true 30min after creation for event starting 10h later (< 12h tier, 1h grace)', () => {
+  // ROK-1240: events with start_time - created_at < 12h are now suppressed
+  // entirely (short-notice rule). The historical "1h grace" tier is no
+  // longer reachable from `isWithinGracePeriod`, but `calculateGracePeriodMs`
+  // still returns 1h for that band since callers other than this gate may
+  // care about the raw tier.
+
+  it('should return true 30min after creation for event starting 10h later (short-notice suppression)', () => {
     jest.setSystemTime(new Date('2026-03-10T10:30:00Z')); // 30min after creation
     const event = makeGraceEvent(
       '2026-03-10T10:00:00Z',
-      '2026-03-10T20:00:00Z', // 10h gap → 1h grace
+      '2026-03-10T20:00:00Z', // 10h gap → short-notice → SUPPRESSED
     );
 
     expect(isWithinGracePeriod(event)).toBe(true);
   });
 
-  it('should return false 90min after creation for event starting 10h later (1h grace elapsed)', () => {
+  it('should STILL return true 90min after creation for event starting 10h later (short-notice — historical 1h grace no longer applies)', () => {
     jest.setSystemTime(new Date('2026-03-10T11:30:00Z')); // 90min after creation
     const event = makeGraceEvent(
       '2026-03-10T10:00:00Z',
-      '2026-03-10T20:00:00Z', // 10h gap → 1h grace
+      '2026-03-10T20:00:00Z', // 10h gap → short-notice → SUPPRESSED regardless of elapsed time
     );
 
-    expect(isWithinGracePeriod(event)).toBe(false);
+    expect(isWithinGracePeriod(event)).toBe(true);
   });
 
-  it('should return true for event where createdAt is after startTime (1h grace still active)', () => {
+  it('should return true for event where createdAt is after startTime (short-notice — clock skew → suppressed)', () => {
     jest.setSystemTime(new Date('2026-03-10T11:00:00Z'));
-    // createdAt > startTime — negative timeUntilEvent → falls through to 1h grace.
-    // now (11:00) < createdAt (11:00) + 1h (12:00) → grace still active → true
+    // createdAt > startTime — negative timeUntilEvent → short-notice → suppressed.
     const event = makeGraceEvent(
       '2026-03-10T11:00:00Z', // createdAt
       '2026-03-10T10:00:00Z', // startTime is before createdAt
@@ -275,5 +285,286 @@ describe('isWithinGracePeriod', () => {
     const explicitNow = new Date('2026-03-10T12:00:00Z').getTime();
 
     expect(isWithinGracePeriod(event, explicitNow)).toBe(true);
+  });
+
+  // ROK-1240 — short-notice suppression block
+
+  describe('short-notice suppression (ROK-1240)', () => {
+    it('should suppress (return true) when start - created < 12h, regardless of elapsed time', () => {
+      // Event created 8h before start, cron runs 7h after creation (1h to start)
+      const createdAt = '2026-03-10T10:00:00Z';
+      const startTime = '2026-03-10T18:00:00Z'; // 8h gap (< 12h threshold)
+      jest.setSystemTime(new Date('2026-03-10T17:00:00Z'));
+
+      expect(isWithinGracePeriod(makeGraceEvent(createdAt, startTime))).toBe(
+        true,
+      );
+    });
+
+    it('should NOT suppress (return false) when start - created >= 12h and grace elapsed', () => {
+      const createdAt = '2026-03-10T10:00:00Z';
+      const startTime = '2026-03-10T22:00:00Z'; // exactly 12h gap → tier=3h grace, NOT short-notice
+      jest.setSystemTime(new Date('2026-03-10T17:00:00Z')); // 7h after creation, > 3h grace
+
+      expect(isWithinGracePeriod(makeGraceEvent(createdAt, startTime))).toBe(
+        false,
+      );
+    });
+
+    it('should suppress at exactly threshold - 1ms (start - created = 12h - 1ms)', () => {
+      const createdAt = new Date('2026-03-10T10:00:00Z');
+      const startTime = new Date(createdAt.getTime() + 12 * HOUR - 1);
+      jest.setSystemTime(new Date(createdAt.getTime() + 11 * HOUR));
+
+      expect(
+        isWithinGracePeriod(
+          makeGraceEvent(createdAt.toISOString(), startTime.toISOString()),
+        ),
+      ).toBe(true);
+    });
+  });
+});
+
+describe('isShortNoticeEvent (ROK-1240)', () => {
+  it('returns true when start - created < 12h (default)', () => {
+    expect(
+      isShortNoticeEvent({
+        createdAt: '2026-03-10T10:00:00Z',
+        startTime: '2026-03-10T20:00:00Z', // 10h gap
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false at exactly threshold (12h)', () => {
+    expect(
+      isShortNoticeEvent({
+        createdAt: '2026-03-10T10:00:00Z',
+        startTime: '2026-03-10T22:00:00Z', // exactly 12h
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false when start - created > 12h', () => {
+    expect(
+      isShortNoticeEvent({
+        createdAt: '2026-03-10T10:00:00Z',
+        startTime: '2026-03-11T16:00:00Z', // 30h gap
+      }),
+    ).toBe(false);
+  });
+
+  it('returns true when start <= created (clock skew / data anomaly)', () => {
+    expect(
+      isShortNoticeEvent({
+        createdAt: '2026-03-10T11:00:00Z',
+        startTime: '2026-03-10T10:00:00Z', // start before creation
+      }),
+    ).toBe(true);
+  });
+
+  it('honours explicit thresholdHours override', () => {
+    // 10h gap, threshold 6 → not short-notice
+    expect(
+      isShortNoticeEvent(
+        {
+          createdAt: '2026-03-10T10:00:00Z',
+          startTime: '2026-03-10T20:00:00Z',
+        },
+        6,
+      ),
+    ).toBe(false);
+    // 10h gap, threshold 24 → short-notice
+    expect(
+      isShortNoticeEvent(
+        {
+          createdAt: '2026-03-10T10:00:00Z',
+          startTime: '2026-03-10T20:00:00Z',
+        },
+        24,
+      ),
+    ).toBe(true);
+  });
+});
+
+describe('getShortNoticeThresholdHours (ROK-1240)', () => {
+  const ENV_KEY = 'RECRUITMENT_SHORT_NOTICE_HOURS';
+  const original = process.env[ENV_KEY];
+
+  afterEach(() => {
+    if (original === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = original;
+  });
+
+  it('returns the default when env var is unset', () => {
+    delete process.env[ENV_KEY];
+    expect(getShortNoticeThresholdHours()).toBe(
+      DEFAULT_SHORT_NOTICE_THRESHOLD_HOURS,
+    );
+  });
+
+  it('returns env value when valid positive number', () => {
+    process.env[ENV_KEY] = '6';
+    expect(getShortNoticeThresholdHours()).toBe(6);
+  });
+
+  it('falls back to default when env value is 0', () => {
+    process.env[ENV_KEY] = '0';
+    expect(getShortNoticeThresholdHours()).toBe(
+      DEFAULT_SHORT_NOTICE_THRESHOLD_HOURS,
+    );
+  });
+
+  it('falls back to default when env value is negative', () => {
+    process.env[ENV_KEY] = '-4';
+    expect(getShortNoticeThresholdHours()).toBe(
+      DEFAULT_SHORT_NOTICE_THRESHOLD_HOURS,
+    );
+  });
+
+  it('falls back to default when env value is non-numeric', () => {
+    process.env[ENV_KEY] = 'banana';
+    expect(getShortNoticeThresholdHours()).toBe(
+      DEFAULT_SHORT_NOTICE_THRESHOLD_HOURS,
+    );
+  });
+});
+
+describe('isSameCalendarDay (ROK-1240)', () => {
+  it('returns true for two timestamps on the same UTC day', () => {
+    expect(
+      isSameCalendarDay(
+        new Date('2026-05-10T01:00:00Z'),
+        new Date('2026-05-10T23:00:00Z'),
+        'UTC',
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for two timestamps on different UTC days', () => {
+    expect(
+      isSameCalendarDay(
+        new Date('2026-05-10T23:00:00Z'),
+        new Date('2026-05-11T01:00:00Z'),
+        'UTC',
+      ),
+    ).toBe(false);
+  });
+
+  it('respects America/New_York calendar boundary (DST-safe pin)', () => {
+    // 2026-06-10T03:00:00Z = 2026-06-09 23:00 EDT (UTC-4)
+    // 2026-06-10T05:00:00Z = 2026-06-10 01:00 EDT
+    // In NY they straddle midnight → different days
+    expect(
+      isSameCalendarDay(
+        new Date('2026-06-10T03:00:00Z'),
+        new Date('2026-06-10T05:00:00Z'),
+        'America/New_York',
+      ),
+    ).toBe(false);
+    // Same UTC moments in UTC tz → same calendar day
+    expect(
+      isSameCalendarDay(
+        new Date('2026-06-10T03:00:00Z'),
+        new Date('2026-06-10T05:00:00Z'),
+        'UTC',
+      ),
+    ).toBe(true);
+  });
+
+  it('returns true at exactly midnight boundary (same instant)', () => {
+    const ts = new Date('2026-05-10T00:00:00Z');
+    expect(isSameCalendarDay(ts, ts, 'UTC')).toBe(true);
+  });
+});
+
+describe('formatRelativeTimeLabel (ROK-1240)', () => {
+  // Pin to an arbitrary non-DST UTC date for boundary deterministic results.
+
+  it('returns "today" for an event scheduled at 11:59 PM tonight', () => {
+    // now = 2026-03-10 09:00 UTC, start = 2026-03-10 23:59 UTC
+    const now = new Date('2026-03-10T09:00:00Z').getTime();
+    const start = '2026-03-10T23:59:00Z';
+    expect(formatRelativeTimeLabel(start, now, 'UTC')).toBe('today');
+  });
+
+  it('returns "tomorrow" for an event at 12:00 AM tomorrow', () => {
+    const now = new Date('2026-03-10T09:00:00Z').getTime();
+    const start = '2026-03-11T00:00:00Z'; // 15h ahead, next calendar day
+    expect(formatRelativeTimeLabel(start, now, 'UTC')).toBe('tomorrow');
+  });
+
+  it('returns "tomorrow" for an event at 1 AM tomorrow', () => {
+    const now = new Date('2026-03-10T09:00:00Z').getTime();
+    const start = '2026-03-11T01:00:00Z'; // 16h ahead, next calendar day
+    expect(formatRelativeTimeLabel(start, now, 'UTC')).toBe('tomorrow');
+  });
+
+  it('returns "today" for scheduled-noon-processed-9am scenario (Gamer Saloon recurrence)', () => {
+    // The exact failure case from the bug report (5/10 3pm reminder for
+    // 5/10 9pm event), translated to deterministic UTC.
+    // now = 2026-05-10 15:00 UTC, event = 2026-05-10 21:00 UTC (6h out, same day)
+    const now = new Date('2026-05-10T15:00:00Z').getTime();
+    const start = '2026-05-10T21:00:00Z';
+    expect(formatRelativeTimeLabel(start, now, 'UTC')).toBe('today');
+  });
+
+  it('returns "tomorrow" when event crosses midnight into next day, < 24h out', () => {
+    // now = 2026-03-10 22:00 UTC, event = 2026-03-11 02:00 UTC
+    // 4h ahead but next calendar day → "tomorrow"
+    const now = new Date('2026-03-10T22:00:00Z').getTime();
+    const start = '2026-03-11T02:00:00Z';
+    expect(formatRelativeTimeLabel(start, now, 'UTC')).toBe('tomorrow');
+  });
+
+  it('returns "now" when start is in the past', () => {
+    const now = new Date('2026-03-10T12:00:00Z').getTime();
+    const start = '2026-03-10T11:00:00Z';
+    expect(formatRelativeTimeLabel(start, now, 'UTC')).toBe('now');
+  });
+
+  it('returns "now" when start is exactly equal to now', () => {
+    const now = new Date('2026-03-10T12:00:00Z').getTime();
+    expect(formatRelativeTimeLabel(now, now, 'UTC')).toBe('now');
+  });
+
+  it('returns "in Xh" when start is more than 24h out', () => {
+    const now = new Date('2026-03-10T10:00:00Z').getTime();
+    const start = '2026-03-11T22:00:00Z'; // 36h out
+    expect(formatRelativeTimeLabel(start, now, 'UTC')).toBe('in 36h');
+  });
+
+  it('returns "tomorrow" when hoursUntil rounds to 24 and start is on next calendar day', () => {
+    // 23h59m out, but next calendar day → tomorrow (rounds to 24)
+    const now = new Date('2026-03-10T10:00:00Z').getTime();
+    const start = '2026-03-11T09:59:00Z';
+    // hoursUntil = round(23.98...) = 24 → falls into "<= 24" branch with
+    // not-same-day → "tomorrow"
+    expect(formatRelativeTimeLabel(start, now, 'UTC')).toBe('tomorrow');
+  });
+
+  it('respects timezone for "today" boundary (NYC same-day vs UTC next-day)', () => {
+    // now = 2026-06-10 22:00 EDT = 2026-06-11 02:00 UTC
+    // start = 2026-06-10 23:30 EDT = 2026-06-11 03:30 UTC
+    // In NY: same calendar day (2026-06-10) → "today"
+    // In UTC: same day (2026-06-11) → also "today"
+    const now = new Date('2026-06-11T02:00:00Z').getTime();
+    const start = '2026-06-11T03:30:00Z';
+    expect(formatRelativeTimeLabel(start, now, 'America/New_York')).toBe(
+      'today',
+    );
+    expect(formatRelativeTimeLabel(start, now, 'UTC')).toBe('today');
+  });
+
+  it('respects timezone for "today" boundary (NY same-day, UTC next-day across midnight)', () => {
+    // start = 2026-06-11 03:30 UTC = 2026-06-10 23:30 EDT (today in NY)
+    // now = 2026-06-10 23:00 UTC = 2026-06-10 19:00 EDT (today in NY, today in UTC)
+    // In NY: same calendar day (2026-06-10) → "today"
+    // In UTC: now is 2026-06-10, start is 2026-06-11 → "tomorrow"
+    const now = new Date('2026-06-10T23:00:00Z').getTime();
+    const start = '2026-06-11T03:30:00Z'; // 4.5h ahead
+    expect(formatRelativeTimeLabel(start, now, 'America/New_York')).toBe(
+      'today',
+    );
+    expect(formatRelativeTimeLabel(start, now, 'UTC')).toBe('tomorrow');
   });
 });

--- a/api/src/notifications/recruitment-reminder.helpers.spec.ts
+++ b/api/src/notifications/recruitment-reminder.helpers.spec.ts
@@ -524,7 +524,7 @@ describe('formatRelativeTimeLabel (ROK-1240)', () => {
 
   it('returns "now" when start is exactly equal to now', () => {
     const now = new Date('2026-03-10T12:00:00Z').getTime();
-    expect(formatRelativeTimeLabel(now, now, 'UTC')).toBe('now');
+    expect(formatRelativeTimeLabel(new Date(now), now, 'UTC')).toBe('now');
   });
 
   it('returns "in Xh" when start is more than 24h out', () => {

--- a/api/src/notifications/recruitment-reminder.helpers.ts
+++ b/api/src/notifications/recruitment-reminder.helpers.ts
@@ -239,8 +239,7 @@ export function isShortNoticeEvent(
   thresholdHours: number = getShortNoticeThresholdHours(),
 ): boolean {
   const timeUntilEvent =
-    new Date(event.startTime).getTime() -
-    new Date(event.createdAt).getTime();
+    new Date(event.startTime).getTime() - new Date(event.createdAt).getTime();
   if (timeUntilEvent <= 0) return true;
   return timeUntilEvent < thresholdHours * HOUR_MS;
 }

--- a/api/src/notifications/recruitment-reminder.helpers.ts
+++ b/api/src/notifications/recruitment-reminder.helpers.ts
@@ -136,6 +136,76 @@ export function buildDiscordUrl(event: EligibleEvent): string {
 const HOUR_MS = 60 * 60 * 1000;
 
 /**
+ * Default short-notice threshold (hours). Events whose
+ * `start_time - created_at` gap is below this value are SUPPRESSED entirely
+ * — neither channel bumps nor recruitment DMs fire. Override via the
+ * `RECRUITMENT_SHORT_NOTICE_HOURS` env var. ROK-1240.
+ */
+export const DEFAULT_SHORT_NOTICE_THRESHOLD_HOURS = 12;
+
+/**
+ * Read the short-notice suppression threshold (hours) from env, falling
+ * back to {@link DEFAULT_SHORT_NOTICE_THRESHOLD_HOURS}. Invalid /
+ * non-positive values are ignored.
+ */
+export function getShortNoticeThresholdHours(): number {
+  const raw = process.env.RECRUITMENT_SHORT_NOTICE_HOURS;
+  if (!raw) return DEFAULT_SHORT_NOTICE_THRESHOLD_HOURS;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_SHORT_NOTICE_THRESHOLD_HOURS;
+}
+
+/**
+ * Compare two timestamps for same calendar day in the supplied timezone.
+ * Uses {@link Intl.DateTimeFormat} (not UTC string slicing) so the
+ * result reflects the community's wall-clock day. ROK-1240.
+ */
+export function isSameCalendarDay(
+  a: number | Date,
+  b: number | Date,
+  timezone: string,
+): boolean {
+  const fmt = new Intl.DateTimeFormat('en-CA', {
+    timeZone: timezone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  return fmt.format(new Date(a)) === fmt.format(new Date(b));
+}
+
+/**
+ * Render a short relative time label for a future event start time.
+ *
+ * Returns one of:
+ *  - `"now"`        — start is in the past or within the current rounded hour
+ *  - `"today"`      — start is on the same calendar day as `now` (TZ-aware)
+ *  - `"tomorrow"`   — start is within ~24h but on a different calendar day
+ *  - `"in Xh"`      — start is more than 24h out
+ *
+ * Replaces an inline ternary that produced `"tomorrow"` for same-day
+ * events (ROK-1240). Always pass the community default timezone so the
+ * "today" boundary respects the operator's wall clock.
+ */
+export function formatRelativeTimeLabel(
+  startTime: string | Date,
+  now: number,
+  timezone: string,
+): string {
+  const start = new Date(startTime).getTime();
+  const msUntil = start - now;
+  const hoursUntil = Math.round(msUntil / HOUR_MS);
+  if (hoursUntil <= 0) return 'now';
+  if (hoursUntil < 24 && isSameCalendarDay(start, now, timezone)) {
+    return 'today';
+  }
+  if (hoursUntil <= 24) return 'tomorrow';
+  return `in ${hoursUntil}h`;
+}
+
+/**
  * Calculate the grace period in milliseconds for a newly created event.
  * Events created far in advance (>= 72h) get no grace period.
  * Events created closer to start time get a shorter grace to prevent
@@ -155,9 +225,32 @@ export function calculateGracePeriodMs(
 }
 
 /**
- * Check whether an event is still within its creation grace period.
- * Returns true if the event should be skipped (grace period active),
- * false if it should be processed (grace period elapsed or none).
+ * Returns true when the event should be SUPPRESSED outright because the
+ * gap between creation and start is below the short-notice threshold —
+ * i.e. the event was scheduled too close to start time for a recruitment
+ * nag to be useful. Suppression covers BOTH the channel bump and the
+ * recipient DMs (they share a single gating call).
+ *
+ * Defensive: `start <= created` (clock skew, data anomaly) is treated as
+ * suppressed. ROK-1240.
+ */
+export function isShortNoticeEvent(
+  event: Pick<EligibleEvent, 'createdAt' | 'startTime'>,
+  thresholdHours: number = getShortNoticeThresholdHours(),
+): boolean {
+  const timeUntilEvent =
+    new Date(event.startTime).getTime() -
+    new Date(event.createdAt).getTime();
+  if (timeUntilEvent <= 0) return true;
+  return timeUntilEvent < thresholdHours * HOUR_MS;
+}
+
+/**
+ * Check whether an event is still within its creation grace period OR is
+ * a short-notice event that should be suppressed entirely.
+ *
+ * Returns true if the event should be skipped (grace active OR
+ * short-notice), false if it should be processed.
  * @param event - The eligible event to check
  * @param now - Optional timestamp (ms) to use instead of Date.now()
  */
@@ -165,6 +258,11 @@ export function isWithinGracePeriod(
   event: EligibleEvent,
   now?: number,
 ): boolean {
+  // Short-notice events are suppressed regardless of how much time has
+  // elapsed since creation — their start_time is just too close to now
+  // for a recruitment nag to be useful. ROK-1240.
+  if (isShortNoticeEvent(event)) return true;
+
   const gracePeriodMs = calculateGracePeriodMs(
     event.createdAt,
     event.startTime,

--- a/api/src/notifications/recruitment-reminder.service.grace-period.spec.ts
+++ b/api/src/notifications/recruitment-reminder.service.grace-period.spec.ts
@@ -128,7 +128,7 @@ describe('RecruitmentReminderService — grace period (ROK-826)', () => {
     expect(mocks.mockDiscordBotClient.sendEmbed).toHaveBeenCalledTimes(1);
   });
 
-  it('should skip event created 10h before start when cron runs 30min after creation (needs 1h grace)', async () => {
+  it('should skip event created 10h before start when cron runs 30min after creation (short-notice ROK-1240)', async () => {
     const createdAt = new Date('2026-03-15T10:00:00Z');
     const startTime = new Date('2026-03-15T20:00:00Z'); // 10h after creation
     const cronTime = new Date('2026-03-15T10:30:00Z'); // 30min after creation
@@ -147,7 +147,10 @@ describe('RecruitmentReminderService — grace period (ROK-826)', () => {
     expect(mocks.mockNotificationService.create).not.toHaveBeenCalled();
   });
 
-  it('should process event created 10h before start when cron runs 2h after creation (1h grace elapsed)', async () => {
+  it('should ALSO skip event created 10h before start even when cron runs 2h later (short-notice suppression is permanent ROK-1240)', async () => {
+    // Pre-ROK-1240 this test used to expect the event to fire after the
+    // 1h grace elapsed. The new policy: events with start - created < 12h
+    // are suppressed entirely, regardless of how much time has passed.
     const createdAt = new Date('2026-03-15T10:00:00Z');
     const startTime = new Date('2026-03-15T20:00:00Z'); // 10h after creation
     const cronTime = new Date('2026-03-15T12:00:00Z'); // 2h after creation
@@ -158,14 +161,14 @@ describe('RecruitmentReminderService — grace period (ROK-826)', () => {
       created_at: createdAt.toISOString(),
       start_time: startTime.toISOString(),
     });
-    mocks.mockDb.execute
-      .mockResolvedValueOnce([event])
-      .mockResolvedValueOnce([{ id: 5 }])
-      .mockResolvedValueOnce([]);
+    mocks.mockDb.execute.mockResolvedValueOnce([event]);
 
-    await service.checkAndSendReminders();
+    const result = await service.checkAndSendReminders();
 
-    expect(mocks.mockNotificationService.create).toHaveBeenCalledTimes(1);
+    expect(result).toBe(false);
+    expect(mocks.mockNotificationService.create).not.toHaveBeenCalled();
+    expect(mocks.mockDiscordBotClient.sendEmbed).not.toHaveBeenCalled();
+    expect(mocks.mockDedupService.checkAndMarkSent).not.toHaveBeenCalled();
   });
 
   it('should NOT set Redis bump key for events still within grace period', async () => {
@@ -289,5 +292,154 @@ describe('RecruitmentReminderService — grace period (ROK-826)', () => {
 
     expect(result).toBe(false);
     expect(mocks.mockDedupService.checkAndMarkSent).not.toHaveBeenCalled();
+  });
+
+  // ROK-1240 — short-notice cadence suppression
+  describe('short-notice suppression (ROK-1240)', () => {
+    it('should suppress an 8h-out event with same-day createdAt (no embed, no DM, no dedup write)', async () => {
+      const now = new Date('2026-04-20T13:00:00Z');
+      jest.setSystemTime(now);
+
+      const createdAt = new Date('2026-04-20T10:00:00Z'); // 3h ago
+      const startTime = new Date('2026-04-20T18:00:00Z'); // 5h from now → 8h gap
+      const event = makeEventRow({
+        id: 555,
+        created_at: createdAt.toISOString(),
+        start_time: startTime.toISOString(),
+      });
+      mocks.mockDb.execute.mockResolvedValueOnce([event]);
+
+      const result = await service.checkAndSendReminders();
+
+      expect(result).toBe(false);
+      expect(mocks.mockDiscordBotClient.sendEmbed).not.toHaveBeenCalled();
+      expect(mocks.mockNotificationService.create).not.toHaveBeenCalled();
+      expect(mocks.mockDedupService.checkAndMarkSent).not.toHaveBeenCalled();
+    });
+
+    it('should NOT suppress when start - created exceeds threshold (12h gap fires normally)', async () => {
+      // 8h-out event scheduled 30h before start → not short-notice. Cron
+      // runs 22h after creation, past any tier grace.
+      const createdAt = new Date('2026-04-20T00:00:00Z');
+      const startTime = new Date('2026-04-21T06:00:00Z'); // 30h gap
+      const cronTime = new Date('2026-04-20T22:00:00Z'); // 22h after creation
+      jest.setSystemTime(cronTime);
+
+      const event = makeEventRow({
+        id: 556,
+        created_at: createdAt.toISOString(),
+        start_time: startTime.toISOString(),
+      });
+      mocks.mockDb.execute
+        .mockResolvedValueOnce([event])
+        .mockResolvedValueOnce([{ id: 5 }])
+        .mockResolvedValueOnce([]);
+
+      await service.checkAndSendReminders();
+
+      expect(mocks.mockDiscordBotClient.sendEmbed).toHaveBeenCalledTimes(1);
+      expect(mocks.mockNotificationService.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('should suppress at boundary minus 1ms (start - created = 12h - 1ms)', async () => {
+      const createdAt = new Date('2026-04-20T10:00:00Z');
+      const startTime = new Date(createdAt.getTime() + 12 * 60 * 60 * 1000 - 1);
+      const cronTime = new Date(createdAt.getTime() + 11 * 60 * 60 * 1000);
+      jest.setSystemTime(cronTime);
+
+      const event = makeEventRow({
+        id: 557,
+        created_at: createdAt.toISOString(),
+        start_time: startTime.toISOString(),
+      });
+      mocks.mockDb.execute.mockResolvedValueOnce([event]);
+
+      const result = await service.checkAndSendReminders();
+
+      expect(result).toBe(false);
+      expect(mocks.mockDedupService.checkAndMarkSent).not.toHaveBeenCalled();
+    });
+
+    it('should NOT suppress at exactly threshold (start - created = 12h)', async () => {
+      // start - created = exactly 12h → threshold means suppress when < 12h,
+      // so this should NOT be suppressed (falls into 12-24h tier with 3h grace).
+      // Cron runs 5h after creation (past 3h grace).
+      const createdAt = new Date('2026-04-20T10:00:00Z');
+      const startTime = new Date(createdAt.getTime() + 12 * 60 * 60 * 1000);
+      const cronTime = new Date(createdAt.getTime() + 5 * 60 * 60 * 1000);
+      jest.setSystemTime(cronTime);
+
+      const event = makeEventRow({
+        id: 558,
+        created_at: createdAt.toISOString(),
+        start_time: startTime.toISOString(),
+      });
+      mocks.mockDb.execute
+        .mockResolvedValueOnce([event])
+        .mockResolvedValueOnce([{ id: 5 }])
+        .mockResolvedValueOnce([]);
+
+      await service.checkAndSendReminders();
+
+      expect(mocks.mockDiscordBotClient.sendEmbed).toHaveBeenCalledTimes(1);
+      expect(mocks.mockNotificationService.create).toHaveBeenCalledTimes(1);
+    });
+
+    it('should suppress both channel bump AND DM dispatch in a single gating call', async () => {
+      // Recurrence regression — Gamer Saloon 2026-05-10: event scheduled
+      // same-day, created 6h before start. Both paths must stay silent.
+      const createdAt = new Date('2026-05-10T15:00:00Z');
+      const startTime = new Date('2026-05-10T21:00:00Z'); // 6h gap
+      const cronTime = new Date('2026-05-10T17:00:00Z'); // 4h to start
+      jest.setSystemTime(cronTime);
+
+      const event = makeEventRow({
+        id: 559,
+        created_at: createdAt.toISOString(),
+        start_time: startTime.toISOString(),
+      });
+      mocks.mockDb.execute.mockResolvedValueOnce([event]);
+
+      await service.checkAndSendReminders();
+
+      // Channel embed not posted
+      expect(mocks.mockDiscordBotClient.sendEmbed).not.toHaveBeenCalled();
+      // DM not created
+      expect(mocks.mockNotificationService.create).not.toHaveBeenCalled();
+      // Dedup keys NOT marked — re-runs of the cron must remain idempotent
+      // and not "burn" the key for an event we never actually notified on
+      expect(mocks.mockDedupService.checkAndMarkSent).not.toHaveBeenCalled();
+    });
+
+    it('should honour RECRUITMENT_SHORT_NOTICE_HOURS env override (raise threshold to 24h)', async () => {
+      const original = process.env.RECRUITMENT_SHORT_NOTICE_HOURS;
+      process.env.RECRUITMENT_SHORT_NOTICE_HOURS = '24';
+      try {
+        // 18h-gap event would normally NOT be short-notice (< 12h default)
+        // but with threshold raised to 24h it becomes one.
+        const createdAt = new Date('2026-04-20T10:00:00Z');
+        const startTime = new Date('2026-04-21T04:00:00Z'); // 18h gap
+        const cronTime = new Date('2026-04-20T15:00:00Z'); // 5h after creation, past 3h grace
+        jest.setSystemTime(cronTime);
+
+        const event = makeEventRow({
+          id: 560,
+          created_at: createdAt.toISOString(),
+          start_time: startTime.toISOString(),
+        });
+        mocks.mockDb.execute.mockResolvedValueOnce([event]);
+
+        const result = await service.checkAndSendReminders();
+
+        expect(result).toBe(false);
+        expect(mocks.mockDiscordBotClient.sendEmbed).not.toHaveBeenCalled();
+      } finally {
+        if (original === undefined) {
+          delete process.env.RECRUITMENT_SHORT_NOTICE_HOURS;
+        } else {
+          process.env.RECRUITMENT_SHORT_NOTICE_HOURS = original;
+        }
+      }
+    });
   });
 });

--- a/api/src/notifications/recruitment-reminder.service.spec.ts
+++ b/api/src/notifications/recruitment-reminder.service.spec.ts
@@ -174,6 +174,14 @@ describe('RecruitmentReminderService', () => {
   });
 
   describe('checkAndSendReminders — DM notification payload', () => {
+    // Use a startTime threaded through closures so individual tests can
+    // assert on the literal value. Pin to a future timestamp far enough
+    // out that short-notice suppression (ROK-1240) does NOT fire for
+    // the default event row's createdAt (3 days ago).
+    const fixedStartTime = new Date(
+      Date.now() + 23 * 60 * 60 * 1000,
+    ).toISOString();
+
     beforeEach(() => {
       // Default: one event, two recipients, no absences
       const event = makeEventRow({
@@ -182,7 +190,7 @@ describe('RecruitmentReminderService', () => {
         game_id: 7,
         game_name: 'World of Warcraft',
         creator_id: 1,
-        start_time: '2026-03-04T20:00:00.000Z',
+        start_time: fixedStartTime,
         max_attendees: 20,
         signup_count: '10',
         channel_id: 'channel-abc',
@@ -266,7 +274,7 @@ describe('RecruitmentReminderService', () => {
       expect(mocks.mockNotificationService.create).toHaveBeenCalledWith(
         expect.objectContaining({
           payload: expect.objectContaining({
-            startTime: '2026-03-04T20:00:00.000Z',
+            startTime: fixedStartTime,
           }),
         }),
       );
@@ -521,39 +529,75 @@ describe('RecruitmentReminderService', () => {
       expect(mocks.mockDiscordBotClient.sendEmbed).toHaveBeenCalledTimes(1);
     });
 
-    it('should use "tomorrow" in embed title when event is <= 24h away', async () => {
-      const event = makeEventRow({
-        start_time: new Date(Date.now() + 20 * 60 * 60 * 1000).toISOString(),
+    // ROK-1240: deterministic fake-timer block so the calendar-day branch
+    // of formatRelativeTimeLabel is reproducible regardless of when the
+    // test runs.
+    describe('time-label rendering (ROK-1240)', () => {
+      beforeEach(() => {
+        jest.useFakeTimers();
       });
-      mocks.mockDb.execute
-        .mockResolvedValueOnce([event])
-        .mockResolvedValueOnce([]);
-
-      await service.checkAndSendReminders();
-
-      const [, embed] = mocks.mockDiscordBotClient.sendEmbed.mock.calls[0] as [
-        string,
-        { toJSON: () => { title: string } },
-      ];
-      expect(embed.toJSON().title).toContain('tomorrow');
-    });
-
-    it('should use "in Xh" in embed title when event is > 24h away', async () => {
-      const event = makeEventRow({
-        start_time: new Date(Date.now() + 36 * 60 * 60 * 1000).toISOString(),
+      afterEach(() => {
+        jest.useRealTimers();
       });
-      mocks.mockDb.execute
-        .mockResolvedValueOnce([event])
-        .mockResolvedValueOnce([]);
 
-      await service.checkAndSendReminders();
+      it('should use "today" in embed title for same-calendar-day same-day events', async () => {
+        // now = 2026-05-12 09:00 UTC, start = 2026-05-12 21:00 UTC (12h ahead, same day)
+        // Threshold for short-notice = 12h. start - created must be >= 12h
+        // to NOT be suppressed. createdAt 5 days earlier → safe.
+        jest.setSystemTime(new Date('2026-05-12T09:00:00Z'));
+        const event = makeEventRow({
+          start_time: '2026-05-12T21:00:00Z',
+          created_at: '2026-05-07T09:00:00Z',
+        });
+        mocks.mockDb.execute
+          .mockResolvedValueOnce([event])
+          .mockResolvedValueOnce([]);
 
-      const [, embed] = mocks.mockDiscordBotClient.sendEmbed.mock.calls[0] as [
-        string,
-        { toJSON: () => { title: string } },
-      ];
-      expect(embed.toJSON().title).toMatch(/in \d+h/);
-      expect(embed.toJSON().title).not.toContain('tomorrow');
+        await service.checkAndSendReminders();
+
+        const [, embed] = mocks.mockDiscordBotClient.sendEmbed.mock
+          .calls[0] as [string, { toJSON: () => { title: string } }];
+        const title = embed.toJSON().title;
+        expect(title).toContain('today');
+        expect(title).not.toContain('tomorrow');
+      });
+
+      it('should use "tomorrow" in embed title when event is on next calendar day, <= 24h away', async () => {
+        // now = 2026-05-12 22:00 UTC, start = 2026-05-13 18:00 UTC (20h ahead, next day)
+        jest.setSystemTime(new Date('2026-05-12T22:00:00Z'));
+        const event = makeEventRow({
+          start_time: '2026-05-13T18:00:00Z',
+          created_at: '2026-05-07T09:00:00Z',
+        });
+        mocks.mockDb.execute
+          .mockResolvedValueOnce([event])
+          .mockResolvedValueOnce([]);
+
+        await service.checkAndSendReminders();
+
+        const [, embed] = mocks.mockDiscordBotClient.sendEmbed.mock
+          .calls[0] as [string, { toJSON: () => { title: string } }];
+        expect(embed.toJSON().title).toContain('tomorrow');
+      });
+
+      it('should use "in Xh" in embed title when event is > 24h away', async () => {
+        jest.setSystemTime(new Date('2026-05-12T10:00:00Z'));
+        const event = makeEventRow({
+          start_time: '2026-05-13T22:00:00Z', // 36h ahead
+          created_at: '2026-05-07T09:00:00Z',
+        });
+        mocks.mockDb.execute
+          .mockResolvedValueOnce([event])
+          .mockResolvedValueOnce([]);
+
+        await service.checkAndSendReminders();
+
+        const [, embed] = mocks.mockDiscordBotClient.sendEmbed.mock
+          .calls[0] as [string, { toJSON: () => { title: string } }];
+        expect(embed.toJSON().title).toMatch(/in \d+h/);
+        expect(embed.toJSON().title).not.toContain('tomorrow');
+        expect(embed.toJSON().title).not.toContain('today');
+      });
     });
 
     it('should embed description contain event title, gameName, and signupSummary', async () => {

--- a/api/src/notifications/recruitment-reminder.service.ts
+++ b/api/src/notifications/recruitment-reminder.service.ts
@@ -303,7 +303,6 @@ export class RecruitmentReminderService {
     defaultTimezone: string,
   ): { embed: EmbedBuilder; row: ActionRowBuilder<ButtonBuilder> } {
     const signupSummary = buildSignupSummary(event);
-    const embedUrl = buildDiscordUrl(event);
     // ROK-1240: TZ-aware "today"/"tomorrow"/"in Xh" label — fixes
     // same-day events being labeled "tomorrow".
     const timeLabel = formatRelativeTimeLabel(
@@ -320,7 +319,15 @@ export class RecruitmentReminderService {
       .setColor(EMBED_COLORS.ANNOUNCEMENT)
       .setTimestamp(new Date(event.startTime));
 
-    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    return { embed, row: this.buildBumpRow(event, clientUrl) };
+  }
+
+  /** Build the action row (View Event + View in Discord buttons). */
+  private buildBumpRow(
+    event: EligibleEvent,
+    clientUrl: string,
+  ): ActionRowBuilder<ButtonBuilder> {
+    return new ActionRowBuilder<ButtonBuilder>().addComponents(
       new ButtonBuilder()
         .setLabel('View Event')
         .setStyle(ButtonStyle.Link)
@@ -328,8 +335,7 @@ export class RecruitmentReminderService {
       new ButtonBuilder()
         .setLabel('View in Discord')
         .setStyle(ButtonStyle.Link)
-        .setURL(embedUrl),
+        .setURL(buildDiscordUrl(event)),
     );
-    return { embed, row };
   }
 }

--- a/api/src/notifications/recruitment-reminder.service.ts
+++ b/api/src/notifications/recruitment-reminder.service.ts
@@ -24,6 +24,7 @@ import {
   buildSignupSummary,
   buildDiscordUrl,
   isWithinGracePeriod,
+  formatRelativeTimeLabel,
 } from './recruitment-reminder.helpers';
 
 /** TTL for recruitment-reminder dedup keys: 48 hours in seconds */
@@ -254,8 +255,15 @@ export class RecruitmentReminderService {
   private async postChannelBump(event: EligibleEvent): Promise<void> {
     if (this.shouldSkipBump(event)) return;
     try {
-      const clientUrl = await this.settingsService.getClientUrl();
-      const { embed, row } = this.buildBumpEmbed(event, clientUrl);
+      const [clientUrl, defaultTimezone] = await Promise.all([
+        this.settingsService.getClientUrl(),
+        this.settingsService.getDefaultTimezone().then((tz) => tz ?? 'UTC'),
+      ]);
+      const { embed, row } = this.buildBumpEmbed(
+        event,
+        clientUrl,
+        defaultTimezone,
+      );
       const message = await this.discordBotClient.sendEmbed(
         event.channelId,
         embed,
@@ -292,13 +300,17 @@ export class RecruitmentReminderService {
   private buildBumpEmbed(
     event: EligibleEvent,
     clientUrl: string,
+    defaultTimezone: string,
   ): { embed: EmbedBuilder; row: ActionRowBuilder<ButtonBuilder> } {
     const signupSummary = buildSignupSummary(event);
     const embedUrl = buildDiscordUrl(event);
-    const hoursUntil = Math.round(
-      (new Date(event.startTime).getTime() - Date.now()) / (1000 * 60 * 60),
+    // ROK-1240: TZ-aware "today"/"tomorrow"/"in Xh" label — fixes
+    // same-day events being labeled "tomorrow".
+    const timeLabel = formatRelativeTimeLabel(
+      event.startTime,
+      Date.now(),
+      defaultTimezone,
     );
-    const timeLabel = hoursUntil <= 24 ? 'tomorrow' : `in ${hoursUntil}h`;
 
     const embed = new EmbedBuilder()
       .setTitle(`\uD83D\uDCE2 Spots still available — event ${timeLabel}!`)

--- a/api/src/slow-queries/slow-queries.service.ts
+++ b/api/src/slow-queries/slow-queries.service.ts
@@ -3,6 +3,7 @@ import { ConfigService } from '@nestjs/config';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { resolveLogDir } from '../common/log-dir';
 import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
 import * as schema from '../drizzle/schema';
 import {
@@ -14,7 +15,6 @@ import {
   type SlowQueryEntryRecord,
 } from './slow-queries.helpers';
 
-const DEFAULT_LOG_DIR = '/data/logs';
 const SLOW_QUERY_LOG_FILENAME = 'slow-queries.log';
 
 /**
@@ -35,16 +35,18 @@ export class SlowQueriesService {
     private readonly db: PostgresJsDatabase<typeof schema>,
     private readonly configService: ConfigService,
   ) {
-    const logDir = this.configService.get<string>('LOG_DIR') || DEFAULT_LOG_DIR;
+    const logDir = resolveLogDir(this.configService);
     this.logFilePath = path.join(logDir, SLOW_QUERY_LOG_FILENAME);
   }
 
   /**
    * Read top-N from `pg_stat_statements`, format a digest block, and append
    * to the slow-query log file. Idempotent and best-effort: missing extension
-   * or unwritable log dir are warnings, not errors.
+   * or unwritable log dir are warnings, not errors. Returns true when the
+   * block was actually appended; callers that need to surface failure (e.g.
+   * the DEMO_MODE seed endpoint) should check the return and act accordingly.
    */
-  async appendDigestToLog(): Promise<void> {
+  async appendDigestToLog(): Promise<boolean> {
     const entries = await this.readPgStatStatements();
     const block = formatDigestBlock(entries);
     const written = await this.appendBlock(block);
@@ -53,6 +55,7 @@ export class SlowQueriesService {
         `Appended slow-query digest entries=${entries.length} → ${this.logFilePath}`,
       );
     }
+    return written;
   }
 
   /** Returns the absolute path to the slow-query log file. */

--- a/packages/contract/src/activity-log.schema.ts
+++ b/packages/contract/src/activity-log.schema.ts
@@ -25,6 +25,7 @@ export const ActivityActionSchema = z.enum([
     'roster_allocated',
     'event_cancelled',
     'event_rescheduled',
+    'signup_reconfirmed',
 ]);
 
 export type ActivityActionDto = z.infer<typeof ActivityActionSchema>;

--- a/tools/test-bot/src/smoke/run.ts
+++ b/tools/test-bot/src/smoke/run.ts
@@ -35,6 +35,7 @@ import { lineupPrivateDmTests } from './tests/lineup-private-dm.test.js';
 import { lineupChannelOverrideTests } from './tests/lineup-channel-override.test.js';
 import { lineupGraceCountdownTests } from './tests/lineup-grace-countdown.test.js';
 import { discordDeactivationTests } from './tests/discord-deactivation.test.js';
+import { recruitmentReminderTests } from './tests/recruitment-reminder.test.js';
 
 /** Build a TestResult from a test, status, and timing info. */
 function buildResult(
@@ -159,6 +160,7 @@ function collectTests(filterCat?: string): SmokeTest[] {
     ...lineupChannelOverrideTests,
     ...lineupGraceCountdownTests,
     ...discordDeactivationTests,
+    ...recruitmentReminderTests,
   ].filter((t) => !filterCat || t.category === filterCat);
 }
 

--- a/tools/test-bot/src/smoke/tests/recruitment-reminder.test.ts
+++ b/tools/test-bot/src/smoke/tests/recruitment-reminder.test.ts
@@ -1,0 +1,141 @@
+/**
+ * ROK-1240 — short-notice / same-day recruitment reminder suppression.
+ *
+ * The "Spots still available" channel reminder + recruitment DM both
+ * run through `RecruitmentReminderService.checkAndSendReminders` on a
+ * 15-minute cron. Pre-fix, an event scheduled for the same day as it
+ * was created (e.g. created 3pm, starts 9pm) would still post a
+ * channel embed reading "event tomorrow" — both the cadence (firing
+ * for short-notice events at all) and the copy ("tomorrow" for a
+ * same-day event) were wrong.
+ *
+ * This smoke test verifies the cadence half end-to-end:
+ *  1. Create an event scheduled within the short-notice threshold
+ *     (default 12h). createdAt is "now", startTime is 4h out.
+ *  2. Add a game interest so the recipient WOULD have been DM'd
+ *     before the fix.
+ *  3. Trigger the recruitment cron.
+ *  4. Assert: channel never receives a "Spots still available" embed.
+ *  5. Assert: dmRecipientUserId never receives a `recruitment_reminder`
+ *     notification.
+ *
+ * Bot DM rationale: companion bot can't receive DMs from another bot
+ * (Discord 50007). The in-app notification mirror at
+ * `/admin/test/notifications` is the canonical proof of dispatch —
+ * same approach used by `lineup-tiebreaker-open.test.ts` and
+ * `standalone-poll-reminders.test.ts`.
+ */
+import { readLastMessages } from '../../helpers/messages.js';
+import {
+  addGameInterest,
+  assertConditionNeverMet,
+  awaitProcessing,
+  createEvent,
+  deleteEvent,
+  futureTime,
+  getNotificationsFor,
+} from '../fixtures.js';
+import type { ApiClient } from '../api.js';
+import type { SmokeTest, TestContext } from '../types.js';
+
+interface EventResponse {
+  id: number;
+  title: string;
+  [k: string]: unknown;
+}
+
+async function triggerRecruitmentCron(api: ApiClient): Promise<void> {
+  await api.post('/admin/test/trigger-recruitment-reminders', {});
+}
+
+async function hasRecruitmentReminderForRecipient(
+  ctx: TestContext,
+  eventId: number,
+): Promise<boolean> {
+  const list = await getNotificationsFor(
+    ctx.api,
+    ctx.dmRecipientUserId,
+    'recruitment_reminder',
+    25,
+  ).catch(() => [] as { type: string; payload?: Record<string, unknown> }[]);
+  return list.some((n) => n.payload?.eventId === eventId);
+}
+
+async function hasRecruitmentBumpInChannel(
+  channelId: string,
+  eventTitle: string,
+): Promise<boolean> {
+  const msgs = await readLastMessages(channelId, 25);
+  return msgs.some((m) =>
+    m.embeds.some((e) => {
+      const title = e.title ?? '';
+      const desc = e.description ?? '';
+      return (
+        /spots still available/i.test(title) && desc.includes(eventTitle)
+      );
+    }),
+  );
+}
+
+const shortNoticeSuppressesBothPaths: SmokeTest = {
+  name: 'Same-day event suppresses recruitment bump + DM (ROK-1240)',
+  category: 'embed',
+  async run(ctx: TestContext) {
+    const gameId = ctx.mmoGameId ?? ctx.games[0]?.id;
+    if (!gameId) {
+      console.log(
+        '    SKIP: No game available for short-notice suppression test',
+      );
+      return;
+    }
+
+    // Wire up game interest so the recipient WOULD be DM'd if the
+    // suppression rule didn't fire. Without this the negative
+    // assertion is meaningless (no recipient candidates either way).
+    await addGameInterest(ctx.api, ctx.dmRecipientUserId, gameId);
+    await awaitProcessing(ctx.api);
+
+    // 4h to start = well below the 12h short-notice threshold.
+    // createdAt will be "now" because we just POST'd /events.
+    const ev = await createEvent(ctx.api, 'rok1240-shortnotice', {
+      gameId,
+      startTime: futureTime(4 * 60),
+      endTime: futureTime(5 * 60),
+    });
+    const event = ev as EventResponse;
+
+    try {
+      await awaitProcessing(ctx.api);
+
+      // Run the recruitment cron once. Pre-fix, this would post a
+      // channel embed AND insert a recruitment_reminder notification
+      // for our recipient.
+      await triggerRecruitmentCron(ctx.api);
+      await awaitProcessing(ctx.api);
+
+      // Negative assertion #1: channel must NOT receive the bump.
+      // 8s window is plenty — the cron path is synchronous.
+      await assertConditionNeverMet(
+        () => hasRecruitmentBumpInChannel(ctx.defaultChannelId, event.title),
+        8_000,
+        `Channel received "Spots still available" embed for short-notice event "${event.title}" — expected suppression`,
+        { intervalMs: 2000 },
+      );
+
+      // Negative assertion #2: no recruitment_reminder notification
+      // for the would-be recipient.
+      await assertConditionNeverMet(
+        () => hasRecruitmentReminderForRecipient(ctx, event.id),
+        4_000,
+        `Recipient received recruitment_reminder notification for short-notice event ${event.id} — expected suppression`,
+        { intervalMs: 1500 },
+      );
+    } finally {
+      await deleteEvent(ctx.api, event.id);
+    }
+  },
+};
+
+export const recruitmentReminderTests: SmokeTest[] = [
+  shortNoticeSuppressesBothPaths,
+];

--- a/web/src/components/common/activity-timeline-helpers.ts
+++ b/web/src/components/common/activity-timeline-helpers.ts
@@ -133,6 +133,13 @@ const ACTION_MAP: Record<string, ActionDisplay> = {
     borderColor: 'border-amber-500/40',
     label: (actor) => `${actor ?? 'System'} rescheduled the event`,
   },
+  signup_reconfirmed: {
+    color: 'text-blue-400',
+    dotColor: 'bg-blue-400',
+    bgColor: 'bg-blue-500/20',
+    borderColor: 'border-blue-500/40',
+    label: (actor) => `${actor ?? 'Someone'} re-confirmed for the reschedule`,
+  },
 };
 
 const FALLBACK: ActionDisplay = {


### PR DESCRIPTION
## Summary

Three High-priority bug fixes shipped via fix-batch. All concentrated, low-risk, with comprehensive regression coverage.

| Story | Label | What changed |
|-------|-------|--------------|
| **ROK-1240** | Bug / Notifications | Short-notice/same-day reminder cadence + copy. New `formatRelativeTimeLabel` helper (TZ-aware "today/tomorrow/in Xh"). Extended `isWithinGracePeriod` to suppress entirely when `start - created < 12h` (env override `RECRUITMENT_SHORT_NOTICE_HOURS`). Fixes the "📣 event tomorrow!" copy bug at `recruitment-reminder.service.ts:301`. **Rolls up ROK-1241** (DM path mirrors channel path via shared `processEvent`). |
| **ROK-1269** | Bug / Events | Rescheduler stays confirmed (Option A: added `ne(userId, reschedulerId)` predicate to `resetSignupConfirmations`). Added `signup_reconfirmed` enum to `packages/contract/src/activity-log.schema.ts` (additive, no migration). Activity-log emission added to Discord ack path + roster-update path. Frontend `ACTION_MAP` entry. |
| **ROK-1266** | Bug / Admin | `/admin/logs` listing returns the slow-queries.log file the seed endpoint just wrote. New `api/src/common/log-dir.ts` centralizes path resolution with writable dev fallback (`os.tmpdir()/raid-ledger-logs`); production unchanged. `appendDigestToLog` now returns `boolean`; DEMO_MODE seed throws 500 on writer failure (silent-success bug fixed). |
| + `chore(config)` | — | CLAUDE.md: document max-lines is `error`, not `warn`. |

## Validation (all locally verified)

| Gate | Result |
|---|---|
| Build (contract + api + web) | PASS |
| TypeScript | PASS (only pre-existing errors in `lineup-notification.service.private-visibility.spec.ts`, not in batch diff) |
| Lint (api + web) | PASS — 0 errors |
| API unit tests | PASS — 437/437 suites, **5941/5941 tests** |
| Web unit tests (vitest + coverage) | PASS — exit 0 |
| API integration tests | PASS — 81/82 suites, **924/925 tests**. 1 flake (`signups-allocation A3`, 401 auth, passes in isolation, file NOT in batch diff) |
| Playwright (desktop + mobile) | PASS_WITH_FLAKES — 590 passed, 9 flake-failed (all in `lineup-tiebreaker`, `paste-nominate`, `scheduling-poll`, `standalone-scheduling-poll`, `community-lineup` — **none** in batch diff). Re-ran one in isolation: passed. CI on main consistently green. |

## Regression coverage

- **ROK-1240**: 54 helper unit tests (boundary battery: midnight crossover, same-day, just-under-24h, scheduled-noon-processed-9am, TZ NY-vs-UTC), 16 new service + grace-period tests (Gamer Saloon recurrence repro), 2 smoke tests (`assertConditionNeverMet` for channel + DM)
- **ROK-1269**: 4 integration cases in `events-dashboard.actions.integration.spec.ts` (rescheduler stays confirmed, no self-DM, activity log emits, tentative variant) + helper-spec regression block (verifies `ne(userId, reschedulerId)` predicate, handles null) + listener spec coverage
- **ROK-1266**: 4 alignment integration tests (`logs.slow-queries-alignment.spec.ts` — writer + listing same dir; seed→listing; filtered listing; mkdir failure) + 1 controller failure-case test

## Notes for reviewer

- **ROK-1269 contract change** is one additive enum value (`signup_reconfirmed`); no DB migration (column is text). Dist regenerated; api + web both consume the new value.
- **`logReconfirms` does N sequential INSERTs** per reconfirmed userId in `signups-roster.service.ts:287-296`. Acceptable for typical roster sizes (5-30); flagged as Medium tech-debt in `planning-artifacts/review-batch-2026-05-12.md`. Not blocking.
- Full review at `planning-artifacts/review-batch-2026-05-12.md`. Plans at `planning-artifacts/plan-ROK-{1240,1269}.md`.

## Test plan

- [ ] Channel reminder copy says "today" (not "tomorrow") for same-day events
- [ ] No "Spots still available" channel reminder OR DM fires for events created less than 12h before start
- [ ] Setting `RECRUITMENT_SHORT_NOTICE_HOURS=6` shifts the threshold to 6h
- [ ] Rescheduling your own event: your signup stays in Confirmed (not Pending)
- [ ] Activity feed shows "X re-confirmed for the reschedule" entry after invitee clicks Confirm in DM
- [ ] Roster-update flow emits `signup_reconfirmed` per flipped attendee
- [ ] `POST /admin/test/seed-slow-queries-log` → `GET /admin/logs` shows the file
- [ ] Production export bundle still contains `slow-queries.log` (cron writer unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)