### PR TITLE
ROK-1280: fix 8-week taste drift chart — stitch historical snapshots

### DIFF
--- a/.claude/skills/status-report/SKILL.md
+++ b/.claude/skills/status-report/SKILL.md
@@ -1,15 +1,20 @@
 ---
 name: status-report
-description: "Print a consistent, scannable status report. On a story branch (matches `rok-\\d+`): per-agent snapshot — story ID, phase, what's done, what's next, blockers; during Reviewing also drives the work forward (implements undelivered ACs, runs missing e2e). On `main` (no story branch): global mode — reconciles the 'Raid Ledger — Active State' Linear doc by re-deriving env lock, in-flight stories, recently shipped, open follow-ups, and known stale state. Use when the operator asks for a status update ('status', 'where are we', 'what's the state', 'update', 'sync state')."
+description: "Print a consistent, scannable status snapshot AND sync the 'Raid Ledger — Active State' Linear doc — both happen on every invocation. On a story branch (matches `rok-\\d+`): per-agent snapshot — story ID, phase, what's done, what's next, blockers; during Reviewing also drives the work forward (implements undelivered ACs, runs missing e2e). On `main` (no story branch): fleet snapshot across every active worktree (env lock, in-flight stories with inferred phase, recently shipped, follow-ups, stale state). After the visible snapshot, the Active State Linear doc Derived section is reconciled silently and a one-line footer confirms the sync. Use when the operator asks for a status update ('status', 'where are we', 'what's the state', 'update', 'sync state')."
 ---
 
-# Status Report — Per-Agent Snapshot or Global State Sync
+# Status Report — Snapshot + Active State Sync
 
-**Two modes**, dispatched by branch:
+**Every invocation produces two outputs:**
 
-1. **Story-branch mode** (`rok-\d+` in branch name) — per-agent snapshot. The operator runs 10+ agent windows in parallel and forgets which window is which; this skill produces a 10-second-readable snapshot of THIS agent's work so they can identify the window and decide whether to interact. Output MUST match the template exactly — same fields, same order, same labels — every invocation. Consistency is the entire point. If a field has no content, write `none`. Never substitute "no progress yet" or other prose for missing fields.
+1. A **visible snapshot** printed to the operator's terminal — what's happening right now.
+2. A **silent Linear doc sync** of the "Raid Ledger — Active State" doc Derived section — so future sessions can read the cross-session picture. A one-line footer confirms it ran.
 
-2. **Global mode** (`main` or any branch with no `rok-\d+`) — reconcile the cross-session "Active State" Linear doc. Reads current doc, re-derives env lock + in-flight + recently shipped + open follow-ups + known stale state from authoritative sources, overwrites the Derived section, preserves Strategic and Conventions sections verbatim, prints a brief 3-line summary.
+The visible snapshot's shape depends on branch — but **both pieces fire on every run**, regardless of branch. You do not pick one or the other.
+
+- **Story-branch mode** (`rok-\d+` in branch name) — per-agent snapshot of THIS window. The operator runs 10+ agent windows in parallel and forgets which window is which; this skill lets them identify the window in 10 seconds. Output MUST match the template exactly — same fields, same order, same labels — every invocation. Consistency is the entire point. If a field has no content, write `none`. Never substitute "no progress yet" or other prose for missing fields.
+
+- **Main-branch mode** (`main` or any branch with no `rok-\d+`) — fleet snapshot across every active worktree. Shows what every other Claude window is currently doing so the operator can decide which window to attend to.
 
 ---
 
@@ -17,10 +22,14 @@ description: "Print a consistent, scannable status report. On a story branch (ma
 
 Run `git branch --show-current`. Pick the path:
 
-- Branch matches `rok-\d+` → **Story-branch mode**: continue with Steps 1–4 below.
-- Branch is `main` (or any branch with no `rok-\d+`) → **Global mode**: jump to the "Global mode" section near the end of this file. Do **not** run Steps 1–4.
+- Branch matches `rok-\d+` → run **Story-branch mode** (Steps 1–4 below), then **Step S: Active State sync** at the very end.
+- Branch is `main` (or any branch with no `rok-\d+`) → run **Main-branch mode** (Steps M1–M2), then **Step S: Active State sync**.
+
+Step S is the same in both modes — it's how the Active State doc gets reconciled regardless of which window the operator invoked from.
 
 ---
+
+# Story-branch mode (Steps 1–4)
 
 ## Step 1: Gather Signals (only what you need)
 
@@ -136,7 +145,7 @@ No additional self-checks today. Do not invent them.
 
 ## Step 3: Print the Report
 
-Print **this template exactly**. No prose before, no commentary after. The report ends with the `BLOCKERS` section.
+Print **this template exactly**. No prose before, no commentary after. The report ends with the `BLOCKERS` section — the only thing allowed after `BLOCKERS` is the Step S footer line (one line, generated post-print).
 
 **Base template (every phase):**
 
