### PR TITLE
fix-batch 2026-05-12b: ROK-1237 + ROK-1271 + ROK-1267

### DIFF
--- a/.claude/skills/_shared/chrome-mcp-e2e.md
+++ b/.claude/skills/_shared/chrome-mcp-e2e.md
@@ -154,8 +154,34 @@ If a later finding requires a fix + re-verify, re-acquire then. Pre-emptive hold
 ## Pass / Fail criteria
 
 - **PASS:** every flow executed, every AC exercised, no BLOCKER/HIGH findings, console + network clean (or known-pre-existing noise documented).
-- **PASS WITH NOTES:** medium / low findings logged for follow-up — operator decides what becomes a story. Proceed to reviewer.
+- **PASS WITH NOTES:** medium / low findings logged for follow-up — see "Where candidate tech-debt goes" below. Proceed to reviewer.
 - **FAIL:** any BLOCKER or HIGH finding (functional regression, security gap, console TypeError, 5xx on AC path). Do NOT spawn the reviewer; do NOT push. Lead either fixes inline (1-3 lines) or respawns dev with the finding. Re-run the gate after the fix.
+
+---
+
+## Where candidate tech-debt goes (STRICT — single canonical location)
+
+Medium / low findings surfaced by this gate are **candidate tech-debt**, not Linear stories. **Append them to `TECH-DEBT-BACKLOG.md` at the repo root.** This is the single canonical location:
+
+- `/readlogs` parses it (`<!-- agents append below this line -->` marker, dated sections).
+- `/build`, `/dispatch`, `/fix-batch`, `/bulk` all append here.
+- The operator triages this file and decides what becomes a Linear story — agents **never** auto-file `tech-debt:` Linear issues. See `feedback_no_auto_tech_debt.md`.
+
+**Do NOT** invent ad-hoc landing zones — no "Known Issues" sections in runbooks, no scratch files in `planning-artifacts/`, no separate `chrome-mcp-findings.md`. ROK-1068 dropped candidates into a runbook's "Known Issues" section instead of `TECH-DEBT-BACKLOG.md` and the next /build agent couldn't find them. The gate's own summary file (`chrome-mcp-summary-<batch-id>.md`) is for the operator to glance at during the immediate review — it's NOT a backlog.
+
+**Append format** (matches the file's own "Format for skills that parse this file" section):
+
+```markdown
+### YYYY-MM-DD — <branch-name> (PR #<num if known, else "pending">)
+
+- **[med]** `path/to/file.ts:LN` — short description.
+  Suggested: one-line fix idea (optional).
+- **[low]** `path/to/other.tsx:LN` — description.
+```
+
+Severities are `high` / `med` / `low` / `nit`. Critical/BLOCKER findings never land in the backlog — they're fixed during the gate or sent back to the dev.
+
+Commit the backlog append as part of the batch's commits with the `chore(config):` prefix (per `feedback_operator_config_rides_along`). The PR description should mirror the appended block under a `## Tech debt observed (not auto-filed)` section so the operator sees it without opening the file.
 
 ---
 

--- a/.claude/skills/_shared/chrome-mcp-e2e.md
+++ b/.claude/skills/_shared/chrome-mcp-e2e.md
@@ -1,0 +1,181 @@
+# Chrome MCP e2e Gate (shared)
+
+This playbook is the **mandatory pre-review browser validation** referenced by `/fix-batch`, `/build`, and `/bulk`. The agent drives the changed user flows against the locally-deployed dev env via `mcp__claude-in-chrome__*` and produces an operator-facing summary BEFORE any reviewer agent / Codex run, PR creation, or auto-merge.
+
+**Source of truth for the rule:** `~/.claude/projects/-Users-sdodge-Documents-Projects-Raid-Ledger/memory/feedback_chrome_mcp_e2e_before_review.md`. Caught 2026-05-12 during fix-batch ROK-1237+1271+1267.
+
+---
+
+## Why this gate exists
+
+Vitest + MSW + jsdom cannot fully simulate real React reconciliation, real network, real DOM, real Sentry hooks, or admin/SSE/Discord-embed flows. Multiple shipped batches passed every Jest/Vitest/Playwright run but bricked the prod UI for guilds (ROK-1237). Chrome MCP exercises the *actually-rendered application* the operator will land on. **Skipping this gate is a pipeline violation, not a discretionary call.**
+
+---
+
+## Inputs
+
+The caller (Lead in fix-batch / build / bulk) must provide:
+
+- **Changed flows:** a list of user-visible flows touched by the batch. Derive from `git diff origin/main..HEAD --name-only` plus the story ACs. Example: `["Event detail page (signup, role-fill)", "Admin dedup audit", "Lineup viewer-filter"]`.
+- **Story IDs:** the `ROK-###` set covered by this run, for the summary table and screenshot naming.
+- **Per-story AC links:** each story's acceptance criteria as Lead understands them — Chrome MCP must exercise each AC, not just "the page loads."
+
+If the batch is API-only with NO UI surface, the gate still runs but is scoped to: (1) verify no upstream UI regressions on the affected feature area, and (2) verify the API endpoint via the in-app surface that uses it (admin page, settings panel, etc.). Pure-internal endpoints that no UI consumes can record `gates.chrome_mcp_e2e: N/A — api-internal-only` with a one-line justification.
+
+---
+
+## Procedure
+
+### 0. Env-lock discipline (STRICT — hold for minimum time)
+
+The dev env (`:3000`, `:5173`, Docker DB) is a single shared resource. Multiple agents / worktrees / operator sessions queue on it. **Hold the lock only for the work that needs the env** — that means: deploy + Playwright + Chrome MCP. **Release the lock immediately after Chrome MCP completes.** Do NOT keep it through reviewer, push, PR creation, auto-merge, Linear flips, or summary writing — those don't touch the env.
+
+Order:
+
+1. **Right before deploy:** `env_lock_acquire`.
+2. **Right after Chrome MCP summary is written:** `env_lock_release`.
+3. **Re-acquire** if a later step (rare — e.g. reviewer finding requires fix + re-verify) needs the env again. Don't pre-emptively hold "just in case."
+
+If you're queued and need to wait, do non-env work in the meantime (PR draft, spec reconcile). Don't bypass.
+
+### 1. Acquire env lock (do this IMMEDIATELY before deploy, not earlier)
+
+```
+mcp__mcp-env__env_lock_status                                                    # check holder + queue
+mcp__mcp-env__env_lock_acquire({ purpose: "chrome-mcp-e2e gate for <batch-id>" })
+```
+
+If queued: do non-env work until the lock returns. Don't bypass — the gate runs on a real deploy, not a shortcut.
+
+### 2. Deploy the batch branch locally
+
+Run from the batch worktree (fix-batch / bulk) or the story worktree (build standard/full):
+
+```bash
+./scripts/deploy_dev.sh --ci --rebuild
+```
+
+Wait for the script to report API + web healthy. If deploy fails, the gate is `FAIL` — debug the deploy first; do NOT proceed to Chrome MCP. If the failure is unrelated to env-state (e.g. a code bug), release the lock while you fix the code, then re-acquire.
+
+### 3. Enumerate Chrome tabs
+
+```
+mcp__claude-in-chrome__tabs_context_mcp
+```
+
+Use the existing dev tab if one is already pointed at `http://localhost:5173`. Otherwise:
+
+```
+mcp__claude-in-chrome__tabs_create_mcp({ url: "http://localhost:5173" })
+```
+
+Never reuse a tab ID from a prior session — IDs are session-scoped.
+
+### 4. Drive each changed flow
+
+For every flow in the Inputs list, exercise the full happy path AND at least one failure / edge case the AC mentions. Recommended pattern per flow:
+
+```
+mcp__claude-in-chrome__navigate({ url: "http://localhost:5173/<route>" })
+mcp__claude-in-chrome__read_page                            # snapshot DOM state
+mcp__claude-in-chrome__find({ ... }) / form_input / computer  # interact
+mcp__claude-in-chrome__read_console_messages({ pattern: "error|warn|Sentry" })
+mcp__claude-in-chrome__read_network_requests                # confirm expected 2xx, no 4xx/5xx
+mcp__claude-in-chrome__gif_creator({ filename: "rok-XXX-<flow>.gif" })  # OR upload_image for stills
+```
+
+Capture at least one image per story (still or GIF). Save to `planning-artifacts/chrome-mcp-screenshots/<batch-id>/`.
+
+**Things to actively look for (not just "did the page render"):**
+
+- Console errors / warnings / Sentry beacons that appeared during the flow
+- Network 4xx / 5xx from `/api/*` calls
+- Skeleton / loading states that never resolve
+- React reconciliation errors (`<input>` controlled / uncontrolled flips)
+- Form submit handlers that fire twice or not at all
+- Modal / toast that never closes or never appears
+- Auth bypass in DEMO_MODE flows (silently dropping to login)
+- Discord-embed-driven flows: round-trip via the test-bot if relevant (cross-ref `tools/test-bot/`)
+
+### 5. Dialog discipline
+
+NEVER trigger a JavaScript `alert` / `confirm` / `prompt` — those block all further extension events. If a UI button might trigger one, route around it OR use `javascript_tool` to override the dialog handler before clicking. If you accidentally trigger one, the gate is `FAIL` and you must ask the operator to dismiss it.
+
+### 6. Emit the gate summary
+
+Write `planning-artifacts/chrome-mcp-summary-<batch-id>.md` (Lead may inline shorter summaries directly into the operator presentation). Format:
+
+```markdown
+# Chrome MCP e2e Gate — <batch-id>
+
+**Branch:** <branch-name>
+**Deploy:** PASS (api :3000, web :5173, 0 startup errors)
+
+## Flows exercised
+
+| Story | Flow | AC | Result | Console | Network | Capture |
+|-------|------|----|--------|---------|---------|---------|
+| ROK-XXX | Event detail signup | AC-3 | PASS | clean | 2xx only | rok-xxx-signup.gif |
+| ROK-YYY | Admin dedup audit | AC-1, AC-2 | PASS | clean | 2xx only | rok-yyy-audit.png |
+| ROK-ZZZ | Lineup viewer-filter | AC-2 | **FAIL** | TypeError on /lineups/active | 500 on GET /api/lineups | rok-zzz-fail.png |
+
+## Findings
+
+- [BLOCKER | HIGH | MEDIUM | LOW] file:line short description, suggested fix
+
+## Verdict
+
+VERDICT: PASS  |  VERDICT: PASS WITH NOTES  |  VERDICT: FAIL
+```
+
+### 7. Update state
+
+In the caller's state file (fix-batch-state.yaml / build-state.yaml / batch-state.yaml):
+
+```yaml
+gates:
+  chrome_mcp_e2e: PASS  # or FAIL, or "N/A — api-internal-only"
+```
+
+### 8. Release env lock IMMEDIATELY after the summary is written
+
+Default: release as soon as the gate's summary file is committed to disk. The reviewer agent, test gap analysis, push, PR creation, and auto-merge do NOT need the env — releasing here unblocks queued agents / operator sessions.
+
+```
+mcp__mcp-env__env_lock_release
+```
+
+**Only keep the lock past this point if** the caller's pipeline explicitly says "operator will browser-test on this deploy" (build standard/full Step 3 → operator FULL STOP). In that case, the lock transfers responsibility to the operator-review window — Lead notes it in the operator-presentation block and releases when the operator signals done.
+
+If a later finding requires a fix + re-verify, re-acquire then. Pre-emptive holding is a pipeline violation.
+
+---
+
+## Pass / Fail criteria
+
+- **PASS:** every flow executed, every AC exercised, no BLOCKER/HIGH findings, console + network clean (or known-pre-existing noise documented).
+- **PASS WITH NOTES:** medium / low findings logged for follow-up — operator decides what becomes a story. Proceed to reviewer.
+- **FAIL:** any BLOCKER or HIGH finding (functional regression, security gap, console TypeError, 5xx on AC path). Do NOT spawn the reviewer; do NOT push. Lead either fixes inline (1-3 lines) or respawns dev with the finding. Re-run the gate after the fix.
+
+---
+
+## Anti-patterns (caught in prior batches — do NOT repeat)
+
+- "I read the spec and the deploy came up healthy, so the gate is PASS." No. The gate requires *driving the changed flows*. Reading specs ≠ exercising UI.
+- "I ran Playwright and it passed, so Chrome MCP is redundant." No. Playwright covers regression; Chrome MCP validates the *new behavior* added by this batch. They are not substitutes.
+- "Pure backend change, skipping." Allowed only if NO in-app surface uses the change. If an admin page / settings panel / Discord embed consumes it, the gate runs and exercises that surface.
+- "I'll run the gate after the reviewer approves." No. The gate runs BEFORE the reviewer. Reviewers waste tokens reviewing code that the gate would have caught as broken-in-browser.
+- "The env was held, so I skipped." No. Either queue + come back, or operator-priority preempt — never skip.
+
+---
+
+## Callers
+
+| Skill | Where the gate runs | State key |
+|-------|---------------------|-----------|
+| `/fix-batch` | Step 3, after unit + integration tests, BEFORE reviewer agent | `gates.chrome_mcp_e2e` |
+| `/build` (standard / full) | Step 3, after Playwright smoke, BEFORE Linear → "In Review" + operator FULL STOP | `gates.chrome_mcp_e2e` per story |
+| `/build` (light) | Skipped — no worktree deploy. Operator reviews directly. | `gates.chrome_mcp_e2e: N/A — light scope` |
+| `/bulk` | Step 3, after Playwright smoke, BEFORE batch push + PR creation | `gates.chrome_mcp_e2e` |
+
+Related memory: [[feedback_chrome_mcp_e2e_before_review]], [[feedback_smoke_tests]], [[feedback_no_push_before_review]].

--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -52,13 +52,18 @@ Requirements Interview (plan mode, if spec incomplete)
   → Linear "In Progress" (1h)
   → E2E Test Agent writes FAILING test (2d — TDD)
   → Dev builds to pass test (2e)
-  → CI → Deploy LOCAL (no push) → Linear "In Review" → FULL STOP for operator
-  → Commit operator changes → Linear "Code Review" → Reviewer
+  → CI → Deploy LOCAL (no push) → Playwright → Chrome MCP e2e (Lead-driven, mandatory)
+  → Linear "In Review" → FULL STOP for operator (operator browser-tests on the same deploy)
+  → Commit operator changes → Linear "Code Review" → Codex Reviewer
   → Optional: Architect final (if needs_architect)
   → Lead smoke tests → git push → Create PR → Auto-merge (LAST) → Linear "Done"
 ```
 
-**Eight gates before PR:** requirements, e2e_test_first (N/A only for light), dev, ci, operator, reviewer, architect_final (if needed), smoke_test.
+**Nine gates before PR:** requirements, e2e_test_first (N/A only for light), dev, ci, **chrome_mcp_e2e** (N/A only for light or pure api-internal), operator, reviewer, architect_final (if needed), smoke_test.
+
+**Chrome MCP e2e (Lead-driven, mandatory for standard / full):** before the operator FULL STOP, Lead drives the changed user flows via `mcp__claude-in-chrome__*` on the locally-deployed worktree — captures screenshots / GIFs, audits console + network, produces a summary block that's included in the operator-presentation table. Playbook: `.claude/skills/_shared/chrome-mcp-e2e.md`. Source-of-truth memory: `feedback_chrome_mcp_e2e_before_review.md`.
+
+**Env-lock discipline:** acquire just before deploy (3c), hold through Playwright + Chrome MCP + the operator FULL STOP (operator needs the env to browser-test), release as soon as the operator gives a verdict (4a). Reviewer (4b), architect (4c), and most of Lead smoke (4d) do NOT need the env — re-acquire ONLY for 4d Playwright on UI changes. Light scope skips the lock entirely.
 
 ---
 

--- a/.claude/skills/build/steps/step-3-validate.md
+++ b/.claude/skills/build/steps/step-3-validate.md
@@ -159,7 +159,7 @@ Full playbook: `.claude/skills/_shared/chrome-mcp-e2e.md`.
 **Gate outcomes:**
 
 - `VERDICT: PASS` → `stories.ROK-XXX.gates.chrome_mcp_e2e: PASS`. Continue to 3d.
-- `VERDICT: PASS WITH NOTES` → `gates.chrome_mcp_e2e: PASS`. Include the notes in the operator-presentation block at 3e so the operator knows what to look at. Continue to 3d.
+- `VERDICT: PASS WITH NOTES` → `gates.chrome_mcp_e2e: PASS`. Include the notes in the operator-presentation block at 3e so the operator knows what to look at. Append medium/low findings to **`TECH-DEBT-BACKLOG.md`** at the repo root using the dated-section + `- **[sev]**` bullet format (single canonical location parsed by `/readlogs`). Do NOT auto-file Linear tech-debt; do NOT invent runbook "Known Issues" sections. Mirror the appended block in the PR body under `## Tech debt observed (not auto-filed)`. Continue to 3d.
 - `VERDICT: FAIL` → `gates.chrome_mcp_e2e: FAIL`. Do NOT flip Linear to "In Review"; do NOT spawn Codex. Lead either fixes inline (1-3 lines, `fix: resolve Chrome MCP finding (ROK-XXX)`) or respawns the dev with the finding. Re-run the gate after the fix.
 
 **Light scope (`scope: light`):** Chrome MCP gate is SKIPPED — there is no worktree deploy and the operator reviews the diff directly. Record `gates.chrome_mcp_e2e: "N/A — light scope"`.

--- a/.claude/skills/build/steps/step-3-validate.md
+++ b/.claude/skills/build/steps/step-3-validate.md
@@ -104,7 +104,16 @@ cd -
 
 ---
 
-## 3c. Deploy Locally
+## 3c. Acquire Env Lock + Deploy Locally
+
+**Env-lock discipline (STRICT):** the env (`:3000`, `:5173`, Docker DB) is a shared resource. Acquire **right before** deploy. Hold through the operator's browser-test window (operator literally needs the env to test). Release when the operator gives their verdict (Step 4a). Reviewer (4b Codex), architect (4c), and most of Lead smoke (4d) do NOT need the env — re-acquire ONLY if 4d's Playwright pass is needed for UI changes.
+
+```
+mcp__mcp-env__env_lock_status                                                              # see who holds it
+mcp__mcp-env__env_lock_acquire({ purpose: "build ROK-XXX operator-review deploy" })        # acquire or queue
+```
+
+If queued, do non-env work (write the dev brief, reconcile spec) until the lock returns.
 
 ```bash
 cd ../Raid-Ledger--rok-<num>
@@ -133,6 +142,32 @@ Gate: `gates.playwright: PASS` or `FAIL`.
 
 ---
 
+## 3c.6. Chrome MCP e2e Gate (MANDATORY before operator review)
+
+The Lead drives the *changed user flows* via `mcp__claude-in-chrome__*` on the deployed app — captures screenshots / GIFs, audits console + network, and produces an operator-facing summary BEFORE flipping Linear to "In Review". **Must complete before the operator FULL STOP (3e), before the Codex reviewer (4b), and before any push or PR work.**
+
+Full playbook: `.claude/skills/_shared/chrome-mcp-e2e.md`.
+
+**What Lead does here (per-story):**
+
+1. Derive the changed-flow list from `git diff main..HEAD --name-only` in the story worktree + the story's ACs.
+2. Pass the flow list + the story ID as inputs to the shared playbook.
+3. Execute it. Do NOT skim it; the anti-pattern section catches the failure modes that triggered this gate's creation (ROK-1237).
+4. Write the summary to `planning-artifacts/chrome-mcp-summary-ROK-XXX.md`. Save captures under `planning-artifacts/chrome-mcp-screenshots/ROK-XXX/`.
+5. **Keep the env lock** — the operator will browser-test on the same deploy in the FULL STOP window. Don't release until 4a (operator verdict).
+
+**Gate outcomes:**
+
+- `VERDICT: PASS` → `stories.ROK-XXX.gates.chrome_mcp_e2e: PASS`. Continue to 3d.
+- `VERDICT: PASS WITH NOTES` → `gates.chrome_mcp_e2e: PASS`. Include the notes in the operator-presentation block at 3e so the operator knows what to look at. Continue to 3d.
+- `VERDICT: FAIL` → `gates.chrome_mcp_e2e: FAIL`. Do NOT flip Linear to "In Review"; do NOT spawn Codex. Lead either fixes inline (1-3 lines, `fix: resolve Chrome MCP finding (ROK-XXX)`) or respawns the dev with the finding. Re-run the gate after the fix.
+
+**Light scope (`scope: light`):** Chrome MCP gate is SKIPPED — there is no worktree deploy and the operator reviews the diff directly. Record `gates.chrome_mcp_e2e: "N/A — light scope"`.
+
+**API-internal stories (rare):** if and only if the story has no in-app surface (no admin page, no settings panel, no Discord embed consumes it), record `gates.chrome_mcp_e2e: "N/A — api-internal-only"` with a one-line justification. Default is to run.
+
+---
+
 ## 3d. Update Linear to "In Review"
 
 ```
@@ -151,7 +186,11 @@ pipeline:
   next_action: "All stories in 'In Review'. Waiting for operator. When they update Linear → read step-4-review.md."
 stories.ROK-XXX:
   status: "waiting_for_operator"
-  gates.operator: WAITING
+  gates:
+    ci: PASS
+    playwright: PASS
+    chrome_mcp_e2e: PASS   # or "N/A — light scope" / "N/A — api-internal-only"
+    operator: WAITING
 ```
 
 Present to operator with the full verification table — this is mandatory, not optional:
@@ -173,16 +212,23 @@ Present to operator with the full verification table — this is mandatory, not 
 |-------|---------|
 | Build (all workspaces) / TypeScript / Lint / Tests api / Tests web / Integration / Coverage api / Coverage web / Migration / Container / Playwright (desktop + mobile) |
 
+### Chrome MCP e2e Pre-Review Summary
+| Story | Flows exercised | Console | Network | Captures | Verdict |
+|-------|-----------------|---------|---------|----------|---------|
+| ROK-XXX | <flow list> | clean | 2xx only | planning-artifacts/chrome-mcp-screenshots/ROK-XXX/ | PASS / PASS WITH NOTES |
+
+Full Chrome MCP report: `planning-artifacts/chrome-mcp-summary-ROK-XXX.md`. Notes for operator attention (if any): <inline bullets from the summary's findings section>.
+
 ### Gate Summary
 | Gate | ROK-XXX |
 |------|---------|
-| E2E Test First (TDD) / Dev AC Audit / CI / Test Coverage Audit |
+| E2E Test First (TDD) / Dev AC Audit / CI / Test Coverage Audit / Chrome MCP e2e |
 
-The app is deployed. Test each story and update Linear:
+The app is deployed (env-lock held — Lead releases when you give a verdict). Test each story and update Linear:
 - **Code Review** = approved, ready for code review
 - **Changes Requested** = needs rework (add feedback as comment)
 
 I'll wait.
 ```
 
-If any row shows FAIL, fix it before presenting. If Local CI Proof is missing from your output, you skipped 3a — go back. Do NOT proceed until operator gives direction.
+If any row shows FAIL, fix it before presenting. If Local CI Proof or Chrome MCP e2e Pre-Review Summary is missing from your output, you skipped 3a or 3c.6 — go back. Do NOT proceed until operator gives direction.

--- a/.claude/skills/build/steps/step-4-review.md
+++ b/.claude/skills/build/steps/step-4-review.md
@@ -10,6 +10,14 @@ The branch remains **local-only** through this step. Do NOT invoke `git push`, `
 
 When operator signals ready, poll each story: `mcp__linear__get_issue({ issueId: "<linear_id>" })`.
 
+**Env-lock release point (STRICT).** As soon as the operator gives any verdict (approve OR rework), release the env lock — the rest of Step 4 (Codex 4b, architect 4c, Lead smoke 4d) does not need the env in most cases:
+
+```
+mcp__mcp-env__env_lock_release
+```
+
+Exception: if rework is `material` and re-running the deploy + Playwright on the worktree is needed before push, re-acquire then. If Lead smoke in 4d needs to run `npx playwright test` (UI changes), re-acquire just for that pass and release after. The default is **release-as-soon-as-possible**; re-acquire on demand. Don't pre-emptively hold.
+
 ### Changes Requested → Rework Loop
 
 1. Read operator's feedback (Linear comments or direct message).
@@ -112,7 +120,7 @@ cd <worktree>
   codex -c model_reasoning_effort=medium review --base main 2>&1
   echo
   echo "## Pass 2: scoped focus prompt"
-  codex -c model_reasoning_effort=medium review "Review the staged + uncommitted changes (or the most recent commit) for: (1) security/auth bugs, (2) correctness/regressions, (3) contract integrity (Zod/types/migration consistency), (4) Discord bot listener safety. Skip style nits, naming preferences, doc gaps. For each finding: severity (BLOCKER | HIGH | MEDIUM | LOW), file:line, one-line description, suggested fix. Final line: 'VERDICT: APPROVED' or 'VERDICT: APPROVED WITH FIXES' or 'VERDICT: BLOCKED'." 2>&1
+  codex -c model_reasoning_effort=medium review "Review the staged + uncommitted changes (or the most recent commit) for: (1) security/auth bugs, (2) correctness/regressions, (3) contract integrity (Zod/types/migration consistency), (4) Discord bot listener safety. Skip style nits, naming preferences, doc gaps. Browser-level validation (changed user flows, console, network, screenshots) is already covered by the Chrome MCP e2e gate at planning-artifacts/chrome-mcp-summary-ROK-XXX.md — do not re-cover that ground; focus on code-level findings. For each finding: severity (BLOCKER | HIGH | MEDIUM | LOW), file:line, one-line description, suggested fix. Final line: 'VERDICT: APPROVED' or 'VERDICT: APPROVED WITH FIXES' or 'VERDICT: BLOCKED'." 2>&1
 } | tee planning-artifacts/review-ROK-XXX.md
 cd -
 ```
@@ -159,7 +167,7 @@ npm run test -w api && npm run test -w web
 npx tsc --noEmit -p api/tsconfig.json && npx tsc --noEmit -p web/tsconfig.json
 ```
 
-If UI changes: `npx playwright test`.
+If UI changes: re-acquire the env lock (`mcp__mcp-env__env_lock_acquire`), run `npx playwright test`, then `mcp__mcp-env__env_lock_release` immediately after. Don't hold the lock through 4e or Step 5 — push and PR creation don't need the env.
 
 Gate: `gates.smoke_test: PASS` or `FAIL`. On failure: diagnose (timing? `sleep()`?). Regression → fix or respawn dev. Test infra issue (flaky, missing wait) → fix the test, don't skip. **Never dismiss as "pre-existing"** — investigate and fix, or create a Linear story with root cause.
 

--- a/.claude/skills/build/steps/step-4-review.md
+++ b/.claude/skills/build/steps/step-4-review.md
@@ -134,7 +134,7 @@ The custom prompt is critical for pass 2 — without scope, Codex returns broad 
 Read the last line of `planning-artifacts/review-ROK-XXX.md`:
 
 - **`VERDICT: APPROVED`** → `gates.reviewer: PASS`. Proceed.
-- **`VERDICT: APPROVED WITH FIXES`** → Lead reads findings, applies trivial fixes inline (1-3 lines per fix), commits `fix: address Codex review (ROK-XXX)`. `gates.reviewer: PASS`. For non-trivial fixes, respawn the dev with the findings file as context.
+- **`VERDICT: APPROVED WITH FIXES`** → Lead reads findings. BLOCKER / HIGH fixes apply inline (1-3 lines per fix) and commit `fix: address Codex review (ROK-XXX)` — non-trivial ones respawn the dev with the findings file as context. **MEDIUM / LOW findings DO NOT get fixed inline** — append them to `TECH-DEBT-BACKLOG.md` at the repo root using the dated-section + `- **[sev]**` bullet format (single canonical location parsed by `/readlogs`). Mirror the appended block in the PR body under `## Tech debt observed (not auto-filed)`. Do NOT auto-file Linear tech-debt; do NOT invent runbook "Known Issues" sections. `gates.reviewer: PASS`.
 - **`VERDICT: BLOCKED`** → present blockers to operator. May need dev respawn or scope discussion.
 - **No clear verdict / Codex errored / output garbled** → fall back to a single `devedup-rl:reviewer` Claude subagent run with the same prompt focus. Don't bypass the reviewer gate just because Codex misbehaved.
 

--- a/.claude/skills/bulk/SKILL.md
+++ b/.claude/skills/bulk/SKILL.md
@@ -28,11 +28,15 @@ Tech debt, chores, perf improvements — light or standard scope only. If a stor
 ```
 Step 1: Gather    → Linear search by label, profile, operator approves
 Step 2: Implement → Batch branch, worktrees, Agent Team with shared task list, dev teammates self-claim → per-story reviewer teammates (parallel, message devs directly for auto-fix) → merge
-Step 3: Validate  → Test gaps, build + typecheck + lint + unit + integration + smoke, inline push
+Step 3: Validate  → Test gaps, build + typecheck + lint + unit + integration + Playwright → Chrome MCP e2e gate → push + PR
 Step 4: Ship      → Auto-merge, Linear → Done, team + worktree cleanup
 ```
 
-**Gates:** per-story (dev, reviewer) + batch-level (test_gaps, ci, integration, smoke). Per-story reviewer teammates run in parallel with still-active devs, before merge — catches attribution cleanly, and reviewers can message devs directly to request fixes without involving the Lead.
+**Gates:** per-story (dev, reviewer) + batch-level (test_gaps, ci, integration, smoke, **chrome_mcp_e2e**). Per-story reviewer teammates run in parallel with still-active devs, before merge — catches attribution cleanly, and reviewers can message devs directly to request fixes without involving the Lead.
+
+**Chrome MCP e2e gate (Lead-driven, mandatory before push + PR):** after Playwright passes on the merged batch branch, Lead drives the changed user flows via `mcp__claude-in-chrome__*` — captures screenshots / GIFs, audits console + network, produces an operator-facing summary linked from the PR body. Playbook: `.claude/skills/_shared/chrome-mcp-e2e.md`. Source-of-truth memory: `feedback_chrome_mcp_e2e_before_review.md`.
+
+**Env-lock discipline:** Step 2b acquires the lock for the deploy. Hold through Playwright (3g) + Chrome MCP (3g.5). Release immediately after the Chrome MCP summary is written — push, PR creation, and auto-merge do NOT need the env. Re-acquire ONLY if a post-review fix requires re-verifying against the deployed app.
 
 ---
 
@@ -99,7 +103,7 @@ Touches `packages/contract`, adds migration, or touches 3+ modules → full → 
 |------|------|-------------|
 | 1 | `steps/step-1-gather.md` | Cleanup, fetch by label, profile, present batch, init state |
 | 2 | `steps/step-2-implement.md` | Batch branch, worktrees, Agent Team + shared task list, dev + reviewer teammates, merge |
-| 3 | `steps/step-3-validate.md` | Review, test gaps, build/type/lint/unit/integration/smoke |
+| 3 | `steps/step-3-validate.md` | Test gaps, build/type/lint/unit/integration/Playwright → Chrome MCP e2e (operator-facing, env-lock-released after) → push + PR |
 | 4 | `steps/step-4-ship.md` | PR, auto-merge, Linear → Done, team + worktree cleanup, wiki sync |
 
 ---

--- a/.claude/skills/bulk/steps/step-3-validate.md
+++ b/.claude/skills/bulk/steps/step-3-validate.md
@@ -41,6 +41,14 @@ State: `gates.ci: PASS`, `gates.integration: PASS` (or FAIL).
 
 Backend changes can break UI flows — always run.
 
+**Env-lock check.** The env (Docker, API :3000, web :5173) is shared. Step 2b deployed locally and should still hold the lock under this batch's worktree — confirm:
+
+```
+mcp__mcp-env__env_lock_status        # confirm this batch's worktree still holds it
+```
+
+If the lock is gone (released by another agent or expired), re-acquire and re-run `deploy_dev.sh --ci --rebuild` from the batch worktree before Playwright. Don't run Playwright against a stale or absent env.
+
 ```bash
 # Docker/API/web already up from Step 2b. Just verify.
 curl -s http://localhost:3000/system/status | head -20
@@ -52,6 +60,32 @@ On failure:
 - Regression → diagnose which story, fix or respawn dev.
 
 State: `gates.smoke: PASS` (or `FAIL`).
+
+---
+
+## 3g.5. Chrome MCP e2e Gate (MANDATORY before push + PR)
+
+The new operator-facing pre-ship gate. Lead drives the *changed user flows* on the merged batch branch via `mcp__claude-in-chrome__*` — captures screenshots / GIFs, audits console + network, and produces a summary the operator can scan when reviewing the PR. **Must complete BEFORE the batch is pushed (3h), BEFORE the PR is created, and BEFORE auto-merge is enabled in Step 4.**
+
+Full playbook: `.claude/skills/_shared/chrome-mcp-e2e.md`.
+
+**What Lead does here:**
+
+1. Derive the changed-flow list from `git diff origin/main..batch/YYYY-MM-DD --name-only` + each story's ACs.
+2. Pass that list + the batch story IDs as inputs to the shared playbook.
+3. Execute it. Do NOT skim it — the anti-pattern section catches the failure modes that triggered this gate's creation (ROK-1237).
+4. Write the summary to `planning-artifacts/chrome-mcp-summary-batch-YYYY-MM-DD.md`. Save captures under `planning-artifacts/chrome-mcp-screenshots/batch-YYYY-MM-DD/`.
+5. **Release the env lock IMMEDIATELY after the summary is written.** Push (3h), PR creation, and auto-merge do NOT need the env. Re-acquire ONLY if a post-review fix requires re-verifying against a fresh deploy.
+
+**Gate outcomes:**
+
+- `VERDICT: PASS` → `gates.chrome_mcp_e2e: PASS`. Continue to 3h.
+- `VERDICT: PASS WITH NOTES` → `gates.chrome_mcp_e2e: PASS`. Include notes in the PR body so operator can scan them post-merge; operator triages tech-debt manually (do NOT auto-file).
+- `VERDICT: FAIL` → `gates.chrome_mcp_e2e: FAIL`. Do NOT push. Lead either fixes inline (1-3 lines, `fix: resolve Chrome MCP finding`) or respawns the originating dev. Re-run the gate after the fix.
+
+**N/A path (rare):** if the entire batch is API-internal with no in-app surface (no admin page, no settings panel, no Discord embed consumes the changes), record `gates.chrome_mcp_e2e: "N/A — api-internal-only"` with a one-line justification. Default is to run.
+
+State: `gates.chrome_mcp_e2e: PASS` (or `FAIL`, or `N/A — ...`).
 
 ---
 
@@ -80,7 +114,8 @@ Batch of <N> stories: <list ROK-### with labels>.
 - Build / TypeScript / Lint: PASS
 - Unit tests: PASS
 - Integration tests: PASS
-- Playwright smoke: PASS
+- Playwright smoke (desktop + mobile): PASS
+- Chrome MCP e2e: PASS — see `planning-artifacts/chrome-mcp-summary-batch-YYYY-MM-DD.md`
 
 ## Stories
 | Story | Label | Reviewer |
@@ -103,6 +138,7 @@ pipeline:
     ci: PASS
     integration: PASS
     smoke: PASS
+    chrome_mcp_e2e: PASS   # or "N/A — api-internal-only"
     pr: PENDING
 ```
 

--- a/.claude/skills/bulk/steps/step-3-validate.md
+++ b/.claude/skills/bulk/steps/step-3-validate.md
@@ -80,7 +80,7 @@ Full playbook: `.claude/skills/_shared/chrome-mcp-e2e.md`.
 **Gate outcomes:**
 
 - `VERDICT: PASS` → `gates.chrome_mcp_e2e: PASS`. Continue to 3h.
-- `VERDICT: PASS WITH NOTES` → `gates.chrome_mcp_e2e: PASS`. Include notes in the PR body so operator can scan them post-merge; operator triages tech-debt manually (do NOT auto-file).
+- `VERDICT: PASS WITH NOTES` → `gates.chrome_mcp_e2e: PASS`. Append medium/low findings to **`TECH-DEBT-BACKLOG.md`** at the repo root using the dated-section + `- **[sev]**` bullet format (single canonical location parsed by `/readlogs`). Mirror the appended block in the PR body under `## Tech debt observed (not auto-filed)`. Do NOT auto-file Linear tech-debt; do NOT invent runbook "Known Issues" sections.
 - `VERDICT: FAIL` → `gates.chrome_mcp_e2e: FAIL`. Do NOT push. Lead either fixes inline (1-3 lines, `fix: resolve Chrome MCP finding`) or respawns the originating dev. Re-run the gate after the fix.
 
 **N/A path (rare):** if the entire batch is API-internal with no in-app surface (no admin page, no settings panel, no Discord embed consumes the changes), record `gates.chrome_mcp_e2e: "N/A — api-internal-only"` with a one-line justification. Default is to run.

--- a/.claude/skills/fix-batch/SKILL.md
+++ b/.claude/skills/fix-batch/SKILL.md
@@ -33,17 +33,21 @@ Pulls small-scope stories (Bug, Tech Debt, Chore, Performance, Spike) from Linea
 ```
 Step 1: Gather    → Linear search by label, profile (incl. root cause + planner assessment), present, operator approves
 Step 2: Implement → Batch branch, worktrees, spike unknown bugs, plan complex stories, parallel devs, merge into batch branch
-Step 3: Review & Validate → Code review, test gap analysis, build + typecheck + lint + unit tests + integration tests + smoke
+Step 3: Validate  → CI (build/ts/lint/unit/integration) → deploy + Playwright → Chrome MCP e2e gate → reviewer → test gaps → regression
 Step 4: Ship      → Single PR, auto-merge, Linear → Done, cleanup
 ```
 
-**Six gates before PR:**
-1. **Code review** — reviewer agent checks correctness, security, performance, and contract integrity
-2. **Test gap analysis** — reviewer identifies untested changes; lead adds missing tests before proceeding
-3. **Regression tests** — every Bug fix includes a regression test (Playwright or unit/integration)
-4. **Unit tests** — all workspaces pass
-5. **Integration tests** — `npm run test:integration -w api`
-6. **CI** — build + type check + lint (validated as part of gate 3-4 process)
+**Eight gates before PR (run in this order — Chrome MCP MUST land before reviewer):**
+1. **CI** — build + type check + lint
+2. **Unit tests** — all workspaces pass
+3. **Integration tests** — `npm run test:integration -w api`
+4. **Playwright smoke** — desktop + mobile, automated regression sweep
+5. **Chrome MCP e2e** — Lead drives the *changed user flows* on the deployed batch branch via `mcp__claude-in-chrome__*`; captures screenshots / GIFs / console / network and produces an operator-facing summary. Playbook: `.claude/skills/_shared/chrome-mcp-e2e.md`. **Must complete before the reviewer agent runs.**
+6. **Code review** — reviewer agent (sonnet) checks correctness, security, performance, contract integrity
+7. **Test gap analysis** — reviewer identifies untested changes; lead adds missing tests before proceeding
+8. **Regression tests** — every Bug fix includes a regression test (Playwright or unit/integration)
+
+**Env-lock rule:** the env lock (`mcp__mcp-env__env_lock_acquire`) is held only for gates 4 + 5 (Playwright + Chrome MCP). Lead releases the lock immediately after the Chrome MCP summary is written. Reviewer, push, PR creation, and auto-merge do NOT need the env.
 
 ---
 
@@ -157,7 +161,7 @@ Execute steps in order. Read each step's file when you reach it — do NOT read 
 |------|------|-------------|
 | 1 | `steps/step-1-gather.md` | Cleanup, fetch stories by label, profile, present batch, init state |
 | 2 | `steps/step-2-implement.md` | Batch branch, worktrees, spawn devs, merge into batch branch |
-| 3 | `steps/step-3-validate.md` | Code review, test gap analysis, build + typecheck + lint + unit tests + integration tests + smoke |
+| 3 | `steps/step-3-validate.md` | CI (build/ts/lint/unit/integration) → deploy + Playwright → Chrome MCP e2e (operator-facing) → reviewer → test gaps → regression → push |
 | 4 | `steps/step-4-ship.md` | Single PR, auto-merge, Linear "Done", cleanup, summary, wiki sync (4f) |
 
 ---

--- a/.claude/skills/fix-batch/steps/step-3-validate.md
+++ b/.claude/skills/fix-batch/steps/step-3-validate.md
@@ -131,7 +131,7 @@ Full playbook: `.claude/skills/_shared/chrome-mcp-e2e.md`.
 **Gate outcomes:**
 
 - `VERDICT: PASS` → `gates.chrome_mcp_e2e: PASS`. Continue to 3i (reviewer).
-- `VERDICT: PASS WITH NOTES` → `gates.chrome_mcp_e2e: PASS`. Log medium/low findings inline in the batch summary; operator decides what becomes a Linear story (do NOT auto-file tech-debt). Continue to 3i.
+- `VERDICT: PASS WITH NOTES` → `gates.chrome_mcp_e2e: PASS`. Append medium/low findings to **`TECH-DEBT-BACKLOG.md`** at the repo root (single canonical location — `/readlogs` parses it; see playbook "Where candidate tech-debt goes"). Use the dated-section + `- **[sev]**` bullet format. Do NOT auto-file Linear tech-debt stories; do NOT invent runbook "Known Issues" sections. Mirror the appended block in the PR body under `## Tech debt observed (not auto-filed)`. Continue to 3i.
 - `VERDICT: FAIL` → `gates.chrome_mcp_e2e: FAIL`. Do NOT spawn the reviewer. Lead either fixes inline (1-3 lines per fix, `fix: resolve Chrome MCP finding`) or respawns the originating dev with the finding. Re-run the gate after the fix.
 
 **N/A path (rare):** If — and only if — the batch is purely API-internal with no in-app surface (no admin page, no settings panel, no Discord embed consumes it), record `gates.chrome_mcp_e2e: "N/A — api-internal-only"` with a one-line justification. Default is to run the gate.
@@ -170,7 +170,7 @@ Agent(subagent_type: "devedup-rl:reviewer", model: "sonnet",
 When the reviewer completes:
 
 1. **Critical/high findings:** Lead fixes directly on the batch branch, or re-spawns a dev if the fix is non-trivial. If a fix touches a changed UI flow, re-run 3h Chrome MCP scoped to that flow.
-2. **Medium/low findings:** log them but proceed — operator triages whether to file a Linear tech-debt story (do not auto-file).
+2. **Medium/low findings:** append to **`TECH-DEBT-BACKLOG.md`** at the repo root using the dated-section + `- **[sev]**` bullet format (single canonical location parsed by `/readlogs`). Do NOT auto-file Linear tech-debt; the operator triages the file.
 3. **Update state:** `gates.review: PASS` (or `FAIL` if critical/high findings remain unfixed)
 
 ---

--- a/.claude/skills/fix-batch/steps/step-3-validate.md
+++ b/.claude/skills/fix-batch/steps/step-3-validate.md
@@ -1,8 +1,8 @@
-# Step 3: Review & Validate — Code Review, Test Gaps, Build, Tests, Smoke
+# Step 3: Review & Validate — CI, Chrome MCP, Reviewer, Push
 
-**Lead runs validation directly on the batch branch. Reviewer agent spawned for code review.**
+**Lead runs validation directly on the batch branch.**
 
-All validation runs in the main worktree on the `fix/batch-YYYY-MM-DD` branch.
+Order matters: cheap static gates first → deploy + Playwright + **Chrome MCP e2e** (operator-facing browser validation) → reviewer agent → push. The Chrome MCP gate must complete BEFORE the reviewer agent spawns, BEFORE the PR is created, and BEFORE auto-merge is enabled. See `~/.claude/projects/-Users-sdodge-Documents-Projects-Raid-Ledger/memory/feedback_chrome_mcp_e2e_before_review.md` for the rationale.
 
 ```bash
 # Ensure you're on the batch branch
@@ -11,75 +11,7 @@ git checkout fix/batch-YYYY-MM-DD
 
 ---
 
-## 3a. Code Review (Reviewer Agent)
-
-Spawn a reviewer agent (sonnet) to review the full batch diff against `origin/main`. The reviewer checks correctness, security, performance, and contract integrity.
-
-```
-Agent(subagent_type: "devedup-rl:reviewer", model: "sonnet",
-      description: "Review batch diff",
-      prompt: """
-      Review the changes on branch fix/batch-YYYY-MM-DD compared to origin/main.
-
-      This is a fix-batch containing the following stories:
-      <list each ROK-### with title and label>
-
-      Run your full review checklist:
-      1. Correctness — logic bugs, edge cases, error handling
-      2. Security — injection, auth bypass, data exposure
-      3. Performance — N+1 queries, unnecessary allocations, missing indexes
-      4. Contract integrity — if any shared types changed, are consumers updated?
-      5. Standards — ESLint compliance, file/function size limits, naming conventions
-
-      For each finding, classify severity: [critical], [high], [medium], [low].
-      Critical/high findings MUST be fixed before shipping.
-      """)
-```
-
-When the reviewer completes:
-
-1. **Critical/high findings:** Lead fixes directly on the batch branch, or re-spawns a dev if the fix is non-trivial.
-2. **Medium/low findings:** Log them but proceed — create Linear tech-debt stories for medium findings if they warrant follow-up.
-3. **Update state:** `gates.review: PASS` (or `FAIL` if critical/high findings remain unfixed)
-
----
-
-## 3b. Test Gap Analysis
-
-After the reviewer completes, analyze the batch diff for **untested changes** — code paths added or modified by the batch that lack corresponding test coverage.
-
-For each changed source file, check:
-1. **Does a corresponding test file exist?** (e.g., `foo.service.ts` → `foo.service.spec.ts`)
-2. **Did the test file get updated in this batch?** If the source changed but the test didn't, investigate whether existing tests cover the new/changed behavior.
-3. **Are new functions/methods tested?** Check that any new exports have test coverage.
-
-**Actions:**
-- If gaps are found: Lead writes the missing tests directly on the batch branch, or spawns a test-writing agent for larger gaps.
-- If no gaps: Proceed.
-
-Update state: `gates.test_gaps: PASS` (or `FAIL` if gaps remain)
-
----
-
-## 3c. Verify Regression Tests (Bug stories only)
-
-Before running the test suites, confirm each Bug-labeled story in the batch includes a regression test:
-
-```bash
-# Check for Playwright regression tests
-grep -n "Regression: ROK-" scripts/verify-ui.spec.ts
-
-# Check for unit/integration regression tests
-grep -rn "Regression: ROK-" api/src/ web/src/
-```
-
-For each Bug story, verify a matching `Regression: ROK-<num>` test block exists in either the Playwright smoke file or a unit/integration test file. If a Bug story is missing its regression test, flag it — do not proceed until every Bug fix has a corresponding regression test.
-
-Update state: `gates.regression: PASS` (or `FAIL`)
-
----
-
-## 3d. Build
+## 3a. Build
 
 ```bash
 npm run build -w packages/contract
@@ -91,7 +23,7 @@ If build fails: diagnose which story caused it. Fix directly, commit as `fix: re
 
 ---
 
-## 3e. TypeScript
+## 3b. TypeScript
 
 ```bash
 npx tsc --noEmit -p api/tsconfig.json
@@ -102,7 +34,7 @@ If type errors: fix directly, commit as `fix: resolve type errors`.
 
 ---
 
-## 3f. Lint
+## 3c. Lint
 
 ```bash
 npm run lint -w api
@@ -113,7 +45,7 @@ If lint errors: fix directly, commit as `fix: resolve lint issues`.
 
 ---
 
-## 3g. Unit Tests
+## 3d. Unit Tests
 
 ```bash
 npm run test -w api
@@ -130,7 +62,7 @@ Update state: `gates.ci: PASS` (or `FAIL`)
 
 ---
 
-## 3h. Integration Tests
+## 3e. Integration Tests
 
 ```bash
 npm run test:integration -w api
@@ -144,36 +76,143 @@ Update state: `gates.integration: PASS` (or `FAIL`)
 
 ---
 
-## 3i. Playwright Smoke Tests (MANDATORY)
+## 3f. Acquire Env Lock + Deploy Locally
 
-Run the Playwright smoke suite against the deployed app. This is required for every batch — not just UI changes — because backend changes can break UI flows.
+**Env-lock discipline (STRICT):** hold the lock for the minimum span needed — just deploy (3f) → Playwright (3g) → Chrome MCP (3h). Release immediately after 3h. The reviewer, push, PR, and auto-merge do NOT need the env.
 
-1. Deploy locally:
-   ```bash
-   ./scripts/deploy_dev.sh
-   ```
+```
+mcp__mcp-env__env_lock_status                                                # see who holds it
+mcp__mcp-env__env_lock_acquire({ purpose: "fix-batch <id> validation" })     # acquire or queue
+```
 
-2. Verify health:
-   ```bash
-   curl -s http://localhost:3000/system/status | head -20
-   ```
+If queued, do non-env work (PR body draft, spec tidy) until the lock returns. Don't bypass.
 
-3. Run smoke tests:
-   ```bash
-   npx playwright test
-   ```
+```bash
+./scripts/deploy_dev.sh --ci --rebuild
+curl -s http://localhost:3000/system/status | head -20
+```
+
+If deploy fails: stop. Debug the deploy before continuing — there is no point running Playwright or Chrome MCP against a broken env. If the fix is purely code (no env state), release the lock while you fix and re-acquire.
+
+---
+
+## 3g. Playwright Smoke (regression sweep)
+
+Automated regression check across all flows. Runs BOTH desktop and mobile projects (CI runs both — local must match).
+
+```bash
+npx playwright test
+```
 
 If Playwright fails:
-- **Selector/flake failures:** Fix the test or the UI, commit as `fix: resolve Playwright issues`
-- **Real regressions:** Diagnose which story broke the flow, fix or re-spawn dev.
+- **Selector/flake failures:** fix the test or the UI, commit `fix: resolve Playwright issues`
+- **Real regressions:** diagnose which story broke the flow, fix or re-spawn dev
+
+Never re-run hoping it passes. Never weaken or skip tests to make CI green.
 
 Update state: `gates.playwright: PASS` (or `FAIL`)
 
 ---
 
-## 3j. Push Batch Branch
+## 3h. Chrome MCP e2e Gate (MANDATORY — operator-facing browser validation)
 
-**Use the `/push` skill** — NEVER use raw `git push`. The skill runs full local CI before pushing.
+This is the new pre-review gate. Drives the *changed user flows* via `mcp__claude-in-chrome__*` on the deployed batch branch, captures screenshots / GIFs, audits console + network, and produces an operator-facing summary. **Must complete BEFORE the reviewer agent runs (3i) and BEFORE the branch is pushed (3j).**
+
+Full playbook: `.claude/skills/_shared/chrome-mcp-e2e.md`.
+
+**What Lead must do here:**
+
+1. Derive the changed-flow list from `git diff origin/main..fix/batch-YYYY-MM-DD --name-only` + each story's ACs.
+2. Pass that list + the batch story IDs as inputs to the shared playbook.
+3. Execute the playbook step-by-step. Do NOT skim it; the anti-pattern section catches the failure modes that triggered this gate's creation (ROK-1237).
+4. Write the summary to `planning-artifacts/chrome-mcp-summary-fix-batch-YYYY-MM-DD.md`. Save captures under `planning-artifacts/chrome-mcp-screenshots/fix-batch-YYYY-MM-DD/`.
+5. **Release the env lock IMMEDIATELY after the summary is written** — `mcp__mcp-env__env_lock_release`. Reviewer (3i), test gap (3j), regression check (3k), push (3l), and Step 4 (PR + auto-merge) do NOT need the env. Re-acquire ONLY if a reviewer finding requires a fix + re-verify against the deployed app.
+
+**Gate outcomes:**
+
+- `VERDICT: PASS` → `gates.chrome_mcp_e2e: PASS`. Continue to 3i (reviewer).
+- `VERDICT: PASS WITH NOTES` → `gates.chrome_mcp_e2e: PASS`. Log medium/low findings inline in the batch summary; operator decides what becomes a Linear story (do NOT auto-file tech-debt). Continue to 3i.
+- `VERDICT: FAIL` → `gates.chrome_mcp_e2e: FAIL`. Do NOT spawn the reviewer. Lead either fixes inline (1-3 lines per fix, `fix: resolve Chrome MCP finding`) or respawns the originating dev with the finding. Re-run the gate after the fix.
+
+**N/A path (rare):** If — and only if — the batch is purely API-internal with no in-app surface (no admin page, no settings panel, no Discord embed consumes it), record `gates.chrome_mcp_e2e: "N/A — api-internal-only"` with a one-line justification. Default is to run the gate.
+
+---
+
+## 3i. Code Review (Reviewer Agent)
+
+Only after Chrome MCP e2e is `PASS` (or `N/A`). Spawn a reviewer agent (sonnet) to review the full batch diff against `origin/main`. The reviewer checks correctness, security, performance, and contract integrity.
+
+```
+Agent(subagent_type: "devedup-rl:reviewer", model: "sonnet",
+      description: "Review batch diff",
+      prompt: """
+      Review the changes on branch fix/batch-YYYY-MM-DD compared to origin/main.
+
+      This is a fix-batch containing the following stories:
+      <list each ROK-### with title and label>
+
+      Browser validation already complete — see planning-artifacts/chrome-mcp-summary-fix-batch-YYYY-MM-DD.md
+      for the changed-flow walkthrough, screenshots, console + network audit, and verdict. Do not duplicate
+      that work; focus your review on code-level correctness.
+
+      Run your full review checklist:
+      1. Correctness — logic bugs, edge cases, error handling
+      2. Security — injection, auth bypass, data exposure
+      3. Performance — N+1 queries, unnecessary allocations, missing indexes
+      4. Contract integrity — if any shared types changed, are consumers updated?
+      5. Standards — ESLint compliance, file/function size limits, naming conventions
+
+      For each finding, classify severity: [critical], [high], [medium], [low].
+      Critical/high findings MUST be fixed before shipping.
+      """)
+```
+
+When the reviewer completes:
+
+1. **Critical/high findings:** Lead fixes directly on the batch branch, or re-spawns a dev if the fix is non-trivial. If a fix touches a changed UI flow, re-run 3h Chrome MCP scoped to that flow.
+2. **Medium/low findings:** log them but proceed — operator triages whether to file a Linear tech-debt story (do not auto-file).
+3. **Update state:** `gates.review: PASS` (or `FAIL` if critical/high findings remain unfixed)
+
+---
+
+## 3j. Test Gap Analysis
+
+After the reviewer completes, analyze the batch diff for **untested changes** — code paths added or modified by the batch that lack corresponding test coverage.
+
+For each changed source file, check:
+1. **Does a corresponding test file exist?** (e.g., `foo.service.ts` → `foo.service.spec.ts`)
+2. **Did the test file get updated in this batch?** If the source changed but the test didn't, investigate whether existing tests cover the new/changed behavior.
+3. **Are new functions/methods tested?** Check that any new exports have test coverage.
+
+**Actions:**
+- If gaps are found: Lead writes the missing tests directly on the batch branch, or spawns a test-writing agent for larger gaps.
+- If no gaps: Proceed.
+
+Update state: `gates.test_gaps: PASS` (or `FAIL` if gaps remain)
+
+---
+
+## 3k. Verify Regression Tests (Bug stories only)
+
+Confirm each Bug-labeled story in the batch includes a regression test:
+
+```bash
+# Check for Playwright regression tests
+grep -n "Regression: ROK-" scripts/verify-ui.spec.ts
+
+# Check for unit/integration regression tests
+grep -rn "Regression: ROK-" api/src/ web/src/
+```
+
+For each Bug story, verify a matching `Regression: ROK-<num>` test block exists in either the Playwright smoke file or a unit/integration test file. If a Bug story is missing its regression test, flag it — do not proceed until every Bug fix has a corresponding regression test.
+
+Update state: `gates.regression: PASS` (or `FAIL`)
+
+---
+
+## 3l. Push Batch Branch
+
+**Only after every prior gate is PASS.** Use the `/push` skill — NEVER use raw `git push`. The skill runs full local CI before pushing.
 
 ```
 /push --skip-pr
@@ -183,7 +222,7 @@ The `--skip-pr` flag skips PR creation — the PR is created in Step 4.
 
 ---
 
-## 3k. Update State
+## 3m. Update State
 
 ```yaml
 pipeline:
@@ -192,12 +231,13 @@ pipeline:
     All validation passed on batch branch. Read steps/step-4-ship.md.
     Create PR, enable auto-merge, sync Linear, cleanup.
   gates:
-    review: PASS
-    test_gaps: PASS
-    regression: PASS
     ci: PASS
     integration: PASS
     playwright: PASS
+    chrome_mcp_e2e: PASS
+    review: PASS
+    test_gaps: PASS
+    regression: PASS
     pr: PENDING
 ```
 

--- a/.claude/skills/fix-batch/steps/step-4-ship.md
+++ b/.claude/skills/fix-batch/steps/step-4-ship.md
@@ -28,7 +28,9 @@ Batch of small fixes shipped via fix-batch pipeline.
 - [x] Lint clean
 - [x] Unit tests pass (api + web)
 - [x] Integration tests pass
-- [x] Smoke tests pass / skipped (no UI changes)
+- [x] Playwright smoke (desktop + mobile) pass
+- [x] Chrome MCP e2e — changed flows exercised, console + network clean (summary: `planning-artifacts/chrome-mcp-summary-fix-batch-YYYY-MM-DD.md`)
+- [x] Reviewer agent: APPROVED
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 EOF
@@ -114,10 +116,13 @@ Present to the operator:
 - Lint: PASS
 - Unit tests: PASS
 - Integration tests: PASS
-- Smoke tests: PASS / SKIP
+- Playwright smoke (desktop + mobile): PASS
+- **Chrome MCP e2e:** PASS — `planning-artifacts/chrome-mcp-summary-fix-batch-YYYY-MM-DD.md` (N flows exercised, M screenshots)
+- Reviewer (sonnet): APPROVED
 
 ### Agent Usage
 - Dev agents: <count> (opus)
+- Reviewer: 1 (sonnet)
 ```
 
 ---

--- a/.claude/skills/tldr/SKILL.md
+++ b/.claude/skills/tldr/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: tldr
+description: "Too Long; Didn't Read — compress the previous agent response into a fixed 4-line headline + action format. Invoke when an agent just returned an essay and the operator wants only the headline and what's needed from them."
+argument-hint: "[optional: which response to summarize, e.g. 'the reviewer report' — defaults to most recent]"
+---
+
+# TL;DR — Compress the Previous Response
+
+The operator just received a long response (often an essay-length report from a subagent, planner, reviewer, or status sweep) and wants the headline + what's needed from them, nothing else.
+
+## What to summarize
+
+Default target: the **most recent substantive output** in the conversation — the last thing an agent (or the main assistant) told the operator before they typed `/tldr`.
+
+If the operator passes an argument (e.g. `/tldr the reviewer report`, `/tldr the build summary`), find that specific output and summarize it instead.
+
+If the previous message was already short (under ~6 lines), reply `Already concise — nothing to compress.` and stop. Don't pad.
+
+## Output format (STRICT — same shape every time)
+
+Output exactly these four sections, in this order, with these labels. Consistency is the entire point — the operator scans for the same fields in the same place every invocation.
+
+```
+**TL;DR:** <one-sentence headline — what happened or what the response is about>
+
+**Needs from you:** <the single concrete thing the operator must do next, OR `none` if no action is required>
+
+**Key points:**
+- <bullet 1 — most important fact>
+- <bullet 2 — second most important>
+- <bullet 3 — only if genuinely needed; cap at 3>
+
+**Skip-safe:** <one phrase describing what was in the long response that the operator can safely ignore, OR `n/a` if everything mattered>
+```
+
+## Rules
+
+- **One sentence per field.** No paragraphs. No nested bullets. No headers beyond the four labels above.
+- **Max 3 key-point bullets.** If you're tempted to add a fourth, the response wasn't actually a TL;DR — pick the top 3.
+- **Lead with the verdict, not the process.** "Migration is safe to ship" beats "After reviewing the migration, I checked locking behavior and..."
+- **`Needs from you` is the load-bearing field.** If the operator only reads one line, that's the line. Be concrete: "Approve the rebase plan" / "Pick option A or B" / `none`.
+- **Preserve numbers and identifiers verbatim.** PR numbers, story IDs (ROK-XXXX), file paths, error counts — don't paraphrase these.
+- **No emojis, no decorative markdown, no closing summary sentence.** The four sections ARE the whole output.
+- **Do not re-do the work** described in the long response. Just compress what was said. If the original was wrong, that's for `/validate`, not `/tldr`.

--- a/TECH-DEBT-BACKLOG.md
+++ b/TECH-DEBT-BACKLOG.md
@@ -125,3 +125,14 @@ Findings from pre-launch validation of the Community Lineup feature (33 runbook 
 - AC 34 (Steam-unlinked-nominator warning) — Chrome MCP drive of `SteamNudgeBanner` against the live env (existing vitest `SteamNudgeBanner.test.tsx` covers copy + visibility logic).
 - AC 35 (vote-at-deadline race) — `api/src/lineups/lineup-deadline-vote-race.integration.spec.ts`.
 - AC 36 (abort-with/without-reason variance) — `abortReasonVarianceWalkthrough` test in `tools/test-bot/src/smoke/tests/lineup-abort.test.ts`.
+
+### 2026-05-12 — fix/batch-2026-05-12b (ROK-1237 + ROK-1271 + ROK-1267 review)
+
+- **[low]** `web/src/lib/api/fetch-api.ts:50` — inline structural type for `schema` parameter (`{ safeParse: ... }`) duplicates Zod's interface and types `result.error.issues` as `unknown[]`. Consider importing `ZodType<T>` from `zod` so the generic narrows automatically and Sentry's `issues` extra carries proper Zod issue typing for future debugging.
+  Suggested: change to `schema?: ZodType<T>` and let TypeScript infer. Two-line change. Defer until the next API-layer touch.
+- **[low]** `api/src/admin/games-dedup-audit.helpers.ts:106-189` — `buildDirectCountQueries` is 84 lines (function-length `warn` rule is 30). It's a flat list of 16 count queries; a small `countDirect(table, col)` helper would cut it to ~20 lines and remove the brittle "order must match destructure" coupling at `computeBlastRadiusForId:220-241`. Mediated by the new unit-spec assertion on all 17 fields (committed in `fa16e2a1`) — destructure swap is now test-detectable.
+  Suggested: refactor in a follow-up when ROK-1270 Phase 1 extends `BlastRadiusRow` (the merge migration will likely add more counts).
+- **[low]** `api/src/admin/games-dedup-audit.service.ts:99-101` — outer `Promise.all(dupIds.map(...))` × inner `Promise.all([...17 queries])` = up to 17N concurrent DB queries. Fine for Phase 0 (operator-only, prod has <100K games), but if a large guild ends up with N > 20 dup ids the endpoint could spike Postgres `max_connections`.
+  Suggested: wrap the outer `Promise.all` with `pLimit(8)` (or similar) if telemetry shows N > 20 on prod. Currently no metrics; defer.
+- **[low]** `packages/contract/src/roster.schema.ts:66` — `signupStatus` is now `.optional()` after referencing canonical `SignupStatusSchema`. Widening the contract to accept `undefined` from the server. Acceptable for forward-compat, but call sites (`RosterSlot.tsx:73-78`, `EventDetailRoster`) compare `===` against literals, so undefined falls through to default treatment. Confirm this is the intended fallback for legacy/missing payloads, or tighten back to non-optional.
+  Suggested: review the read-side query helpers — if signupStatus is always present in practice, drop `.optional()`. Spike before next contract refactor.

--- a/api/src/admin/admin.module.ts
+++ b/api/src/admin/admin.module.ts
@@ -36,6 +36,8 @@ import { TasteProfileModule } from '../taste-profile/taste-profile.module';
 import { CommunityInsightsModule } from '../community-insights/community-insights.module';
 import { SlowQueriesModule } from '../slow-queries/slow-queries.module';
 import { AiChatTestController } from './ai-chat-test.controller';
+import { GamesDedupAuditController } from './games-dedup-audit.controller';
+import { GamesDedupAuditService } from './games-dedup-audit.service';
 
 @Module({
   imports: [
@@ -72,6 +74,7 @@ import { AiChatTestController } from './ai-chat-test.controller';
     ItadSettingsController,
     CommunityInsightsSettingsController,
     OnboardingController,
+    GamesDedupAuditController,
   ],
   providers: [
     DemoDataService,
@@ -79,6 +82,7 @@ import { AiChatTestController } from './ai-chat-test.controller';
     DemoTestResetService,
     DemoTestLineupService,
     SlashCommandTestService,
+    GamesDedupAuditService,
   ],
 })
 export class AdminModule {}

--- a/api/src/admin/demo-test.schemas.ts
+++ b/api/src/admin/demo-test.schemas.ts
@@ -133,7 +133,13 @@ export const SetAutoNominatePrefSchema = z.object({
   enabled: z.boolean(),
 });
 
-const VALID_STATUSES = ['signed_up', 'tentative', 'declined'] as const;
+const VALID_STATUSES = [
+  'signed_up',
+  'tentative',
+  'declined',
+  'roached_out',
+  'departed',
+] as const;
 
 export const CreateTestSignupSchema = z.object({
   eventId: z.number().int().positive(),

--- a/api/src/admin/games-dedup-audit.controller.ts
+++ b/api/src/admin/games-dedup-audit.controller.ts
@@ -1,0 +1,28 @@
+/**
+ * ROK-1271: read-only dedup audit controller.
+ *
+ * `GET /admin/games/dedup-audit` — JWT-admin-gated. NOT DEMO_MODE gated.
+ * Returns dup groups + blast-radius counts for ROK-1270 planning.
+ */
+import { Controller, Get, UseGuards } from '@nestjs/common';
+import { AuthGuard } from '@nestjs/passport';
+import { Roles } from '../auth/roles.decorator';
+import { RolesGuard } from '../auth/roles.guard';
+import { RateLimit } from '../throttler/rate-limit.decorator';
+import {
+  GamesDedupAuditService,
+  type DedupAuditResponse,
+} from './games-dedup-audit.service';
+
+@RateLimit('admin')
+@Controller('admin/games')
+@UseGuards(AuthGuard('jwt'), RolesGuard)
+@Roles('admin')
+export class GamesDedupAuditController {
+  constructor(private readonly svc: GamesDedupAuditService) {}
+
+  @Get('dedup-audit')
+  audit(): Promise<DedupAuditResponse> {
+    return this.svc.runAudit();
+  }
+}

--- a/api/src/admin/games-dedup-audit.helpers.ts
+++ b/api/src/admin/games-dedup-audit.helpers.ts
@@ -1,0 +1,285 @@
+/**
+ * ROK-1271: read-only dedup audit for games rows.
+ *
+ * Helpers extracted from GamesDedupAuditService so the service file stays
+ * within the 300-line ESLint cap. Pure logic (bucketing + canonical pick)
+ * lives here alongside the per-id blast-radius query map.
+ */
+import { count, eq, sql } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from '../drizzle/schema';
+import { normalizeForDedup } from '../igdb/igdb-search-dedup.helpers';
+
+/** Minimal game-row projection used by the audit pipeline. */
+export interface GameRow {
+  id: number;
+  name: string;
+  slug: string;
+  igdbId: number | null;
+  itadGameId: string | null;
+  steamAppId: number | null;
+  cachedAt: Date;
+}
+
+/** Match key for a row, indicates how the dup was detected. */
+export type DedupKey = `igdb:${number}` | `steam:${number}` | `name:${string}`;
+
+/**
+ * Bucket rows by dedup key with precedence: igdb → steam → name.
+ *
+ * A row that has any of `igdbId`, `steamAppId`, or a non-empty normalized
+ * name is placed in exactly one bucket — the first matching precedence
+ * tier. Rows whose normalized name is empty (cannot happen for valid
+ * seed data but guards against junk) are silently dropped.
+ */
+export function bucketRowsByDedupKey(
+  rows: GameRow[],
+): Map<DedupKey, GameRow[]> {
+  const buckets = new Map<DedupKey, GameRow[]>();
+  for (const row of rows) {
+    const key = dedupKeyFor(row);
+    if (!key) continue;
+    const existing = buckets.get(key);
+    if (existing) existing.push(row);
+    else buckets.set(key, [row]);
+  }
+  return buckets;
+}
+
+function dedupKeyFor(row: GameRow): DedupKey | null {
+  if (row.igdbId != null) return `igdb:${row.igdbId}`;
+  if (row.steamAppId != null) return `steam:${row.steamAppId}`;
+  const normName = normalizeForDedup(row.name);
+  if (normName.length === 0) return null;
+  return `name:${normName}`;
+}
+
+/**
+ * Tiebreak the canonical id within a dup group:
+ *   1. row with non-null `itadGameId` wins
+ *   2. row with non-null `igdbId` wins
+ *   3. lowest id wins
+ */
+export function pickCanonicalId(rows: GameRow[]): number {
+  if (rows.length === 0) throw new Error('pickCanonicalId requires ≥1 row');
+  const byItad = rows.filter((r) => r.itadGameId != null);
+  if (byItad.length > 0) return Math.min(...byItad.map((r) => r.id));
+  const byIgdb = rows.filter((r) => r.igdbId != null);
+  if (byIgdb.length > 0) return Math.min(...byIgdb.map((r) => r.id));
+  return Math.min(...rows.map((r) => r.id));
+}
+
+/** Per-game downstream-row counts across the 17 FK tables. */
+export interface BlastRadiusCounts {
+  events: number;
+  eventPlans: number;
+  lineupsDecided: number;
+  lineupEntries: number;
+  lineupMatches: number;
+  lineupMatchMembers: number;
+  tiebreakers: number;
+  characters: number;
+  tasteVectors: number;
+  interests: number;
+  activityRollups: number;
+  activitySessions: number;
+  availability: number;
+  channelBindings: number;
+  discordMappings: number;
+  eventTypes: number;
+  interestSuppressions: number;
+}
+
+export interface BlastRadiusRow extends BlastRadiusCounts {
+  gameId: number;
+}
+
+type Db = PostgresJsDatabase<typeof schema>;
+
+function takeCount(rows: { c: number }[]): number {
+  return Number(rows[0]?.c ?? 0);
+}
+
+/** 16 of the 17 FK tables expose a direct `gameId` (or `decidedGameId`/`winnerGameId`)
+ * column — these all share a single SELECT shape. The 17th table
+ * (`community_lineup_match_members`) needs a JOIN, handled separately. */
+function buildDirectCountQueries(db: Db, id: number): Promise<number>[] {
+  const c = () => count();
+  return [
+    db
+      .select({ c: c() })
+      .from(schema.events)
+      .where(eq(schema.events.gameId, id))
+      .then(takeCount),
+    db
+      .select({ c: c() })
+      .from(schema.eventPlans)
+      .where(eq(schema.eventPlans.gameId, id))
+      .then(takeCount),
+    db
+      .select({ c: c() })
+      .from(schema.communityLineups)
+      .where(eq(schema.communityLineups.decidedGameId, id))
+      .then(takeCount),
+    db
+      .select({ c: c() })
+      .from(schema.communityLineupEntries)
+      .where(eq(schema.communityLineupEntries.gameId, id))
+      .then(takeCount),
+    db
+      .select({ c: c() })
+      .from(schema.communityLineupMatches)
+      .where(eq(schema.communityLineupMatches.gameId, id))
+      .then(takeCount),
+    db
+      .select({ c: c() })
+      .from(schema.communityLineupTiebreakers)
+      .where(eq(schema.communityLineupTiebreakers.winnerGameId, id))
+      .then(takeCount),
+    db
+      .select({ c: c() })
+      .from(schema.characters)
+      .where(eq(schema.characters.gameId, id))
+      .then(takeCount),
+    db
+      .select({ c: c() })
+      .from(schema.gameTasteVectors)
+      .where(eq(schema.gameTasteVectors.gameId, id))
+      .then(takeCount),
+    db
+      .select({ c: c() })
+      .from(schema.gameInterests)
+      .where(eq(schema.gameInterests.gameId, id))
+      .then(takeCount),
+    db
+      .select({ c: c() })
+      .from(schema.gameActivityRollups)
+      .where(eq(schema.gameActivityRollups.gameId, id))
+      .then(takeCount),
+    db
+      .select({ c: c() })
+      .from(schema.gameActivitySessions)
+      .where(eq(schema.gameActivitySessions.gameId, id))
+      .then(takeCount),
+    db
+      .select({ c: c() })
+      .from(schema.availability)
+      .where(eq(schema.availability.gameId, id))
+      .then(takeCount),
+    db
+      .select({ c: c() })
+      .from(schema.channelBindings)
+      .where(eq(schema.channelBindings.gameId, id))
+      .then(takeCount),
+    db
+      .select({ c: c() })
+      .from(schema.discordGameMappings)
+      .where(eq(schema.discordGameMappings.gameId, id))
+      .then(takeCount),
+    db
+      .select({ c: c() })
+      .from(schema.eventTypes)
+      .where(eq(schema.eventTypes.gameId, id))
+      .then(takeCount),
+    db
+      .select({ c: c() })
+      .from(schema.gameInterestSuppressions)
+      .where(eq(schema.gameInterestSuppressions.gameId, id))
+      .then(takeCount),
+  ];
+}
+
+async function countLineupMatchMembers(db: Db, id: number): Promise<number> {
+  const rows = (await db.execute(sql`
+    SELECT COUNT(*)::int AS c
+    FROM community_lineup_match_members m
+    JOIN community_lineup_matches lm ON m.match_id = lm.id
+    WHERE lm.game_id = ${id}
+  `)) as { c: number }[];
+  return takeCount(rows);
+}
+
+/**
+ * Compute the 17-table blast radius for a single game id.
+ * All 17 queries run in parallel via Promise.all.
+ *
+ * Notes:
+ * - `lineupMatchMembers` has no direct `gameId` FK — counted via JOIN through
+ *   `communityLineupMatches.gameId`.
+ * - `tiebreakers` is counted via `winnerGameId` only. The `tiedGameIds` JSONB
+ *   column is NOT counted here; full tie-breaker merge logic lives in
+ *   ROK-1270's commit phase, not this audit endpoint.
+ *
+ * The direct-count helpers are emitted in the order matching the
+ * destructuring below; if you reorder them, update both lists together.
+ */
+export async function computeBlastRadiusForId(
+  db: Db,
+  id: number,
+): Promise<BlastRadiusRow> {
+  const [
+    events,
+    eventPlans,
+    lineupsDecided,
+    lineupEntries,
+    lineupMatches,
+    tiebreakers,
+    characters,
+    tasteVectors,
+    interests,
+    activityRollups,
+    activitySessions,
+    availability,
+    channelBindings,
+    discordMappings,
+    eventTypes,
+    interestSuppressions,
+    lineupMatchMembers,
+  ] = await Promise.all([
+    ...buildDirectCountQueries(db, id),
+    countLineupMatchMembers(db, id),
+  ]);
+  return {
+    gameId: id,
+    events,
+    eventPlans,
+    lineupsDecided,
+    lineupEntries,
+    lineupMatches,
+    lineupMatchMembers,
+    tiebreakers,
+    characters,
+    tasteVectors,
+    interests,
+    activityRollups,
+    activitySessions,
+    availability,
+    channelBindings,
+    discordMappings,
+    eventTypes,
+    interestSuppressions,
+  };
+}
+
+/** Total downstream rows for a blast-radius row (used for sorting). */
+export function totalBlastRadius(row: BlastRadiusCounts): number {
+  return (
+    row.events +
+    row.eventPlans +
+    row.lineupsDecided +
+    row.lineupEntries +
+    row.lineupMatches +
+    row.lineupMatchMembers +
+    row.tiebreakers +
+    row.characters +
+    row.tasteVectors +
+    row.interests +
+    row.activityRollups +
+    row.activitySessions +
+    row.availability +
+    row.channelBindings +
+    row.discordMappings +
+    row.eventTypes +
+    row.interestSuppressions
+  );
+}

--- a/api/src/admin/games-dedup-audit.integration.spec.ts
+++ b/api/src/admin/games-dedup-audit.integration.spec.ts
@@ -1,0 +1,217 @@
+/**
+ * ROK-1271: integration spec for `GET /admin/games/dedup-audit`.
+ *
+ * Hits a real Postgres with 50 seeded games (3 dup pairs) + blast-radius
+ * dep rows in events, characters, and game_interests. Asserts the
+ * response shape, summary counts, and zero mutations (games row count is
+ * identical before/after, no rows added to a sample dep table).
+ *
+ * NOT DEMO_MODE gated — the endpoint is admin-only via JWT + RolesGuard
+ * and runs in any environment.
+ */
+import { count } from 'drizzle-orm';
+import { getTestApp, type TestApp } from '../common/testing/test-app';
+import {
+  loginAsAdmin,
+  truncateAllTables,
+} from '../common/testing/integration-helpers';
+import * as schema from '../drizzle/schema';
+
+interface AuditResponse {
+  summary: {
+    totalGames: number;
+    totalGroups: number;
+    totalDupRows: number;
+  };
+  groups: Array<{
+    matchType: 'igdb' | 'steam' | 'name';
+    matchKey: string;
+    canonicalId: number;
+    dupIds: number[];
+  }>;
+  blastRadius: Array<{
+    gameId: number;
+    events: number;
+    characters: number;
+    interests: number;
+  }>;
+}
+
+/** Insert 50 games: 3 dup pairs + 44 unique. Returns the inserted ids.
+ *
+ * The `games.igdb_id` column has a UNIQUE constraint at the DB level
+ * (see games.ts:23), so an "igdb-key dup pair" cannot exist with both
+ * rows holding the same non-null igdb_id. We exercise that path purely
+ * in the unit spec via mocks. Integration coverage:
+ *   - pair A: steam-key match (steam_app_id is NOT unique)
+ *   - pair B: name-key match (both rows have null igdb_id + null steam_app_id)
+ *   - pair C: second steam-key match — gives us 3 groups total and
+ *     exercises sort/grouping over multiple distinct dup keys.
+ */
+async function seedGames(testApp: TestApp): Promise<{
+  steamDupIds: [number, number];
+  nameDupIds: [number, number];
+  steamDup2Ids: [number, number];
+  uniqueIds: number[];
+}> {
+  const pairs = await testApp.db
+    .insert(schema.games)
+    .values([
+      { name: 'Steam-Dup Game', slug: 'steam-dup-a', steamAppId: 81001 },
+      { name: 'Steam-Dup Game Alt', slug: 'steam-dup-b', steamAppId: 81001 },
+      { name: 'Slay the Spire 2', slug: 'name-dup-a' },
+      { name: 'Slay the Spire II', slug: 'name-dup-b' },
+      { name: 'Hades Game', slug: 'steam-dup-c', steamAppId: 82002 },
+      { name: 'Hades Alt', slug: 'steam-dup-d', steamAppId: 82002 },
+    ])
+    .returning({ id: schema.games.id });
+
+  // 44 unique games — distinct igdbId so each lands in its own bucket.
+  const unique = await testApp.db
+    .insert(schema.games)
+    .values(
+      Array.from({ length: 44 }, (_, i) => ({
+        name: `Unique Game ${i}`,
+        slug: `unique-${i}`,
+        igdbId: 20000 + i,
+      })),
+    )
+    .returning({ id: schema.games.id });
+
+  return {
+    steamDupIds: [pairs[0].id, pairs[1].id],
+    nameDupIds: [pairs[2].id, pairs[3].id],
+    steamDup2Ids: [pairs[4].id, pairs[5].id],
+    uniqueIds: unique.map((r) => r.id),
+  };
+}
+
+/** Seed one event + one character + one interest on each dup-pair-loser id. */
+async function seedDepRowsForLoser(
+  testApp: TestApp,
+  loserId: number,
+): Promise<void> {
+  await testApp.db.insert(schema.events).values({
+    title: `loser-event-${loserId}`,
+    duration: [
+      new Date(Date.now() + 60_000),
+      new Date(Date.now() + 120_000),
+    ] as [Date, Date],
+    creatorId: testApp.seed.adminUser.id,
+    gameId: loserId,
+    maxAttendees: 10,
+  });
+  await testApp.db.insert(schema.characters).values({
+    userId: testApp.seed.adminUser.id,
+    gameId: loserId,
+    name: `loser-char-${loserId}`,
+  });
+  await testApp.db.insert(schema.gameInterests).values({
+    userId: testApp.seed.adminUser.id,
+    gameId: loserId,
+    source: 'manual',
+  });
+}
+
+describe('GET /admin/games/dedup-audit', () => {
+  let testApp: TestApp;
+  let adminToken: string;
+
+  beforeAll(async () => {
+    testApp = await getTestApp();
+    adminToken = await loginAsAdmin(testApp.request, testApp.seed);
+  });
+
+  afterEach(async () => {
+    testApp.seed = await truncateAllTables(testApp.db);
+    adminToken = await loginAsAdmin(testApp.request, testApp.seed);
+  });
+
+  it('rejects unauthenticated requests with 401', async () => {
+    const res = await testApp.request.get('/admin/games/dedup-audit');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 with dup groups + blast-radius counts and does NOT mutate any rows', async () => {
+    const { steamDupIds, nameDupIds, steamDup2Ids } = await seedGames(testApp);
+
+    // Attach dep rows to the NON-canonical (loser) id of each dup pair.
+    // All three groups break ties on lowest id (no itadGameId / igdbId set
+    // on the dup rows), so losers are the second element of each tuple.
+    await seedDepRowsForLoser(testApp, steamDupIds[1]);
+    await seedDepRowsForLoser(testApp, nameDupIds[1]);
+    await seedDepRowsForLoser(testApp, steamDup2Ids[1]);
+
+    // Baseline counts BEFORE the audit call.
+    const [{ c: gamesBefore }] = await testApp.db
+      .select({ c: count() })
+      .from(schema.games);
+    const [{ c: eventsBefore }] = await testApp.db
+      .select({ c: count() })
+      .from(schema.events);
+
+    const res = await testApp.request
+      .get('/admin/games/dedup-audit')
+      .set('Authorization', `Bearer ${adminToken}`);
+
+    expect(res.status).toBe(200);
+    const body = res.body as AuditResponse;
+    expect(body.summary.totalGames).toBe(Number(gamesBefore));
+    expect(body.summary.totalGroups).toBe(3);
+    expect(body.summary.totalDupRows).toBe(3);
+
+    expect(body.groups).toHaveLength(3);
+    const matchTypes = body.groups.map((g) => g.matchType).sort();
+    expect(matchTypes).toEqual(['name', 'steam', 'steam']);
+
+    const steamGroup = body.groups.find(
+      (g) => g.matchType === 'steam' && g.matchKey === '81001',
+    );
+    expect(steamGroup?.canonicalId).toBe(steamDupIds[0]);
+    expect(steamGroup?.dupIds).toEqual([steamDupIds[1]]);
+
+    const steamGroup2 = body.groups.find(
+      (g) => g.matchType === 'steam' && g.matchKey === '82002',
+    );
+    expect(steamGroup2?.canonicalId).toBe(steamDup2Ids[0]);
+    expect(steamGroup2?.dupIds).toEqual([steamDup2Ids[1]]);
+
+    const nameGroup = body.groups.find((g) => g.matchType === 'name');
+    expect(nameGroup?.canonicalId).toBe(nameDupIds[0]);
+    expect(nameGroup?.dupIds).toEqual([nameDupIds[1]]);
+
+    // Blast radius: each loser has exactly 1 event + 1 character + 1
+    // interest seeded by seedDepRowsForLoser.
+    expect(body.blastRadius).toHaveLength(3);
+    const blastByGameId = new Map(body.blastRadius.map((b) => [b.gameId, b]));
+    for (const loserId of [steamDupIds[1], nameDupIds[1], steamDup2Ids[1]]) {
+      const row = blastByGameId.get(loserId);
+      expect(row?.events).toBe(1);
+      expect(row?.characters).toBe(1);
+      expect(row?.interests).toBe(1);
+    }
+
+    // No mutations: games and events row counts are unchanged.
+    const [{ c: gamesAfter }] = await testApp.db
+      .select({ c: count() })
+      .from(schema.games);
+    const [{ c: eventsAfter }] = await testApp.db
+      .select({ c: count() })
+      .from(schema.events);
+    expect(gamesAfter).toBe(gamesBefore);
+    expect(eventsAfter).toBe(eventsBefore);
+  }, 60_000);
+
+  it('returns empty groups when no duplicates exist', async () => {
+    // Just the baseline-seed game from truncateAllTables — no dups.
+    const res = await testApp.request
+      .get('/admin/games/dedup-audit')
+      .set('Authorization', `Bearer ${adminToken}`);
+    expect(res.status).toBe(200);
+    const body = res.body as AuditResponse;
+    expect(body.summary.totalGroups).toBe(0);
+    expect(body.summary.totalDupRows).toBe(0);
+    expect(body.groups).toEqual([]);
+    expect(body.blastRadius).toEqual([]);
+  }, 60_000);
+});

--- a/api/src/admin/games-dedup-audit.service.spec.ts
+++ b/api/src/admin/games-dedup-audit.service.spec.ts
@@ -252,23 +252,25 @@ describe('GamesDedupAuditService.runAudit', () => {
     // Snapshot is the 17 counts returned for id=2 in helper-call order:
     // 16 direct counts via buildDirectCountQueries, then 1 JOIN count via
     // countLineupMatchMembers (execute() raw SQL path).
+    // Unique non-zero counts per slot so a destructure swap (e.g. events↔eventPlans)
+    // would fail the test. Each value is distinct in the range [1..17].
     const counts = [
       3, // events                  [direct 1]
       1, // eventPlans              [direct 2]
-      0, // lineupsDecided          [direct 3]
+      8, // lineupsDecided          [direct 3]
       2, // lineupEntries           [direct 4]
       4, // lineupMatches           [direct 5]
-      0, // tiebreakers             [direct 6]
+      9, // tiebreakers             [direct 6]
       7, // characters              [direct 7]
-      0, // tasteVectors            [direct 8]
+      10, // tasteVectors            [direct 8]
       6, // interests               [direct 9]
-      0, // activityRollups         [direct 10]
-      0, // activitySessions        [direct 11]
-      0, // availability            [direct 12]
-      0, // channelBindings         [direct 13]
-      0, // discordMappings         [direct 14]
-      0, // eventTypes              [direct 15]
-      0, // interestSuppressions    [direct 16]
+      11, // activityRollups         [direct 10]
+      12, // activitySessions        [direct 11]
+      13, // availability            [direct 12]
+      14, // channelBindings         [direct 13]
+      15, // discordMappings         [direct 14]
+      16, // eventTypes              [direct 15]
+      17, // interestSuppressions    [direct 16]
       5, // lineupMatchMembers      [JOIN via execute()]
     ];
     const { svc } = await buildService(
@@ -284,11 +286,21 @@ describe('GamesDedupAuditService.runAudit', () => {
     expect(br.gameId).toBe(2);
     expect(br.events).toBe(3);
     expect(br.eventPlans).toBe(1);
+    expect(br.lineupsDecided).toBe(8);
     expect(br.lineupEntries).toBe(2);
     expect(br.lineupMatches).toBe(4);
-    expect(br.lineupMatchMembers).toBe(5);
+    expect(br.tiebreakers).toBe(9);
     expect(br.characters).toBe(7);
+    expect(br.tasteVectors).toBe(10);
     expect(br.interests).toBe(6);
+    expect(br.activityRollups).toBe(11);
+    expect(br.activitySessions).toBe(12);
+    expect(br.availability).toBe(13);
+    expect(br.channelBindings).toBe(14);
+    expect(br.discordMappings).toBe(15);
+    expect(br.eventTypes).toBe(16);
+    expect(br.interestSuppressions).toBe(17);
+    expect(br.lineupMatchMembers).toBe(5);
   });
 
   it('sorts groups by totalDupRows DESC then by group size DESC', async () => {

--- a/api/src/admin/games-dedup-audit.service.spec.ts
+++ b/api/src/admin/games-dedup-audit.service.spec.ts
@@ -1,0 +1,316 @@
+/**
+ * ROK-1271: unit spec for GamesDedupAuditService and helpers.
+ *
+ * Uses Drizzle chain mocks (pattern from demo-test-reset.service.spec.ts).
+ * Covers bucketing, canonical pick, blast-radius wiring, and full
+ * service orchestration for igdb/steam/name dup paths.
+ */
+import { Test } from '@nestjs/testing';
+import { GamesDedupAuditService } from './games-dedup-audit.service';
+import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
+import {
+  bucketRowsByDedupKey,
+  pickCanonicalId,
+  type GameRow,
+} from './games-dedup-audit.helpers';
+
+function zeros(n: number): number[] {
+  return Array.from<number>({ length: n }).fill(0);
+}
+
+function row(
+  partial: Partial<GameRow> & { id: number; name: string },
+): GameRow {
+  return {
+    slug: `slug-${partial.id}`,
+    igdbId: null,
+    itadGameId: null,
+    steamAppId: null,
+    cachedAt: new Date('2026-01-01T00:00:00Z'),
+    ...partial,
+  };
+}
+
+describe('bucketRowsByDedupKey', () => {
+  it('groups two rows that share an igdbId under one igdb key', () => {
+    const rows = [
+      row({ id: 1, name: 'A', igdbId: 100 }),
+      row({ id: 2, name: 'B', igdbId: 100 }),
+    ];
+    const buckets = bucketRowsByDedupKey(rows);
+    expect(buckets.size).toBe(1);
+    expect(buckets.get('igdb:100')).toHaveLength(2);
+  });
+
+  it('groups two rows that share a steamAppId under a steam key (no igdbId)', () => {
+    const rows = [
+      row({ id: 3, name: 'Foo', steamAppId: 555 }),
+      row({ id: 4, name: 'Foo2', steamAppId: 555 }),
+    ];
+    const buckets = bucketRowsByDedupKey(rows);
+    expect(buckets.size).toBe(1);
+    expect(buckets.get('steam:555')).toHaveLength(2);
+  });
+
+  it('groups rows by normalized name when neither igdb nor steam keys match', () => {
+    const rows = [
+      row({ id: 5, name: 'Slay the Spire 2' }),
+      row({ id: 6, name: 'Slay the Spire II' }),
+    ];
+    const buckets = bucketRowsByDedupKey(rows);
+    expect(buckets.size).toBe(1);
+    const [[, group]] = [...buckets.entries()];
+    expect(group).toHaveLength(2);
+  });
+
+  it('prefers igdb over steam over name when multiple keys apply', () => {
+    // Same igdbId but different steam and name — must bucket by igdb only.
+    const rows = [
+      row({ id: 7, name: 'Alpha', igdbId: 1, steamAppId: 11 }),
+      row({ id: 8, name: 'Beta', igdbId: 1, steamAppId: 22 }),
+    ];
+    const buckets = bucketRowsByDedupKey(rows);
+    expect(buckets.size).toBe(1);
+    expect(buckets.get('igdb:1')).toHaveLength(2);
+  });
+
+  it('returns single-row buckets when no rows share keys (caller filters > 1)', () => {
+    const rows = [
+      row({ id: 9, name: 'Alone One', igdbId: 9 }),
+      row({ id: 10, name: 'Alone Two', igdbId: 10 }),
+    ];
+    const buckets = bucketRowsByDedupKey(rows);
+    expect(buckets.size).toBe(2);
+    expect([...buckets.values()].every((g) => g.length === 1)).toBe(true);
+  });
+});
+
+describe('pickCanonicalId', () => {
+  it('prefers row with non-null itadGameId', () => {
+    const rows = [
+      row({ id: 11, name: 'A', igdbId: 1 }),
+      row({ id: 12, name: 'B', igdbId: 2, itadGameId: 'itad-abc' }),
+    ];
+    expect(pickCanonicalId(rows)).toBe(12);
+  });
+
+  it('falls back to row with non-null igdbId when no itad', () => {
+    const rows = [
+      row({ id: 13, name: 'A' }),
+      row({ id: 14, name: 'B', igdbId: 999 }),
+    ];
+    expect(pickCanonicalId(rows)).toBe(14);
+  });
+
+  it('falls back to lowest id when no itad and no igdb', () => {
+    const rows = [
+      row({ id: 20, name: 'A' }),
+      row({ id: 15, name: 'B' }),
+      row({ id: 18, name: 'C' }),
+    ];
+    expect(pickCanonicalId(rows)).toBe(15);
+  });
+
+  it('uses lowest id among itad candidates when multiple have itadGameId', () => {
+    const rows = [
+      row({ id: 21, name: 'A', itadGameId: 'x' }),
+      row({ id: 19, name: 'B', itadGameId: 'y' }),
+    ];
+    expect(pickCanonicalId(rows)).toBe(19);
+  });
+});
+
+/**
+ * Drizzle chain mock.
+ *
+ * - The service's "load all rows" call (`db.select({...}).from(games)`) is
+ *   thenable: `.from(...)` is awaited directly. We detect it by exposing a
+ *   `then` on the `from` return value, and we trigger it only when no
+ *   `.where(...)` follows.
+ * - Per-id count queries call `.where(...)` which resolves to the next entry
+ *   in `countSnapshots`. The lineupMatchMembers JOIN goes through
+ *   `db.execute(...)`, which uses the same snapshot index.
+ */
+function buildDbMock(
+  loadRows: () => GameRow[] | Promise<GameRow[]>,
+  countSnapshots: number[],
+) {
+  let idx = 0;
+  const nextCount = () => {
+    const v = countSnapshots[idx] ?? 0;
+    idx += 1;
+    return [{ c: v }];
+  };
+  const db = {
+    select: jest.fn(() => ({
+      from: jest.fn(() => ({
+        where: jest.fn(() => Promise.resolve(nextCount())),
+        then: (resolve: (v: GameRow[]) => unknown) =>
+          Promise.resolve(loadRows()).then(resolve),
+      })),
+    })),
+    execute: jest.fn(() => Promise.resolve(nextCount())),
+  };
+  return { db, getQueryCount: () => idx };
+}
+
+async function buildService(
+  loadRows: () => GameRow[] | Promise<GameRow[]>,
+  countSnapshots: number[],
+): Promise<{
+  svc: GamesDedupAuditService;
+  dbMock: ReturnType<typeof buildDbMock>;
+}> {
+  const dbMock = buildDbMock(loadRows, countSnapshots);
+  const module = await Test.createTestingModule({
+    providers: [
+      GamesDedupAuditService,
+      { provide: DrizzleAsyncProvider, useValue: dbMock.db },
+    ],
+  }).compile();
+  return { svc: module.get(GamesDedupAuditService), dbMock };
+}
+
+describe('GamesDedupAuditService.runAudit', () => {
+  it('returns empty result when no games rows exist', async () => {
+    const { svc } = await buildService(() => [], []);
+    const result = await svc.runAudit();
+    expect(result.summary.totalGames).toBe(0);
+    expect(result.summary.totalGroups).toBe(0);
+    expect(result.summary.totalDupRows).toBe(0);
+    expect(result.groups).toEqual([]);
+    expect(result.blastRadius).toEqual([]);
+  });
+
+  it('returns empty groups for a single row with no dup', async () => {
+    const { svc } = await buildService(
+      () => [row({ id: 1, name: 'Lone Game', igdbId: 42 })],
+      [],
+    );
+    const result = await svc.runAudit();
+    expect(result.summary.totalGames).toBe(1);
+    expect(result.summary.totalGroups).toBe(0);
+    expect(result.groups).toEqual([]);
+    expect(result.blastRadius).toEqual([]);
+  });
+
+  it('detects an igdb-key dup pair and emits a group + blast radius row for the non-canonical id', async () => {
+    // Two rows share igdbId=10. Row id=5 has itadGameId so it wins canonical.
+    // Blast radius is computed for the LOSER (id=2) — 17 counts of zero suffice.
+    const { svc } = await buildService(
+      () => [
+        row({ id: 5, name: 'Foo', igdbId: 10, itadGameId: 'itad-foo' }),
+        row({ id: 2, name: 'Foo Alt', igdbId: 10 }),
+      ],
+      zeros(17),
+    );
+    const result = await svc.runAudit();
+    expect(result.summary.totalGames).toBe(2);
+    expect(result.summary.totalGroups).toBe(1);
+    expect(result.summary.totalDupRows).toBe(1); // 2 in group - 1 canonical
+    expect(result.groups).toHaveLength(1);
+    expect(result.groups[0].canonicalId).toBe(5);
+    expect(result.groups[0].dupIds).toEqual([2]);
+    expect(result.groups[0].matchType).toBe('igdb');
+    expect(result.groups[0].matchKey).toBe('10');
+    expect(result.blastRadius).toHaveLength(1);
+    expect(result.blastRadius[0].gameId).toBe(2);
+  });
+
+  it('detects a steam-key dup pair when igdbId is null on both rows', async () => {
+    const { svc } = await buildService(
+      () => [
+        row({ id: 1, name: 'A', steamAppId: 777 }),
+        row({ id: 2, name: 'B', steamAppId: 777 }),
+      ],
+      zeros(17),
+    );
+    const result = await svc.runAudit();
+    expect(result.summary.totalGroups).toBe(1);
+    expect(result.groups[0].matchType).toBe('steam');
+    expect(result.groups[0].matchKey).toBe('777');
+    expect(result.groups[0].canonicalId).toBe(1); // lowest id wins
+  });
+
+  it('detects a name-key dup pair when no igdb/steam keys match', async () => {
+    const { svc } = await buildService(
+      () => [
+        row({ id: 30, name: 'Slay the Spire 2' }),
+        row({ id: 31, name: 'Slay the Spire II' }),
+      ],
+      zeros(17),
+    );
+    const result = await svc.runAudit();
+    expect(result.summary.totalGroups).toBe(1);
+    expect(result.groups[0].matchType).toBe('name');
+    expect(result.groups[0].matchKey).toMatch(/slay the spire 2/);
+    expect(result.groups[0].canonicalId).toBe(30);
+  });
+
+  it('emits blast-radius counts populated from drizzle responses (per-table mapping)', async () => {
+    // Two rows share igdbId=20. Canonical: id=1 (lower id). Loser: id=2.
+    // Snapshot is the 17 counts returned for id=2 in helper-call order:
+    // 16 direct counts via buildDirectCountQueries, then 1 JOIN count via
+    // countLineupMatchMembers (execute() raw SQL path).
+    const counts = [
+      3, // events                  [direct 1]
+      1, // eventPlans              [direct 2]
+      0, // lineupsDecided          [direct 3]
+      2, // lineupEntries           [direct 4]
+      4, // lineupMatches           [direct 5]
+      0, // tiebreakers             [direct 6]
+      7, // characters              [direct 7]
+      0, // tasteVectors            [direct 8]
+      6, // interests               [direct 9]
+      0, // activityRollups         [direct 10]
+      0, // activitySessions        [direct 11]
+      0, // availability            [direct 12]
+      0, // channelBindings         [direct 13]
+      0, // discordMappings         [direct 14]
+      0, // eventTypes              [direct 15]
+      0, // interestSuppressions    [direct 16]
+      5, // lineupMatchMembers      [JOIN via execute()]
+    ];
+    const { svc } = await buildService(
+      () => [
+        row({ id: 1, name: 'A', igdbId: 20 }),
+        row({ id: 2, name: 'B', igdbId: 20 }),
+      ],
+      counts,
+    );
+    const result = await svc.runAudit();
+    expect(result.blastRadius).toHaveLength(1);
+    const br = result.blastRadius[0];
+    expect(br.gameId).toBe(2);
+    expect(br.events).toBe(3);
+    expect(br.eventPlans).toBe(1);
+    expect(br.lineupEntries).toBe(2);
+    expect(br.lineupMatches).toBe(4);
+    expect(br.lineupMatchMembers).toBe(5);
+    expect(br.characters).toBe(7);
+    expect(br.interests).toBe(6);
+  });
+
+  it('sorts groups by totalDupRows DESC then by group size DESC', async () => {
+    // Three groups: group A=4 rows (3 dups), group B=2 rows (1 dup),
+    // group C=3 rows (2 dups). Expected order: A (3 dups), C (2 dups), B (1).
+    const rows: GameRow[] = [
+      row({ id: 1, name: 'A1', igdbId: 100 }),
+      row({ id: 2, name: 'A2', igdbId: 100 }),
+      row({ id: 3, name: 'A3', igdbId: 100 }),
+      row({ id: 4, name: 'A4', igdbId: 100 }),
+      row({ id: 5, name: 'B1', igdbId: 200 }),
+      row({ id: 6, name: 'B2', igdbId: 200 }),
+      row({ id: 7, name: 'C1', igdbId: 300 }),
+      row({ id: 8, name: 'C2', igdbId: 300 }),
+      row({ id: 9, name: 'C3', igdbId: 300 }),
+    ];
+    // 3 + 1 + 2 = 6 losers; 6 * 17 = 102 zero counts.
+    const { svc } = await buildService(() => rows, zeros(102));
+    const result = await svc.runAudit();
+    expect(result.groups).toHaveLength(3);
+    expect(result.groups[0].matchKey).toBe('100'); // A
+    expect(result.groups[1].matchKey).toBe('300'); // C
+    expect(result.groups[2].matchKey).toBe('200'); // B
+  });
+});

--- a/api/src/admin/games-dedup-audit.service.ts
+++ b/api/src/admin/games-dedup-audit.service.ts
@@ -132,7 +132,7 @@ function compareGroups(a: DedupGroup, b: DedupGroup): number {
   const aDups = a.dupIds.length;
   const bDups = b.dupIds.length;
   if (aDups !== bDups) return bDups - aDups;
-  return b.dupIds.length + 1 - (a.dupIds.length + 1);
+  return a.canonicalId - b.canonicalId;
 }
 
 function compareBlastRadius(a: BlastRadiusRow, b: BlastRadiusRow): number {

--- a/api/src/admin/games-dedup-audit.service.ts
+++ b/api/src/admin/games-dedup-audit.service.ts
@@ -1,0 +1,140 @@
+/**
+ * ROK-1271: GamesDedupAuditService.
+ *
+ * Phase 0 of ROK-1270: read-only audit of duplicate `games` rows.
+ * Returns dup groups, per-loser blast-radius counts (17 FK tables), and
+ * a summary. NO mutations — purely SELECT queries.
+ *
+ * Algorithm:
+ *   1. Load (id, name, slug, igdbId, itadGameId, steamAppId, cachedAt)
+ *      from every row in `games`.
+ *   2. Bucket rows by precedence key: igdb → steam → name.
+ *   3. For each bucket with > 1 rows: pick canonical (itad → igdb → min id),
+ *      everything else is a "dup id".
+ *   4. For every dup id, run the 17-table blast-radius counter in parallel.
+ *   5. Sort groups by total dups DESC, blast radius by total downstream DESC.
+ */
+import { Inject, Injectable, Logger } from '@nestjs/common';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
+import * as schema from '../drizzle/schema';
+import {
+  bucketRowsByDedupKey,
+  computeBlastRadiusForId,
+  pickCanonicalId,
+  totalBlastRadius,
+  type BlastRadiusRow,
+  type DedupKey,
+  type GameRow,
+} from './games-dedup-audit.helpers';
+
+export type DedupMatchType = 'igdb' | 'steam' | 'name';
+
+export interface DedupGroup {
+  matchType: DedupMatchType;
+  matchKey: string;
+  canonicalId: number;
+  dupIds: number[];
+}
+
+export interface DedupAuditSummary {
+  totalGames: number;
+  totalGroups: number;
+  totalDupRows: number;
+}
+
+export interface DedupAuditResponse {
+  summary: DedupAuditSummary;
+  groups: DedupGroup[];
+  blastRadius: BlastRadiusRow[];
+}
+
+@Injectable()
+export class GamesDedupAuditService {
+  private readonly logger = new Logger(GamesDedupAuditService.name);
+
+  constructor(
+    @Inject(DrizzleAsyncProvider)
+    private readonly db: PostgresJsDatabase<typeof schema>,
+  ) {}
+
+  async runAudit(): Promise<DedupAuditResponse> {
+    const rows = await this.loadGameRows();
+    const buckets = bucketRowsByDedupKey(rows);
+    const groups = buildGroups(buckets);
+    const dupIds = groups.flatMap((g) => g.dupIds);
+    this.logger.log(
+      `dedup-audit: ${rows.length} games, ${groups.length} groups, ${dupIds.length} dup rows`,
+    );
+    const blastRadius = await this.computeBlastRadius(dupIds);
+    return {
+      summary: {
+        totalGames: rows.length,
+        totalGroups: groups.length,
+        totalDupRows: dupIds.length,
+      },
+      groups: groups.sort(compareGroups),
+      blastRadius: blastRadius.sort(compareBlastRadius),
+    };
+  }
+
+  private async loadGameRows(): Promise<GameRow[]> {
+    return this.db
+      .select({
+        id: schema.games.id,
+        name: schema.games.name,
+        slug: schema.games.slug,
+        igdbId: schema.games.igdbId,
+        itadGameId: schema.games.itadGameId,
+        steamAppId: schema.games.steamAppId,
+        cachedAt: schema.games.cachedAt,
+      })
+      .from(schema.games);
+  }
+
+  private async computeBlastRadius(
+    dupIds: number[],
+  ): Promise<BlastRadiusRow[]> {
+    if (dupIds.length === 0) return [];
+    return Promise.all(
+      dupIds.map((id) => computeBlastRadiusForId(this.db, id)),
+    );
+  }
+}
+
+function buildGroups(buckets: Map<DedupKey, GameRow[]>): DedupGroup[] {
+  const groups: DedupGroup[] = [];
+  for (const [key, rows] of buckets.entries()) {
+    if (rows.length < 2) continue;
+    const canonicalId = pickCanonicalId(rows);
+    const dupIds = rows
+      .map((r) => r.id)
+      .filter((id) => id !== canonicalId)
+      .sort((a, b) => a - b);
+    const { matchType, matchKey } = parseKey(key);
+    groups.push({ matchType, matchKey, canonicalId, dupIds });
+  }
+  return groups;
+}
+
+function parseKey(key: DedupKey): {
+  matchType: DedupMatchType;
+  matchKey: string;
+} {
+  if (key.startsWith('igdb:'))
+    return { matchType: 'igdb', matchKey: key.slice(5) };
+  if (key.startsWith('steam:'))
+    return { matchType: 'steam', matchKey: key.slice(6) };
+  return { matchType: 'name', matchKey: key.slice(5) };
+}
+
+function compareGroups(a: DedupGroup, b: DedupGroup): number {
+  const aDups = a.dupIds.length;
+  const bDups = b.dupIds.length;
+  if (aDups !== bDups) return bDups - aDups;
+  return b.dupIds.length + 1 - (a.dupIds.length + 1);
+}
+
+function compareBlastRadius(a: BlastRadiusRow, b: BlastRadiusRow): number {
+  return totalBlastRadius(b) - totalBlastRadius(a);
+}

--- a/api/src/events/events.integration.spec.ts
+++ b/api/src/events/events.integration.spec.ts
@@ -11,7 +11,7 @@ import {
   truncateAllTables,
   loginAsAdmin,
 } from '../common/testing/integration-helpers';
-import { events } from '../drizzle/schema';
+import { events, eventSignups } from '../drizzle/schema';
 
 let testApp: TestApp;
 let adminToken: string;
@@ -379,4 +379,60 @@ describe('GET /events/:id/detail (ROK-1046)', () => {
     testDetailShapeParityPerSlice());
   it('returns 404 when the event does not exist', () =>
     testDetail404OnMissingEvent());
+});
+
+// ============================================================
+// ROK-1237: GET /events/:id/detail tolerates roster rows whose
+// underlying signup is in the 'departed' state. Reproduces the
+// enum-drift bug that bricked event detail in production.
+// ============================================================
+
+async function assignAdminToTankSlot(eventId: number) {
+  const res = await testApp.request
+    .patch(`/events/${eventId}/roster`)
+    .set('Authorization', `Bearer ${adminToken}`)
+    .send({
+      assignments: [
+        {
+          userId: testApp.seed.adminUser.id,
+          slot: 'tank',
+          position: 1,
+          isOverride: false,
+        },
+      ],
+    });
+  expect(res.status).toBe(200);
+}
+
+async function testDetailWithDepartedRosterRow() {
+  const eventId = await createDetailFixtureEvent();
+  await assignAdminToTankSlot(eventId);
+
+  // Mutate the admin's signup row directly to 'departed' — this is the state
+  // that bricked the page in prod when the frontend Zod parse rejected the
+  // value (ROK-1237). The endpoint must still respond with 200.
+  await testApp.db
+    .update(eventSignups)
+    .set({ status: 'departed' })
+    .where(eq(eventSignups.eventId, eventId));
+
+  const res = await testApp.request
+    .get(`/events/${eventId}/detail`)
+    .set('Authorization', `Bearer ${adminToken}`);
+
+  expect(res.status).toBe(200);
+  const assignments = res.body.rosterAssignments.assignments as Array<{
+    signupStatus?: string;
+    userId: number;
+  }>;
+  const adminAssignment = assignments.find(
+    (a) => a.userId === testApp.seed.adminUser.id,
+  );
+  expect(adminAssignment).toBeDefined();
+  expect(adminAssignment?.signupStatus).toBe('departed');
+}
+
+describe('GET /events/:id/detail — departed signup (ROK-1237)', () => {
+  it('returns 200 when a roster row has signupStatus="departed"', () =>
+    testDetailWithDepartedRosterRow());
 });

--- a/api/src/events/signups-roster.helpers.ts
+++ b/api/src/events/signups-roster.helpers.ts
@@ -181,9 +181,6 @@ export function buildRosterAssignmentResponseDto(
       (row.event_signups.preferredRoles as
         | ('tank' | 'healer' | 'dps')[]
         | null) ?? null,
-    signupStatus: row.event_signups.status as
-      | 'signed_up'
-      | 'tentative'
-      | 'declined',
+    signupStatus: row.event_signups.status as SignupStatus,
   };
 }

--- a/packages/contract/src/roster.schema.ts
+++ b/packages/contract/src/roster.schema.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { SignupStatusSchema } from './signups.schema.js';
 
 /**
  * Valid role types for roster slots (ROK-114, ROK-183).
@@ -61,8 +62,8 @@ export const RosterAssignmentResponseSchema = z.object({
     }).nullable(),
     /** ROK-452: Preferred roles the player is willing to play */
     preferredRoles: z.array(z.enum(['tank', 'healer', 'dps'])).nullable().optional(),
-    /** ROK-459: Signup attendance status (signed_up, tentative, declined) */
-    signupStatus: z.enum(['signed_up', 'tentative', 'declined']).optional(),
+    /** ROK-459 / ROK-1237: Signup attendance status — canonical enum (covers departed/roached_out too). */
+    signupStatus: SignupStatusSchema.optional(),
 });
 export type RosterAssignmentResponse = z.infer<typeof RosterAssignmentResponseSchema>;
 

--- a/scripts/smoke/events.smoke.spec.ts
+++ b/scripts/smoke/events.smoke.spec.ts
@@ -3,7 +3,7 @@
  */
 import { test, expect } from './base';
 import { navigateToFirstEvent } from './helpers';
-import { getAdminToken, apiGet, apiPost, apiDelete } from './api-helpers';
+import { getAdminToken, apiGet, apiPost, apiPatch, apiDelete } from './api-helpers';
 
 // ROK-1070 Codex review (P2): removed the file-level reset-to-seed
 // beforeAll. Playwright runs desktop+mobile projects in parallel and a
@@ -462,6 +462,62 @@ test.describe('Regression: ROK-868 — character info on duplicate signup', () =
 
             // FlexibilityBadges renders a span with title="Prefers: Dps" containing role icons
             await expect(page.locator('[title="Prefers: Dps"]').first()).toBeVisible({ timeout: 5_000 });
+        } finally {
+            await apiDelete(token, `/events/${event.id}`);
+        }
+    });
+});
+
+// ---------------------------------------------------------------------------
+// Regression: ROK-1237 — event detail tolerates departed roster rows
+// ---------------------------------------------------------------------------
+
+test.describe('Regression: ROK-1237 — departed roster row', () => {
+    test('event detail renders when a roster slot is filled by a departed signup', async ({ page, world }) => {
+        const token = await getAdminToken();
+        const me = (await apiGet(token, '/auth/me')) as { id: number };
+
+        // MMO slot config so we can PATCH the admin into a tank slot.
+        const futureStart = new Date(Date.now() + 86_400_000).toISOString();
+        const futureEnd = new Date(Date.now() + 90_000_000).toISOString();
+        const event = (await apiPost(token, '/events', {
+            title: world.uid('rok-1237-departed'),
+            startTime: futureStart,
+            endTime: futureEnd,
+            maxAttendees: 10,
+            slotConfig: { type: 'mmo', tank: 1, healer: 1, dps: 3, flex: 0, bench: 0 },
+        })) as { id: number };
+
+        try {
+            // Admin is auto-signed-up when the event was created — assign to tank-1.
+            await apiPatch(token, `/events/${event.id}/roster`, {
+                assignments: [
+                    { userId: me.id, slot: 'tank', position: 1, isOverride: false },
+                ],
+            });
+
+            // Flip the existing signup's status to 'departed'. The test-only
+            // /admin/test/signup endpoint resolves to the existing signup
+            // (svc.signup is idempotent for duplicates) and then overrides the
+            // status row. This reproduces the production state that bricked
+            // the event detail page before the contract fix.
+            await apiPost(token, '/admin/test/signup', {
+                eventId: event.id,
+                userId: me.id,
+                status: 'departed',
+            });
+
+            await page.goto(`/events/${event.id}`);
+
+            // The bug rendered an "Event not found" header here. Assert that
+            // header is NOT present and that the roster section IS visible.
+            await expect(page.getByRole('heading', { name: /Event not found/i })).toHaveCount(0, { timeout: 10_000 });
+            await expect(page.getByRole('heading', { name: /Something went wrong loading this event/i })).toHaveCount(0, { timeout: 5_000 });
+            await expect(page.getByRole('heading', { name: /Roster Slots/i })).toBeVisible({ timeout: 10_000 });
+
+            // The DOM must NEVER contain the raw Zod issue payload (the
+            // visible bug that operators saw in production).
+            await expect(page.locator('body')).not.toHaveText(/"code":\s*"invalid_enum_value"/, { timeout: 1_000 });
         } finally {
             await apiDelete(token, `/events/${event.id}`);
         }

--- a/tools/mcp-env/src/tools/env-copy.test.ts
+++ b/tools/mcp-env/src/tools/env-copy.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { resolve } from 'node:path';
+
+// We mock config so PROJECT_DIR / MAIN_REPO / IS_WORKTREE point at tmp dirs.
+let projectDir = '';
+let mainRepo = '';
+
+vi.mock('../config.js', () => ({
+  get PROJECT_DIR() {
+    return projectDir;
+  },
+  get MAIN_REPO() {
+    return mainRepo;
+  },
+  get IS_WORKTREE() {
+    return true;
+  },
+}));
+
+import { execute, propagateDemoMode } from './env-copy.js';
+
+function writeFile(path: string, content: string): void {
+  mkdirSync(resolve(path, '..'), { recursive: true });
+  writeFileSync(path, content, 'utf-8');
+}
+
+describe('env-copy: DEMO_MODE propagation (ROK-1267)', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(resolve(tmpdir(), 'env-copy-test-'));
+    mainRepo = resolve(tmpRoot, 'main');
+    projectDir = resolve(tmpRoot, 'worktree');
+    mkdirSync(mainRepo, { recursive: true });
+    mkdirSync(projectDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  describe('propagateDemoMode (unit)', () => {
+    it('appends DEMO_MODE to api/.env when missing and root .env has it', () => {
+      writeFile(resolve(mainRepo, '.env'), 'CLIENT_URL=http://x\nDEMO_MODE=true\n');
+      const apiEnv = resolve(projectDir, 'api/.env');
+      writeFile(apiEnv, 'DATABASE_URL=postgres://x\n');
+
+      const status = propagateDemoMode(apiEnv);
+
+      expect(status).toBe('applied');
+      const content = readFileSync(apiEnv, 'utf-8');
+      expect(content).toContain('DEMO_MODE=true');
+      expect(content).toContain('DATABASE_URL=postgres://x');
+    });
+
+    it('is idempotent — re-running does not duplicate the line', () => {
+      writeFile(resolve(mainRepo, '.env'), 'DEMO_MODE=true\n');
+      const apiEnv = resolve(projectDir, 'api/.env');
+      writeFile(apiEnv, 'DATABASE_URL=postgres://x\n');
+
+      propagateDemoMode(apiEnv);
+      const afterFirst = readFileSync(apiEnv, 'utf-8');
+      const second = propagateDemoMode(apiEnv);
+
+      expect(second).toBe('already_present');
+      expect(readFileSync(apiEnv, 'utf-8')).toBe(afterFirst);
+    });
+
+    it('reports already_present when api/.env already has DEMO_MODE', () => {
+      writeFile(resolve(mainRepo, '.env'), 'DEMO_MODE=true\n');
+      const apiEnv = resolve(projectDir, 'api/.env');
+      writeFile(apiEnv, 'DEMO_MODE=false\nDATABASE_URL=x\n');
+
+      const status = propagateDemoMode(apiEnv);
+
+      expect(status).toBe('already_present');
+      // Existing DEMO_MODE value is preserved — we never overwrite.
+      expect(readFileSync(apiEnv, 'utf-8')).toMatch(/^DEMO_MODE=false$/m);
+    });
+
+    it('reports no_source_value when root .env lacks DEMO_MODE', () => {
+      writeFile(resolve(mainRepo, '.env'), 'CLIENT_URL=http://x\n');
+      const apiEnv = resolve(projectDir, 'api/.env');
+      writeFile(apiEnv, 'DATABASE_URL=x\n');
+
+      expect(propagateDemoMode(apiEnv)).toBe('no_source_value');
+    });
+
+    it('reports no_dest_file when api/.env does not exist', () => {
+      writeFile(resolve(mainRepo, '.env'), 'DEMO_MODE=true\n');
+      const apiEnv = resolve(projectDir, 'api/.env');
+
+      expect(propagateDemoMode(apiEnv)).toBe('no_dest_file');
+    });
+
+    it('handles api/.env without a trailing newline', () => {
+      writeFile(resolve(mainRepo, '.env'), 'DEMO_MODE=true\n');
+      const apiEnv = resolve(projectDir, 'api/.env');
+      writeFile(apiEnv, 'DATABASE_URL=x');
+
+      propagateDemoMode(apiEnv);
+      const content = readFileSync(apiEnv, 'utf-8');
+
+      expect(content).toMatch(/DATABASE_URL=x\nDEMO_MODE=true\n$/);
+    });
+  });
+
+  describe('execute (integration with file copy)', () => {
+    it('copying api/.env from a main repo without DEMO_MODE still ends with DEMO_MODE applied', async () => {
+      // Setup: main repo has DEMO_MODE only in root .env (the real-world bug).
+      writeFile(resolve(mainRepo, '.env'), 'DEMO_MODE=true\nCLIENT_URL=http://x\n');
+      writeFile(resolve(mainRepo, 'api/.env'), 'DATABASE_URL=postgres://x\n');
+
+      const result = await execute({ file: 'api/.env' });
+
+      expect('copied' in result).toBe(true);
+      if (!('copied' in result)) return;
+      expect(result.copied[0]).toEqual({
+        path: 'api/.env',
+        status: 'copied',
+        demoModeOverlay: 'applied',
+      });
+      const dest = resolve(projectDir, 'api/.env');
+      expect(readFileSync(dest, 'utf-8')).toContain('DEMO_MODE=true');
+    });
+
+    it('skipped_exists api/.env still receives the DEMO_MODE overlay', async () => {
+      writeFile(resolve(mainRepo, '.env'), 'DEMO_MODE=true\n');
+      writeFile(resolve(mainRepo, 'api/.env'), 'DATABASE_URL=postgres://x\n');
+      // Worktree already has api/.env (skipped_exists path).
+      writeFile(resolve(projectDir, 'api/.env'), 'DATABASE_URL=postgres://x\n');
+
+      const result = await execute({ file: 'api/.env' });
+
+      if (!('copied' in result)) throw new Error('expected copied[]');
+      expect(result.copied[0].status).toBe('skipped_exists');
+      expect(result.copied[0].demoModeOverlay).toBe('applied');
+      expect(readFileSync(resolve(projectDir, 'api/.env'), 'utf-8')).toContain('DEMO_MODE=true');
+    });
+
+    it('non-api .env files do not get demoModeOverlay annotation', async () => {
+      writeFile(resolve(mainRepo, '.env'), 'DEMO_MODE=true\nCLIENT_URL=http://x\n');
+
+      const result = await execute({ file: '.env' });
+
+      if (!('copied' in result)) throw new Error('expected copied[]');
+      expect(result.copied[0].path).toBe('.env');
+      expect(result.copied[0].demoModeOverlay).toBeUndefined();
+    });
+  });
+});

--- a/tools/mcp-env/src/tools/env-copy.ts
+++ b/tools/mcp-env/src/tools/env-copy.ts
@@ -1,18 +1,23 @@
-import { copyFileSync, existsSync, mkdirSync } from 'node:fs';
+import { appendFileSync, copyFileSync, existsSync, mkdirSync, readFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { PROJECT_DIR, IS_WORKTREE, MAIN_REPO } from '../config.js';
 import { ENV_FILES } from '../env-locations.js';
 
 export const TOOL_NAME = 'env_copy';
 export const TOOL_DESCRIPTION =
-  'Copy .env files from the main repo into this worktree. Skips files that already exist (never overwrites).';
+  'Copy .env files from the main repo into this worktree. Skips files that already exist (never overwrites). Propagates DEMO_MODE from the main repo root .env to the worktree api/.env so smoke tests and manual runs inherit auth-bypass.';
 
 /** Copy status for a single file. */
 type CopyStatus = 'copied' | 'skipped_exists' | 'skipped_no_source';
 
+/** Overlay status when propagating DEMO_MODE into api/.env. */
+type OverlayStatus = 'applied' | 'already_present' | 'no_source_value' | 'no_dest_file';
+
 interface CopyEntry {
   path: string;
   status: CopyStatus;
+  /** Present only for api/.env entries. */
+  demoModeOverlay?: OverlayStatus;
 }
 
 interface EnvCopyResult {
@@ -25,21 +30,58 @@ interface EnvCopyResult {
 /** List of valid .env file paths for error messages. */
 const VALID_PATHS = ENV_FILES.map((f) => f.relativePath);
 
+/** Read the DEMO_MODE assignment line from the main repo's root .env, if present. */
+function readDemoModeFromMainRoot(): string | null {
+  if (!MAIN_REPO) return null;
+  const rootEnv = resolve(MAIN_REPO, '.env');
+  if (!existsSync(rootEnv)) return null;
+  const content = readFileSync(rootEnv, 'utf-8');
+  // Match the last DEMO_MODE= assignment, ignoring `export` prefix and surrounding whitespace.
+  const matches = [...content.matchAll(/^\s*(?:export\s+)?DEMO_MODE=(.*)$/gm)];
+  if (matches.length === 0) return null;
+  const value = matches[matches.length - 1][1].trim();
+  return `DEMO_MODE=${value}`;
+}
+
+/**
+ * Propagate DEMO_MODE from main repo root .env into a worktree's api/.env.
+ * Idempotent: appends only if DEMO_MODE is not already present in the destination.
+ */
+export function propagateDemoMode(destApiEnvPath: string): OverlayStatus {
+  const demoLine = readDemoModeFromMainRoot();
+  if (!demoLine) return 'no_source_value';
+  if (!existsSync(destApiEnvPath)) return 'no_dest_file';
+
+  const current = readFileSync(destApiEnvPath, 'utf-8');
+  if (/^\s*(?:export\s+)?DEMO_MODE=/m.test(current)) {
+    return 'already_present';
+  }
+  const prefix = current.length > 0 && !current.endsWith('\n') ? '\n' : '';
+  appendFileSync(destApiEnvPath, `${prefix}${demoLine}\n`);
+  return 'applied';
+}
+
 /** Copy a single .env file from main repo to worktree. */
 function copySingleFile(relativePath: string): CopyEntry {
   const dest = resolve(PROJECT_DIR, relativePath);
+  let status: CopyStatus;
   if (existsSync(dest)) {
-    return { path: relativePath, status: 'skipped_exists' };
+    status = 'skipped_exists';
+  } else {
+    const source = resolve(MAIN_REPO!, relativePath);
+    if (!existsSync(source)) {
+      return { path: relativePath, status: 'skipped_no_source' };
+    }
+    mkdirSync(dirname(dest), { recursive: true });
+    copyFileSync(source, dest);
+    status = 'copied';
   }
 
-  const source = resolve(MAIN_REPO!, relativePath);
-  if (!existsSync(source)) {
-    return { path: relativePath, status: 'skipped_no_source' };
+  const entry: CopyEntry = { path: relativePath, status };
+  if (relativePath === 'api/.env') {
+    entry.demoModeOverlay = propagateDemoMode(dest);
   }
-
-  mkdirSync(dirname(dest), { recursive: true });
-  copyFileSync(source, dest);
-  return { path: relativePath, status: 'copied' };
+  return entry;
 }
 
 /** Build summary string from copy results. */

--- a/web/src/components/roster/RosterSlot.test.tsx
+++ b/web/src/components/roster/RosterSlot.test.tsx
@@ -131,3 +131,36 @@ describe('RosterSlot — keyboard accessibility (ROK-881)', () => {
         expect(slot?.className).toContain('focus-visible:ring-2');
     });
 });
+
+describe('RosterSlot — departed signup treatment (ROK-1237)', () => {
+    it('renders departed assignments with the dimmed red border and door glyph', () => {
+        const { container } = render(
+            <RosterSlot
+                role="tank"
+                position={1}
+                color="bg-blue-500"
+                item={createAssignment({ signupStatus: 'departed' })}
+            />,
+        );
+        const slot = container.querySelector('.rounded-lg');
+        expect(slot?.className).toContain('border-red-500/40');
+        expect(slot?.className).toContain('opacity-60');
+        // Door glyph (U+1F6AA) replaces the bare position number so the row
+        // visually parallels the EventDetailRoster departed group.
+        expect(container.textContent).toContain('\u{1F6AA}');
+    });
+
+    it('does not apply the current-user pulse glow when the slot is departed', () => {
+        const { container } = render(
+            <RosterSlot
+                role="tank"
+                position={1}
+                color="bg-blue-500"
+                item={createAssignment({ signupStatus: 'departed' })}
+                isCurrentUser
+            />,
+        );
+        const slot = container.querySelector('.rounded-lg');
+        expect(slot?.className ?? '').not.toContain('animate-pulse-subtle');
+    });
+});

--- a/web/src/components/roster/RosterSlot.tsx
+++ b/web/src/components/roster/RosterSlot.tsx
@@ -28,6 +28,9 @@ interface RosterSlotProps {
 
 function slotBorderClass(item: RosterAssignmentResponse | undefined, isCurrentUser: boolean, isClickable: boolean) {
     if (!item) return isClickable ? 'border-dashed border-edge-strong bg-panel/20 hover:border-indigo-400 hover:bg-indigo-500/10' : 'border-dashed border-edge bg-panel/20';
+    // ROK-1237: mirror the EventDetailRoster.tsx departed treatment so the
+    // assignment grid and the attendee list agree on visual state.
+    if (item.signupStatus === 'departed') return 'border-dashed border-red-500/40 bg-red-900/10 opacity-60';
     if (item.signupStatus === 'tentative') return 'border-dashed border-amber-500/60 bg-amber-900/10';
     if (isCurrentUser) return 'border-emerald-400/50 bg-emerald-900/20';
     return 'border-edge bg-panel/80';
@@ -68,15 +71,18 @@ export const RosterSlot = React.memo(function RosterSlot({ role, position, item,
 
     const isClickable = !!onAdminClick || (!item && !!onJoinClick);
     const isTentative = item?.signupStatus === 'tentative';
-    const glowClass = isCurrentUser ? 'ring-2 ring-emerald-400/60 shadow-[0_0_15px_rgba(52,211,153,0.4)] animate-pulse-subtle' : '';
+    const isDeparted = item?.signupStatus === 'departed';
+    const glowClass = isCurrentUser && !isDeparted ? 'ring-2 ring-emerald-400/60 shadow-[0_0_15px_rgba(52,211,153,0.4)] animate-pulse-subtle' : '';
     const focusClass = isClickable ? 'focus-visible:ring-2 focus-visible:ring-emerald-500' : '';
+    const badgeBg = isDeparted ? 'bg-red-600' : isTentative ? 'bg-amber-600' : color;
+    const badgeContent = isDeparted ? `\u{1F6AA} ${position}` : isTentative ? `\u23F3 ${position}` : position;
 
     return (
         <div onClick={handleClick}
             {...(isClickable ? { role: 'button', tabIndex: 0, onKeyDown: handleKeyDown } : {})}
             className={`relative min-h-[60px] rounded-lg border transition-all ${isClickable ? 'cursor-pointer' : ''} ${focusClass} ${glowClass} ${slotBorderClass(item, isCurrentUser, isClickable)}`}>
-            <span className={`absolute -top-2 left-2 z-10 rounded px-1.5 text-xs font-semibold ${isTentative ? 'bg-amber-600' : color} text-foreground`}>
-                {isTentative ? `\u23F3 ${position}` : position}
+            <span className={`absolute -top-2 left-2 z-10 rounded px-1.5 text-xs font-semibold ${badgeBg} text-foreground`}>
+                {badgeContent}
             </span>
             {item ? (
                 <div className="p-1"><RosterCard item={item} onRemove={resolveRemoveFn(item, onRemove, isCurrentUser, onSelfRemove)} /></div>

--- a/web/src/lib/api/fetch-api.test.ts
+++ b/web/src/lib/api/fetch-api.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { z } from 'zod';
+
+import { server } from '../../test/mocks/server';
+import { fetchApi, SchemaValidationError } from './fetch-api';
+
+const captureExceptionMock = vi.fn();
+
+vi.mock('../../sentry', () => ({
+    Sentry: {
+        captureException: (...args: unknown[]) => captureExceptionMock(...args),
+    },
+}));
+
+vi.mock('../../hooks/use-auth', () => ({
+    getAuthToken: () => null,
+}));
+
+const API_BASE = 'http://localhost:3000';
+
+const FixtureSchema = z.object({
+    id: z.number(),
+    status: z.enum(['signed_up', 'tentative', 'declined']),
+});
+
+describe('fetchApi — schema validation boundary (ROK-1237)', () => {
+    beforeEach(() => {
+        captureExceptionMock.mockClear();
+    });
+
+    it('returns parsed data on schema match', async () => {
+        server.use(
+            http.get(`${API_BASE}/fixture`, () =>
+                HttpResponse.json({ id: 1, status: 'signed_up' }),
+            ),
+        );
+        const result = await fetchApi('/fixture', {}, FixtureSchema);
+        expect(result).toEqual({ id: 1, status: 'signed_up' });
+        expect(captureExceptionMock).not.toHaveBeenCalled();
+    });
+
+    it('throws SchemaValidationError when the payload does not match', async () => {
+        server.use(
+            http.get(`${API_BASE}/fixture`, () =>
+                HttpResponse.json({ id: 1, status: 'departed' }),
+            ),
+        );
+        await expect(fetchApi('/fixture', {}, FixtureSchema)).rejects.toBeInstanceOf(
+            SchemaValidationError,
+        );
+    });
+
+    it('uses a stable user-facing message that does not include the issue array', async () => {
+        server.use(
+            http.get(`${API_BASE}/fixture`, () =>
+                HttpResponse.json({ id: 'oops', status: 'gibberish' }),
+            ),
+        );
+        let caught: Error | null = null;
+        try {
+            await fetchApi('/fixture', {}, FixtureSchema);
+        } catch (err) {
+            caught = err as Error;
+        }
+        expect(caught).toBeInstanceOf(SchemaValidationError);
+        expect(caught?.message).toBe('We received an unexpected response from the server.');
+        // The Zod issue codes/paths must NEVER be on the visible message.
+        expect(caught?.message).not.toMatch(/invalid_enum_value/);
+        expect(caught?.message).not.toMatch(/invalid_type/);
+        expect(caught?.message).not.toMatch(/\[\s*\{/);
+    });
+
+    it('captures the raw issue array in Sentry extras, not on the message', async () => {
+        server.use(
+            http.get(`${API_BASE}/fixture`, () =>
+                HttpResponse.json({ id: 1, status: 'departed' }),
+            ),
+        );
+        await expect(fetchApi('/fixture', {}, FixtureSchema)).rejects.toBeInstanceOf(
+            SchemaValidationError,
+        );
+        expect(captureExceptionMock).toHaveBeenCalledTimes(1);
+        const [err, ctx] = captureExceptionMock.mock.calls[0];
+        expect(err).toBeInstanceOf(Error);
+        expect((err as Error).message).toBe('Response schema validation failed');
+        const extra = (ctx as { extra: { endpoint: string; issues: unknown[] } }).extra;
+        expect(extra.endpoint).toBe('/fixture');
+        expect(Array.isArray(extra.issues)).toBe(true);
+        expect(extra.issues.length).toBeGreaterThan(0);
+    });
+});

--- a/web/src/lib/api/fetch-api.ts
+++ b/web/src/lib/api/fetch-api.ts
@@ -1,5 +1,6 @@
 import { API_BASE_URL } from '../config';
 import { getAuthToken } from '../../hooks/use-auth';
+import { Sentry } from '../../sentry';
 
 function buildHeaders(options: RequestInit): Record<string, string> {
     const token = getAuthToken();
@@ -24,13 +25,29 @@ async function handleErrorResponse(response: Response): Promise<never> {
 }
 
 /**
+ * Thrown when an API response fails Zod schema validation.
+ * ROK-1237: the raw issue array MUST NEVER reach `.message` — it's only
+ * carried in Sentry's `extra` payload. UI consumers display a stable
+ * user-facing string and branch on `instanceof SchemaValidationError`
+ * to render a soft error state instead of a 404.
+ */
+export class SchemaValidationError extends Error {
+    readonly endpoint: string;
+    constructor(endpoint: string) {
+        super('We received an unexpected response from the server.');
+        this.name = 'SchemaValidationError';
+        this.endpoint = endpoint;
+    }
+}
+
+/**
  * Generic fetch wrapper with Zod validation.
  * Central HTTP layer for all API calls.
  */
 export async function fetchApi<T>(
     endpoint: string,
     options: RequestInit = {},
-    schema?: { parse: (data: unknown) => T }
+    schema?: { safeParse: (data: unknown) => { success: true; data: T } | { success: false; error: { issues: unknown[] } } }
 ): Promise<T> {
     const response = await fetch(`${API_BASE_URL}${endpoint}`, {
         ...options,
@@ -42,5 +59,15 @@ export async function fetchApi<T>(
     if (response.status === 204) return undefined as T;
 
     const data = await response.json();
-    return schema ? schema.parse(data) : (data as T);
+    if (!schema) return data as T;
+
+    const result = schema.safeParse(data);
+    if (result.success) return result.data;
+
+    // Capture the raw issue array in Sentry only — never on the thrown
+    // message, to keep the issue payload out of the rendered DOM.
+    Sentry.captureException(new Error('Response schema validation failed'), {
+        extra: { endpoint, issues: result.error.issues },
+    });
+    throw new SchemaValidationError(endpoint);
 }

--- a/web/src/lib/api/fetch-api.ts
+++ b/web/src/lib/api/fetch-api.ts
@@ -35,6 +35,7 @@ export class SchemaValidationError extends Error {
     readonly endpoint: string;
     constructor(endpoint: string) {
         super('We received an unexpected response from the server.');
+        Object.setPrototypeOf(this, SchemaValidationError.prototype);
         this.name = 'SchemaValidationError';
         this.endpoint = endpoint;
     }

--- a/web/src/pages/event-detail-page.test.tsx
+++ b/web/src/pages/event-detail-page.test.tsx
@@ -310,3 +310,70 @@ describe('EventDetailPage — composite endpoint consumer (ROK-1046)', () => {
         );
     });
 });
+
+// ============================================================
+// ROK-1237: payload schema validation failures must render a soft
+// error state — NEVER a 404, and NEVER the raw Zod issue array.
+// ============================================================
+
+function renderEventDetailPageWithMalformedPayload() {
+    server.use(
+        http.get(`${API_BASE}/events/:id/detail`, () =>
+            HttpResponse.json({
+                event: { id: EVENT_ID, title: FIXTURE_TITLE },
+                // Missing required fields — schema parse will fail.
+            }),
+        ),
+        http.get(`${API_BASE}/events/:id/activity`, () =>
+            HttpResponse.json({ entries: [] }),
+        ),
+    );
+    const queryClient = createTestQueryClient();
+    return render(
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter initialEntries={[`/events/${EVENT_ID}`]}>
+                <Routes>
+                    <Route path="/events/:id" element={<EventDetailPage />} />
+                </Routes>
+            </MemoryRouter>
+        </QueryClientProvider>,
+    );
+}
+
+describe('EventDetailPage — schema validation soft error (ROK-1237)', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('renders the soft error UI when the payload fails schema validation', async () => {
+        renderEventDetailPageWithMalformedPayload();
+        await waitFor(
+            () => {
+                expect(
+                    screen.getByText(/something went wrong loading this event/i),
+                ).toBeInTheDocument();
+            },
+            { timeout: 4000 },
+        );
+        // Must NOT render the 404 "Event not found" header.
+        expect(screen.queryByText(/event not found/i)).toBeNull();
+    });
+
+    it('does not leak the raw Zod issue array into the rendered DOM', async () => {
+        const { container } = renderEventDetailPageWithMalformedPayload();
+        await waitFor(
+            () => {
+                expect(
+                    screen.getByText(/something went wrong loading this event/i),
+                ).toBeInTheDocument();
+            },
+            { timeout: 4000 },
+        );
+        // The Zod issue shape (`{ code: "invalid_type", path: [...] }`) must
+        // never appear in the DOM. Same for stringified issue arrays.
+        const text = container.textContent ?? '';
+        expect(text).not.toMatch(/"code":\s*"invalid_enum_value"/);
+        expect(text).not.toMatch(/"code":\s*"invalid_type"/);
+        expect(text).not.toMatch(/Required/);
+    });
+});

--- a/web/src/pages/event-detail-page.tsx
+++ b/web/src/pages/event-detail-page.tsx
@@ -26,6 +26,7 @@ import {
 import { useEventDetailHandlers } from './event-detail/use-event-detail-handlers';
 import {
     EventDetailError,
+    EventDetailSoftError,
     EventDetailFallbackSignup,
     EventDetailGameTimeWidget,
     EventDetailVoiceSection,
@@ -34,6 +35,7 @@ import {
     PostEventSections,
     MobileQuickInfo,
 } from './event-detail/EventDetailSubComponents';
+import { SchemaValidationError } from '../lib/api/fetch-api';
 import { RosterSlotSection } from './event-detail/EventDetailRosterSlot';
 import { ActivityTimeline } from '../components/common/ActivityTimeline';
 import './event-detail-page.css';
@@ -91,14 +93,14 @@ function useEventDetailPageState() {
     const hasHistory = location.key !== 'default';
 
     const { user, isAuthenticated } = useAuth();
-    const { data: detail, isLoading: detailLoading, error: detailError } = useEventDetail(eventId);
+    const { data: detail, isLoading: detailLoading, error: detailError, refetch: detailRefetch } = useEventDetail(eventId);
     const event = detail?.event;
     const roster = detail?.roster;
     const rosterAssignments = detail?.rosterAssignments;
     const pugs = detail?.pugs ?? [];
     const voiceChannelData = detail?.voiceChannel ?? null;
 
-    return { eventId, navigate, navState, fromCalendar, hasHistory, user, isAuthenticated, event, detailLoading, detailError, roster, rosterAssignments, pugs, voiceChannelData };
+    return { eventId, navigate, navState, fromCalendar, hasHistory, user, isAuthenticated, event, detailLoading, detailError, detailRefetch, roster, rosterAssignments, pugs, voiceChannelData };
 }
 
 function useEventDetailVoice(event: EventResponseDto | undefined, eventId: number, voiceChannelData: VoiceChannelResponseDto | null) {
@@ -224,7 +226,12 @@ export function EventDetailPage(): JSX.Element | null {
     const modals = useModalState();
     const handlers = useEventDetailHandlers(page.eventId, { canManageRoster: derived.canManageRoster, isAuthenticated: page.isAuthenticated, shouldShowCharacterModal: derived.shouldShowCharacterModal, pugs: page.pugs });
 
-    if (page.detailError) return <EventDetailError message={page.detailError.message} onBack={() => page.navigate('/calendar')} />;
+    if (page.detailError) {
+        if (page.detailError instanceof SchemaValidationError || page.detailError.name === 'SchemaValidationError') {
+            return <EventDetailSoftError onRetry={() => page.detailRefetch()} onBack={() => page.navigate('/calendar')} />;
+        }
+        return <EventDetailError message={page.detailError.message} onBack={() => page.navigate('/calendar')} />;
+    }
     if (page.detailLoading) return <div className="event-detail-page"><EventDetailSkeleton /></div>;
     if (!page.event) return null;
 

--- a/web/src/pages/event-detail/EventDetailSubComponents.tsx
+++ b/web/src/pages/event-detail/EventDetailSubComponents.tsx
@@ -37,6 +37,26 @@ export function EventDetailError({ message, onBack }: { message: string; onBack:
     );
 }
 
+/**
+ * ROK-1237: shown when the event detail payload fails schema validation
+ * (e.g. enum drift between server and contract). Never leaks the raw Zod
+ * issue array — the issues are sent to Sentry by the fetch boundary.
+ */
+export function EventDetailSoftError({ onRetry, onBack }: { onRetry: () => void; onBack: () => void }) {
+    return (
+        <div className="event-detail-page event-detail-page--error">
+            <div className="event-detail-error">
+                <h2>Something went wrong loading this event</h2>
+                <p>We've reported this to the team. Try refreshing — if it keeps happening, head back to the calendar and let us know.</p>
+                <div className="flex gap-2 mt-2">
+                    <button onClick={onRetry} className="btn btn-primary">Refresh</button>
+                    <button onClick={onBack} className="btn btn-secondary">Back to Calendar</button>
+                </div>
+            </div>
+        </div>
+    );
+}
+
 export function EventDetailFallbackSignup({ rosterAssignments, isAuthenticated, isSignedUp, isCancelled, onSignup, isPending }: {
     rosterAssignments: unknown; isAuthenticated: boolean; isSignedUp: boolean; isCancelled: boolean; onSignup: () => void; isPending: boolean;
 }) {


### PR DESCRIPTION
## Summary

Three-story batch on `fix/batch-2026-05-12b`:

- **ROK-1237** (Bug, rolls up ROK-1238/1239) — `signupStatus 'departed'` enum drift bricks event detail page. Fixed by aligning `packages/contract/src/roster.schema.ts` to canonical `SignupStatusSchema` + adding a global `safeParse` boundary in `web/src/lib/api/fetch-api.ts` (with `SchemaValidationError` class) so future Zod issue payloads never reach the rendered DOM. Adds an `EventDetailSoftError` branch for parse failures and the 🚪-glyph treatment for departed slots in the assignment grid.
- **ROK-1271** (Feature, Phase 0 of [[ROK-1270]]) — new `GET /admin/games/dedup-audit` admin endpoint returning a JSON audit of duplicate `games` rows + their blast-radius FK counts across 17 dependent tables. JWT-admin-gated, not DEMO_MODE gated (operator hits this on prod). Single concentrated module (`api/src/admin/games-dedup-audit.*`), no contract or migration touched.
- **ROK-1267** (Chore) — `mcp-env` `env_copy` now propagates `DEMO_MODE=true` from the main repo's root `.env` to worktree `api/.env` automatically. Fixes "have to manually set DEMO_MODE for every worktree smoke run." Path 1 (cleanest) implementation.

## Workspaces

| Workspace | Changes |
|-----------|---------|
| `packages/contract` | `roster.schema.ts` references canonical `SignupStatusSchema` (drops drift; covers `departed` + `roached_out`) |
| `api` | New admin endpoint (`games-dedup-audit.{controller,service,helpers,*spec}.ts`), wired in `admin.module.ts`. Integration spec for departed signup (`events.integration.spec.ts`). Minor type-cast tidy in `signups-roster.helpers.ts`. Widened DEMO_MODE `VALID_STATUSES` in `demo-test.schemas.ts` for smoke fixture support. |
| `web` | Global `safeParse` boundary in `fetch-api.ts` + new `SchemaValidationError` class. New `EventDetailSoftError` component. `event-detail-page.tsx` branches `SchemaValidationError` → soft UI; else 404. `RosterSlot.tsx` adds 🚪 N treatment for `departed` (dashed red border, opacity-60). |
| `tools/mcp-env` | `env-copy.ts` overlays `DEMO_MODE=true` onto worktree `api/.env` when present in root `.env` — both copied + skipped_exists paths. |
| `scripts/smoke` | New `events.smoke.spec.ts` regression block for ROK-1237 (desktop + mobile). |

## Test plan (already verified locally)

- [x] `npm run build` — all workspaces
- [x] `npx tsc --noEmit -p api/tsconfig.json` and `-p web/tsconfig.json` (0 batch errors; 4 pre-existing on `main` in `lineup-notification.service.private-visibility.spec.ts`)
- [x] `npm run lint -w api` and `-w web` (0 errors; pre-existing `max-lines-per-function` warnings only)
- [x] `npm run test -w api` — unit incl. `games-dedup-audit.service.spec.ts` (16 ✓)
- [x] `npm run test -w web` — unit incl. `fetch-api.test.ts` (4 ✓), `event-detail-page.test.tsx` (+2 ✓), `RosterSlot.test.tsx` (+2 ✓)
- [x] `npm run test:integration -w api` — incl. `games-dedup-audit.integration.spec.ts` (3 ✓) and new departed case in `events.integration.spec.ts`
- [x] Playwright smoke (desktop + mobile) — `scripts/smoke/events.smoke.spec.ts` ROK-1237 regression block
- [x] Chrome MCP e2e gate — deployed batch branch locally, drove ROK-1237 departed roster row (DPS slot 🚪 3 visible, no "Event not found", no Zod leak in DOM) and ROK-1271 endpoint (200 in 65ms, correct shape). See `planning-artifacts/chrome-mcp-summary-fix-batch-2026-05-12b.md`.
- [x] Reviewer agent — APPROVE WITH NOTES; 0 blockers. MEDIUM + LOW + NIT findings fixed inline (commit `fa16e2a1`). 4 LOWs deferred to TECH-DEBT-BACKLOG.md (commit `e91cb4c3`).

## Tech debt observed (not auto-filed)

See `TECH-DEBT-BACKLOG.md` — section `### 2026-05-12 — fix/batch-2026-05-12b`:

- **[low]** `fetch-api.ts:50` schema-param structural type could use `ZodType<T>`.
- **[low]** `games-dedup-audit.helpers.ts:106-189` `buildDirectCountQueries` 84-line flat function — extract `countDirect()` helper when ROK-1270 Phase 1 extends `BlastRadiusRow`.
- **[low]** `games-dedup-audit.service.ts:99-101` 17N concurrent count queries — consider `pLimit(8)` if telemetry shows N > 20 dup ids in prod.
- **[low]** `roster.schema.ts:66` `signupStatus.optional()` widening — confirm undefined fallback semantics on legacy payloads.

## Notes

- All three stories' Linear status → `In Progress` at batch start; will flip to `Done` on auto-merge.
- ROK-1237 rolls up ROK-1238 + ROK-1239 (same root cause, closed as duplicate).
- ROK-1271 is Phase 0 of [[ROK-1270]] — operator hits the endpoint on prod after deploy, pastes JSON into ROK-1270 to inform the merge-migration plan.
- Operator-config commits (`988679d3`, `7bc3898f`) ride along per `[[feedback_operator_config_rides_along]]` — they ship with whatever PR is open and are unrelated to story scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)