### PR TITLE
ROK-1264: diagnostics + falsification gates + cheap-validation harness (H4 identified, global fix deferred to ROK-1268)

### DIFF
--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -99,6 +99,7 @@ These rules cut tokens without cutting quality. They DO NOT trade quality for co
 - **Lead does not capture stdout into context.** Long-running command output (`validate-ci.sh`, `npx playwright test`, `deploy_dev.sh`) is read via `tail -20` or a one-line summary line — never the full log. If the command exits 0, accept it. If it exits non-zero, read only the failing block.
 - **Architect for `standard`:** allowed when the story has genuine architectural ambiguity — ≥2 viable implementation paths, or AC bar high enough that picking the wrong path means redo. Lead's call. Default is still no architect for standard, but don't ration it when it would prevent rework.
 - **Reviewer is the default, not the exception.** Reviewer runs for `standard` and `full`. Skip ONLY when the diff is genuinely trivial: single-file, <100 lines, pure copy/config/dep-bump with no logic change. Operator approval is NOT a substitute for reviewer on anything with logic — past skipped reviews caused the rework this section exists to prevent.
+- **Reproduce flakes BEFORE designing fixes** (STRICT — full protocol in `CLAUDE.md` "Flake-investigation protocol"). For any change framed as a fix for a flaky integration test: run `./scripts/spec-loop.sh <spec> 50` FIRST to establish baseline rate, design fix AFTER measurable signal, validate post-fix at the same per-spec scale, then run full suite. Skipping step 1 means the fix has no falsifiable baseline — ROK-1264's H2 cycle burned ~6 hours on this anti-pattern; the rule exists to prevent recurrence.
 
 ---
 

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ scripts/*
 !scripts/launch-discord.sh
 !scripts/repro-test-infra-flake.sh
 !scripts/loop-integration.sh
+!scripts/spec-loop.sh
 !/api/scripts/
 implementation_plan.md
 walkthrough.md

--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ scripts/*
 !scripts/auth-paths.ts
 !scripts/launch-discord.sh
 !scripts/repro-test-infra-flake.sh
+!scripts/loop-integration.sh
 !/api/scripts/
 implementation_plan.md
 walkthrough.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -159,6 +159,23 @@ Backups exclude the `drizzle` schema (migration metadata is code, not data) to p
 - **Read `TESTING.md` before writing or modifying any test file.**
 - Shared test infra: `api/src/common/testing/` (drizzle-mock, factories), `web/src/test/` (MSW handlers, render helpers, factories)
 
+### Cheap validation harness — `scripts/spec-loop.sh` (STRICT — cheap experiments first)
+
+Per memory `feedback_cheap_experiments_first.md`: falsify hypotheses with N=1 deterministic experiments BEFORE paying for N=30 instrumented loops.
+
+`./scripts/spec-loop.sh <spec-pattern> [N] [STOP_ON_FIRST=true|false]` loops a single Jest integration spec N times (default 50) and tabulates results. Single-file isolation is **7-15 s per run vs ~7 min** for the full suite. The script greps each run for flake-class patterns (`socket hang up`, `ECONNRESET`, `Parse Error`, `HPE_*`) — same set the runtime `socket-debug.ts::isFlakeError` matches.
+
+**When to use:**
+- **Pre-fix repro:** confirm a flake exists at a measurable rate before designing a fix. Saves rework on phantom bugs.
+- **Post-fix validation:** 0/50 on the carrier spec is a strong signal the fix works at the per-file level. Pair with a full-suite run before shipping.
+- **Mechanism discrimination:** intra-file (reproduces in isolation) vs cross-file (only on full suite) → narrows the search space cheaply.
+- **Config A/B sweeps:** 3-5 runs each for several config values (e.g. `maxSockets: 1 / 2 / 5`) → discriminate trade-offs in minutes.
+- **Hypothesis falsification:** if you suspect mechanism X, write a focused micro-test, run it 100× in seconds, and either confirm or eliminate the path.
+
+**Output:** `/tmp/spec-loop-<pattern>-<ts>/summary.tsv` (run / exit / wallclock_s / flake_count / excerpt) plus per-run logs. Exit 0 = all clean; 1 = at least one flake hit or non-zero exit.
+
+**Provenance:** the pattern emerged from ROK-1264's Tier-1 investigation. The history is captured in `docs/spikes/rok-1250-residual-layer-5.md` §2 (the original ad-hoc loops that produced the H4 identification + 0/50 post-fix validation + maxSockets sweep).
+
 ### Local CI
 
 Run `./scripts/validate-ci.sh --full` before pushing any branch. This replaces manual per-step checks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,31 @@ Per memory `feedback_cheap_experiments_first.md`: falsify hypotheses with N=1 de
 
 **Provenance:** the pattern emerged from ROK-1264's Tier-1 investigation. The history is captured in `docs/spikes/rok-1250-residual-layer-5.md` §2 (the original ad-hoc loops that produced the H4 identification + 0/50 post-fix validation + maxSockets sweep).
 
+#### Flake-investigation protocol (STRICT — reproduce BEFORE designing a fix)
+
+For ANY change presented as a fix for a flaky, intermittent, or non-deterministic integration test failure, an agent **MUST** establish empirical baseline rates BEFORE designing the fix. Skipping this step has cost the project multiple multi-hour spike cycles (ROK-1249, ROK-1250, ROK-1264 H2 false-positive — see `docs/spikes/rok-1250-residual-layer-5.md`).
+
+**Required order:**
+
+1. **Reproduce in isolation first** — `./scripts/spec-loop.sh <suspected-carrier-spec> [N]`. Default N=50. Two outcomes:
+   - **Reproduces** (≥1 hit in 50 runs) → intra-file mechanism. Cheap iterative fix-validation is now unlocked.
+   - **Does NOT reproduce** in 50+ runs → cross-file, environmental, or wrong carrier suspect. STOP and re-examine. Do not jump to a global fix on an unreproduced hypothesis.
+2. **Design the fix** only AFTER step 1 gives you measurable signal.
+3. **Validate the fix at the same per-spec scale** — `./scripts/spec-loop.sh <same-spec> 50`. Bar: **0 hits in 50 runs**. If the rate dropped but isn't zero, the fix is incomplete OR the wrong shape.
+4. **Run the full integration suite** AFTER per-spec validation passes. This is where global-config changes (shared agents, server timeouts, env-level patches) reveal incompatibility with OTHER specs — the failure mode that bit ROK-1264's `maxSockets:1` wrap.
+
+**Skipping any step:**
+- Skip step 1 → no falsifiable baseline. Fix may address a phantom bug or the wrong mechanism. Operator and reviewer have no way to validate the diagnosis.
+- Skip step 3 → no per-spec proof the fix actually does what's claimed.
+- Skip step 4 → ship a regression to unrelated specs (the events.spec failure pattern this rule exists to prevent).
+
+**When the protocol doesn't apply:**
+- Pure unit tests (deterministic by design — they're either passing or buggy)
+- Environmental flakes only reproducible on Render/CI (record this explicitly; spec-loop is local)
+- Discord-bot or browser-UI flakes (use the companion bot or Playwright loops instead)
+
+In ambiguous cases: run the protocol anyway. The cost is 7 minutes; the rework cost when skipped is days.
+
 ### Local CI
 
 Run `./scripts/validate-ci.sh --full` before pushing any branch. This replaces manual per-step checks.

--- a/api/src/common/testing/dump-failure-snapshot.spec.ts
+++ b/api/src/common/testing/dump-failure-snapshot.spec.ts
@@ -125,4 +125,27 @@ describe('dumpFailureSnapshot — filesystem + buckets', () => {
     expect(prefixes['jwt_block'].count).toBe(3);
     fs.unlinkSync(filePath);
   });
+
+  // ROK-1264 layer-4 buckets — TIME_WAIT counts, peer-port histogram,
+  // and supertest server port. Each must be present and shape-correct.
+  it('captures the three ROK-1264 layer-4 buckets', async () => {
+    const filePath = await dumpFailureSnapshot('rok-1264-layer-4');
+    const snapshot = readLatestSnapshot(filePath);
+    expect(snapshot).toHaveProperty('netstatTimeWait');
+    expect(snapshot).toHaveProperty('peerPortHistogram');
+    expect(snapshot).toHaveProperty('testServerPort');
+    const histogram = snapshot.peerPortHistogram as {
+      status: string;
+      total: number;
+      byPeerPort: unknown[];
+    };
+    expect(histogram.status).toBe('ok');
+    expect(typeof histogram.total).toBe('number');
+    expect(Array.isArray(histogram.byPeerPort)).toBe(true);
+    const tsPort = snapshot.testServerPort as { status: string };
+    // Fake app lacks `getHttpServer`, so readTestServerPort should fall
+    // through the defensive checks and report `no-server` (not throw).
+    expect(tsPort.status).toBe('no-server');
+    fs.unlinkSync(filePath);
+  });
 });

--- a/api/src/common/testing/dump-failure-snapshot.ts
+++ b/api/src/common/testing/dump-failure-snapshot.ts
@@ -19,6 +19,11 @@ import {
   readCronJobs,
   readRedisMockStore,
 } from './snapshot-buckets';
+import {
+  readNetstatTimeWaitBuckets,
+  readPeerPortHistogram,
+  readTestServerPort,
+} from './snapshot-buckets-tcp';
 
 const SNAPSHOT_DIR = path.resolve(
   __dirname,
@@ -49,6 +54,11 @@ export async function dumpFailureSnapshot(
       readCronJobs(instance),
       readRedisMockStore(instance),
     ]);
+  // ROK-1264: TIME_WAIT bucket + peer-port histogram + supertest port.
+  // Synchronous — net/spawnSync calls return immediately; no await needed.
+  const netstatTimeWait = readNetstatTimeWaitBuckets();
+  const peerPortHistogram = readPeerPortHistogram();
+  const testServerPort = readTestServerPort(instance);
   const snapshot = {
     capturedAt: new Date().toISOString(),
     reason,
@@ -59,6 +69,9 @@ export async function dumpFailureSnapshot(
     activeHandles,
     cronJobs,
     redisMockStore,
+    netstatTimeWait,
+    peerPortHistogram,
+    testServerPort,
   };
   fs.mkdirSync(SNAPSHOT_DIR, { recursive: true });
   const filePath = buildSnapshotFilePath();

--- a/api/src/common/testing/snapshot-buckets-tcp.ts
+++ b/api/src/common/testing/snapshot-buckets-tcp.ts
@@ -1,0 +1,239 @@
+/**
+ * TCP / kernel-state bucket readers for `dumpFailureSnapshot` (ROK-1264).
+ *
+ * The ROK-1249/1250 instrumentation captured libuv-tracked handles only.
+ * Sockets in `TIME_WAIT` state are NOT visible to `process._getActiveHandles()`
+ * — the JS-land FD is closed, but the kernel still holds the 4-tuple for
+ * ~60s. If the residual mid-suite TCP RST is driven by ephemeral-port or
+ * `TIME_WAIT` accumulation, the older snapshot cannot see it.
+ *
+ * This module adds three signals that together let the layer-4 spike
+ * (`docs/spikes/rok-1250-residual-layer-4.md`) name the carrier:
+ *   - `readNetstatTimeWaitBuckets` — shells out to `netstat`/`ss` and
+ *     buckets TIME_WAIT counts by peer port.
+ *   - `readPeerPortHistogram` — derives a histogram of `remotePort` over
+ *     the already-captured libuv socket list. Cheap and runs without exec.
+ *   - `readTestServerPort` — records the supertest HTTP server bind port
+ *     so the spike doc can correlate the failing port against the snapshot.
+ *
+ * All readers are defensive: missing CLI tool, parse failure, or non-zero
+ * exit returns a `status` placeholder rather than throwing. The snapshot
+ * helper must never amplify the flake it diagnoses.
+ */
+import { spawnSync } from 'child_process';
+import type { getTestAppInstance } from './test-app';
+
+type Instance = ReturnType<typeof getTestAppInstance>;
+
+const NETSTAT_TIMEOUT_MS = 500;
+
+interface PortBucket {
+  port: number;
+  count: number;
+}
+
+interface NetstatResult {
+  status: 'ok' | 'no-tool' | 'error' | 'parse-error';
+  tool?: 'netstat' | 'ss';
+  totalTimeWait?: number;
+  byPeerPort?: PortBucket[];
+  error?: string;
+}
+
+/**
+ * Parse BSD `netstat -an -p tcp` output (darwin). Local + foreign address
+ * columns use `.` as the host/port separator (`127.0.0.1.50624`). State is
+ * the last column.
+ */
+function parseNetstatBsd(stdout: string): Map<number, number> {
+  const counts = new Map<number, number>();
+  for (const line of stdout.split('\n')) {
+    if (!line.includes('TIME_WAIT')) continue;
+    const cols = line.trim().split(/\s+/);
+    if (cols.length < 5) continue;
+    const foreign = cols[4];
+    if (!foreign) continue;
+    const dot = foreign.lastIndexOf('.');
+    if (dot === -1) continue;
+    const port = Number(foreign.slice(dot + 1));
+    if (!Number.isFinite(port)) continue;
+    counts.set(port, (counts.get(port) ?? 0) + 1);
+  }
+  return counts;
+}
+
+/**
+ * Parse Linux `ss -tan state time-wait` output. Columns: `Recv-Q Send-Q
+ * Local Address:Port Peer Address:Port`. Port separator is `:`.
+ */
+function parseSsLinux(stdout: string): Map<number, number> {
+  const counts = new Map<number, number>();
+  const lines = stdout.split('\n').slice(1); // skip header
+  for (const line of lines) {
+    const cols = line.trim().split(/\s+/);
+    if (cols.length < 4) continue;
+    const peer = cols[3];
+    if (!peer) continue;
+    const colon = peer.lastIndexOf(':');
+    if (colon === -1) continue;
+    const port = Number(peer.slice(colon + 1));
+    if (!Number.isFinite(port)) continue;
+    counts.set(port, (counts.get(port) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function bucketsFromMap(counts: Map<number, number>): {
+  total: number;
+  byPeerPort: PortBucket[];
+} {
+  let total = 0;
+  const buckets: PortBucket[] = [];
+  for (const [port, count] of counts) {
+    total += count;
+    buckets.push({ port, count });
+  }
+  buckets.sort((a, b) => b.count - a.count);
+  return { total, byPeerPort: buckets.slice(0, 20) };
+}
+
+function runNetstatBsd(): NetstatResult | null {
+  const r = spawnSync('netstat', ['-an', '-p', 'tcp'], {
+    encoding: 'utf8',
+    timeout: NETSTAT_TIMEOUT_MS,
+  });
+  if (r.error || r.status !== 0) return null;
+  try {
+    const counts = parseNetstatBsd(r.stdout);
+    const { total, byPeerPort } = bucketsFromMap(counts);
+    return {
+      status: 'ok',
+      tool: 'netstat',
+      totalTimeWait: total,
+      byPeerPort,
+    };
+  } catch (err) {
+    return {
+      status: 'parse-error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+function runSsLinux(): NetstatResult | null {
+  const r = spawnSync('ss', ['-tan', 'state', 'time-wait'], {
+    encoding: 'utf8',
+    timeout: NETSTAT_TIMEOUT_MS,
+  });
+  if (r.error || r.status !== 0) return null;
+  try {
+    const counts = parseSsLinux(r.stdout);
+    const { total, byPeerPort } = bucketsFromMap(counts);
+    return { status: 'ok', tool: 'ss', totalTimeWait: total, byPeerPort };
+  } catch (err) {
+    return {
+      status: 'parse-error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/**
+ * TIME_WAIT bucket — kernel-visible sockets the JS process can't see.
+ * Tries BSD `netstat` first (darwin/macOS dev), then Linux `ss`. Returns
+ * a placeholder if neither tool is available.
+ */
+export function readNetstatTimeWaitBuckets(): NetstatResult {
+  try {
+    const bsd = runNetstatBsd();
+    if (bsd) return bsd;
+    const linux = runSsLinux();
+    if (linux) return linux;
+    return { status: 'no-tool' };
+  } catch (err) {
+    return {
+      status: 'error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/**
+ * Histogram of `remotePort` across the libuv-tracked TCP socket handles.
+ * Pure JS — derived from `process._getActiveHandles()`. Surfaces ioredis
+ * (6379), test-postgres-container port, and supertest in-process server
+ * port concentrations without depending on any external tool.
+ */
+export function readPeerPortHistogram(): {
+  status: 'ok';
+  total: number;
+  byPeerPort: PortBucket[];
+} {
+  const proc = process as unknown as { _getActiveHandles?: () => unknown[] };
+  const handles = proc._getActiveHandles?.() ?? [];
+  const counts = new Map<number, number>();
+  let total = 0;
+  for (const h of handles) {
+    const ctorName = (h as { constructor?: { name?: string } })?.constructor
+      ?.name;
+    if (ctorName !== 'Socket') continue;
+    const port = (h as { remotePort?: unknown }).remotePort;
+    if (typeof port !== 'number') continue;
+    total += 1;
+    counts.set(port, (counts.get(port) ?? 0) + 1);
+  }
+  const buckets: PortBucket[] = [];
+  for (const [port, count] of counts) buckets.push({ port, count });
+  buckets.sort((a, b) => b.count - a.count);
+  return { status: 'ok', total, byPeerPort: buckets };
+}
+
+interface TestServerPortResult {
+  status: 'ok' | 'no-app' | 'no-server' | 'no-address' | 'error';
+  port?: number;
+  family?: string;
+  address?: string;
+  error?: string;
+}
+
+/**
+ * Read the supertest HTTP server's bound port from the live NestJS app.
+ * Used to correlate the failing-request `testServerPort` against the
+ * peer-port histogram and TIME_WAIT bucket at snapshot time. Without
+ * this, layer-4 can't tell which `remotePort=NNNN` entries are "us".
+ */
+export function readTestServerPort(instance: Instance): TestServerPortResult {
+  try {
+    const app = (
+      instance as {
+        app?: { getHttpServer?: () => unknown };
+      } | null
+    )?.app;
+    if (!app) return { status: 'no-app' };
+    const server = app.getHttpServer?.() as
+      | { address?: () => unknown }
+      | undefined;
+    if (!server || typeof server.address !== 'function') {
+      return { status: 'no-server' };
+    }
+    const addr = server.address() as {
+      port?: number;
+      family?: string;
+      address?: string;
+    } | null;
+    if (!addr || typeof addr.port !== 'number') {
+      return { status: 'no-address' };
+    }
+    return {
+      status: 'ok',
+      port: addr.port,
+      family: addr.family,
+      address: addr.address,
+    };
+  } catch (err) {
+    return {
+      status: 'error',
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}

--- a/api/src/common/testing/socket-debug.ts
+++ b/api/src/common/testing/socket-debug.ts
@@ -85,8 +85,23 @@ const HTTP_METHODS = [
 type HttpMethod = (typeof HTTP_METHODS)[number];
 
 function isFlakeError(err: unknown): boolean {
-  const msg = String((err as { message?: string })?.message ?? err);
-  return msg.includes('socket hang up') || msg.includes('ECONNRESET');
+  const e = err as { message?: string; code?: string };
+  const msg = String(e?.message ?? err);
+  const code = String(e?.code ?? '');
+  // Original ROK-1249/1250 trigger class: canonical socket-level RST.
+  if (msg.includes('socket hang up') || msg.includes('ECONNRESET')) {
+    return true;
+  }
+  // ROK-1264: HTTP-parser-level errors fire when a client reads non-HTTP
+  // bytes from what should be a fresh response. Same root-cause class as
+  // socket-RST (stale socket reuse from keep-alive pool, or half-closed
+  // peer state) but surfaces with a different error code. Node's llhttp
+  // uses the HPE_* prefix for all parser errors; the most common message
+  // form is "Parse Error: Expected HTTP/, RTSP/ or ICE/".
+  if (msg.includes('Parse Error') || code.startsWith('HPE_')) {
+    return true;
+  }
+  return false;
 }
 
 function wrapMethod(

--- a/api/src/common/testing/supertest-keepalive.spec.ts
+++ b/api/src/common/testing/supertest-keepalive.spec.ts
@@ -1,0 +1,110 @@
+/**
+ * ROK-1264 H2-fix propagation gate.
+ *
+ * Deterministic unit test that answers ONE question: does assigning a
+ * keep-alive-off `http.Agent` to supertest's TestAgent via `_options.agent`
+ * actually reach the per-request HTTP dispatch?
+ *
+ * If keep-alive is OFF: 2 sequential supertest calls open 2 distinct TCP
+ * connections (each FINs after the response). Assertion: connections === 2.
+ *
+ * If the assignment is dead code (keep-alive still ON via supertest's
+ * superagent default): 2 sequential calls reuse 1 pooled socket.
+ * Assertion fails with connections === 1.
+ *
+ * This is the cheap pre-AC3 gate: 10 lines, deterministic, < 1 second.
+ * It replaces a 30-minute multi-run smoke for the "did the fix take effect?"
+ * question.
+ */
+import * as http from 'http';
+import * as supertest from 'supertest';
+
+describe('ROK-1264 H2 fix propagation', () => {
+  it('opens a fresh TCP connection per sequential request when keepAlive:false is wired via _options.agent', async () => {
+    let connections = 0;
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('ok');
+    });
+    server.on('connection', () => {
+      connections += 1;
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', () => resolve());
+    });
+
+    try {
+      // Mirror buildKeepAliveOffSupertest() from test-app.ts.
+      const keepAliveOffAgent = new http.Agent({
+        keepAlive: false,
+        maxSockets: Infinity,
+      });
+      const request = supertest.default(server);
+      const requestWithOptions = request as unknown as {
+        _options?: { agent?: unknown };
+      };
+      requestWithOptions._options = {
+        ...(requestWithOptions._options ?? {}),
+        agent: keepAliveOffAgent,
+      };
+
+      // Two sequential requests on the same TestAgent. If _options.agent
+      // is honored, each request opens a NEW TCP connection (keepAlive:false
+      // forces FIN after response). If _options.agent is ignored (the
+      // validator's claim), supertest falls back to its default which
+      // either pools via http.globalAgent (keep-alive ON) OR uses
+      // `agent: false` per request (no pool but ALSO no reuse — 2 connects).
+      // The discriminating signal is the connection count.
+      await request.get('/');
+      await request.get('/');
+
+      // Belt-and-suspenders: also destroy the agent to confirm the
+      // closeTestApp path doesn't throw.
+      keepAliveOffAgent.destroy();
+
+      expect(connections).toBe(2);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    }
+  });
+
+  it('SANITY CHECK: WITHOUT the agent override, supertest default behaviour produces N connections (control)', async () => {
+    let connections = 0;
+    const server = http.createServer((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/plain' });
+      res.end('ok');
+    });
+    server.on('connection', () => {
+      connections += 1;
+    });
+
+    await new Promise<void>((resolve) => {
+      server.listen(0, '127.0.0.1', () => resolve());
+    });
+
+    try {
+      // No agent override — pure supertest defaults.
+      const request = supertest.default(server);
+      await request.get('/');
+      await request.get('/');
+
+      // Hard assertion: supertest's default produces 2 distinct connections
+      // for 2 sequential awaited requests. This is the falsification proof
+      // for ROK-1264's H2 hypothesis — there is NO keep-alive pool, so
+      // "stale pool reuse" cannot be the carrier. If this assertion ever
+      // fails (e.g., supertest upgrade flips to pooling), any future "H2-
+      // class" diagnosis must be revisited.
+      console.error(
+        `[ROK-1264 sanity] supertest default connections=${connections} (must be 2 — no pooling)`,
+      );
+      expect(connections).toBe(2);
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    }
+  });
+});

--- a/api/src/common/testing/supertest-persistent-agent.spec.ts
+++ b/api/src/common/testing/supertest-persistent-agent.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * ROK-1264 — regression gate for `wrapWithPersistentAgent`.
+ *
+ * Pins the propagation contract: every supertest call returned from a wrapped
+ * TestAgent shares ONE keep-alive socket. If a future supertest/superagent
+ * upgrade silently flips `Test._agent` plumbing such that `.agent(myAgent)`
+ * is no longer honored per-request, this test fails — and any future
+ * residual TCP-RST regression has a head-start on the diagnosis.
+ *
+ * Mirrors `supertest-keepalive.spec.ts` (which falsified the older H2 fix).
+ * Together those two specs lock down the supertest behavior model the
+ * ROK-1264 fix depends on.
+ */
+import * as http from 'http';
+import * as supertest from 'supertest';
+import {
+  destroyPersistentAgent,
+  wrapWithPersistentAgent,
+} from './supertest-persistent-agent';
+
+async function withServer<T>(
+  handler: http.RequestListener,
+  fn: (server: http.Server, port: number) => Promise<T>,
+): Promise<T> {
+  const server = http.createServer(handler);
+  await new Promise<void>((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve());
+  });
+  const addr = server.address();
+  const port = typeof addr === 'object' && addr !== null ? addr.port : 0;
+  try {
+    return await fn(server, port);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((err) => (err ? reject(err) : resolve()));
+    });
+  }
+}
+
+describe('wrapWithPersistentAgent (ROK-1264)', () => {
+  it('serializes 5 sequential requests onto exactly 1 TCP connection', async () => {
+    let connections = 0;
+    await withServer(
+      (_req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/plain' });
+        res.end('ok');
+      },
+      async (server) => {
+        server.on('connection', () => {
+          connections += 1;
+        });
+        const request = wrapWithPersistentAgent(supertest.default(server));
+        try {
+          await request.get('/');
+          await request.get('/');
+          await request.post('/').send({ hi: 1 });
+          await request.put('/').send({ hi: 2 });
+          await request.delete('/');
+          expect(connections).toBe(1);
+        } finally {
+          destroyPersistentAgent(request);
+        }
+      },
+    );
+  });
+
+  it('is idempotent — re-wrapping does not double-pin the agent', async () => {
+    let connections = 0;
+    await withServer(
+      (_req, res) => res.end('ok'),
+      async (server) => {
+        server.on('connection', () => {
+          connections += 1;
+        });
+        let request = supertest.default(server);
+        request = wrapWithPersistentAgent(request);
+        request = wrapWithPersistentAgent(request);
+        request = wrapWithPersistentAgent(request);
+        try {
+          await request.get('/');
+          await request.get('/');
+          expect(connections).toBe(1);
+        } finally {
+          destroyPersistentAgent(request);
+        }
+      },
+    );
+  });
+
+  it('destroyPersistentAgent on an unwrapped TestAgent is a safe no-op', async () => {
+    await withServer(
+      () => undefined,
+      async (server) => {
+        const request = supertest.default(server);
+        expect(() => destroyPersistentAgent(request)).not.toThrow();
+      },
+    );
+  });
+});

--- a/api/src/common/testing/supertest-persistent-agent.spec.ts
+++ b/api/src/common/testing/supertest-persistent-agent.spec.ts
@@ -97,4 +97,41 @@ describe('wrapWithPersistentAgent (ROK-1264)', () => {
       },
     );
   });
+
+  // ROK-1264 follow-up: discriminate whether the residual full-suite ECONNRESET
+  // observed in `events.integration.spec.ts › shape parity per slice` is caused
+  // by Promise.all'd parallel requests queueing through the maxSockets:1 agent.
+  // The server adds a small delay so head-of-line waits are realistic.
+  it('survives 100× Promise.all([5 parallel GETs]) on the pinned socket without RST', async () => {
+    let connections = 0;
+    const handler: http.RequestListener = (_req, res) => {
+      setTimeout(() => {
+        res.writeHead(200);
+        res.end('ok');
+      }, 5);
+    };
+    await withServer(handler, async (server) => {
+      server.on('connection', () => {
+        connections += 1;
+      });
+      const request = wrapWithPersistentAgent(supertest.default(server));
+      try {
+        for (let i = 0; i < 100; i++) {
+          const responses = await Promise.all([
+            request.get('/'),
+            request.get('/'),
+            request.get('/'),
+            request.get('/'),
+            request.get('/'),
+          ]);
+          for (const r of responses) expect(r.status).toBe(200);
+        }
+        // 100 iterations × 5 parallel requests through maxSockets:1 should
+        // still use exactly one socket (queueing, not new sockets per call).
+        expect(connections).toBe(1);
+      } finally {
+        destroyPersistentAgent(request);
+      }
+    });
+  }, 15_000);
 });

--- a/api/src/common/testing/supertest-persistent-agent.spec.ts
+++ b/api/src/common/testing/supertest-persistent-agent.spec.ts
@@ -90,9 +90,10 @@ describe('wrapWithPersistentAgent (ROK-1264)', () => {
   it('destroyPersistentAgent on an unwrapped TestAgent is a safe no-op', async () => {
     await withServer(
       () => undefined,
-      async (server) => {
+      (server) => {
         const request = supertest.default(server);
         expect(() => destroyPersistentAgent(request)).not.toThrow();
+        return Promise.resolve();
       },
     );
   });

--- a/api/src/common/testing/supertest-persistent-agent.ts
+++ b/api/src/common/testing/supertest-persistent-agent.ts
@@ -1,6 +1,30 @@
 /**
  * ROK-1264 — pin every supertest call to a single keep-alive pooled socket.
  *
+ * **STATUS (2026-05-12): available but NOT wired in `test-app.ts`.** Applying
+ * this wrapper globally with `maxSockets: 1` provably eliminates the H4
+ * loopback-bleed carrier in `lineups-voting.integration.spec.ts` (0/50 hits
+ * post-fix vs 1/20 pre-fix), BUT deterministically breaks any spec that
+ * fans out parallel HTTP requests via `Promise.all`. Specifically
+ * `events.integration.spec.ts › GET /events/:id/detail (ROK-1046) ›
+ * shape parity per slice vs legacy endpoints` failed 10/10 in isolation
+ * because `fetchLegacySlices` queues 5 parallel requests through one socket,
+ * one of which (`/voice-channel`) does a DB+Discord lookup that exceeds
+ * supertest's default response timeout when serialized.
+ *
+ * Intermediate `maxSockets` values were tested: `:1` (events.spec 10/10 fail),
+ * `:2` (events.spec 3/3 fail, ~5× wallclock blowup), `:5` (events.spec passes
+ * 3/3, but lineups-voting carrier returns to ~4% — statistically equivalent
+ * to the 5% pre-fix baseline). No single `maxSockets` value satisfies both
+ * hard-serialization (needed for H4) AND parallel-friendly (needed for
+ * `fetchLegacySlices`). See `docs/spikes/rok-1250-residual-layer-5.md`.
+ *
+ * The helper + spec are retained so any future opt-in deployment (per-file
+ * annotation, per-test-scope reset, etc.) has ready-to-use machinery and a
+ * deterministic regression gate. Do NOT wire globally without re-validating
+ * against the full integration suite.
+ *
+ *
  * Mechanism (architecture-v2 §3 H4 + Tier-1 probe-1 reproducer 2026-05-12):
  *   The 'Parse Error: Expected HTTP/, RTSP/ or ICE/' (and 'socket hang up')
  *   class fires CLIENT-SIDE inside superagent's llhttp parser when sequential

--- a/api/src/common/testing/supertest-persistent-agent.ts
+++ b/api/src/common/testing/supertest-persistent-agent.ts
@@ -69,9 +69,7 @@ export function wrapWithPersistentAgent(
 }
 
 /** Destroy the persistent agent's pooled socket; safe if never wrapped. */
-export function destroyPersistentAgent(
-  agent: TestAgent<supertest.Test>,
-): void {
+export function destroyPersistentAgent(agent: TestAgent<supertest.Test>): void {
   const holder = agent as unknown as AgentHolder;
   const persistent = holder[PERSISTENT_AGENT_KEY];
   if (persistent) {

--- a/api/src/common/testing/supertest-persistent-agent.ts
+++ b/api/src/common/testing/supertest-persistent-agent.ts
@@ -1,0 +1,81 @@
+/**
+ * ROK-1264 — pin every supertest call to a single keep-alive pooled socket.
+ *
+ * Mechanism (architecture-v2 §3 H4 + Tier-1 probe-1 reproducer 2026-05-12):
+ *   The 'Parse Error: Expected HTTP/, RTSP/ or ICE/' (and 'socket hang up')
+ *   class fires CLIENT-SIDE inside superagent's llhttp parser when sequential
+ *   supertest requests in the same `it()` race the loopback driver. Server
+ *   socket events never fire on these failures (instrumentHttpServer
+ *   confirms). Sub-mechanism: the prior request's response stream tail bytes
+ *   leak onto the next request's NEW socket — supertest's per-request
+ *   `agent: false` default gives every request a fresh ephemeral port with
+ *   no serialization barrier between FIN-flush and next connect.
+ *
+ *   Forcing `agent: keepAlive=true, maxSockets=1` makes ALL calls share ONE
+ *   long-lived socket. The agent's request queue serializes per-socket; each
+ *   request awaits the prior response's full drain before writing the next.
+ *   No cross-socket bleed possible because there is only one socket.
+ *
+ * Why this is NOT the falsified ROK-1264 H2 fix:
+ *   The H2 fix set `_options.agent` on the TestAgent FACTORY, which supertest
+ *   does NOT plumb to per-request `Test._agent`. Each Test starts with
+ *   `_agent = false` regardless of factory options. See
+ *   `supertest-keepalive.spec.ts` for the falsification proof. This wrapper
+ *   instead sets `_agent` on each `Test` instance via `Test.agent(myAgent)`,
+ *   which IS honored — `superagent/lib/node/index.js:736` reads
+ *   `options.agent = this._agent` per request.
+ */
+import * as http from 'http';
+import type * as supertest from 'supertest';
+import type TestAgent from 'supertest/lib/agent';
+
+const HTTP_METHODS = [
+  'get',
+  'post',
+  'put',
+  'delete',
+  'patch',
+  'head',
+  'options',
+] as const;
+
+const PERSISTENT_AGENT_KEY = Symbol('rok-1264-persistent-agent');
+
+interface AgentHolder {
+  [PERSISTENT_AGENT_KEY]?: http.Agent;
+}
+
+/**
+ * Wrap a supertest TestAgent so every request method pins the returned
+ * `Test`'s underlying http.Agent to a single keep-alive pooled agent
+ * (`maxSockets: 1`). Idempotent — re-wrapping is a no-op.
+ */
+export function wrapWithPersistentAgent(
+  agent: TestAgent<supertest.Test>,
+): TestAgent<supertest.Test> {
+  const holder = agent as unknown as AgentHolder;
+  if (holder[PERSISTENT_AGENT_KEY]) return agent;
+  const persistent = new http.Agent({ keepAlive: true, maxSockets: 1 });
+  holder[PERSISTENT_AGENT_KEY] = persistent;
+  for (const method of HTTP_METHODS) {
+    const slot = agent as unknown as Record<
+      string,
+      (...args: unknown[]) => supertest.Test
+    >;
+    const orig = slot[method].bind(agent);
+    slot[method] = (...args: unknown[]) => orig(...args).agent(persistent);
+  }
+  return agent;
+}
+
+/** Destroy the persistent agent's pooled socket; safe if never wrapped. */
+export function destroyPersistentAgent(
+  agent: TestAgent<supertest.Test>,
+): void {
+  const holder = agent as unknown as AgentHolder;
+  const persistent = holder[PERSISTENT_AGENT_KEY];
+  if (persistent) {
+    persistent.destroy();
+    delete holder[PERSISTENT_AGENT_KEY];
+  }
+}

--- a/api/src/common/testing/test-app.ts
+++ b/api/src/common/testing/test-app.ts
@@ -287,18 +287,27 @@ export async function closeTestApp(): Promise<void> {
     destroySocketsOnPort(ourPort);
   }
 
-  // ROK-1250 layer 2 (post-empirical-debug): also force-destroy ioredis
-  // sockets to the local BullMQ Redis container on port 6379. Even though
-  // `app.close()` triggers Nest lifecycle hooks that should close BullMQ
-  // workers, captured snapshot 2026-05-10T17-30-40-570Z showed 40 of 47
-  // active sockets at flake time were still ::1:6379 ioredis connections.
-  // The drain barrier above ensures no jobs are in-flight, so destroying
-  // these sockets is a no-op for application correctness — it just frees
-  // the kernel-side resources before the next spec file boots its own
-  // 13×3 BullMQ worker connections. Skip this if REDIS_URL is set to a
-  // non-default port (e.g. CI uses a sidecar container on a different port).
-  // Match `queue.module.ts` semantics: `Number(parsed.port) || 6379` —
-  // an empty `parsed.port` (URL with no explicit port) resolves to 6379.
+  destroyBullmqRedisSocketsIfDefault();
+
+  if (instance.container) {
+    await instance.container.stop();
+  }
+  setInstance(null);
+}
+
+/**
+ * ROK-1250 layer 2 (post-empirical-debug): force-destroy ioredis sockets to
+ * the local BullMQ Redis container on port 6379. Captured snapshot
+ * 2026-05-10T17-30-40-570Z showed 40 of 47 active sockets at flake time were
+ * ::1:6379 ioredis connections that survived `app.close()`'s Nest lifecycle
+ * hooks. The drain barrier in `closeTestApp` ensures no jobs are in-flight,
+ * so destroying these sockets is a no-op for application correctness — it
+ * just frees the kernel-side resources before the next spec file boots its
+ * own 13×3 BullMQ worker connections. Skip if REDIS_URL targets a non-default
+ * port (e.g. CI sidecar container). Match `queue.module.ts` semantics:
+ * `Number(parsed.port) || 6379` — empty `parsed.port` resolves to 6379.
+ */
+function destroyBullmqRedisSocketsIfDefault(): void {
   const redisUrl = process.env.REDIS_URL ?? 'redis://localhost:6379';
   let redisPort: number | null = null;
   try {
@@ -310,9 +319,4 @@ export async function closeTestApp(): Promise<void> {
   if (redisPort === 6379) {
     destroySocketsOnPort(6379);
   }
-
-  if (instance.container) {
-    await instance.container.stop();
-  }
-  setInstance(null);
 }

--- a/api/src/common/testing/test-app.ts
+++ b/api/src/common/testing/test-app.ts
@@ -24,7 +24,6 @@ import {
 import { drizzle } from 'drizzle-orm/postgres-js';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
-import * as http from 'http';
 import * as supertest from 'supertest';
 import type TestAgent from 'supertest/lib/agent';
 import { migrate } from 'drizzle-orm/postgres-js/migrator';
@@ -61,16 +60,6 @@ export interface TestApp {
    * Postgres `max_connections` budget without explicit teardown. ROK-1104.
    */
   _appClient: ReturnType<typeof postgres>;
-  /**
-   * ROK-1264: supertest's superagent globalAgent is keep-alive by default,
-   * causing rotating-suite TCP-RST when the pool hands out a half-FIN'd
-   * socket on a new request. The architect's H2 fix (confirmed by AC1
-   * snapshot evidence — see docs/spikes/rok-1250-residual-layer-4.md) is
-   * to use a `keepAlive: false` agent so every request opens a fresh
-   * connection and every response closes cleanly. Stored on TestApp so
-   * `closeTestApp` can `.destroy()` it as belt-and-suspenders cleanup.
-   */
-  _keepAliveOffAgent: http.Agent;
 }
 
 /**
@@ -161,45 +150,10 @@ function setTestEnvVars(connectionString: string): void {
   }
 }
 
-/**
- * ROK-1264 H2 fix: build a supertest agent that disables keep-alive on its
- * underlying http.Agent. Every request opens a FRESH TCP connection and
- * every response triggers a kernel-side FIN. Prevents stale-socket reuse
- * from the pool (the carrier confirmed in docs/spikes/rok-1250-residual-layer-4.md).
- * `maxSockets: Infinity` keeps concurrency unrestricted; we're disabling
- * pool reuse, not throttling. Architect §8 H2 code block.
- */
-function buildKeepAliveOffSupertest(server: http.Server): {
-  request: TestAgent<supertest.Test>;
-  keepAliveOffAgent: http.Agent;
-} {
-  const keepAliveOffAgent = new http.Agent({
-    keepAlive: false,
-    maxSockets: Infinity,
-  });
-  const request = supertest.default(server);
-  // supertest exposes the underlying superagent options via `_options`.
-  // Assigning `agent` here makes every per-`Test` request inherit the
-  // keep-alive-off agent. Cast via unknown — _options is not in supertest's
-  // public typings.
-  const requestWithOptions = request as unknown as {
-    _options?: { agent?: unknown };
-  };
-  requestWithOptions._options = {
-    ...(requestWithOptions._options ?? {}),
-    agent: keepAliveOffAgent,
-  };
-  return { request, keepAliveOffAgent };
-}
-
 async function buildNestApp(
   db: PostgresJsDatabase<typeof schema>,
   redisMock: RedisMockHandle,
-): Promise<{
-  app: INestApplication;
-  request: TestAgent<supertest.Test>;
-  keepAliveOffAgent: http.Agent;
-}> {
+): Promise<{ app: INestApplication; request: TestAgent<supertest.Test> }> {
   const moduleRef = await Test.createTestingModule({ imports: [AppModule] })
     .overrideProvider(DrizzleAsyncProvider)
     .useValue(db)
@@ -211,17 +165,14 @@ async function buildNestApp(
   if (process.env.CRON_DISABLED === 'true') {
     stopAllCronJobs(app);
   }
-  const httpServer = app.getHttpServer() as http.Server;
   if (process.env.RL_TEST_SOCKET_DEBUG === 'true') {
-    instrumentHttpServer(httpServer);
+    instrumentHttpServer(app.getHttpServer() as import('http').Server);
   }
-  const { keepAliveOffAgent, request: baseRequest } =
-    buildKeepAliveOffSupertest(httpServer);
-  const request =
-    process.env.RL_TEST_SOCKET_DEBUG === 'true'
-      ? wrapAgentForSnapshot(baseRequest)
-      : baseRequest;
-  return { app, request, keepAliveOffAgent };
+  let request = supertest.default(app.getHttpServer() as import('http').Server);
+  if (process.env.RL_TEST_SOCKET_DEBUG === 'true') {
+    request = wrapAgentForSnapshot(request);
+  }
+  return { app, request };
 }
 
 /**
@@ -260,7 +211,7 @@ export async function getTestApp(): Promise<TestApp> {
   setInstance(preInstance as TestApp);
   const seed = await truncateAllTables(db);
   setTestEnvVars(connectionString);
-  const { app, request, keepAliveOffAgent } = await buildNestApp(db, redisMock);
+  const { app, request } = await buildNestApp(db, redisMock);
   const testApp: TestApp = {
     app,
     request,
@@ -269,7 +220,6 @@ export async function getTestApp(): Promise<TestApp> {
     container,
     redisMock,
     _appClient: appClient,
-    _keepAliveOffAgent: keepAliveOffAgent,
   };
   setInstance(testApp);
   return testApp;
@@ -314,16 +264,6 @@ export async function closeTestApp(): Promise<void> {
   await instance.app.close();
   if (instance._appClient) {
     await instance._appClient.end({ timeout: 30 });
-  }
-
-  // ROK-1264 H2 fix cleanup: destroy any residual sockets in the supertest
-  // http.Agent. With `keepAlive: false` the pool should already be empty
-  // (each request opens fresh + closes on response), so this is belt-and-
-  // suspenders — guards against the rare case where the kernel-side close
-  // races the JS-side Promise resolution and a socket lingers as a half-
-  // closed handle.
-  if (instance._keepAliveOffAgent) {
-    instance._keepAliveOffAgent.destroy();
   }
 
   // ROK-1250 fallback guard: if anything is still bound to the test

--- a/api/src/common/testing/test-app.ts
+++ b/api/src/common/testing/test-app.ts
@@ -40,6 +40,10 @@ import {
   extractPortFromConnectionString,
 } from './socket-handle-audit';
 import { instrumentHttpServer, wrapAgentForSnapshot } from './socket-debug';
+import {
+  destroyPersistentAgent,
+  wrapWithPersistentAgent,
+} from './supertest-persistent-agent';
 
 export type { RedisMockHandle } from './redis-mock';
 
@@ -169,6 +173,10 @@ async function buildNestApp(
     instrumentHttpServer(app.getHttpServer() as import('http').Server);
   }
   let request = supertest.default(app.getHttpServer() as import('http').Server);
+  // ROK-1264: pin all sequential supertest calls to one keep-alive socket so
+  // the loopback driver cannot bleed prior-response bytes onto the next
+  // request's fresh socket. See supertest-persistent-agent.ts header.
+  request = wrapWithPersistentAgent(request);
   if (process.env.RL_TEST_SOCKET_DEBUG === 'true') {
     request = wrapAgentForSnapshot(request);
   }
@@ -254,6 +262,11 @@ export async function closeTestApp(): Promise<void> {
   } catch {
     // best-effort — fall through to app.close() regardless
   }
+
+  // ROK-1264: destroy the persistent supertest agent's pooled socket BEFORE
+  // app.close() so the server sees a clean client FIN, not RST. No-op if the
+  // wrap was never applied (e.g. tests using a non-shared TestAgent).
+  destroyPersistentAgent(instance.request);
 
   // Capture the test container's port BEFORE _appClient.end() / container.stop()
   // so the fallback destroy can scope itself to ONLY our test-DB sockets.

--- a/api/src/common/testing/test-app.ts
+++ b/api/src/common/testing/test-app.ts
@@ -24,6 +24,7 @@ import {
 import { drizzle } from 'drizzle-orm/postgres-js';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
+import * as http from 'http';
 import * as supertest from 'supertest';
 import type TestAgent from 'supertest/lib/agent';
 import { migrate } from 'drizzle-orm/postgres-js/migrator';
@@ -60,6 +61,16 @@ export interface TestApp {
    * Postgres `max_connections` budget without explicit teardown. ROK-1104.
    */
   _appClient: ReturnType<typeof postgres>;
+  /**
+   * ROK-1264: supertest's superagent globalAgent is keep-alive by default,
+   * causing rotating-suite TCP-RST when the pool hands out a half-FIN'd
+   * socket on a new request. The architect's H2 fix (confirmed by AC1
+   * snapshot evidence — see docs/spikes/rok-1250-residual-layer-4.md) is
+   * to use a `keepAlive: false` agent so every request opens a fresh
+   * connection and every response closes cleanly. Stored on TestApp so
+   * `closeTestApp` can `.destroy()` it as belt-and-suspenders cleanup.
+   */
+  _keepAliveOffAgent: http.Agent;
 }
 
 /**
@@ -150,10 +161,45 @@ function setTestEnvVars(connectionString: string): void {
   }
 }
 
+/**
+ * ROK-1264 H2 fix: build a supertest agent that disables keep-alive on its
+ * underlying http.Agent. Every request opens a FRESH TCP connection and
+ * every response triggers a kernel-side FIN. Prevents stale-socket reuse
+ * from the pool (the carrier confirmed in docs/spikes/rok-1250-residual-layer-4.md).
+ * `maxSockets: Infinity` keeps concurrency unrestricted; we're disabling
+ * pool reuse, not throttling. Architect §8 H2 code block.
+ */
+function buildKeepAliveOffSupertest(server: http.Server): {
+  request: TestAgent<supertest.Test>;
+  keepAliveOffAgent: http.Agent;
+} {
+  const keepAliveOffAgent = new http.Agent({
+    keepAlive: false,
+    maxSockets: Infinity,
+  });
+  const request = supertest.default(server);
+  // supertest exposes the underlying superagent options via `_options`.
+  // Assigning `agent` here makes every per-`Test` request inherit the
+  // keep-alive-off agent. Cast via unknown — _options is not in supertest's
+  // public typings.
+  const requestWithOptions = request as unknown as {
+    _options?: { agent?: unknown };
+  };
+  requestWithOptions._options = {
+    ...(requestWithOptions._options ?? {}),
+    agent: keepAliveOffAgent,
+  };
+  return { request, keepAliveOffAgent };
+}
+
 async function buildNestApp(
   db: PostgresJsDatabase<typeof schema>,
   redisMock: RedisMockHandle,
-): Promise<{ app: INestApplication; request: TestAgent<supertest.Test> }> {
+): Promise<{
+  app: INestApplication;
+  request: TestAgent<supertest.Test>;
+  keepAliveOffAgent: http.Agent;
+}> {
   const moduleRef = await Test.createTestingModule({ imports: [AppModule] })
     .overrideProvider(DrizzleAsyncProvider)
     .useValue(db)
@@ -165,14 +211,17 @@ async function buildNestApp(
   if (process.env.CRON_DISABLED === 'true') {
     stopAllCronJobs(app);
   }
+  const httpServer = app.getHttpServer() as http.Server;
   if (process.env.RL_TEST_SOCKET_DEBUG === 'true') {
-    instrumentHttpServer(app.getHttpServer() as import('http').Server);
+    instrumentHttpServer(httpServer);
   }
-  let request = supertest.default(app.getHttpServer() as import('http').Server);
-  if (process.env.RL_TEST_SOCKET_DEBUG === 'true') {
-    request = wrapAgentForSnapshot(request);
-  }
-  return { app, request };
+  const { keepAliveOffAgent, request: baseRequest } =
+    buildKeepAliveOffSupertest(httpServer);
+  const request =
+    process.env.RL_TEST_SOCKET_DEBUG === 'true'
+      ? wrapAgentForSnapshot(baseRequest)
+      : baseRequest;
+  return { app, request, keepAliveOffAgent };
 }
 
 /**
@@ -211,7 +260,7 @@ export async function getTestApp(): Promise<TestApp> {
   setInstance(preInstance as TestApp);
   const seed = await truncateAllTables(db);
   setTestEnvVars(connectionString);
-  const { app, request } = await buildNestApp(db, redisMock);
+  const { app, request, keepAliveOffAgent } = await buildNestApp(db, redisMock);
   const testApp: TestApp = {
     app,
     request,
@@ -220,6 +269,7 @@ export async function getTestApp(): Promise<TestApp> {
     container,
     redisMock,
     _appClient: appClient,
+    _keepAliveOffAgent: keepAliveOffAgent,
   };
   setInstance(testApp);
   return testApp;
@@ -264,6 +314,16 @@ export async function closeTestApp(): Promise<void> {
   await instance.app.close();
   if (instance._appClient) {
     await instance._appClient.end({ timeout: 30 });
+  }
+
+  // ROK-1264 H2 fix cleanup: destroy any residual sockets in the supertest
+  // http.Agent. With `keepAlive: false` the pool should already be empty
+  // (each request opens fresh + closes on response), so this is belt-and-
+  // suspenders — guards against the rare case where the kernel-side close
+  // races the JS-side Promise resolution and a socket lingers as a half-
+  // closed handle.
+  if (instance._keepAliveOffAgent) {
+    instance._keepAliveOffAgent.destroy();
   }
 
   // ROK-1250 fallback guard: if anything is still bound to the test

--- a/api/src/common/testing/test-app.ts
+++ b/api/src/common/testing/test-app.ts
@@ -40,10 +40,12 @@ import {
   extractPortFromConnectionString,
 } from './socket-handle-audit';
 import { instrumentHttpServer, wrapAgentForSnapshot } from './socket-debug';
-import {
-  destroyPersistentAgent,
-  wrapWithPersistentAgent,
-} from './supertest-persistent-agent';
+// ROK-1264: `supertest-persistent-agent` is intentionally NOT wired here.
+// The helper + spec exist as ready-to-deploy machinery if a future targeted
+// investigation needs single-socket pinning, but applying it globally
+// deterministically breaks tests that use Promise.all to fan out parallel
+// supertest calls (e.g. `events.integration.spec.ts › shape parity per slice`
+// failed 10/10 with maxSockets:1). See `docs/spikes/rok-1250-residual-layer-5.md`.
 
 export type { RedisMockHandle } from './redis-mock';
 
@@ -169,14 +171,20 @@ async function buildNestApp(
   if (process.env.CRON_DISABLED === 'true') {
     stopAllCronJobs(app);
   }
+  const httpServer = app.getHttpServer() as import('http').Server;
+  // ROK-1264: bump server-side keepAliveTimeout WAY above any inter-test gap
+  // so any future keep-alive pool (or supertest default if upgraded) does not
+  // race the server's 5 s socket reaper. truncateAllTables + bcrypt + setup
+  // helpers easily exceed 5 s between adjacent `it()`s. The patch is benign
+  // because Jest force-exits the worker and `closeTestApp` destroys server
+  // handles; never reaches the 10-minute lifetime in practice.
+  // headersTimeout must be >= keepAliveTimeout (Node http docs).
+  httpServer.keepAliveTimeout = 600_000;
+  httpServer.headersTimeout = 610_000;
   if (process.env.RL_TEST_SOCKET_DEBUG === 'true') {
-    instrumentHttpServer(app.getHttpServer() as import('http').Server);
+    instrumentHttpServer(httpServer);
   }
-  let request = supertest.default(app.getHttpServer() as import('http').Server);
-  // ROK-1264: pin all sequential supertest calls to one keep-alive socket so
-  // the loopback driver cannot bleed prior-response bytes onto the next
-  // request's fresh socket. See supertest-persistent-agent.ts header.
-  request = wrapWithPersistentAgent(request);
+  let request = supertest.default(httpServer);
   if (process.env.RL_TEST_SOCKET_DEBUG === 'true') {
     request = wrapAgentForSnapshot(request);
   }
@@ -262,11 +270,6 @@ export async function closeTestApp(): Promise<void> {
   } catch {
     // best-effort — fall through to app.close() regardless
   }
-
-  // ROK-1264: destroy the persistent supertest agent's pooled socket BEFORE
-  // app.close() so the server sees a clean client FIN, not RST. No-op if the
-  // wrap was never applied (e.g. tests using a non-shared TestAgent).
-  destroyPersistentAgent(instance.request);
 
   // Capture the test container's port BEFORE _appClient.end() / container.stop()
   // so the fallback destroy can scope itself to ONLY our test-DB sockets.

--- a/docs/spikes/rok-1250-residual-layer-4.md
+++ b/docs/spikes/rok-1250-residual-layer-4.md
@@ -1,0 +1,160 @@
+# ROK-1264 — Layer-4 Spike: Residual Carrier Diagnosis
+
+**Date captured:** 2026-05-12
+**Snapshot:** `planning-artifacts/test-infra-snapshots/snapshot-2026-05-12T03-54-02-146Z.json`
+**Failure:** `socket hang up` on `GET /events?page=1&limit=2`, elapsed 1ms, in `events-dashboard.dashboard.integration.spec.ts` › `Events Dashboard — findAll › should paginate correctly`
+**AC1 budget consumed:** 6 of 30 (1 FLAKE_DETECTED at RUN 6, 4 prior CLEAN, 1 NON_FLAKE_FAIL at RUN 5 — see §3).
+
+---
+
+## Verdict
+
+**H2 confirmed: HTTP keep-alive socket reuse via supertest's superagent globalAgent.**
+
+The architect's hypothesis #2 (`planning-artifacts/specs/ROK-1264-architecture.md` §4) matches the snapshot evidence exactly. H1 (macOS TIME_WAIT pressure) is ruled out by the per-port TIME_WAIT distribution. H3 (accept-queue / FIN-storm) is a stable bystander, not the carrier.
+
+---
+
+## 1. Evidence from snapshot
+
+### Active handles (43 sockets total)
+
+```
+40 sockets → ::1:6379  (BullMQ ioredis worker connections — stable, long-lived)
+ 3 sockets → ::1:56309 (THE current test server — pagination test in flight)
+```
+
+Peer-port histogram from snapshot:
+```json
+"peerPortHistogram": {
+  "total": 43,
+  "byPeerPort": [
+    { "port": 6379, "count": 40 },
+    { "port": 56309, "count": 3 }
+  ]
+}
+```
+
+**The 3 sockets to `::1:56309` is the carrier signal.** Each supertest request opens a new client TCP connection to the in-process Nest HTTP server (which bound port 56309 via `app.listen(0)`). At RST time, three sockets exist on that single server port — meaning the keep-alive pool is holding stale connections from the test's earlier requests in addition to the current one.
+
+### TIME_WAIT distribution
+
+```
+Total TIME_WAIT: 592
+By peer port:
+  6379  →  91  (prior closeTestApp's destroySocketsOnPort(6379) FINs)
+  56304 →  10  (prior spec file's test server port, now closed)
+  56302 →   9
+  56307 →   8
+  56303 →   5
+  56305 →   5
+  56306 →   5
+  56308 →   5
+  443   →   4  (HTTPS — unrelated, prob mdns)
+  56309 →   2  (current test server port — healthy)
+```
+
+**Current test server port `:56309` has only 2 TIME_WAITs.** Far below any kernel-pressure threshold (macOS default range is 16K ports, 60s 2MSL). This rules out H1: there's no ephemeral-port exhaustion or per-4-tuple TIME_WAIT pressure on the test server port range.
+
+### Failure context
+
+```json
+{
+  "method": "GET",
+  "url": "/events?page=1&limit=2",
+  "elapsedMs": 1
+}
+```
+
+**RST'd within 1 ms.** The architect's §4: *"the bad-socket reuse is detected on first byte"*. An RST that fast cannot be application-layer — it's the TCP stack rejecting the SYN/data on a stale 4-tuple, OR the HTTP client immediately failing to parse a half-FIN'd response. Both are H2's mechanism.
+
+---
+
+## 2. Hypothesis classification per architect §6 step 3
+
+| Architect criterion | Observed | Verdict |
+|---|---|---|
+| Multiple sockets share `remote=<server_eph_port>` AND TIME_WAIT count healthy → H2 | 3 sockets to `::1:56309`, only 2 TIME_WAITs there | ✓ **H2 confirmed** |
+| `netstat` TIME_WAIT > 1000 on test server port range AND handle count healthy → H1 | 592 total, but only 2 on the current server port; rest are PRIOR spec files' ports | ✗ H1 ruled out |
+| ≥5 sockets to `::1:6379` mid-test → H3 partial-confirm | 40 sockets to `::1:6379`, but these are stable BullMQ workers (`isRunning: null` = workers are idle-listening, not churning); no in-flight `closeTestApp(6379)` from current file | ⚠ H3 stable bystander, NOT carrier |
+
+The architect's pre-dev §4 explicitly predicted: "Second PATCH after a sequence of other requests — exactly the pattern keep-alive reuse exploits." The pagination test makes multiple sequential GET requests (`?page=1`, `?page=2`, …) against the SAME server port. The carrier hit was on the second-or-third request in the sequence — exactly the H2 trigger pattern.
+
+---
+
+## 3. Run-by-run summary
+
+| Run | Result | Duration | Failure / Notes |
+|-----|--------|----------|-----------------|
+| 1 | CLEAN | 397s | — |
+| 2 | CLEAN | 392s | — |
+| 3 | CLEAN | 388s | — |
+| 4 | CLEAN | 370s | — |
+| 5 | NON_FLAKE_FAIL | 342s | `Parse Error: Expected HTTP/, RTSP/ or ICE/` in `game-taste.integration.spec.ts › runAggregateGameVectors`. NOT canonical `socket hang up` — HTTP parser-level error. Surfaced an instrumentation gap (see §5). |
+| 6 | **FLAKE_DETECTED** | 353s | Canonical `socket hang up` in `events-dashboard.dashboard.integration.spec.ts › Events Dashboard — findAll › should paginate correctly`. Snapshot captured. **STOP signal.** |
+
+**Carrier file rotates per run:** RUN 5 hit `game-taste`, RUN 6 hit `events-dashboard`. This matches ROK-1268's observation: the same root cause manifests in different carrier tests each time the suite runs, depending on which test file happens to be the one whose first request lands on a stale pooled socket. The rotating-carrier behavior is a strong second-order indicator that the cause is in shared infrastructure (the supertest globalAgent pool), not in any individual test.
+
+---
+
+## 4. Confounders ruled out during diagnosis
+
+Documenting the false leads so future debuggers don't repeat them:
+
+### (a) Docker orphan compounding (first AC1 attempt, pre-park)
+
+Prior `validate-ci.sh` runs in adjacent worktrees left orphan `pgvector/pgvector:pg16` testcontainers alive on the Docker daemon, causing `PostgreSqlContainer.start()` to time out on the testcontainers internal 10s port-bind. Symptom looks similar (mid-test failure, exit 1) but is **environmental, not a flake of our system under test**.
+
+Fix: per-RUN orphan cleanup in `scripts/loop-integration.sh` (commit `e77f2689`), using name-exclusion (NOT image-ancestor — that would collateral-kill `raid-ledger-db`; see memory `feedback_docker_cleanup_name_filter.md`).
+
+### (b) Host resource pressure under co-tenancy
+
+When another worktree's `validate-ci.sh --full` was concurrent, the host load hit 8.88 (88% of 10-core) and free RAM dropped to 0.6 GB. This pushed pgvector spinups past the 10s port-bind budget. Symptom: `testcontainers` timeouts cascade across 79 spec files.
+
+Workaround for this story: serialize work via the `env_lock` queue and wait for a quiet host (Path 1a per `planning-artifacts/resume-plan-ROK-1264.md`). Permanent fix would be a separate test-infra story (Path 1c or 1d).
+
+### (c) Bash harness 10-min reap
+
+The Claude Code Bash tool's `run_in_background: true` reaps at ~10 min regardless of the `timeout` param. A 30-run tier (~3.5 hr) is impossible from a single Bash call.
+
+Workaround: single-run mode in `scripts/loop-integration.sh` (`START_RUN=N MAX_RUNS=1`). Lead drives one run per Bash call (~7 min each, fits in the harness window). Run-table at `$LOG_DIR/table.tsv` accumulates across invocations.
+
+### (d) Loop's original hit-detection regex was too narrow
+
+The original loop only matched `(socket hang up|ECONNRESET)`. RUN 5's `Parse Error: Expected HTTP/, RTSP/ or ICE/` (HTTP parser-level error from node's llhttp) is in the same TCP-RST class but wasn't caught. Extended in commit `8ea14dae` to also match `Parse Error: Expected HTTP` and `HPE_INVALID`. The wrapped supertest agent's `isFlakeError` was extended to the same predicate so `dumpFailureSnapshot` fires for the broader class.
+
+This is non-trivial guidance for future flake hunts: TCP-level errors in node manifest with multiple surface codes (`ECONNRESET`, `socket hang up`, `HPE_INVALID_CONSTANT`, `EPIPE`, etc.) depending on which side detects the bad state first. Match the class, not just the canonical message.
+
+---
+
+## 5. ROK-1268 disposition
+
+[ROK-1268](https://linear.app/roknua-projects/issue/ROK-1268) was filed during `/fix-batch` on 2026-05-11T23:32Z when 3 consecutive `validate-ci.sh --full` runs flaked on 3 different unrelated tests. The rotating-carrier behavior matches this AC2 evidence exactly: same root cause (H2 pool reuse), different victim test per run.
+
+Per the revised recommendation in `planning-artifacts/resume-plan-ROK-1264.md`, ROK-1268 stays open until ROK-1264's AC3 5-run smoke is green AND a week of post-merge CI on `main` accumulates without the flake re-surfacing. If both hold, close ROK-1268 with link to ROK-1264's merge commit.
+
+---
+
+## 6. AC3 plan (handoff to fix application)
+
+Per architect §8 H2 fix shape:
+
+1. **Modify `api/src/common/testing/test-app.ts`** (around line 171, where the supertest agent is constructed). Build a `new http.Agent({ keepAlive: false, maxSockets: Infinity })` and assign it via `request._options.agent` so every supertest request opens a fresh TCP connection AND every response triggers a kernel-side FIN. No stale-socket reuse possible.
+2. **In `closeTestApp`** (around line 242), call `keepAliveOffAgent.destroy()` to flush any residual sockets the agent held.
+3. **5-run smoke loop** with `RL_TEST_SOCKET_DEBUG=false` (production-equivalent flag). Append run-table to `docs/spikes/rok-1249-successor-validation.md`.
+4. **Performance regression gate** per resume plan: capture pre-fix wall-clock from this AC1 run table (~370-397s = mean ~376s) and post-fix from the smoke. If post-fix is ≥20% slower (mean >450s/run), revert and pivot to architect §8 "H1-only fix" alternative (`destroySocketsOnPort(testServerPort)` in closeTestApp, ~3 lines).
+
+Total surface for AC3: ~10 lines in `test-app.ts`, no other files. Within the spec's `api/src/common/testing/**` envelope.
+
+---
+
+## 7. References
+
+- Architect findings: `planning-artifacts/specs/ROK-1264-architecture.md` (§4 H2, §6 ranked recommendation with 2026-05-12 CORRECTION, §8 fix shape)
+- Resume plan: `planning-artifacts/resume-plan-ROK-1264.md` (Phase 3 with DO NOT SKIP AC1 guard and perf-regression gate)
+- Predecessor: `docs/spikes/rok-1249-successor-validation.md` (ROK-1250 the architect's path-1 fix, layer-2 BullMQ ioredis destroy)
+- ROK-1268: `tech-debt: residual integration-suite socket-leak flake post-ROK-1250` (Backlog; same flake family — keep open until ROK-1264 AC3 + 7 days CI clean)
+- Snapshot file: `planning-artifacts/test-infra-snapshots/snapshot-2026-05-12T03-54-02-146Z.json`
+- AC1 run logs: `/tmp/rok-1264-ac1-runs/run-{1..6}.log` (RUN 6's log contains the canonical failure trace)
+- Commit `e77f2689` — Phase 2 loop refactor (single-run mode + cleanup + INCONCLUSIVE)
+- Commit `8ea14dae` — extended FLAKE detection (Parse Error + HPE_*)

--- a/docs/spikes/rok-1250-residual-layer-4.md
+++ b/docs/spikes/rok-1250-residual-layer-4.md
@@ -8,6 +8,8 @@
 >
 > **Updated diagnosis lives at `planning-artifacts/specs/ROK-1264-architecture-v2.md`.** Top candidates after the falsification: H4 (supertest client-read stream-close race) and H5 (IPv4/IPv6 dual-stack loopback mismatch). H1 (TIME_WAIT) and H3 (FIN storm) remain demoted by the snapshot evidence.
 >
+> **Resolution (2026-05-12 — Tier-1 Lead):** H4 confirmed by single-file isolation reproducer (`lineups-voting`, 1 hit / 20 runs = ~5%). Fix landed in commit `bddc3e4a` — pin every supertest call to one keep-alive socket. Post-fix isolation: 0 carrier hits / 50 runs. See `docs/spikes/rok-1250-residual-layer-5.md` for the carrier-confirmation + fix writeup.
+>
 > **What's still useful in this doc:** §3 run-by-run summary, §4 confounders (Docker orphan compounding, host resource pressure, Bash harness 10-min reap, loop hit-detection regex too narrow). Those remain valid.
 >
 > **Original "H2 confirmed" verdict preserved verbatim below for audit-trail continuity.**

--- a/docs/spikes/rok-1250-residual-layer-4.md
+++ b/docs/spikes/rok-1250-residual-layer-4.md
@@ -1,5 +1,19 @@
 # ROK-1264 — Layer-4 Spike: Residual Carrier Diagnosis
 
+> ⚠️ **SUPERSEDED (2026-05-12 evening — Lead).** The "H2 confirmed" verdict below was based on a misread of the snapshot evidence: 3 active sockets to the test server port was interpreted as keep-alive pool depth, but supertest defaults to non-pooled (`agent: false`) — there is no pool to reuse from. The unit test in `api/src/common/testing/supertest-keepalive.spec.ts` (commit `b91b418a`) deterministically falsifies the H2 mechanism (2 sequential supertest requests open 2 distinct sockets WITHOUT any agent override).
+>
+> The "3 sockets" was actually 3 recent un-GC'd handles in various close states — fresh-socket-per-request behavior, not pool reuse.
+>
+> The H2 fix from this spike (commit `6a69cb4a`) was reverted in commit `48eb1c4d`.
+>
+> **Updated diagnosis lives at `planning-artifacts/specs/ROK-1264-architecture-v2.md`.** Top candidates after the falsification: H4 (supertest client-read stream-close race) and H5 (IPv4/IPv6 dual-stack loopback mismatch). H1 (TIME_WAIT) and H3 (FIN storm) remain demoted by the snapshot evidence.
+>
+> **What's still useful in this doc:** §3 run-by-run summary, §4 confounders (Docker orphan compounding, host resource pressure, Bash harness 10-min reap, loop hit-detection regex too narrow). Those remain valid.
+>
+> **Original "H2 confirmed" verdict preserved verbatim below for audit-trail continuity.**
+
+---
+
 **Date captured:** 2026-05-12
 **Snapshot:** `planning-artifacts/test-infra-snapshots/snapshot-2026-05-12T03-54-02-146Z.json`
 **Failure:** `socket hang up` on `GET /events?page=1&limit=2`, elapsed 1ms, in `events-dashboard.dashboard.integration.spec.ts` › `Events Dashboard — findAll › should paginate correctly`
@@ -7,7 +21,7 @@
 
 ---
 
-## Verdict
+## Verdict (SUPERSEDED — see notice above)
 
 **H2 confirmed: HTTP keep-alive socket reuse via supertest's superagent globalAgent.**
 

--- a/docs/spikes/rok-1250-residual-layer-4.md
+++ b/docs/spikes/rok-1250-residual-layer-4.md
@@ -8,7 +8,7 @@
 >
 > **Updated diagnosis lives at `planning-artifacts/specs/ROK-1264-architecture-v2.md`.** Top candidates after the falsification: H4 (supertest client-read stream-close race) and H5 (IPv4/IPv6 dual-stack loopback mismatch). H1 (TIME_WAIT) and H3 (FIN storm) remain demoted by the snapshot evidence.
 >
-> **Resolution (2026-05-12 — Tier-1 Lead):** H4 confirmed by single-file isolation reproducer (`lineups-voting`, 1 hit / 20 runs = ~5%). Fix landed in commit `bddc3e4a` — pin every supertest call to one keep-alive socket. Post-fix isolation: 0 carrier hits / 50 runs. See `docs/spikes/rok-1250-residual-layer-5.md` for the carrier-confirmation + fix writeup.
+> **Resolution (2026-05-12 — Tier-1 Lead):** H4 confirmed by single-file isolation reproducer (`lineups-voting`, 1 hit / 20 runs = ~5%). Fix landed in commit `bddc3e4a` — pin every supertest call to one keep-alive socket. Post-fix isolation: 0 carrier hits / 50 runs. **The wrap was subsequently REVERTED** after full-suite validation showed it deterministically breaks `events.integration.spec.ts › shape parity per slice` (10/10) due to a Promise.all-on-pinned-socket interaction. The helper + regression unit tests are retained on disk for future opt-in deployment. ROK-1268 stays open. See `docs/spikes/rok-1250-residual-layer-5.md` §8 for full disposition.
 >
 > **What's still useful in this doc:** §3 run-by-run summary, §4 confounders (Docker orphan compounding, host resource pressure, Bash harness 10-min reap, loop hit-detection regex too narrow). Those remain valid.
 >

--- a/docs/spikes/rok-1250-residual-layer-5.md
+++ b/docs/spikes/rok-1250-residual-layer-5.md
@@ -129,11 +129,51 @@ ROK-1268 (`tech-debt: residual integration-suite socket-leak flake post-ROK-1250
 
 ## 7. What this branch ships
 
-7 prior commits (snapshot-buckets-tcp + loop-integration single-run mode + flake-detector extensions + H2 falsification unit test + H2 fix revert + spike-doc SUPERSEDED banner) + 1 new commit (`bddc3e4a` — the H4 fix). Net behavior change of the branch:
+7 prior commits (snapshot-buckets-tcp + loop-integration single-run mode + flake-detector extensions + H2 falsification unit test + H2 fix revert + spike-doc SUPERSEDED banner) + 1 new commit (`bddc3e4a` — the H4 wrap).
 
-- Test infrastructure: deeper snapshot data, deterministic regression gates against supertest behavior pinning.
-- Carrier elimination: `Parse Error` and `socket hang up` class fixed via persistent-agent wrap.
-- No production code changed.
+---
+
+## 8. Post-validation finding (2026-05-12 — REVERTED IN COMMIT TBD)
+
+After the H4 wrap landed in `bddc3e4a` and probe-1 confirmed 0/50 carrier hits in isolation, the full integration suite was re-run end-to-end. **The wrap deterministically broke `events.integration.spec.ts › GET /events/:id/detail (ROK-1046) › shape parity per slice vs legacy endpoints`** (10/10 failures in isolated repeats with `socket hang up`).
+
+### Mechanism
+
+`fetchLegacySlices` (events.integration.spec.ts:332-345) fans out 5 parallel supertest requests via `Promise.all`. With `maxSockets: 1` they serialize through one socket. One of them (`/voice-channel`) does a DB lookup + Discord client mock resolution and is the slowest. **Serialized through one socket, the 5th request waits long enough that something in the chain (likely supertest's default response timeout or Nest's request lifecycle) errors out and the socket is destroyed.** The 100×`Promise.all([5×GET])` unit test does NOT reproduce this — it uses an in-process echo handler with no backend latency.
+
+### maxSockets sweep
+
+Intermediate values were tested:
+
+| `maxSockets` | events.spec | lineups-voting carrier | wallclock |
+|---|---|---|---|
+| 1 | 10/10 FAIL | 0/50 ✓ | 12 s |
+| 2 | 3/3 FAIL | not run | ~50 s (5× regression) |
+| 5 | 3/3 PASS | 2/50 (~4%) | 17 s |
+| (no wrap baseline) | passes | 1/20 (~5%) | 7-10 s |
+
+`maxSockets: 5` only marginally improves over baseline (4% vs 5%) and the difference is inside the 95% CI for N=50. **Hard serialization (needed for the H4 fix) and Promise.all parallelism (needed for `fetchLegacySlices`) are mutually exclusive at the agent level.**
+
+### Disposition
+
+**The wrap call is reverted in `test-app.ts`** (`wrapWithPersistentAgent` no longer applied). The helper file (`supertest-persistent-agent.ts`) and its regression spec (`supertest-persistent-agent.spec.ts`) are RETAINED on disk as:
+
+- Ready-to-deploy machinery if a future targeted fix (per-spec-file annotation, per-test agent reset, retry-on-ECONNRESET middleware, etc.) wants single-socket pinning.
+- Deterministic regression gate proving the propagation contract (4 tests, 3.5 s).
+
+The server-side `keepAliveTimeout = 600_000` patch in `test-app.ts:buildNestApp` IS retained because it independently fixed the `feedback.integration.spec.ts` `socket hang up` (RUN 1 → RUN 2 of full-suite validation) and is benign without the wrap — it only matters if a future supertest upgrade switches to pooled defaults.
+
+### What ROK-1268 inherits
+
+ROK-1268 stays OPEN with a strictly improved diagnostic posture:
+
+- Falsified H2 hypothesis (with deterministic unit test that re-falsifies any future regression).
+- Confirmed H4 carrier mechanism for lineups-voting class (intra-file fresh-socket loopback bleed).
+- Confirmed: full-pin (`maxSockets:1`) breaks `fetchLegacySlices` deterministically.
+- Confirmed: looser pin (`maxSockets:5`) is statistically indistinguishable from no-pin.
+- Snapshot instrumentation extensions, single-run loop harness, and an end-to-end carrier reproducer (`lineups-voting` in isolation, ~5% per-run).
+
+Next likely fix path (not pursued here): per-spec-file annotation that opts INTO the wrap, applied only to files with sequential awaited supertest calls and no `Promise.all` patterns. Or: a retry-on-flake-class middleware in `wrapAgentForSnapshot` that swallows the first RST and reissues. Both require their own spike.
 
 ---
 

--- a/docs/spikes/rok-1250-residual-layer-5.md
+++ b/docs/spikes/rok-1250-residual-layer-5.md
@@ -161,6 +161,23 @@ Intermediate values were tested:
 - Ready-to-deploy machinery if a future targeted fix (per-spec-file annotation, per-test agent reset, retry-on-ECONNRESET middleware, etc.) wants single-socket pinning.
 - Deterministic regression gate proving the propagation contract (4 tests, 3.5 s).
 
+### No-go files for global wrap deployment
+
+If a future agent considers re-wiring `wrapWithPersistentAgent` globally, these spec files use HTTP `Promise.all` patterns that deterministically break with `maxSockets: 1`:
+
+- `api/src/events/events.integration.spec.ts:332-345` — `fetchLegacySlices` fans out 5 parallel GETs (event, roster, assignments, pugs, voice-channel). 10/10 fail in isolation when wrapped.
+- `api/src/events/events-dashboard.actions.integration.spec.ts:326` — `Promise.all([3 × createMemberAndLogin])`, each a `POST /auth/local`. Same class of failure (untested under wrap; flagged by completeness audit, not empirically reproduced).
+
+These are not bugs in the tests — they're legitimate parallel-request patterns that any global serializing wrap will starve. Targeted opt-in deployment must exclude them.
+
+### Cheap-experiments-first harness (shipped this branch)
+
+The investigation produced a reusable pattern, now committed as `scripts/spec-loop.sh`. Single-file isolation (7-15 s per run) reproduces flakes with strong statistical signal in minutes rather than hours.
+
+Usage: `./scripts/spec-loop.sh <spec-pattern> [N] [STOP_ON_FIRST=true|false]`.
+
+See CLAUDE.md "Cheap validation harness" section for the agent-facing operator guide. The ad-hoc loops that produced this story's evidence (probe-1 pre-fix 1/20, post-fix 0/50, maxSockets sweep, Promise.all unit-test falsification) are exactly what this script formalizes.
+
 The server-side `keepAliveTimeout = 600_000` patch in `test-app.ts:buildNestApp` IS retained because it independently fixed the `feedback.integration.spec.ts` `socket hang up` (RUN 1 → RUN 2 of full-suite validation) and is benign without the wrap — it only matters if a future supertest upgrade switches to pooled defaults.
 
 ### What ROK-1268 inherits

--- a/docs/spikes/rok-1250-residual-layer-5.md
+++ b/docs/spikes/rok-1250-residual-layer-5.md
@@ -1,0 +1,140 @@
+# Layer 5 — H4 carrier confirmed and fixed (ROK-1264)
+
+**Date:** 2026-05-12
+**Branch:** `rok-1264-residual-tcp-rst-flake`
+**Predecessors:** `rok-1250-residual-layer-4.md` (SUPERSEDED — H2 falsified), `planning-artifacts/specs/ROK-1264-architecture-v2.md` (ranked H4 top, called for evidence-driven Tier 1)
+**Verdict:** **H4 confirmed.** Fix landed in commit `bddc3e4a` — pin every supertest call to one keep-alive socket via `wrapWithPersistentAgent`.
+
+---
+
+## 1. What was open going in
+
+Architect v2 ranked four hypotheses on the residual rotating-carrier flake:
+
+| Rank | Hypothesis | Confidence (vibes) |
+|---|---|---|
+| 1 | H4 — supertest stream-close race (intra-file) | ~55% |
+| 2 | H5 — IPv4/IPv6 family mismatch | ~25% |
+| 3 | H1 — TIME_WAIT pressure | ~10% |
+| 4 | H3 — FIN-storm interference | ~5% |
+
+Operator parked the story on 2026-05-11 and required the next-pass agent to **apply cheap-experiments-first** before any fix attempt — falsify hypotheses with N=1 unit tests before paying for N=30 instrumented loops.
+
+---
+
+## 2. Tier 1 cheap experiments (the discriminating evidence)
+
+### Probe 2 — package-lock bisect (NEGATIVE in <2 min)
+
+Hypothesis: a recent supertest/superagent version bump correlates with the residual flake's appearance.
+
+```bash
+git log --oneline -- package-lock.json | head -30 | while read h _; do
+  v=$(git show "$h:package-lock.json" | python3 -c "import json,sys; print(json.load(sys.stdin)['packages']['node_modules/supertest']['version'])")
+  echo "$h supertest=$v"
+done
+```
+
+Result: `supertest=7.2.2` pinned **since at least PR #268** (pre-dates the integration test infrastructure itself in PR #272). Dependabot merge `9cba77c3` (filed the same day as ROK-1264) only touched `package.json` semver constraint; lockfile-locked version unchanged. **Carrier is NOT a dep regression.**
+
+### Probe 1 — carrier isolation loop (REPRODUCED on RUN 20 of 50)
+
+Hypothesis: if the flake reproduces in a single-file isolated loop, mechanism is intra-file (H4 family). If it doesn't, mechanism is cross-file (H6 — Jest VM teardown race).
+
+```bash
+for i in $(seq 1 50); do
+  npx jest --config jest.integration.config.js --runInBand \
+    --testPathPatterns=lineups-voting > "run-${i}.log" 2>&1
+done
+```
+
+| Pre-fix probe-1 | RUN 20 / 50 | exit 1 | `Parse Error: Expected HTTP/, RTSP/ or ICE/` on `POST /lineups/:id/vote` (`should require authentication`) |
+|---|---|---|---|
+
+**Verdict:** intra-file carrier — single file looped, no other tests in the JVM, parser still errored. **H6 (cross-file VM teardown) ruled out.** **H4-class confirmed**: per-run rate ~5% with 27 sequential awaited supertest calls in the file.
+
+---
+
+## 3. Mechanism — why H4 fires
+
+Architecture-v2 §3 H4 sub-mechanism 2:
+
+1. Request A completes; server writes response, FIN-acks the socket.
+2. supertest awaits Request A's response promise — **resolves before the TCP stream is fully drained on the wire**.
+3. Test fires Request B with default supertest behavior (`agent: false` → fresh ephemeral socket).
+4. macOS loopback driver: Request A's tail bytes are still in flight on the loopback bus; Request B's connect handshake races them.
+5. Request B's NEW socket receives one of two outcomes:
+   - **Stale tail bytes prefix the response** → `Parse Error: Expected HTTP/, RTSP/ or ICE/` (llhttp client-side parser sees garbage where it expected an HTTP status line).
+   - **Stream closes mid-handshake** → `socket hang up` (Node http client detects RST on a fresh socket).
+
+Both surfaces share a root: per-request fresh sockets with no serialization barrier on macOS loopback.
+
+**Server-side instrumentation never fired** for any captured failure (`socket-debug.ts:61-67` `socket.on('error')` and `socket.on('close', hadError=true)` matched 0 bytes across both AC1 snapshots and probe-1 RUN 20 log). From Nest's perspective every request completed normally. The fault is exclusively on the client read pipeline.
+
+---
+
+## 4. Fix and validation
+
+### Fix shape
+
+`api/src/common/testing/supertest-persistent-agent.ts` — wrap every supertest factory method (`get`, `post`, `put`, `delete`, `patch`, `head`, `options`) so the returned `Test` instance has its `_agent` pinned to a single `http.Agent({ keepAlive: true, maxSockets: 1 })`. **All requests in the file share ONE long-lived socket.** The agent's internal request queue serializes per-socket: each request awaits the prior response's full drain before writing the next. No cross-socket bleed possible because there is only one socket.
+
+Wired in `test-app.ts` after `supertest.default(app.getHttpServer())`. Destroy hook in `closeTestApp` before `app.close()` so the server sees a clean client FIN.
+
+**Why this is NOT the falsified ROK-1264 H2 fix** (commit `6a69cb4a`, reverted in `48eb1c4d`):
+The H2 fix set `_options.agent` on the TestAgent FACTORY, which supertest does NOT plumb to per-request `Test._agent`. Each Test instance starts with `_agent = false` regardless of factory options (proven by `supertest-keepalive.spec.ts`). This wrapper sets `_agent` on each `Test` instance via `Test.agent(myAgent)`, which IS honored — `superagent/lib/node/index.js:736` reads `options.agent = this._agent` per request.
+
+### Validation
+
+| Probe | Carrier hits | Other failures | Notes |
+|---|---|---|---|
+| Pre-fix isolation (50 budgeted) | **1 / 20** (stopped early) | 0 | RUN 20 — Parse Error (`should require authentication`). 5% per-run rate. |
+| Post-fix isolation | **0 / 50** | 1 / 50 — pre-existing 401 on `votesPerPlayer:1` (see §5) | Carrier eliminated. |
+| New unit test `supertest-persistent-agent.spec.ts` | — | — | 3/3 pass. Pins propagation contract: 5 sequential requests → exactly 1 TCP connection. |
+| Existing unit test `supertest-keepalive.spec.ts` | — | — | 2/2 still pass. Together both specs lock the supertest behavior model the fix depends on. |
+
+**Statistical strength of carrier-elimination:** with 0 hits in 50 runs at 95% CI, the upper bound on residual rate is ~5.8% (vs measured 5% pre-fix). For a tighter bound the operator can run another 50 isolated runs (would push CI upper bound to ~3% with 0/100), but the deterministic unit test + single-file-isolation reproduction asymmetry is a stronger qualitative signal: pre-fix produced the carrier in 20 runs of one file; post-fix produced 0 in 50 runs of the same file with the same parallelism, same test sequence, same machine.
+
+### Wallclock perf
+
+Pre-fix isolated run: 6-9s (median 7s).
+Post-fix isolated run: 7-9s (median 8s).
+**No measurable regression** at the file level. Plausible: pooled keep-alive saves TCP handshake overhead per call, offsetting any serialization cost.
+
+---
+
+## 5. Side-finding (out of scope here)
+
+Probe-1 RUN 38 (post-fix) hit a 1-in-50 `401` on `votesPerPlayer:1 should allow only 1 vote` — not the carrier class, did not appear in any pre-fix run (but pre-fix runs cut off early on the carrier so absence is weak evidence). Root cause is `loginAsMember` helper at `api/src/lineups/lineups-voting.integration.spec.ts:55-58`:
+
+```ts
+const res = await testApp.request
+  .post('/auth/local')
+  .send({ email, password: 'MemberPass1!' });
+return { token: res.body.access_token as string, userId: user.id };
+```
+
+No `expect(res.status).toBe(201)` before extracting `access_token`. If the auth response is empty (transient race or db-visibility issue), `access_token` is `undefined`, the next request sends `Authorization: Bearer undefined`, and the test fails with `Expected 200, Received: 401` instead of the more useful "auth setup did not return a token". **Tracked separately as a test-helper-quality issue, NOT a ROK-1264 carrier.** Adding the assertion would tighten future diagnosis at the cost of a tiny scope-creep change to a sibling spec file.
+
+---
+
+## 6. ROK-1268 disposition (re-eval)
+
+ROK-1268 (`tech-debt: residual integration-suite socket-leak flake post-ROK-1250`) was kept open as the umbrella holding ticket while ROK-1264 narrowed the carrier. With H4 confirmed and fixed:
+
+- **Recommended:** keep ROK-1268 open until 7 days of post-merge CI on main complete without resurfacing of `Parse Error` / `socket hang up`. Then close with a pointer at this branch's merge commit.
+- The trigger to close is **CI quiet on main**, not "AC3 5-run smoke green" — the 5-run smoke is per-spec validation; CI quiet is the ecological validation.
+
+---
+
+## 7. What this branch ships
+
+7 prior commits (snapshot-buckets-tcp + loop-integration single-run mode + flake-detector extensions + H2 falsification unit test + H2 fix revert + spike-doc SUPERSEDED banner) + 1 new commit (`bddc3e4a` — the H4 fix). Net behavior change of the branch:
+
+- Test infrastructure: deeper snapshot data, deterministic regression gates against supertest behavior pinning.
+- Carrier elimination: `Parse Error` and `socket hang up` class fixed via persistent-agent wrap.
+- No production code changed.
+
+---
+
+End-of-spike.

--- a/scripts/loop-integration.sh
+++ b/scripts/loop-integration.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Loop the integration suite repeatedly to repro the residual rotating-suite
+# TCP-RST flake that survived ROK-1250's layer-2 fix.
+#
+# ROK-1264 layer-4 reproduction script. The predecessor /tmp loops from
+# ROK-1249/1250 were not version-controlled; this lives in repo so the
+# spike + smoke runs are reproducible across sessions.
+#
+# Modes:
+#   * Default (AC1 repro): RL_TEST_SOCKET_HANDLE_AUDIT=false, snapshot dump
+#     on first failure, MAX_RUNS=30.
+#   * Smoke (AC3): MAX_RUNS=5 RL_TEST_SOCKET_HANDLE_AUDIT=true — audit on,
+#     no early-stop on hit so the table shows the full 5 outcomes.
+#
+# Usage:
+#   ./scripts/loop-integration.sh                       # 30 runs
+#   MAX_RUNS=60 ./scripts/loop-integration.sh           # extended search
+#   MAX_RUNS=5 RL_TEST_SOCKET_HANDLE_AUDIT=true ./scripts/loop-integration.sh
+#   LOG_DIR=/tmp/rok-1264-runs ./scripts/loop-integration.sh
+#
+# Exit codes:
+#   0 — completed all runs with no socket-RST hit
+#   1 — at least one socket hang up / ECONNRESET captured
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT/api" || exit 99
+
+LOG_DIR="${LOG_DIR:-/tmp/rok-1264-loop-runs}"
+MAX_RUNS="${MAX_RUNS:-30}"
+SNAPSHOT_DIR="$REPO_ROOT/planning-artifacts/test-infra-snapshots"
+
+# Two modes — the smoke (AC3) run wants the FULL run table, so it must
+# not abort on first hit. The AC1 repro is happy to short-circuit once a
+# snapshot is captured.
+STOP_ON_FIRST_HIT="${STOP_ON_FIRST_HIT:-true}"
+
+# Audit gate from ROK-1250 — keep OFF for AC1 repro so we don't perturb
+# teardown timing, but allow opt-in for AC3 smoke validation.
+RL_TEST_SOCKET_HANDLE_AUDIT="${RL_TEST_SOCKET_HANDLE_AUDIT:-false}"
+
+# Socket-debug instrumentation: ALWAYS on for this loop. The supertest
+# interceptor in socket-debug.ts is what triggers `dumpFailureSnapshot`
+# on the trapped `socket hang up` / ECONNRESET promise.
+export RL_TEST_SOCKET_DEBUG=true
+export RL_TEST_SOCKET_HANDLE_AUDIT
+
+mkdir -p "$LOG_DIR"
+mkdir -p "$SNAPSHOT_DIR"
+
+# Baseline snapshot count — only count NEW snapshots created during this
+# loop. Without this, an orphaned snapshot from a prior run would cause
+# the first unrelated non-zero exit to be misclassified as a flake repro.
+BASELINE_SNAPSHOTS=$(ls "$SNAPSHOT_DIR" 2>/dev/null | grep -c "^snapshot-")
+
+HITS=0
+HIT_RUNS=""
+HIT_LOGS=""
+
+for i in $(seq 1 "$MAX_RUNS"); do
+  ts=$(date +"%H:%M:%S")
+  echo "RUN $i START $ts (audit=$RL_TEST_SOCKET_HANDLE_AUDIT)"
+  LOG="$LOG_DIR/run-$i.log"
+  npx jest \
+    --config jest.integration.config.js \
+    --runInBand \
+    > "$LOG" 2>&1
+  code=$?
+  ts2=$(date +"%H:%M:%S")
+  echo "RUN $i exit=$code end=$ts2"
+
+  hit=0
+  if grep -qE "(socket hang up|ECONNRESET)" "$LOG"; then
+    hit=1
+  elif [ "$code" -ne 0 ]; then
+    current_snapshots=$(ls "$SNAPSHOT_DIR" 2>/dev/null | grep -c "^snapshot-")
+    if [ "$current_snapshots" -gt "$BASELINE_SNAPSHOTS" ]; then
+      hit=1
+      BASELINE_SNAPSHOTS=$current_snapshots
+    fi
+  fi
+
+  if [ "$hit" -eq 1 ]; then
+    echo "FLAKE_DETECTED run=$i log=$LOG"
+    HITS=$((HITS + 1))
+    HIT_RUNS="$HIT_RUNS $i"
+    HIT_LOGS="$HIT_LOGS $LOG"
+    if [ "$STOP_ON_FIRST_HIT" = "true" ]; then
+      break
+    fi
+  elif [ "$code" -ne 0 ]; then
+    echo "RUN $i non-flake failure (exit=$code) — continuing"
+  fi
+done
+
+echo "---"
+if [ "$HITS" -gt 0 ]; then
+  echo "DONE hits=$HITS runs_hit=$HIT_RUNS"
+  echo "logs:$HIT_LOGS"
+  ls -la "$SNAPSHOT_DIR/" 2>/dev/null | tail -5
+  exit 1
+else
+  echo "DONE hits=0 runs=$MAX_RUNS"
+  exit 0
+fi

--- a/scripts/loop-integration.sh
+++ b/scripts/loop-integration.sh
@@ -11,11 +11,16 @@
 #     on first failure, MAX_RUNS=30.
 #   * Smoke (AC3): MAX_RUNS=5 RL_TEST_SOCKET_HANDLE_AUDIT=true — audit on,
 #     no early-stop on hit so the table shows the full 5 outcomes.
+#   * Single-run (Lead-driven outside the 10-min Bash harness window — see
+#     ROK-1264 dev-report-park §Blocker B): START_RUN=N MAX_RUNS=1 invokes
+#     exactly one iteration labeled as RUN N. Lead drives N tiers from
+#     outside, reading $LOG_DIR/table.tsv to stitch the per-tier summary.
 #
 # Usage:
-#   ./scripts/loop-integration.sh                       # 30 runs
+#   ./scripts/loop-integration.sh                       # 30 runs starting at 1
 #   MAX_RUNS=60 ./scripts/loop-integration.sh           # extended search
 #   MAX_RUNS=5 RL_TEST_SOCKET_HANDLE_AUDIT=true ./scripts/loop-integration.sh
+#   START_RUN=7 MAX_RUNS=1 ./scripts/loop-integration.sh # only RUN 7
 #   LOG_DIR=/tmp/rok-1264-runs ./scripts/loop-integration.sh
 #
 # Exit codes:
@@ -29,7 +34,14 @@ cd "$REPO_ROOT/api" || exit 99
 
 LOG_DIR="${LOG_DIR:-/tmp/rok-1264-loop-runs}"
 MAX_RUNS="${MAX_RUNS:-30}"
+# ROK-1264: single-run mode for Lead-driven per-call invocation. START_RUN
+# is the numeric label of the FIRST iteration this invocation runs. Defaults
+# to 1 (back-compat with the multi-run mode). Pair with MAX_RUNS=1 to run
+# exactly one iteration labeled RUN $START_RUN. The TSV table at
+# $LOG_DIR/table.tsv accumulates across invocations.
+START_RUN="${START_RUN:-1}"
 SNAPSHOT_DIR="$REPO_ROOT/planning-artifacts/test-infra-snapshots"
+RUN_TABLE="$LOG_DIR/table.tsv"
 
 # Two modes — the smoke (AC3) run wants the FULL run table, so it must
 # not abort on first hit. The AC1 repro is happy to short-circuit once a
@@ -48,6 +60,12 @@ export RL_TEST_SOCKET_HANDLE_AUDIT
 
 mkdir -p "$LOG_DIR"
 mkdir -p "$SNAPSHOT_DIR"
+# Initialize run-table on first invocation (single-run mode appends to it
+# across calls so Lead can read a stitched summary). Header lines are
+# idempotent — only written if the file is fresh.
+if [ ! -s "$RUN_TABLE" ]; then
+  echo -e "run\tresult\tduration_s\texit_code\tlog" > "$RUN_TABLE"
+fi
 
 # Baseline snapshot count — only count NEW snapshots created during this
 # loop. Without this, an orphaned snapshot from a prior run would cause
@@ -57,22 +75,52 @@ BASELINE_SNAPSHOTS=$(ls "$SNAPSHOT_DIR" 2>/dev/null | grep -c "^snapshot-")
 HITS=0
 HIT_RUNS=""
 HIT_LOGS=""
+# ROK-1264: third state — testcontainer port-bind timeouts are NOT
+# socket-RST flakes (different carrier entirely), but they DO produce a
+# non-zero exit. Without a separate bucket the budget tracker
+# misclassifies them as either "pass" (wrong) or "flake hit" (wrong).
+# These runs are retried implicitly — they do not count toward MAX_RUNS
+# completion.
+INCONCLUSIVE=0
+INCONCLUSIVE_RUNS=""
 
-for i in $(seq 1 "$MAX_RUNS"); do
+# ROK-1264: docker-orphan cleanup helper. Kill leaked pgvector +
+# testcontainers-ryuk instances between RUN iterations. Filters by NAME
+# (not image-ancestor) so we never collateral-kill `raid-ledger-db`
+# which uses the same pgvector image. Name-exclusion is the safe pattern.
+cleanup_testcontainer_orphans() {
+  docker ps --filter "ancestor=pgvector/pgvector:pg16" --format "{{.Names}}" \
+    | grep -v "^raid-ledger" | xargs -r docker kill >/dev/null 2>&1 || true
+  docker ps --filter "ancestor=testcontainers/ryuk" --format "{{.Names}}" \
+    | grep -v "^raid-ledger" | xargs -r docker kill >/dev/null 2>&1 || true
+}
+
+END_RUN=$((START_RUN + MAX_RUNS - 1))
+for i in $(seq "$START_RUN" "$END_RUN"); do
   ts=$(date +"%H:%M:%S")
   echo "RUN $i START $ts (audit=$RL_TEST_SOCKET_HANDLE_AUDIT)"
   LOG="$LOG_DIR/run-$i.log"
+  start_epoch=$(date +%s)
   npx jest \
     --config jest.integration.config.js \
     --runInBand \
     > "$LOG" 2>&1
   code=$?
+  end_epoch=$(date +%s)
+  duration=$((end_epoch - start_epoch))
   ts2=$(date +"%H:%M:%S")
-  echo "RUN $i exit=$code end=$ts2"
+  echo "RUN $i exit=$code end=$ts2 duration=${duration}s"
+
+  # Cleanup orphans after every iteration so the next RUN starts from a
+  # clean Docker state regardless of jest's outcome. Idempotent.
+  cleanup_testcontainer_orphans
 
   hit=0
+  inconclusive=0
   if grep -qE "(socket hang up|ECONNRESET)" "$LOG"; then
     hit=1
+  elif grep -qE "PostgreSqlContainer.start.*Timed out|Timed out after .* while waiting for container ports" "$LOG"; then
+    inconclusive=1
   elif [ "$code" -ne 0 ]; then
     current_snapshots=$(ls "$SNAPSHOT_DIR" 2>/dev/null | grep -c "^snapshot-")
     if [ "$current_snapshots" -gt "$BASELINE_SNAPSHOTS" ]; then
@@ -82,25 +130,39 @@ for i in $(seq 1 "$MAX_RUNS"); do
   fi
 
   if [ "$hit" -eq 1 ]; then
+    result="FLAKE"
     echo "FLAKE_DETECTED run=$i log=$LOG"
     HITS=$((HITS + 1))
     HIT_RUNS="$HIT_RUNS $i"
     HIT_LOGS="$HIT_LOGS $LOG"
-    if [ "$STOP_ON_FIRST_HIT" = "true" ]; then
-      break
-    fi
+  elif [ "$inconclusive" -eq 1 ]; then
+    result="INCONCLUSIVE"
+    echo "INCONCLUSIVE_TESTCONTAINER_TIMEOUT run=$i log=$LOG (not counted as flake hit OR as clean pass)"
+    INCONCLUSIVE=$((INCONCLUSIVE + 1))
+    INCONCLUSIVE_RUNS="$INCONCLUSIVE_RUNS $i"
   elif [ "$code" -ne 0 ]; then
+    result="NON_FLAKE_FAIL"
     echo "RUN $i non-flake failure (exit=$code) — continuing"
+  else
+    result="CLEAN"
+  fi
+
+  # Append to run-table — one line per iteration. Lead reads this between
+  # single-run invocations to track progress across the AC1 budget.
+  echo -e "$i\t$result\t$duration\t$code\t$LOG" >> "$RUN_TABLE"
+
+  if [ "$hit" -eq 1 ] && [ "$STOP_ON_FIRST_HIT" = "true" ]; then
+    break
   fi
 done
 
 echo "---"
 if [ "$HITS" -gt 0 ]; then
-  echo "DONE hits=$HITS runs_hit=$HIT_RUNS"
+  echo "DONE hits=$HITS runs_hit=$HIT_RUNS inconclusive=$INCONCLUSIVE inconclusive_runs=$INCONCLUSIVE_RUNS"
   echo "logs:$HIT_LOGS"
   ls -la "$SNAPSHOT_DIR/" 2>/dev/null | tail -5
   exit 1
 else
-  echo "DONE hits=0 runs=$MAX_RUNS"
+  echo "DONE hits=0 runs=$MAX_RUNS inconclusive=$INCONCLUSIVE inconclusive_runs=$INCONCLUSIVE_RUNS"
   exit 0
 fi

--- a/scripts/loop-integration.sh
+++ b/scripts/loop-integration.sh
@@ -117,7 +117,10 @@ for i in $(seq "$START_RUN" "$END_RUN"); do
 
   hit=0
   inconclusive=0
-  if grep -qE "(socket hang up|ECONNRESET)" "$LOG"; then
+  # ROK-1264: extended FLAKE detection — Parse Error / HPE_* errors are
+  # in the same TCP-RST class (HTTP parser reading non-HTTP bytes from a
+  # stale/half-closed socket). Matches the architect's H2 mechanism.
+  if grep -qE "(socket hang up|ECONNRESET|Parse Error: Expected HTTP|HPE_INVALID)" "$LOG"; then
     hit=1
   elif grep -qE "PostgreSqlContainer.start.*Timed out|Timed out after .* while waiting for container ports" "$LOG"; then
     inconclusive=1

--- a/scripts/spec-loop.sh
+++ b/scripts/spec-loop.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# Cheap validation harness — run a single Jest integration spec N times and
+# tabulate results. Designed for the "cheap experiments first" workflow:
+# reproduce a flake with confidence, validate a fix, A/B a config change,
+# or falsify a hypothesis BEFORE paying for a full 7-minute integration run.
+#
+# Pattern emerged from ROK-1264's Tier-1 investigation (see
+# docs/spikes/rok-1250-residual-layer-5.md). Single-file isolation is
+# 7-15 seconds per run vs ~7 minutes for the full suite, so 50 iterations
+# fit comfortably in one Bash window with deterministic flake-class signal.
+#
+# Usage:
+#   ./scripts/spec-loop.sh <spec-pattern> [N] [STOP_ON_FIRST=true|false]
+#
+# Examples:
+#   ./scripts/spec-loop.sh lineups-voting              # 50 runs, stop on first flake
+#   ./scripts/spec-loop.sh events.integration 10       # 10 runs of events spec
+#   ./scripts/spec-loop.sh feedback 30 false           # 30 runs, no early stop
+#   N=5 ./scripts/spec-loop.sh lineups-voting          # env override for N
+#
+# Arguments:
+#   spec-pattern    Passed to `jest --testPathPatterns=<pattern>`. Matches
+#                   any file name containing the pattern.
+#   N               Iteration count (default 50; env: N).
+#   STOP_ON_FIRST   true/false (default true). Break on first non-zero exit
+#                   OR first flake-class match.
+#
+# Flake-class patterns matched in each run's log:
+#   socket hang up | ECONNRESET | Parse Error | HPE_*
+# (Mirrors `api/src/common/testing/socket-debug.ts::isFlakeError`.)
+#
+# Output:
+#   $LOG_DIR/spec-loop-<pattern>-<ts>/
+#     run-<N>.log    — full jest stdout/stderr per iteration
+#     summary.tsv    — run<TAB>exit<TAB>wallclock_s<TAB>flake_count<TAB>excerpt
+#
+# Exit codes:
+#   0 — all iterations clean (zero exit, zero flake matches)
+#   1 — at least one iteration produced a flake-class match or non-zero exit
+#   2 — argument error
+
+set -u
+
+if [ $# -lt 1 ]; then
+  echo "usage: $0 <spec-pattern> [N] [STOP_ON_FIRST=true|false]" >&2
+  echo "       e.g. $0 lineups-voting 50" >&2
+  exit 2
+fi
+
+SPEC_PATTERN="$1"
+N="${2:-${N:-50}}"
+STOP_ON_FIRST="${3:-${STOP_ON_FIRST:-true}}"
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT/api" || exit 99
+
+TS="$(date +%Y%m%d-%H%M%S)"
+SAFE_PATTERN="$(echo "$SPEC_PATTERN" | tr '/' '_' | tr -c 'a-zA-Z0-9._-' '_')"
+LOG_DIR_DEFAULT="/tmp/spec-loop-${SAFE_PATTERN}-${TS}"
+LOG_DIR="${LOG_DIR:-$LOG_DIR_DEFAULT}"
+mkdir -p "$LOG_DIR"
+
+SUMMARY="$LOG_DIR/summary.tsv"
+printf "run\texit\twallclock_s\tflake_count\tflake_excerpt\n" > "$SUMMARY"
+
+FLAKE_REGEX='(socket hang up|ECONNRESET|Parse Error|HPE_)'
+
+echo "spec-loop: pattern='$SPEC_PATTERN' N=$N stop_on_first=$STOP_ON_FIRST"
+echo "spec-loop: logs -> $LOG_DIR"
+
+any_fail=0
+for i in $(seq 1 "$N"); do
+  start=$(date +%s)
+  log="$LOG_DIR/run-${i}.log"
+  npx jest --config jest.integration.config.js --runInBand \
+    --testPathPatterns="$SPEC_PATTERN" > "$log" 2>&1
+  ec=$?
+  end=$(date +%s)
+  dur=$((end - start))
+  # grep -c prints the count to stdout regardless of exit; capture it cleanly.
+  flakes=$(grep -cE "$FLAKE_REGEX" "$log" 2>/dev/null) || true
+  flakes="${flakes:-0}"
+  excerpt=""
+  if [ "$flakes" -gt 0 ]; then
+    excerpt=$(grep -m 1 -E "$FLAKE_REGEX" "$log" | head -c 180 | tr '\t' ' ')
+  fi
+  printf "%d\t%d\t%d\t%d\t%s\n" "$i" "$ec" "$dur" "$flakes" "${excerpt:-NONE}" >> "$SUMMARY"
+  printf "RUN %d/%d ec=%d dur=%ds flakes=%d\n" "$i" "$N" "$ec" "$dur" "$flakes"
+
+  if [ "$ec" -ne 0 ] || [ "$flakes" -gt 0 ]; then
+    any_fail=1
+    if [ "$STOP_ON_FIRST" = "true" ]; then
+      echo "spec-loop: STOP_ON_FIRST hit at run $i"
+      break
+    fi
+  fi
+done
+
+echo "=== DONE ==="
+awk -F'\t' 'NR>1' "$SUMMARY" | wc -l | awk '{print "ran",$1,"iterations"}'
+awk -F'\t' 'NR>1 && $4 != "0" && $4 != "" {n++} END {print "flake hits:", n+0}' "$SUMMARY"
+awk -F'\t' 'NR>1 && $2 != "0" {n++} END {print "non-zero exits:", n+0}' "$SUMMARY"
+echo "summary: $SUMMARY"
+
+exit "$any_fail"


### PR DESCRIPTION
## Summary

Investigation closes ROK-1264 with **diagnostics and protocol shipped, global flake fix deferred to ROK-1268**. The branch identifies the test-infra carrier mechanism (H4 — macOS loopback tail-byte race on per-request fresh supertest sockets) but cannot ship a global remediation: the natural fix shape (`maxSockets:1` keep-alive wrap) provably eliminates the carrier in isolation BUT deterministically breaks one Promise.all-of-supertest pattern in the suite. The mutual exclusivity is documented; the helper is retained as opt-in machinery.

**Value shipping this PR is epistemic + tooling, not a flake-rate reduction:**

- ROK-1264 H2 hypothesis falsified by a deterministic 0.4 s unit test (commit `b91b418a`). Future investigations of the same class avoid the ~6 h cycle this story burned validating H2.
- ROK-1264 Promise.all-on-pinned-socket hypothesis falsified by 100×Promise.all unit test (commit `71f69b4c`).
- H4 mechanism identified, documented, and reproduced empirically (1/20 pre-fix, 0/50 post-fix on `lineups-voting` in isolation).
- `scripts/spec-loop.sh` — cheap-validation harness for any future flake investigation (~7 min for 50 iterations of a single spec vs ~7 min for one full-suite run).
- Project-wide STRICT protocol baked into `CLAUDE.md` + `.claude/skills/build/SKILL.md`: reproduce-before-fix is now a written rule.

## Linear

ROK-1264

## What ships

### Diagnostic infrastructure (test-infra only, no production code)
- `46cdc693` snapshot-buckets-tcp instrumentation (TIME_WAIT bucket + peer histogram)
- `c11be79f` `scripts/loop-integration.sh` single-run mode + cleanup hook + INCONCLUSIVE classification
- `1019de53` flake detector matches `Parse Error` + `HPE_*`

### Falsification regression gates
- `b91b418a` `supertest-keepalive.spec.ts` — H2 (keep-alive pool reuse) deterministically falsified
- `bddc3e4a` + `71f69b4c` `supertest-persistent-agent.spec.ts` — propagation contract for the opt-in helper, Promise.all-on-pinned-socket falsification

### Documentation
- `f3eed32e` + `80e904d3` + `36bade3e` Spike docs (layer-4 SUPERSEDED banner pointing at layer-5; layer-5 documents H4 confirmation + maxSockets sweep + disposition)
- `7a7d17c3` `revert` commit explaining why the wrap is unwired globally

### Tooling shipped (cheap-experiments-first)
- `ae077417` `scripts/spec-loop.sh` — single-spec isolation harness. Mirrors the ad-hoc bash loops that produced this story's evidence. CLAUDE.md "Cheap validation harness" section documents the agent-facing protocol.
- `fae9ba22` STRICT flake-investigation protocol in CLAUDE.md + `.claude/skills/build/SKILL.md` "Cost discipline" — reproduce-before-fix is now a written rule (4-step protocol: reproduce in isolation → design fix → validate per-spec → run full suite).

### Server-side patch (retained from investigation)
- `bddc3e4a` (test-app.ts portion) `httpServer.keepAliveTimeout = 600_000` — fixed an observed inter-test-gap variant in the feedback spec. Benign without the wrap.

## What does NOT ship

The `wrapWithPersistentAgent` helper is retained on disk but **NOT wired** in `test-app.ts`. Reason: `maxSockets:1` deterministically breaks `events.integration.spec.ts › shape parity per slice` (10/10 in isolation). Helper JSDoc + spike layer-5 §8 "No-go files" enumerate the conflicting Promise.all patterns. Any future opt-in deployment must exclude those files.

## Net flake rate impact

Unchanged. Pre-PR CI baseline ~3.3% suite-run failure (per ROK-1250 AC2 30-run measurement) persists. This PR does NOT reduce the rate — it improves the next investigation's starting position.

## ROK-1268

Stays open as the umbrella holding ticket for actually eliminating the residual carrier. Trigger condition (from validation): re-engage if integration flake rate exceeds 5% over any 30-day window, or if any new spec adds parallel-supertest patterns that the per-file opt-in could cover.

## Test plan
- [x] `./scripts/validate-ci.sh --full` PASS (build, typecheck, lint, unit tests + coverage, integration 398 s)
- [x] Migration validation: SKIPPED (no migration files)
- [x] Container startup: SKIPPED (no Dockerfile changes)
- [x] Playwright: SKIPPED (no `web/` changes)
- [x] Self-test of new harness: `./scripts/spec-loop.sh lineups-voting 3 false` → 3/3 clean in 21 s
- [x] Codex pre-push review: APPROVED WITH FIXES (5 P2/P3 findings on `scripts/loop-integration.sh`, no BLOCKER/HIGH)
- [x] `/validate` (twice): code verifier ACCURATE; logic MOSTLY SOUND with documented over-claims softened in this PR description; completeness MOSTLY COMPLETE; risk LOW

🤖 Generated with [Claude Code](https://claude.com/claude-code)