### PR TITLE
ROK-1278: games-dedup Phase 2 — merge migration + steam_app_id UNIQUE + audit-accuracy fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,51 @@ This rule exists because parallel agents kept seeing these commits, assuming "no
 - **Ports:** API on `:3000`, Web on `:5173` (Vite may increment to `:5174` if `:5173` is in use — CORS allows both)
 - **DEMO_MODE=true** in root `.env` enables auth bypass with prefilled credentials
 - **Docker volume gotcha (handled automatically):** The deploy script uses `docker start` by name first, falling back to `docker compose` from the main repo's compose file. This prevents worktrees from creating separate volumes with wrong directory prefixes.
-- **Clone prod → local:** `./scripts/clone-prod-to-local.sh` triggers a sanitized prod backup, downloads it, restores into the local DB, resets the local admin password, and preserves your local `app_settings` (API keys) across clones. Requires `.env.clone` at repo root (`PROD_URL`, `PROD_ADMIN_EMAIL`, `PROD_ADMIN_PASSWORD`, `LOCAL_URL`, `LOCAL_ADMIN_EMAIL`, `DATABASE_URL`). Operator must type `clone` to confirm; pass `--yes` for non-interactive runs.
+- **Clone prod → local:** `./scripts/clone-prod-to-local.sh` triggers a sanitized prod backup, downloads it, restores into the local DB, resets the local admin password, and preserves your local `app_settings` (API keys) across clones. See **Cloning prod → local — agent runbook** below for the full step-by-step.
+
+### Cloning prod → local — agent runbook (STRICT — gotchas baked in)
+
+This procedure is destructive to the LOCAL DB (replaces every non-sanitized table with a sanitized copy of prod) — get explicit operator authorization before running.
+
+1. **Hold the env lock and have the local API running.** `mcp__mcp-env__env_lock_acquire({ purpose: "..." })` → `./scripts/deploy_dev.sh --ci` from your worktree. If `npx tsc` errors with `command not found`, `npm install` in the worktree first (worktrees don't share `node_modules`). Re-run deploy.
+
+2. **Create `.env.clone` at the worktree root.** Required vars:
+
+   ```ini
+   # Prod side
+   PROD_URL=https://raid.gamernight.net/api      # /api prefix is REQUIRED — without it nginx serves the SPA, POST returns 405
+   # Prod auth — pick ONE:
+   PROD_BEARER_TOKEN=eyJhbGc...                  # preferred — paste from prod web session
+   # OR
+   # PROD_ADMIN_EMAIL=...
+   # PROD_ADMIN_PASSWORD=...
+
+   # Local side
+   LOCAL_URL=http://localhost:3000
+   LOCAL_ADMIN_EMAIL=admin@local
+   LOCAL_ADMIN_PASSWORD=<current local admin pwd>  # needed for Step 5 local /auth/local login
+   DATABASE_URL=postgresql://user:password@localhost:5432/raid_ledger
+   ```
+
+   - **`PROD_URL` must end in `/api`.** Without that the script POSTs to nginx's SPA route and gets 405.
+   - **Bearer token is preferred** over storing the prod password. To grab one: in the browser logged into prod, DevTools console → `copy(localStorage.getItem('raid_ledger_token'))`. JWTs are short-lived (~24h) — one-shot use, then they expire.
+   - **`LOCAL_ADMIN_PASSWORD`** is needed because the script calls `POST /auth/local` on the LOCAL API to authorize the restore. If you don't know it, run `./scripts/deploy_dev.sh --reset-password`, copy the printed password, set it here. (Step 7 of the script will reset it again at the end — that's fine.)
+
+3. **Run the clone.** `./scripts/clone-prod-to-local.sh --fresh --yes` (or `--latest --yes --force` to reuse an existing prod backup). Operator authorization is captured by the `--yes` flag — only pass it after they've explicitly approved this clone.
+
+4. **Bounce the API to invalidate the settings cache.** The settings service caches decrypted `app_settings` for 30 min on startup. After clone, the cache holds the pre-clone (now-deleted-and-replaced) entries until the cache TTL or process restart. UI surfaces will appear "wiped" (e.g. `/admin/settings/itad` returns `configured: false`) until the cache reloads. Quickest fix: `echo "" >> api/src/main.ts` to force the `nest start --watch` watcher to restart the process, then revert (`git checkout -- api/src/main.ts`).
+
+5. **Verify success.**
+   - `curl -fsS http://localhost:3000/health | jq` — both `db.connected` and `redis.connected` should be true.
+   - `docker exec raid-ledger-db psql -U user -d raid_ledger -c "SELECT count(*) FROM games;"` — should be >>0 (prod-sized).
+   - `docker exec raid-ledger-db psql -U user -d raid_ledger -c "SELECT count(*) FROM app_settings;"` — should be your local row count (preserved across the clone).
+   - Hit a settings probe like `curl -sS http://localhost:3000/admin/settings/itad -H "Authorization: Bearer <local-token>"` — should return `configured: true` after the API restart in Step 4.
+
+6. **Release the env lock when done** (`mcp__mcp-env__env_lock_release`).
+
+**Sanitization (server-side) excludes ROW DATA for:** `app_settings`, `local_credentials`, `sessions`, `consumed_intent_tokens`. Schema preserved, rows empty after restore. The script then re-applies the LOCAL preserved `app_settings` rows (those were encrypted with the local `JWT_SECRET` so they decrypt correctly afterwards). `local_credentials`/`sessions`/`consumed_intent_tokens` stay empty — the local admin password gets regenerated by Step 7.
+
+**Backups exclude the `drizzle` schema** (migration metadata is code, not data). If a restore appears to "skip" migrations, run `DATABASE_URL=... node scripts/reconcile-migrations.mjs` to mark already-applied migrations as such. `deploy_dev.sh` runs reconcile automatically after auto-restoring from `api/backups/daily/`.
 
 ### Env coordination across agents (STRICT)
 