@@ -192,7 +201,7 @@ Cite check names verbatim from `statusCheckRollup` so the operator can `gh run v
 - **BLOCKERS** — anything preventing forward progress: failing tests, missing decisions, missing creds, awaiting operator approval, unresolved questions, plus every AC-trace gap surfaced in Step 2.5. Write `none` if there are none.
 - **AC TRACE** — required when Phase started as `Reviewing` in Step 2 (even if downgraded by Step 2.5). Omit entirely for any other phase. One line per AC, ≤120 chars per line. The `e2e` field cites the actual test path (e.g. `web/e2e/lineup-vote.spec.ts`) or writes `missing`.
 - **PR STATUS** — required when Phase started as `PR-Open` in Step 2 (even if downgraded to `Merged` or `Blocked` by Step 2.5). Omit entirely for any other phase. Field labels are fixed; values come straight from `gh pr view --json` output.
-- Do **not** add summary, recommendations, or "let me know if…" lines after the template. Stop **printing text** at `BLOCKERS`. Tool calls invoked from Step 4 (Drive Forward) are not text and do not violate this rule — they fire silently after the report renders.
+- Do **not** add summary, recommendations, or "let me know if…" lines after the template. Stop **printing text** at `BLOCKERS`, with one exception: the Step S footer (a single confirmation line, generated after the doc sync runs). Tool calls invoked from Step 4 (Drive Forward) or Step S (doc sync) are not text and do not violate this rule — they fire silently.
 - Do **not** wrap the report in additional markdown headers, code fences, or callouts. Print it as-is.
 - If invoked twice in the same conversation, the report should be reproducible — same phase + same DONE list as last time, plus any new entries.
 
@@ -200,7 +209,7 @@ Cite check names verbatim from `statusCheckRollup` so the operator can `gh run v
 
 ## Step 4: Phase-Conditional Drive Forward (post-print)
 
-After the report renders, run the action that matches the originally-chosen phase from Step 2. These are the **action counterpart to Step 2.5's checks** — same per-phase structure, same "If Phase == X / Other phases: do not invent" voice, just running *after* the operator sees the snapshot rather than before. Step 4 may invoke tools (commits, tests, env management) but never prints additional text — the report still ends at `BLOCKERS`.
+After the report renders, run the action that matches the originally-chosen phase from Step 2. These are the **action counterpart to Step 2.5's checks** — same per-phase structure, same "If Phase == X / Other phases: do not invent" voice, just running *after* the operator sees the snapshot rather than before. Step 4 may invoke tools (commits, tests, env management) but never prints additional text — the report still ends at `BLOCKERS` (plus the Step S footer).
 
 ### If Phase == `Reviewing`
 
@@ -253,36 +262,132 @@ No driving today. Do not invent it.
 
 ### Halts that override every phase
 
