### PR TITLE
chore(release): bump root version to v1.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "raid-ledger",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "private": true,
     "workspaces": [
         "api",


### PR DESCRIPTION
## Summary

Aligns `package.json` root version with the `v1.1.0` release tag.

The `v1.1.0` tag was created against `6f964bdd` (the squash-merge commit of PR #782) which closes out the v1.1.0 development window — ~200 PRs merged since v1.0.0 on 2026-02-06.

## Test plan

- [ ] CI passes (it's a one-line metadata change; nothing else should be affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)