--- a/api/src/admin/games-dedup-audit.integration.spec.ts
+++ b/api/src/admin/games-dedup-audit.integration.spec.ts
@@ -61,9 +61,7 @@ async function seedGames(testApp: TestApp): Promise<{
   // DETECTS such rows when they exist (e.g. residual prod data pre-cleanup).
   // Drop the index for the seed; `ensureSteamUniqueIndex` re-creates it after
   // each test's truncate so subsequent inserts see the production schema.
-  await testApp.db.execute(
-    sql`DROP INDEX IF EXISTS games_steam_app_id_unique`,
-  );
+  await testApp.db.execute(sql`DROP INDEX IF EXISTS games_steam_app_id_unique`);
   const pairs = await testApp.db
     .insert(schema.games)
     .values([
@@ -143,9 +141,7 @@ async function ensureSteamUniqueIndex(testApp: TestApp): Promise<void> {
  * layer in production). The afterEach hook restores it after each test.
  */
 async function dropSteamUniqueIndex(testApp: TestApp): Promise<void> {
-  await testApp.db.execute(
-    sql`DROP INDEX IF EXISTS games_steam_app_id_unique`,
-  );
+  await testApp.db.execute(sql`DROP INDEX IF EXISTS games_steam_app_id_unique`);
 }
 
 describe('GET /admin/games/dedup-audit', () => {

--- a/api/src/admin/games-dedup-audit.integration.spec.ts
+++ b/api/src/admin/games-dedup-audit.integration.spec.ts
@@ -54,6 +54,16 @@ async function seedGames(testApp: TestApp): Promise<{
   steamDup2Ids: [number, number];
   uniqueIds: number[];
 }> {
+  // ROK-1278 added a partial UNIQUE INDEX on games.steam_app_id WHERE NOT NULL,
+  // so we can no longer insert two rows with the same steam_app_id at the DB
+  // layer. The historical state this spec seeds (steam-key dups) can't happen
+  // via normal inserts going forward — but we still need to verify the audit
+  // DETECTS such rows when they exist (e.g. residual prod data pre-cleanup).
+  // Drop the index for the seed; `ensureSteamUniqueIndex` re-creates it after
+  // each test's truncate so subsequent inserts see the production schema.
+  await testApp.db.execute(
+    sql`DROP INDEX IF EXISTS games_steam_app_id_unique`,
+  );
   const pairs = await testApp.db
     .insert(schema.games)
     .values([
@@ -113,6 +123,31 @@ async function seedDepRowsForLoser(
   });
 }
 
+/**
+ * Re-create the partial UNIQUE INDEX on games.steam_app_id (ROK-1278) if a
+ * prior `seedGames` / `dropSteamUniqueIndex` call dropped it. Safe to call
+ * when the index already exists (IF NOT EXISTS). Run after `truncateAllTables`
+ * so dup-rows are already gone and the index can be created without violating
+ * itself.
+ */
+async function ensureSteamUniqueIndex(testApp: TestApp): Promise<void> {
+  await testApp.db.execute(
+    sql`CREATE UNIQUE INDEX IF NOT EXISTS games_steam_app_id_unique
+        ON games (steam_app_id) WHERE steam_app_id IS NOT NULL`,
+  );
+}
+
+/**
+ * Drop the partial UNIQUE INDEX on games.steam_app_id so this spec can seed
+ * historical-style steam-key dup rows (which the index prevents at the DB
+ * layer in production). The afterEach hook restores it after each test.
+ */
+async function dropSteamUniqueIndex(testApp: TestApp): Promise<void> {
+  await testApp.db.execute(
+    sql`DROP INDEX IF EXISTS games_steam_app_id_unique`,
+  );
+}
+
 describe('GET /admin/games/dedup-audit', () => {
   let testApp: TestApp;
   let adminToken: string;
@@ -124,6 +159,7 @@ describe('GET /admin/games/dedup-audit', () => {
 
   afterEach(async () => {
     testApp.seed = await truncateAllTables(testApp.db);
+    await ensureSteamUniqueIndex(testApp);
     adminToken = await loginAsAdmin(testApp.request, testApp.seed);
   });
 
@@ -324,6 +360,7 @@ describe('POST /admin/games/dedup-audit/run', () => {
 
   afterEach(async () => {
     testApp.seed = await truncateAllTables(testApp.db);
+    await ensureSteamUniqueIndex(testApp);
     adminToken = await loginAsAdmin(testApp.request, testApp.seed);
   });
 
@@ -563,6 +600,9 @@ describe('POST /admin/games/dedup-audit/run', () => {
   // Expected canonical = row C's id even though rows A and B have lower ids.
   // -------------------------------------------------------------------------
   it('breaks ties by itad_game_id > igdb_id > min id (mixed-tiebreak group)', async () => {
+    // Seed shares steam_app_id across 3 rows — bypass ROK-1278's partial
+    // UNIQUE index for the test duration; afterEach restores it.
+    await dropSteamUniqueIndex(testApp);
     const inserted = await testApp.db
       .insert(schema.games)
       .values([
@@ -752,6 +792,7 @@ describe('union-find grouping (POST /admin/games/dedup-audit/run)', () => {
 
   afterEach(async () => {
     testApp.seed = await truncateAllTables(testApp.db);
+    await ensureSteamUniqueIndex(testApp);
     adminToken = await loginAsAdmin(testApp.request, testApp.seed);
   });
 
@@ -878,6 +919,9 @@ describe('union-find grouping (POST /admin/games/dedup-audit/run)', () => {
   // steam_app_id; A's igdb_id is unique to A.
   // -------------------------------------------------------------------------
   it('forms one group for a 3-row chain connected through different shared keys (A-B by name, B-C by steam)', async () => {
+    // Seed shares steam_app_id across rows B and C — bypass ROK-1278's
+    // partial UNIQUE index for the test; afterEach restores it.
+    await dropSteamUniqueIndex(testApp);
     const inserted = await testApp.db
       .insert(schema.games)
       .values([

--- a/api/src/admin/games-dedup-audit.integration.spec.ts
+++ b/api/src/admin/games-dedup-audit.integration.spec.ts
@@ -461,7 +461,9 @@ describe('POST /admin/games/dedup-audit/run', () => {
     expect(steamRow!.group_size).toBe(2);
 
     // Each loser was seeded with 1 event + 1 character + 1 interest.
-    // downstream_counts sums across ALL dup ids in the group (not canonical).
+    // downstream_counts sums across the WHOLE group (canonical + every dup),
+    // so any rows on either side contribute (ROK-1278 fix — earlier semantics
+    // were dup-only and undercounted real impact).
     expect(steamRow!.downstream_counts.events).toBeGreaterThanOrEqual(1);
     expect(steamRow!.downstream_counts.characters).toBeGreaterThanOrEqual(1);
     expect(steamRow!.downstream_counts.interests).toBeGreaterThanOrEqual(1);

--- a/api/src/admin/games-dedup-audit.service.ts
+++ b/api/src/admin/games-dedup-audit.service.ts
@@ -131,20 +131,28 @@ export class GamesDedupAuditService {
   /**
    * ROK-1270: same audit as `runAudit()`, but TRUNCATE+INSERT the result
    * into `games_dedup_audit` in a single transaction. One row per dup
-   * group; downstream_counts is the per-key sum across the group's dupIds.
+   * group; downstream_counts is the per-key sum across the WHOLE group
+   * (canonical + every dup), so the persisted value reflects total data
+   * impact rather than dup-side-only repoint count (ROK-1278 fix —
+   * dup-only undercounted real impact when canonical had its own rows).
    * Returns a compact summary with the top 10 groups by downstream rows.
    */
   async persistSnapshot(): Promise<PersistSummary> {
     const audit = await this.runAudit();
-    const blastByGameId = new Map<number, BlastRadiusRow>(
-      audit.blastRadius.map((b) => [b.gameId, b]),
-    );
+    const canonicalIds = audit.groups.map((g) => g.canonicalId);
+    const canonicalBlast = await this.computeBlastRadius(canonicalIds);
+    const blastByGameId = new Map<number, BlastRadiusRow>([
+      ...audit.blastRadius.map((b) => [b.gameId, b] as const),
+      ...canonicalBlast.map((b) => [b.gameId, b] as const),
+    ]);
     const snapshotAt = new Date();
 
     const rows = await Promise.all(
       audit.groups.map(async (group) => {
         const downstreamCounts = sumBlastRadius(
-          group.dupIds.map((id) => blastByGameId.get(id) ?? null),
+          [group.canonicalId, ...group.dupIds].map(
+            (id) => blastByGameId.get(id) ?? null,
+          ),
         );
         const uniqueConflicts = await computeUniqueConflicts(this.db, {
           canonicalId: group.canonicalId,
@@ -290,3 +298,5 @@ function buildPersistSummary(
     topGroups,
   };
 }
+
+

--- a/api/src/admin/games-dedup-merge.integration.spec.ts
+++ b/api/src/admin/games-dedup-merge.integration.spec.ts
@@ -1,0 +1,195 @@
+/**
+ * ROK-1278: integration spec for the games-dedup merge migration (0140).
+ *
+ * The migration itself is one-shot SQL that runs during deploy. This spec
+ * exercises the merge LOGIC by:
+ *   1. Seeding a dup pattern (one steam-key dup + one name-key dup) with
+ *      downstream rows (rollups, characters, interests).
+ *   2. POSTing /admin/games/dedup-audit/run to populate games_dedup_audit.
+ *   3. Re-executing the same multi-statement SQL the migration would, against
+ *      the test DB.
+ *   4. Asserting: dup games gone, FKs repointed, additive rollup merge worked,
+ *      audit re-run returns zero groups.
+ *
+ * The steam_app_id UNIQUE index is already installed by the migration during
+ * the test DB's initial migration run — verifying it exists at the end is
+ * a separate quick check.
+ */
+import { sql } from 'drizzle-orm';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { getTestApp, type TestApp } from '../common/testing/test-app';
+import {
+  loginAsAdmin,
+  truncateAllTables,
+} from '../common/testing/integration-helpers';
+import * as schema from '../drizzle/schema';
+
+const MIGRATION_SQL_PATH = path.join(
+  __dirname,
+  '../drizzle/migrations/0140_games_dedup_merge.sql',
+);
+
+async function executeMigrationSql(testApp: TestApp): Promise<void> {
+  const raw = readFileSync(MIGRATION_SQL_PATH, 'utf8');
+  // Strip line-comments + blank lines, then split on `;` at end-of-statement.
+  // Migration uses no `;` inside string literals or DO blocks, so simple split
+  // is safe here.
+  const stripped = raw
+    .split('\n')
+    .filter((l) => !l.trim().startsWith('--'))
+    .join('\n');
+  const statements = stripped
+    .split(/;\s*\n/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+  for (const stmt of statements) {
+    await testApp.db.execute(sql.raw(stmt));
+  }
+}
+
+describe('ROK-1278 games-dedup merge migration', () => {
+  let testApp: TestApp;
+  let adminToken: string;
+
+  beforeAll(async () => {
+    testApp = await getTestApp();
+    adminToken = await loginAsAdmin(testApp.request, testApp.seed);
+  });
+
+  afterEach(async () => {
+    testApp.seed = await truncateAllTables(testApp.db);
+    adminToken = await loginAsAdmin(testApp.request, testApp.seed);
+  });
+
+  it('merges dup groups: deletes dup games, repoints FKs, additively sums rollups', async () => {
+    // ── Seed: 2 name-only dup pairs (steam_app_id UNIQUE prevents steam dups) ─
+    // The first pair exercises Roman-numeral normalization (2 ↔ II).
+    const games = await testApp.db
+      .insert(schema.games)
+      .values([
+        { name: 'Test Slay 2', slug: 'test-slay-2' }, // canonical (no shared id)
+        { name: 'Test Slay II', slug: 'test-slay-ii' }, // dup (name-key via roman)
+        { name: 'Test BG 3', slug: 'test-bg-3' }, // canonical
+        { name: 'Test BG 3', slug: 'test-bg-3-alt' }, // dup (exact-name)
+      ])
+      .returning({ id: schema.games.id });
+    const [slayCanonId, slayDupId, bgCanonId, bgDupId] = games.map((g) => g.id);
+
+    const userId = testApp.seed.adminUser.id;
+
+    // ── Seed: rollups on canonical AND dup (so additive merge applies) ────
+    await testApp.db.insert(schema.gameActivityRollups).values([
+      // Slay canonical: u1 = 10h
+      {
+        userId,
+        gameId: slayCanonId,
+        period: 'week',
+        periodStart: '2026-05-01',
+        totalSeconds: 36000,
+      },
+      // Slay dup: u1 = 5h on SAME (user, period, period_start) → additive
+      {
+        userId,
+        gameId: slayDupId,
+        period: 'week',
+        periodStart: '2026-05-01',
+        totalSeconds: 18000,
+      },
+      // Slay dup: u1 = 3h on DIFFERENT period → repoint, no merge
+      {
+        userId,
+        gameId: slayDupId,
+        period: 'week',
+        periodStart: '2026-05-08',
+        totalSeconds: 10800,
+      },
+    ]);
+
+    // ── Seed: characters + interests on dup side (canonical-wins delete) ──
+    await testApp.db.insert(schema.characters).values([
+      { userId, gameId: bgCanonId, name: 'Dupe-Conflict', realm: 'R1' },
+      { userId, gameId: bgDupId, name: 'Dupe-Conflict', realm: 'R1' }, // collision
+      { userId, gameId: bgDupId, name: 'Survivor', realm: 'R1' }, // repoint
+    ]);
+
+    // ── Populate games_dedup_audit ────────────────────────────────────────
+    const auditRes = await testApp.request
+      .post('/admin/games/dedup-audit/run')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({});
+    expect(auditRes.status).toBe(200);
+    expect(auditRes.body.totalGroups).toBeGreaterThanOrEqual(2);
+
+    // ── Run the migration SQL ─────────────────────────────────────────────
+    await executeMigrationSql(testApp);
+
+    // ── Assert: dup game rows are gone ────────────────────────────────────
+    const remaining = await testApp.db.execute(sql<{ id: number }>`
+      SELECT id FROM games WHERE id IN (${slayDupId}, ${bgDupId})
+    `);
+    expect(remaining).toEqual([]);
+
+    // ── Assert: rollups additively merged ─────────────────────────────────
+    const merged = await testApp.db.execute<{ totalSeconds: number }>(sql`
+      SELECT total_seconds FROM game_activity_rollups
+      WHERE game_id = ${slayCanonId} AND user_id = ${userId}
+        AND period = 'week' AND period_start = '2026-05-01'
+    `);
+    expect((merged as { total_seconds: number }[])[0].total_seconds).toBe(
+      36000 + 18000,
+    );
+
+    // ── Assert: non-colliding dup rollup got repointed (not duplicated) ───
+    const repointed = await testApp.db.execute(sql`
+      SELECT period_start, total_seconds FROM game_activity_rollups
+      WHERE game_id = ${slayCanonId} AND period = 'week'
+      ORDER BY period_start
+    `);
+    expect((repointed as { total_seconds: number }[]).length).toBe(2);
+
+    // ── Assert: characters — canonical wins on collision, survivor repointed
+    const charRows = await testApp.db.execute<{
+      gameId: number;
+      name: string;
+    }>(sql`
+      SELECT game_id, name FROM characters
+      WHERE user_id = ${userId} AND game_id IN (${bgCanonId}, ${bgDupId})
+      ORDER BY name
+    `);
+    const charArr = charRows as { game_id: number; name: string }[];
+    expect(charArr).toHaveLength(2); // Dupe-Conflict (canonical) + Survivor (repointed)
+    expect(charArr.every((c) => c.game_id === bgCanonId)).toBe(true);
+
+    // ── Assert: audit is empty after merge ────────────────────────────────
+    const post = await testApp.request
+      .post('/admin/games/dedup-audit/run')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({});
+    expect(post.status).toBe(200);
+    expect(post.body.totalGroups).toBe(0);
+
+    // ── Assert: steam_app_id UNIQUE index exists ──────────────────────────
+    const idx = await testApp.db.execute<{ count: number }>(sql`
+      SELECT count(*)::int AS count FROM pg_indexes
+      WHERE tablename = 'games' AND indexname = 'games_steam_app_id_unique'
+    `);
+    expect((idx as { count: number }[])[0].count).toBe(1);
+  }, 60_000);
+
+  it('rejects an INSERT into games that would duplicate steam_app_id (UNIQUE index works)', async () => {
+    await testApp.db.insert(schema.games).values({
+      name: 'Steam-Unique-Test A',
+      slug: 'steam-unique-a',
+      steamAppId: 88880001,
+    });
+
+    await expect(
+      testApp.db.insert(schema.games).values({
+        name: 'Steam-Unique-Test B',
+        slug: 'steam-unique-b',
+        steamAppId: 88880001,
+      }),
+    ).rejects.toThrow();
+  }, 30_000);
+});

--- a/api/src/drizzle/migrations/0140_games_dedup_merge.sql
+++ b/api/src/drizzle/migrations/0140_games_dedup_merge.sql
@@ -1,0 +1,251 @@
+-- ROK-1278: merge duplicate `games` rows (per `games_dedup_audit`) and add a
+-- partial UNIQUE constraint on `games.steam_app_id` to prevent the Slay-2/II
+-- class of dup from re-appearing.
+--
+-- Reads dup groups from `games_dedup_audit` (populated by ROK-1277's union-find).
+-- For each (canonical_game_id, dup_game_ids) group:
+--   1. Pre-merge UNIQUE-constraint collisions across the 9 affected tables
+--      (additive merge for game_activity_rollups; canonical-wins delete elsewhere).
+--   2. Repoint every FK from any dup id to the canonical id (23 columns across
+--      19 tables, mixed CASCADE / SET NULL / NO ACTION).
+--   3. Delete the dup `games` rows.
+-- Then add the partial UNIQUE INDEX on games.steam_app_id WHERE steam_app_id IS NOT NULL.
+-- Finally truncate games_dedup_audit (its rows are now stale; canonical+dup_ids
+-- they point at have been collapsed). Audit can be re-run any time.
+--
+-- Idempotency: the migration runs once per drizzle journal. If somehow re-run
+-- against a state where games_dedup_audit is empty, the UPDATEs/DELETEs are
+-- no-ops and the CREATE UNIQUE INDEX uses IF NOT EXISTS.
+
+-- ─── 1. Pre-merge UNIQUE collisions ─────────────────────────────────────────
+
+-- 1a. game_activity_rollups: ADDITIVE merge total_seconds when (user_id, period,
+-- period_start) collides between canonical and a dup. The dup row's seconds are
+-- added to the canonical's, then the dup row is deleted so the later FK repoint
+-- has no conflict. game_activity_rollups has a composite key (no `id` column),
+-- so we match on (user_id, game_id, period, period_start).
+WITH grp AS (
+  SELECT canonical_game_id AS cid, unnest(dup_game_ids) AS did
+  FROM games_dedup_audit
+),
+add_seconds AS (
+  SELECT
+    g.cid AS canon_game_id,
+    r_canon.user_id, r_canon.period, r_canon.period_start,
+    sum(r_dup.total_seconds) AS extra
+  FROM game_activity_rollups r_dup
+  JOIN grp g ON r_dup.game_id = g.did
+  JOIN game_activity_rollups r_canon
+    ON r_canon.game_id = g.cid
+   AND r_canon.user_id = r_dup.user_id
+   AND r_canon.period = r_dup.period
+   AND r_canon.period_start = r_dup.period_start
+  GROUP BY g.cid, r_canon.user_id, r_canon.period, r_canon.period_start
+)
+UPDATE game_activity_rollups r
+SET total_seconds = r.total_seconds + s.extra
+FROM add_seconds s
+WHERE r.game_id = s.canon_game_id
+  AND r.user_id = s.user_id
+  AND r.period = s.period
+  AND r.period_start = s.period_start;
+
+WITH grp AS (
+  SELECT canonical_game_id AS cid, unnest(dup_game_ids) AS did
+  FROM games_dedup_audit
+)
+DELETE FROM game_activity_rollups r_dup
+USING grp g, game_activity_rollups r_canon
+WHERE r_dup.game_id = g.did
+  AND r_canon.game_id = g.cid
+  AND r_canon.user_id = r_dup.user_id
+  AND r_canon.period = r_dup.period
+  AND r_canon.period_start = r_dup.period_start;
+
+-- 1b. characters: UNIQUE(user_id, game_id, name, realm). Canonical wins.
+WITH grp AS (
+  SELECT canonical_game_id AS cid, unnest(dup_game_ids) AS did
+  FROM games_dedup_audit
+)
+DELETE FROM characters d
+USING grp g, characters c
+WHERE d.game_id = g.did
+  AND c.game_id = g.cid
+  AND c.user_id = d.user_id
+  AND c.name = d.name
+  AND c.realm IS NOT DISTINCT FROM d.realm;
+
+-- 1c. community_lineup_entries: UNIQUE(lineup_id, game_id). Canonical wins.
+WITH grp AS (
+  SELECT canonical_game_id AS cid, unnest(dup_game_ids) AS did
+  FROM games_dedup_audit
+)
+DELETE FROM community_lineup_entries d
+USING grp g, community_lineup_entries c
+WHERE d.game_id = g.did
+  AND c.game_id = g.cid
+  AND c.lineup_id = d.lineup_id;
+
+-- 1d. community_lineup_matches: UNIQUE(lineup_id, game_id). Canonical wins.
+-- NOTE: community_lineup_match_members FKs to community_lineup_matches.id with
+-- ON DELETE CASCADE, so deleting a dup-side match row will also drop its members
+-- automatically. The audit's `lineupMatchMembers` counts will go to zero for the
+-- dup match's members; this is intentional — the canonical match keeps its own
+-- members.
+WITH grp AS (
+  SELECT canonical_game_id AS cid, unnest(dup_game_ids) AS did
+  FROM games_dedup_audit
+)
+DELETE FROM community_lineup_matches d
+USING grp g, community_lineup_matches c
+WHERE d.game_id = g.did
+  AND c.game_id = g.cid
+  AND c.lineup_id = d.lineup_id;
+
+-- 1e. community_lineup_votes: UNIQUE(lineup_id, user_id, game_id). Canonical wins.
+WITH grp AS (
+  SELECT canonical_game_id AS cid, unnest(dup_game_ids) AS did
+  FROM games_dedup_audit
+)
+DELETE FROM community_lineup_votes d
+USING grp g, community_lineup_votes c
+WHERE d.game_id = g.did
+  AND c.game_id = g.cid
+  AND c.lineup_id = d.lineup_id
+  AND c.user_id = d.user_id;
+
+-- 1f. event_types: UNIQUE(game_id, slug). Canonical wins.
+WITH grp AS (
+  SELECT canonical_game_id AS cid, unnest(dup_game_ids) AS did
+  FROM games_dedup_audit
+)
+DELETE FROM event_types d
+USING grp g, event_types c
+WHERE d.game_id = g.did
+  AND c.game_id = g.cid
+  AND c.slug = d.slug;
+
+-- 1g. game_interests: UNIQUE(user_id, game_id, source). Canonical wins.
+WITH grp AS (
+  SELECT canonical_game_id AS cid, unnest(dup_game_ids) AS did
+  FROM games_dedup_audit
+)
+DELETE FROM game_interests d
+USING grp g, game_interests c
+WHERE d.game_id = g.did
+  AND c.game_id = g.cid
+  AND c.user_id = d.user_id
+  AND c.source = d.source;
+
+-- 1h. game_interest_suppressions: UNIQUE(user_id, game_id). Canonical wins.
+WITH grp AS (
+  SELECT canonical_game_id AS cid, unnest(dup_game_ids) AS did
+  FROM games_dedup_audit
+)
+DELETE FROM game_interest_suppressions d
+USING grp g, game_interest_suppressions c
+WHERE d.game_id = g.did
+  AND c.game_id = g.cid
+  AND c.user_id = d.user_id;
+
+-- 1i. game_taste_vectors: UNIQUE(game_id). Canonical wins; its vector will
+-- regenerate on the next vector-recompute cron from the merged activity.
+WITH grp AS (
+  SELECT canonical_game_id AS cid, unnest(dup_game_ids) AS did
+  FROM games_dedup_audit
+)
+DELETE FROM game_taste_vectors d
+USING grp g
+WHERE d.game_id = g.did
+  AND EXISTS (
+    SELECT 1 FROM game_taste_vectors c WHERE c.game_id = g.cid
+  );
+
+-- ─── 2. Repoint all 23 FK columns to the canonical id ──────────────────────
+
+UPDATE events SET game_id = a.canonical_game_id
+FROM games_dedup_audit a WHERE events.game_id = ANY(a.dup_game_ids);
+
+UPDATE event_plans SET game_id = a.canonical_game_id
+FROM games_dedup_audit a WHERE event_plans.game_id = ANY(a.dup_game_ids);
+
+UPDATE community_lineups SET decided_game_id = a.canonical_game_id
+FROM games_dedup_audit a WHERE community_lineups.decided_game_id = ANY(a.dup_game_ids);
+
+UPDATE community_lineup_entries SET game_id = a.canonical_game_id
+FROM games_dedup_audit a WHERE community_lineup_entries.game_id = ANY(a.dup_game_ids);
+
+UPDATE community_lineup_matches SET game_id = a.canonical_game_id
+FROM games_dedup_audit a WHERE community_lineup_matches.game_id = ANY(a.dup_game_ids);
+
+UPDATE community_lineup_tiebreakers SET winner_game_id = a.canonical_game_id
+FROM games_dedup_audit a WHERE community_lineup_tiebreakers.winner_game_id = ANY(a.dup_game_ids);
+
+UPDATE community_lineup_tiebreaker_bracket_matchups SET game_a_id = a.canonical_game_id
+FROM games_dedup_audit a WHERE community_lineup_tiebreaker_bracket_matchups.game_a_id = ANY(a.dup_game_ids);
+
+UPDATE community_lineup_tiebreaker_bracket_matchups SET game_b_id = a.canonical_game_id
+FROM games_dedup_audit a WHERE community_lineup_tiebreaker_bracket_matchups.game_b_id = ANY(a.dup_game_ids);
+
+UPDATE community_lineup_tiebreaker_bracket_matchups SET winner_game_id = a.canonical_game_id
+FROM games_dedup_audit a WHERE community_lineup_tiebreaker_bracket_matchups.winner_game_id = ANY(a.dup_game_ids);
+
+UPDATE community_lineup_tiebreaker_bracket_votes SET game_id = a.canonical_game_id
+FROM games_dedup_audit a WHERE community_lineup_tiebreaker_bracket_votes.game_id = ANY(a.dup_game_ids);
+
+UPDATE community_lineup_tiebreaker_vetoes SET game_id = a.canonical_game_id
+FROM games_dedup_audit a WHERE community_lineup_tiebreaker_vetoes.game_id = ANY(a.dup_game_ids);
+
+UPDATE community_lineup_votes SET game_id = a.canonical_game_id
+FROM games_dedup_audit a WHERE community_lineup_votes.game_id = ANY(a.dup_game_ids);
+
+UPDATE characters SET game_id = a.canonical_game_id
+FROM games_dedup_audit a WHERE characters.game_id = ANY(a.dup_game_ids);
+
+UPDATE game_taste_vectors SET game_id = a.canonical_game_id
+FROM games_dedup_audit a WHERE game_taste_vectors.game_id = ANY(a.dup_game_ids);
+
+UPDATE game_interests SET game_id = a.canonical_game_id
+FROM games_dedup_audit a WHERE game_interests.game_id = ANY(a.dup_game_ids);
+
+UPDATE game_activity_rollups SET game_id = a.canonical_game_id
+FROM games_dedup_audit a WHERE game_activity_rollups.game_id = ANY(a.dup_game_ids);
+
+UPDATE game_activity_sessions SET game_id = a.canonical_game_id
+FROM games_dedup_audit a WHERE game_activity_sessions.game_id = ANY(a.dup_game_ids);
+
+UPDATE availability SET game_id = a.canonical_game_id
+FROM games_dedup_audit a WHERE availability.game_id = ANY(a.dup_game_ids);
+
+UPDATE channel_bindings SET game_id = a.canonical_game_id
+FROM games_dedup_audit a WHERE channel_bindings.game_id = ANY(a.dup_game_ids);
+
+UPDATE discord_game_mappings SET game_id = a.canonical_game_id
+FROM games_dedup_audit a WHERE discord_game_mappings.game_id = ANY(a.dup_game_ids);
+
+UPDATE event_types SET game_id = a.canonical_game_id
+FROM games_dedup_audit a WHERE event_types.game_id = ANY(a.dup_game_ids);
+
+UPDATE game_interest_suppressions SET game_id = a.canonical_game_id
+FROM games_dedup_audit a WHERE game_interest_suppressions.game_id = ANY(a.dup_game_ids);
+
+UPDATE player_intensity_snapshots SET longest_session_game_id = a.canonical_game_id
+FROM games_dedup_audit a WHERE player_intensity_snapshots.longest_session_game_id = ANY(a.dup_game_ids);
+
+-- ─── 3. Delete the dup games rows ──────────────────────────────────────────
+
+DELETE FROM games WHERE id IN (
+  SELECT unnest(dup_game_ids) FROM games_dedup_audit
+);
+
+-- ─── 4. Clear the audit table (its rows reference now-deleted dup IDs) ────
+
+TRUNCATE TABLE games_dedup_audit;
+
+-- ─── 5. Add partial UNIQUE constraint on games.steam_app_id ───────────────
+-- Prevents future Slay-2/II-class dups at the DB layer regardless of which
+-- code path attempts the INSERT. Partial because most rows have NULL steam_app_id
+-- (IGDB-only games) and we want to allow that.
+
+CREATE UNIQUE INDEX IF NOT EXISTS games_steam_app_id_unique
+  ON games (steam_app_id) WHERE steam_app_id IS NOT NULL;

--- a/api/src/drizzle/migrations/meta/_journal.json
+++ b/api/src/drizzle/migrations/meta/_journal.json
@@ -981,6 +981,13 @@
       "when": 1779000200000,
       "tag": "0139_games_dedup_audit",
       "breakpoints": true
+    },
+    {
+      "idx": 140,
+      "version": "7",
+      "when": 1779000300000,
+      "tag": "0140_games_dedup_merge",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "raid-ledger",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "raid-ledger",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "workspaces": [
                 "api",
                 "web",

--- a/scripts/clone-prod-to-local.sh
+++ b/scripts/clone-prod-to-local.sh
@@ -25,8 +25,10 @@
 #   - Interactive confirmation: operator must type 'clone' (--yes skips).
 #
 # Env file: .env.clone at repo root (gitignored), required vars:
-#   PROD_URL, PROD_ADMIN_EMAIL, PROD_ADMIN_PASSWORD,
-#   LOCAL_URL, LOCAL_ADMIN_EMAIL, DATABASE_URL
+#   PROD_URL, LOCAL_URL, LOCAL_ADMIN_EMAIL, DATABASE_URL
+# Prod auth (pick ONE):
+#   PROD_BEARER_TOKEN                  (paste from browser/DM auth)
+#   PROD_ADMIN_EMAIL + PROD_ADMIN_PASSWORD  (script logs in via /auth/local)
 # Optional:
 #   PRESERVE_LOCAL_APP_SETTINGS=true   (default: true)
 #   LOCAL_DB_CONTAINER=raid-ledger-db  (default)
@@ -124,13 +126,24 @@ set -a
 source "$ENV_FILE"
 set +a
 
-REQUIRED_VARS=(PROD_URL PROD_ADMIN_EMAIL PROD_ADMIN_PASSWORD LOCAL_URL LOCAL_ADMIN_EMAIL DATABASE_URL)
+REQUIRED_VARS=(PROD_URL LOCAL_URL LOCAL_ADMIN_EMAIL DATABASE_URL)
 for v in "${REQUIRED_VARS[@]}"; do
     if [[ -z "${!v:-}" ]]; then
         red "Missing required var in .env.clone: $v"
         exit 1
     fi
 done
+
+# Either PROD_BEARER_TOKEN (preferred — paste from Discord/web session)
+# OR PROD_ADMIN_EMAIL + PROD_ADMIN_PASSWORD (script logs in via /auth/local).
+if [[ -z "${PROD_BEARER_TOKEN:-}" ]]; then
+    for v in PROD_ADMIN_EMAIL PROD_ADMIN_PASSWORD; do
+        if [[ -z "${!v:-}" ]]; then
+            red "Missing prod auth: set PROD_BEARER_TOKEN, or set both PROD_ADMIN_EMAIL+PROD_ADMIN_PASSWORD."
+            exit 1
+        fi
+    done
+fi
 
 # Defaults for optional vars.
 : "${PRESERVE_LOCAL_APP_SETTINGS:=true}"
@@ -242,24 +255,37 @@ else
     PRESERVED_NOTE="none (disabled by env)"
 fi
 
-# ─── Step 1: prod login ───────────────────────────────────────────────────
-bold "Step 1: prod login as $PROD_ADMIN_EMAIL ..."
-LOGIN_BODY=$(jq -n --arg e "$PROD_ADMIN_EMAIL" --arg p "$PROD_ADMIN_PASSWORD" \
-    '{email:$e, password:$p}')
-LOGIN_RESP=$(prod_post_safe /auth/local \
-    -H 'Content-Type: application/json' \
-    -d "$LOGIN_BODY") || {
-    red "Prod login failed."
-    red "  PROD_URL=$PROD_URL  PROD_ADMIN_EMAIL=$PROD_ADMIN_EMAIL"
-    red "  (password not shown)"
-    exit 1
-}
-TOKEN=$(printf '%s' "$LOGIN_RESP" | jq -r '.access_token // empty')
-if [[ -z "$TOKEN" ]]; then
-    red "Prod login: no access_token in response."
-    exit 1
+# ─── Step 1: prod auth ────────────────────────────────────────────────────
+if [[ -n "${PROD_BEARER_TOKEN:-}" ]]; then
+    bold "Step 1: using PROD_BEARER_TOKEN (skipping /auth/local login) ..."
+    TOKEN="$PROD_BEARER_TOKEN"
+    # Sanity-check the token by hitting the allow-listed list endpoint.
+    if ! prod_get_safe /admin/backups \
+            -H "Authorization: Bearer $TOKEN" \
+            -o /dev/null >/dev/null 2>&1; then
+        red "Token rejected by $PROD_URL/admin/backups (expired or insufficient role?)."
+        exit 1
+    fi
+    green "  token accepted"
+else
+    bold "Step 1: prod login as $PROD_ADMIN_EMAIL ..."
+    LOGIN_BODY=$(jq -n --arg e "$PROD_ADMIN_EMAIL" --arg p "$PROD_ADMIN_PASSWORD" \
+        '{email:$e, password:$p}')
+    LOGIN_RESP=$(prod_post_safe /auth/local \
+        -H 'Content-Type: application/json' \
+        -d "$LOGIN_BODY") || {
+        red "Prod login failed."
+        red "  PROD_URL=$PROD_URL  PROD_ADMIN_EMAIL=$PROD_ADMIN_EMAIL"
+        red "  (password not shown)"
+        exit 1
+    }
+    TOKEN=$(printf '%s' "$LOGIN_RESP" | jq -r '.access_token // empty')
+    if [[ -z "$TOKEN" ]]; then
+        red "Prod login: no access_token in response."
+        exit 1
+    fi
+    green "  authenticated"
 fi
-green "  authenticated"
 
 prod_auth=( -H "Authorization: Bearer $TOKEN" )
 


### PR DESCRIPTION
Closes ROK-1278. Builds on ROK-1270 (audit Phase 1), ROK-1277 (union-find), ROK-1279 (prod-clone), ROK-1113 (search dedup).

## Summary

* **Migration `0140_games_dedup_merge.sql`** — reads `games_dedup_audit` (populated by ROK-1277's union-find), pre-merges UNIQUE-constraint collisions across 9 tables (additive `total_seconds` for `game_activity_rollups`, canonical-wins delete elsewhere), repoints 23 FK columns to canonical id, deletes the dup `games` rows, TRUNCATEs the audit table.
* **DB-level prevention** — partial `UNIQUE INDEX games_steam_app_id_unique ON games (steam_app_id) WHERE steam_app_id IS NOT NULL` closes the gap that allowed the Slay-the-Spire-2/II dup (both rows had `steam_app_id=2868840`).
* **Audit accuracy fix** — `games_dedup_audit.downstream_counts` previously summed only dup-side rows, undercounting real impact by ~50% when the canonical also had rows. Now sums across the whole group (canonical + every dup). Verified against raw queries on prod-mirror.
* **Clone-script enhancement** — `scripts/clone-prod-to-local.sh` accepts `PROD_BEARER_TOKEN` (paste from browser DevTools), skipping the `/auth/local` password path. `PROD_URL` now expects `/api` suffix.
* **CLAUDE.md runbook** — "Cloning prod → local — agent runbook" documents the gotchas surfaced during this story's Gate A (PROD_URL needs `/api`, settings cache reload after clone, LOCAL_ADMIN_PASSWORD required for restore step, npm install in worktree).
* **Integration test** — `games-dedup-merge.integration.spec.ts` seeds dup pairs + downstream rollups/characters, runs the migration SQL inline, asserts post-merge state (additive sum, canonical wins, repoint, audit returns 0 groups, UNIQUE index rejects duplicate steam_app_id).

## Local validation against prod-mirror

Ran `scripts/clone-prod-to-local.sh --latest` to mirror prod into local DB, then applied 0140. Numbers:

| Metric | Pre-merge | Post-merge | Expected |
|---|---|---|---|
| `games` row count | 1906 | 1885 | 1906 - 21 dup rows = 1885 ✓ |
| `games_dedup_audit` rows | 17 | 0 | 0 groups remaining ✓ |
| BG3 (canonical id=20160) user 109 rollup hours | 18 + 44 (split across 2 rows) | 62 (additive merge) | 62 ✓ |
| Slay the Spire 2 (canonical=22639) user 1 rollup hours | 16 (dup-only) | 16 | 16 ✓ |
| Slay user 107 rollup hours | 47 (dup-only) | 47 | 47 ✓ |
| Slay user 109 rollup hours | 12 + 12 | 25 | 24–25 ✓ |
| `games_steam_app_id_unique` index | absent | installed (partial) | installed ✓ |

POST `/admin/games/dedup-audit/run` now returns `totalGroups: 0, totalDupRows: 0`.

## What was merged

17 groups, decisions locked by operator:

* **3 true dups (IGDB-side + ITAD/Steam-side same game):** BG3, Divinity OS2, GTA V — additive rollup merge preserves all user hours.
* **1 same-steam_app_id smoking gun:** Slay the Spire 2 vs II.
* **10 Pattern-A groups** (different IGDB IDs sharing a normalized name — Pulsar, Peak, Ape Escape, Golf, Isaac Repentance, F-1 World GP, Destiny Star GF, Bond 007 WINE, Pen Pals, Path): merged. Per-row activity audit showed near-zero user data on the alternative-IGDB rows; operator chose consistency over preserving alt-IGDB metadata.
* **1 case-difference (Plasmatic / PLASMATIC):** merged.
* **2 same-name different-Steam-SKU groups** (GTA Vice City, Metro Exodus): merged.

## What changes on production

When the PR merges to `main`, Watchtower auto-pulls to NAS at 5AM (per `reference_prod_host`). The migration runs on container startup via `drizzle-kit migrate`:

1. Audit table is processed in a single transaction.
2. Dup rows are deleted.
3. `games_steam_app_id_unique` partial UNIQUE index is added.

No downtime — the migration is `BEGIN; ...; COMMIT;` semantics within the deploy. Sessions reading `games` during the migration block briefly (typical for DDL/DML mixed migration).

## Rollback procedure

If the migration causes a user-visible regression:

1. **Immediate (within minutes):**
   * `ssh` to NAS, `docker exec` into the API container.
   * Restore from the most recent pre-migration backup: `api/backups/migration/pre_migration_<timestamp>.dump` (the backup service automatically captures one before any drizzle migration runs).
   * Run `DATABASE_URL=... node scripts/reconcile-migrations.mjs` to re-mark already-applied migrations as such.
2. **Then:** revert this PR via `gh pr revert <n>` or `git revert <merge-sha>` + push. The reverted PR re-deploys without 0140, leaving prod on the restored backup state.

## Test plan

- [x] Local CI: `./scripts/validate-ci.sh --full` — all checks PASS (build, typecheck, lint, unit+coverage, integration, migration validation; container-startup skipped — no container files changed)
- [x] Integration test for the migration logic: `games-dedup-merge.integration.spec.ts` passes
- [x] Existing audit-spec still passes after UNIQUE-index bypass helper: `games-dedup-audit.integration.spec.ts` 16/16 passing
- [x] Verified locally against prod-mirror — see table above
- [ ] Operator browser-test of `/users/109` (BG3 + Slay merged correctly) after Watchtower auto-deploys
- [ ] 7-day soak post-deploy — `POST /admin/games/dedup-audit/run` should keep returning `totalGroups: 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)