-- Operator has explicitly asked in *this conversation* for a passive snapshot ("just give me the status, don't do anything") → skip Step 4 entirely.
-- No story is associated (`Story: no story — ...`) → skip; without ACs, "drive forward" has no target.
+- Operator has explicitly asked in *this conversation* for a passive snapshot ("just give me the status, don't do anything") → skip Step 4 entirely. Step S still runs (it's a sync, not a driver) unless the operator also said "don't update the doc."
+- No story is associated (`Story: no story — ...`) → skip Step 4; without ACs, "drive forward" has no target. Step S still runs.
 
-(Note: `main` no longer halts — Step 0 routes main-branch invocations to Global mode below.)
+After Step 4's actions complete (or are skipped), proceed to **Step S** to sync the Active State doc.
 
 ---
 
-## Global mode — reconcile the Active State Linear doc
+# Main-branch mode (Steps M1–M2)
 
 Trigger: Step 0 routed here because branch is `main` (or any branch with no `rok-\d+`).
 
-**Goal:** keep the cross-session "Raid Ledger — Active State" Linear doc current by re-deriving the auto-managed sections from authoritative sources, while preserving operator/agent-authored strategic context untouched.
+**Goal:** give the operator a 10-second-readable picture of EVERY active worktree (so they can see what their whole fleet of Claude windows is doing) before the doc sync writes that same picture to Linear.
+
+## Step M1: Gather fleet signals
+
+Run these in parallel where possible. Several feed both the snapshot AND the Step S doc sync — capture once, reuse.
+
+| Signal | Source |
+|---|---|
+| Worktrees | `git worktree list` |
+| Open PRs | `gh pr list --state open --json number,title,headRefName,state,isDraft,reviewDecision,mergeable,mergeStateStatus,statusCheckRollup,autoMergeRequest,url --limit 30` |
+| Recently shipped (7d) | `gh pr list --state merged --search "merged:>=$(date -u -v-7d +%Y-%m-%d)" --json number,title,headRefName,mergedAt --limit 20` |
+| Env lock | `cat ~/.raid-ledger/env-lock.json 2>/dev/null` (file may not exist — that's `null` holder, empty queue) |
+| Linear in-flight | `mcp__linear__list_issues` filtered to statuses `In Progress`, `Code Review` |
+| Linear follow-ups (7d) | `mcp__linear__list_issues --createdAt -P7D` filtered to states `Backlog`, `Todo` |
+
+For each non-main worktree from `git worktree list`:
+
+- `git -C <path> log -1 --format='%h %ar %s'` — last commit (use the path so it works regardless of this window's cwd).
+- `git -C <path> rev-list --count origin/main..HEAD 2>/dev/null` — commits ahead of main.
+- Extract story ID from the worktree's branch name via `rok-\d+` (uppercase for display).
+
+Cross-reference each worktree:
+- Worktree story ID → matching open PR (by `headRefName`) → matching Linear story (by story ID prefix).
+- Worktree on a branch whose PR is `MERGED` → flag for STALE.
+- Worktree on a branch with no PR and 0 commits ahead → `Idle`.
+
+If any source command fails, write `(unavailable — <one-line reason>)` for the affected subsection and surface the failure in BLOCKERS. Never invent values.
+
+---
+
+## Step M2: Print the fleet snapshot
+
+Print **this template exactly**. No prose before, no commentary after. The snapshot ends with `BLOCKERS` — the only thing allowed after is the Step S footer line.
+
+```
+═══ FLEET STATUS ═══
+Branch:   main (this window)
+Env lock: <holder branch + purpose, or `null`>
+Queue:    <comma-separated queued branches in order, or `empty`>
+
+IN FLIGHT (<n> worktrees)
+- <ROK-XXXX> [<phase>]  branch <branch>  last <relative time>  PR #<n> <CI summary or "no PR yet">
+- ...
+
+RECENTLY SHIPPED (last 7d, newest first)
+- PR #<n> — <ROK-XXXX> <title>
+- ...
+
+OPEN FOLLOW-UPS (filed last 7d)
+- <ROK-XXXX> (<status>) — <one-line why-it-matters>
+- ...
+
+STALE
+- <worktree path>  branch <branch>  story shipped — safe to remove
+- ...  OR  none
+
+BLOCKERS
+- <bullet, or "none">
+```
+
+### Rules
+
+- **Env lock / Queue** — holder format: `<branch> (<purpose>, held <relative time>)`. If `holder: null` and queue empty, write `null` / `empty`. If queue has entries, comma-separate in queue order.
+- **IN FLIGHT** — every non-main worktree with commits ahead of main OR a matching open PR. Skip worktrees at parity with main (those go in STALE if their story shipped, otherwise ignore). Order: newest activity first (by last commit timestamp).
+- **Phase per worktree** — infer (cannot read each worktree's TaskList from here):
+  - PR `MERGED` → `Merged`
+  - PR `OPEN`, not draft, `reviewDecision=APPROVED`, `autoMergeRequest=null` → `Reviewing`
+  - PR `OPEN`, not draft, any CI check failing → `Blocked`
+  - PR `OPEN`, draft → `Implementing` (draft = WIP)
+  - PR `OPEN`, otherwise → `PR-Open`
+  - No PR, branch has commits ahead → `Implementing`
+  - No PR, 0 commits ahead → `Idle`
+- **CI summary** — when a PR exists: `<passing>/<total>` (bucket per Step 2.5 PR-Open tally rules — `conclusion` wins over `status`). If any failing, append `, <failing> failing`. If draft, prefix `[draft]`. If `autoMergeRequest` set, append ` [auto-merge]`. If no PR, write `no PR yet`.
+- **RECENTLY SHIPPED** — map merged PRs to story IDs (via branch name `rok-\d+` or PR title). Cap at 10; if more, append `- (+<N> more)`.
+- **OPEN FOLLOW-UPS** — skip stories that already appear in IN FLIGHT. Cap at 10.
+- **STALE** — worktree on a branch whose PR is `MERGED` (story shipped). NOT stale: worktrees whose story is still in flight, worktrees with uncommitted operator work. If nothing, write `none`.
+- **BLOCKERS** — env-lock held by a dead PID / lease past TTL with queue waiting; PR CI failing for >1h; source command failures from M1; doc sync failures from Step S (added after S runs). Write `none` if nothing.
+- Cap IN FLIGHT at 10 entries. If more, append `- (+<N> more)` and prioritize: (a) any with failing CI, (b) most-recently active.
+- Do **not** add prose, recommendations, or summary after BLOCKERS. The only post-BLOCKERS text is the Step S footer.
+
+After printing, proceed to **Step S** to sync the Active State Linear doc.
+
+---
+
+# Step S: Active State Linear doc sync (silent — runs in BOTH modes)
+
+This step fires on every invocation, after the visible snapshot has printed. It is the second of the two outputs every `/status-report` produces.
+
+**Goal:** keep the cross-session "Raid Ledger — Active State" Linear doc current by re-deriving the auto-managed Derived section from authoritative sources, while preserving operator/agent-authored Strategic + Conventions sections untouched.
 
 **Doc reference (stable):** see memory `reference_active_state_doc.md`.
 - URL: `https://linear.app/roknua-projects/document/raid-ledger-active-state-7a4ddc5652c9`
 - Doc ID for `mcp__linear__save_document`: `bbacd5ae-0c99-4eaf-bbd7-24e7eb90ffce`
 - Slug: `7a4ddc5652c9`
 
-### Step G1: Read the current doc
+## Step S1: Read the current doc
 
 `mcp__linear__get_document` with the slug above. Capture the full content. **Identify three section anchors** by markdown heading:
 - `## Derived (auto-overwritten by ...)` — to be replaced
 - `## Strategic (operator + agent updates ...)` — preserve verbatim
 - `## Conventions` — preserve verbatim
 
-If any anchor is missing or out of order, **stop and surface a BLOCKER** (`active state doc structure broken: <which anchor>`). Do not write a malformed doc.
+If any anchor is missing or out of order, **skip S2–S4** and print the failure footer:
 
-### Step G2: Re-derive each Derived bucket
+```
+─── Active State sync FAILED ─── doc structure broken: <which anchor>
+```
 
-Run these in parallel where possible. Each bucket maps to a labelled subsection in the new Derived block.
+Do not attempt to write a malformed doc.
+
+## Step S2: Re-derive each Derived bucket
+
+**In Main-branch mode:** the data was already gathered in Step M1 — reuse it directly. Do not re-query.
+
+**In Story-branch mode:** gather it now (in parallel where possible). Each bucket maps to a labelled subsection in the new Derived block.
 
 | Bucket | Source command(s) | Notes |
 |---|---|---|
@@ -292,14 +397,14 @@ Run these in parallel where possible. Each bucket maps to a labelled subsection 
 | **Open follow-ups (last 7 days)** | `mcp__linear__list_issues --createdAt -P7D` filtered to states `Backlog`, `Todo` | Skip stories already in flight (covered above). Brief why-it-matters one-liner per entry. |
 | **Known stale state** | Cross-reference `git worktree list` against `git log --oneline origin/main` | Worktrees on commits that aren't on main AND whose corresponding story is shipped → flag as cleanable. Worktrees on commits that aren't on main AND whose story is in flight → not stale, skip. |
 
-If any source command fails (network, auth, missing file), surface the failure as a BLOCKER in the print summary AND skip that bucket (write the literal text `(unavailable — <one-line reason>)`). Do not invent values.
+If any source command fails (network, auth, missing file), surface the failure in the footer AND skip that bucket (write the literal text `(unavailable — <one-line reason>)`). Do not invent values.
 
-### Step G3: Construct the new Derived section
+## Step S3: Construct the new Derived section
 
 Use this exact layout:
 
 ```markdown
-## Derived (auto-overwritten by `/status-report` on `main`)
+## Derived (auto-overwritten by `/status-report`)
 
 ### Env lock
 - Holder: <holder block or `null`>
@@ -320,39 +425,47 @@ Use this exact layout:
 
 If a subsection has no content, write `- none` rather than omitting the subsection — readers should see the structure even when the bucket is empty.
 
-### Step G4: Write back
+## Step S4: Write back
 
 Reassemble the full doc:
 
 ```
 <header up to and including the two intro blockquotes>
 ---
-<new ## Derived section from Step G3>
+<new ## Derived section from Step S3>
 ---
-<preserved ## Strategic section from Step G1, byte-for-byte>
+<preserved ## Strategic section from Step S1, byte-for-byte>
 ---
-<preserved ## Conventions section from Step G1, byte-for-byte>
+<preserved ## Conventions section from Step S1, byte-for-byte>
 ```
 
 The horizontal rules (`---`) between sections are part of the layout; preserve them. Update the `**Last derived update:**` date at the top to today's ISO-8601 date (UTC).
 
 Call `mcp__linear__save_document` with `id: bbacd5ae-0c99-4eaf-bbd7-24e7eb90ffce` and the reassembled content.
 
-### Step G5: Print a 3-line summary
+## Step S5: Print the one-line footer
 
-Output **exactly** this format (no template, no addenda — global mode has its own minimal output):
+After the doc save returns (success or failure), append a single line to the output (the only text allowed after the snapshot's `BLOCKERS`):
 
+**On success:**
 ```
-═══ ACTIVE STATE SYNCED ═══
-Doc:      https://linear.app/roknua-projects/document/raid-ledger-active-state-7a4ddc5652c9
-Derived:  <N> in-flight | <M> shipped 7d | <K> follow-ups | <S> stale items
-Note:     <one-line — anything that warranted attention, or "no anomalies">
+─── Active State synced ─── https://linear.app/roknua-projects/document/raid-ledger-active-state-7a4ddc5652c9
 ```
 
-The `Note:` line is for things the operator should see at a glance — e.g. "ROK-1250 in flight 24h+ without PR", "env lock held by ROK-XXXX since <time>", "stale --rok-XXXX worktree can be removed". One sentence max. If nothing is notable, write `no anomalies`.
+**On failure (S1 anchor check failed, S4 save errored, or operator opted out):**
+```
+─── Active State sync FAILED ─── <one-line error>
+```
 
-### Halts specific to Global mode
+or, if the operator said "don't update the doc" in this conversation:
+```
+─── Active State sync skipped per operator request ───
+```
 
-- Doc structure broken (Step G1 anchor check failed) → print BLOCKER and stop without writing.
-- `mcp__linear__save_document` returns an error → print BLOCKER `doc save failed: <error>`. The next invocation will re-derive and retry.
-- Operator explicitly says "don't update the doc" in this conversation → run Steps G1–G3, print Step G5's summary with `Note: doc-write skipped per operator request`, but skip Step G4 entirely.
+This is the only text allowed after the snapshot. Do not add summaries, recommendations, or follow-up commentary.
+
+## Halts specific to Step S
+
+- Doc structure broken (S1 anchor check failed) → print failure footer, do not write.
+- `mcp__linear__save_document` returns an error → print failure footer with the error. The next invocation will re-derive and retry.
+- Operator explicitly said "don't update the doc" in this conversation → run S1–S3 silently for consistency-check purposes, skip S4, print the "skipped per operator request" footer.

--- a/api/src/community-insights/community-insights.integration.spec.ts
+++ b/api/src/community-insights/community-insights.integration.spec.ts
@@ -66,11 +66,25 @@ async function createOperatorAndLogin(testApp: TestApp): Promise<string> {
 async function seedSnapshot(
   testApp: TestApp,
   snapshotDate: string,
+  options: { rpgDriftScore?: number } = {},
 ): Promise<void> {
   const fixture = buildSnapshotFixture(snapshotDate);
+  const radarPayload =
+    options.rpgDriftScore !== undefined
+      ? {
+          ...fixture.radar,
+          driftSeries: [
+            {
+              weekStart: snapshotDate,
+              axis: 'rpg' as const,
+              meanScore: options.rpgDriftScore,
+            },
+          ],
+        }
+      : fixture.radar;
   await testApp.db.insert(schema.communityInsightsSnapshots).values({
     snapshotDate,
-    radarPayload: fixture.radar,
+    radarPayload,
     engagementPayload: fixture.engagement,
     churnPayload: fixture.churn,
     socialGraphPayload: fixture.socialGraph,
@@ -149,6 +163,91 @@ describe('Community Insights (ROK-1099)', () => {
         .set('Authorization', `Bearer ${adminToken}`);
       expect(res.status).toBe(200);
       expect(res.body.insights).toHaveLength(1);
+    });
+  });
+
+  describe('GET /insights/community/radar drift history (ROK-1280)', () => {
+    it('stitches one drift entry per ISO week across multiple snapshots', async () => {
+      // Three snapshots in three distinct ISO weeks. Apr 20 / Apr 27 / May 4
+      // are all Mondays, so each snapshot lands in its own week.
+      await seedSnapshot(testApp, '2026-04-22', { rpgDriftScore: 30 });
+      await seedSnapshot(testApp, '2026-04-29', { rpgDriftScore: 45 });
+      await seedSnapshot(testApp, '2026-05-06', { rpgDriftScore: 60 });
+
+      const res = await testApp.request
+        .get('/insights/community/radar')
+        .set('Authorization', `Bearer ${adminToken}`);
+      expect(res.status).toBe(200);
+
+      const drift = res.body.driftSeries as Array<{
+        weekStart: string;
+        axis: string;
+        meanScore: number;
+      }>;
+      const weeks = Array.from(new Set(drift.map((p) => p.weekStart))).sort();
+      expect(weeks).toEqual(['2026-04-20', '2026-04-27', '2026-05-04']);
+      const rpgByWeek = Object.fromEntries(
+        drift
+          .filter((p) => p.axis === 'rpg')
+          .map((p) => [p.weekStart, p.meanScore]),
+      );
+      expect(rpgByWeek).toEqual({
+        '2026-04-20': 30,
+        '2026-04-27': 45,
+        '2026-05-04': 60,
+      });
+    });
+
+    it('keeps the latest snapshot per ISO week when multiple snapshots share a week', async () => {
+      // Both 2026-04-22 (Wed) and 2026-04-25 (Sat) live in ISO week 2026-04-20.
+      await seedSnapshot(testApp, '2026-04-22', { rpgDriftScore: 10 });
+      await seedSnapshot(testApp, '2026-04-25', { rpgDriftScore: 99 });
+
+      const res = await testApp.request
+        .get('/insights/community/radar')
+        .set('Authorization', `Bearer ${adminToken}`);
+      expect(res.status).toBe(200);
+
+      expect(res.body.driftSeries).toHaveLength(1);
+      expect(res.body.driftSeries[0]).toMatchObject({
+        weekStart: '2026-04-20',
+        axis: 'rpg',
+        meanScore: 99,
+      });
+    });
+
+    it('caps the drift series at 8 weeks even when more snapshots exist', async () => {
+      // 10 snapshots, each in its own ISO week, every Monday going back.
+      const mondays = [
+        '2026-03-09',
+        '2026-03-16',
+        '2026-03-23',
+        '2026-03-30',
+        '2026-04-06',
+        '2026-04-13',
+        '2026-04-20',
+        '2026-04-27',
+        '2026-05-04',
+        '2026-05-11',
+      ];
+      for (const d of mondays) {
+        await seedSnapshot(testApp, d, { rpgDriftScore: 50 });
+      }
+
+      const res = await testApp.request
+        .get('/insights/community/radar')
+        .set('Authorization', `Bearer ${adminToken}`);
+      expect(res.status).toBe(200);
+
+      const weeks = Array.from(
+        new Set(
+          (res.body.driftSeries as { weekStart: string }[]).map(
+            (p) => p.weekStart,
+          ),
+        ),
+      ).sort();
+      expect(weeks).toHaveLength(8);
+      expect(weeks[weeks.length - 1]).toBe('2026-05-11');
     });
   });
 

--- a/api/src/community-insights/community-insights.service.ts
+++ b/api/src/community-insights/community-insights.service.ts
@@ -69,4 +69,20 @@ export class CommunityInsightsService {
       .limit(1);
     return rows[0] ?? null;
   }
+
+  /**
+   * Up to `limit` most recent snapshots, newest-first. Used by the radar
+   * query to stitch multi-week drift history (ROK-1280). LIMIT-based
+   * rather than date-based so tests can seed historical dates without
+   * coupling to the system clock.
+   */
+  async readRecentSnapshots(
+    limit: number,
+  ): Promise<CommunityInsightsSnapshotRow[]> {
+    return this.db
+      .select()
+      .from(schema.communityInsightsSnapshots)
+      .orderBy(desc(schema.communityInsightsSnapshots.snapshotDate))
+      .limit(limit);
+  }
 }

--- a/api/src/community-insights/queries/radar-query.ts
+++ b/api/src/community-insights/queries/radar-query.ts
@@ -1,10 +1,67 @@
-import type { CommunityRadarResponseDto } from '@raid-ledger/contract';
-import type { CommunityInsightsService } from '../community-insights.service';
+import type {
+  CommunityRadarResponseDto,
+  TasteDriftPointDto,
+} from '@raid-ledger/contract';
+import type {
+  CommunityInsightsService,
+  CommunityInsightsSnapshotRow,
+} from '../community-insights.service';
 
+const DRIFT_WEEK_COUNT = 8;
+// 56 = worst case where every day in 8 weeks has its own snapshot row;
+// dedupe-by-week collapses that to 8 points.
+const DRIFT_SNAPSHOT_LIMIT = DRIFT_WEEK_COUNT * 7;
+
+/**
+ * Radar payload for the latest snapshot, with the `driftSeries` field
+ * stitched from up to 8 ISO weeks of historical snapshots so the
+ * frontend's 8-week drift chart actually has multi-week data to plot
+ * (ROK-1280). Each per-snapshot `driftSeries` only contains the current
+ * week — we collapse daily snapshots into weekly buckets here.
+ */
 export async function getRadarResponse(
   service: CommunityInsightsService,
 ): Promise<CommunityRadarResponseDto | null> {
-  const row = await service.readLatestSnapshot();
-  if (!row) return null;
-  return row.radarPayload;
+  const rows = await service.readRecentSnapshots(DRIFT_SNAPSHOT_LIMIT);
+  if (rows.length === 0) return null;
+  const latest = rows[0];
+  return {
+    ...latest.radarPayload,
+    driftSeries: mergeWeeklyDrift(rows, DRIFT_WEEK_COUNT),
+  };
+}
+
+function mergeWeeklyDrift(
+  rows: CommunityInsightsSnapshotRow[],
+  weekCap: number,
+): TasteDriftPointDto[] {
+  // Rows arrive newest-first; keep the first (= latest) snapshot per ISO
+  // week, then cap to the most recent `weekCap` weeks and re-stamp each
+  // point with the Monday-of-week date so the chart's X-axis groups
+  // multi-day snapshots into a single weekly point.
+  const byWeek = new Map<string, CommunityInsightsSnapshotRow>();
+  for (const row of rows) {
+    const weekStart = isoWeekStart(toDateString(row.snapshotDate));
+    if (!byWeek.has(weekStart)) byWeek.set(weekStart, row);
+  }
+  const weeks = Array.from(byWeek.keys()).sort().slice(-weekCap);
+  return weeks.flatMap((weekStart) => {
+    const row = byWeek.get(weekStart);
+    if (!row) return [];
+    return row.radarPayload.driftSeries.map((p) => ({ ...p, weekStart }));
+  });
+}
+
+/** Drizzle's `date` column may surface as string or Date; normalize. */
+function toDateString(value: string | Date): string {
+  return typeof value === 'string' ? value : value.toISOString().slice(0, 10);
+}
+
+/** Monday of the ISO week containing `dateStr`, as `YYYY-MM-DD` (UTC). */
+export function isoWeekStart(dateStr: string): string {
+  const d = new Date(`${dateStr}T00:00:00Z`);
+  const day = d.getUTCDay();
+  const offset = day === 0 ? -6 : 1 - day;
+  d.setUTCDate(d.getUTCDate() + offset);
+  return d.toISOString().slice(0, 10);
 }

--- a/web/src/components/insights/community/TasteDriftChart.test.tsx
+++ b/web/src/components/insights/community/TasteDriftChart.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import { TasteDriftChart } from './TasteDriftChart';
+import { reshape } from './taste-drift-helpers';
 
 describe('TasteDriftChart', () => {
     it('renders empty state when no drift series is provided', () => {
@@ -18,5 +19,51 @@ describe('TasteDriftChart', () => {
             />,
         );
         expect(screen.getByTestId('taste-drift-chart')).toBeInTheDocument();
+    });
+});
+
+describe('TasteDriftChart reshape()', () => {
+    it('collapses to a single week when only one weekStart is present', () => {
+        const result = reshape([
+            { weekStart: '2026-05-04', axis: 'rpg', meanScore: 42 },
+            { weekStart: '2026-05-04', axis: 'co_op', meanScore: 35 },
+        ]);
+        expect(result.weeks).toEqual(['2026-05-04']);
+        expect(result.rows).toHaveLength(1);
+    });
+
+    it('sorts weeks ascending and rounds meanScore', () => {
+        const result = reshape([
+            { weekStart: '2026-05-04', axis: 'rpg', meanScore: 42.7 },
+            { weekStart: '2026-04-20', axis: 'rpg', meanScore: 30.2 },
+            { weekStart: '2026-04-27', axis: 'rpg', meanScore: 36.6 },
+        ]);
+        expect(result.weeks).toEqual(['2026-04-20', '2026-04-27', '2026-05-04']);
+        expect(result.rows.map((r) => r.rpg)).toEqual([30, 37, 43]);
+    });
+
+    it('picks top-3 axes by latest-week meanScore', () => {
+        const latest = '2026-05-04';
+        const result = reshape([
+            { weekStart: latest, axis: 'rpg', meanScore: 90 },
+            { weekStart: latest, axis: 'co_op', meanScore: 70 },
+            { weekStart: latest, axis: 'pvp', meanScore: 50 },
+            { weekStart: latest, axis: 'survival', meanScore: 10 },
+        ]);
+        expect(result.topAxes).toEqual(['rpg', 'co_op', 'pvp']);
+    });
+
+    it('fills missing weekly samples with 0 for the selected axes', () => {
+        const result = reshape([
+            { weekStart: '2026-04-20', axis: 'rpg', meanScore: 30 },
+            // 2026-04-27 has no rpg sample
+            { weekStart: '2026-04-27', axis: 'co_op', meanScore: 25 },
+            { weekStart: '2026-05-04', axis: 'rpg', meanScore: 60 },
+            { weekStart: '2026-05-04', axis: 'co_op', meanScore: 50 },
+        ]);
+        expect(result.topAxes).toEqual(['rpg', 'co_op']);
+        // Middle row missing rpg sample → falls back to 0
+        expect(result.rows[1].rpg).toBe(0);
+        expect(result.rows[1].co_op).toBe(25);
     });
 });

--- a/web/src/components/insights/community/TasteDriftChart.tsx
+++ b/web/src/components/insights/community/TasteDriftChart.tsx
@@ -3,6 +3,7 @@ import {
 } from 'recharts';
 import type { CommunityRadarResponseDto, TasteProfilePoolAxis } from '@raid-ledger/contract';
 import { axisLabel } from '../../taste-profile/taste-profile-helpers';
+import { reshape } from './taste-drift-helpers';
 
 interface Props {
     driftSeries: CommunityRadarResponseDto['driftSeries'];
@@ -35,33 +36,14 @@ export function TasteDriftChart({ driftSeries }: Props) {
                     <Legend wrapperStyle={{ fontSize: 12 }} />
                     {topAxes.map((axis, i) => (
                         <Line key={axis} type="monotone" dataKey={axis}
-                            stroke={COLORS[i] ?? '#a855f7'} strokeWidth={2} dot={false}
+                            stroke={COLORS[i] ?? '#a855f7'} strokeWidth={2}
+                            dot={weeks.length === 1}
                             isAnimationActive={false}
                             name={axisLabel(axis as TasteProfilePoolAxis)} />
                     ))}
-                    {/* weeks consumed as X-axis categories */}
-                    {weeks.length === 0 && null}
                 </LineChart>
             </ResponsiveContainer>
         </div>
     );
 }
 
-function reshape(driftSeries: CommunityRadarResponseDto['driftSeries']) {
-    const weeks = Array.from(new Set(driftSeries.map((p) => p.weekStart))).sort();
-    const latest = weeks[weeks.length - 1];
-    const topAxes = driftSeries
-        .filter((p) => p.weekStart === latest)
-        .sort((a, b) => b.meanScore - a.meanScore)
-        .slice(0, 3)
-        .map((p) => p.axis);
-    const rows = weeks.map((weekStart) => {
-        const row: Record<string, string | number> = { weekStart };
-        for (const axis of topAxes) {
-            const p = driftSeries.find((x) => x.weekStart === weekStart && x.axis === axis);
-            row[axis] = Math.round(p?.meanScore ?? 0);
-        }
-        return row;
-    });
-    return { weeks, topAxes, rows };
-}

--- a/web/src/components/insights/community/taste-drift-helpers.ts
+++ b/web/src/components/insights/community/taste-drift-helpers.ts
@@ -1,0 +1,26 @@
+import type { CommunityRadarResponseDto } from '@raid-ledger/contract';
+
+/**
+ * Pivots the flat per-week-per-axis drift series into Recharts-shaped
+ * rows keyed by `weekStart`, selecting the top-3 axes by latest-week
+ * mean score. Lives in its own file so the component module remains
+ * Fast-Refresh-clean (react-refresh/only-export-components).
+ */
+export function reshape(driftSeries: CommunityRadarResponseDto['driftSeries']) {
+    const weeks = Array.from(new Set(driftSeries.map((p) => p.weekStart))).sort();
+    const latest = weeks[weeks.length - 1];
+    const topAxes = driftSeries
+        .filter((p) => p.weekStart === latest)
+        .sort((a, b) => b.meanScore - a.meanScore)
+        .slice(0, 3)
+        .map((p) => p.axis);
+    const rows = weeks.map((weekStart) => {
+        const row: Record<string, string | number> = { weekStart };
+        for (const axis of topAxes) {
+            const p = driftSeries.find((x) => x.weekStart === weekStart && x.axis === axis);
+            row[axis] = Math.round(p?.meanScore ?? 0);
+        }
+        return row;
+    });
+    return { weeks, topAxes, rows };
+}


### PR DESCRIPTION
## Summary

- **Backend (`api/src/community-insights`)** — `getRadarResponse` now reads up to 56 newest snapshots, dedupes them by ISO week (latest snapshot per week wins), and stitches their `driftSeries` into 8-week buckets. Previously it returned only the latest snapshot's single-point series, so the chart could never plot more than one date — no matter how many daily snapshots had accumulated. Added `readRecentSnapshots(limit)` helper to the service.
- **Frontend (`web/src/components/insights/community/TasteDriftChart`)** — extracted `reshape()` into a sibling helper (Fast-Refresh-clean module split). Shows dots when only one week is present so the degenerate state still renders something visible. No layout / styling / chart-library changes.
- **Operator config ride-along** — `chore(config): /status-report — always run snapshot + Active State sync` (the operator's SKILL.md update that landed during this session; bundled per CLAUDE.md "Operator Config Files" rule).

## Linear

ROK-1280

## Visual verification (Chrome MCP)

Deployed locally, seeded 4 weekly snapshots (2026-04-20 → 05-11), confirmed chart renders 3 connected lines (MMO / RPG / Co-op) across 4 distinct X-axis weekly labels. Before the fix: a single dot per axis (no lines, only the current week's date labeled).

## Test plan

- [x] Contract / API / Web build pass
- [x] TypeScript across api + web passes (`validate-ci.sh --full`)
- [x] Lint across api + web passes
- [x] Unit tests + coverage pass
- [x] Community-insights integration tests pass in isolation (17/17, includes 3 new tests covering 3-week stitch, same-week dedup, 8-week cap)
- [x] Vitest `reshape()` covers: single-week, multi-week sort order, top-3 axis selection, missing-sample fallback (6/6 in the touched test file)
- [x] Chrome MCP visual verification on /insights chart (multi-week lines render correctly)
- [ ] Full `npm run test:integration -w api` — failed locally with `testcontainers port-binding timeout` due to Docker contention with a parallel `fix-batch-2026-05-13` validate-ci run; **environmental, not a test failure**. GitHub CI is the authoritative gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)