### PR TITLE
fix-batch 2026-05-14: ROK-1282 + ROK-1283 + test-infra clone reliability

### DIFF
--- a/.claude/skills/build/steps/step-5-ship.md
+++ b/.claude/skills/build/steps/step-5-ship.md
@@ -84,6 +84,19 @@ git pull --rebase origin main
 
 ---
 
+## 5e.5. Reconcile planning artifacts (STRICT)
+
+Per CLAUDE.md "Post-merge planning artifact reconciliation." After `gh pr view ... --json state` confirms `MERGED`:
+
+1. **Story in `planning-artifacts/current-sprint.md`?** Strike-through the row (`~~ROK-XXXX~~ — ~~title~~`) and append `— **Shipped YYYY-MM-DD PR #N**.` to the Notes column. Preserve the row — don't delete.
+2. **Story NOT in `current-sprint.md`?** Append a row to the `### Reactive shipments (filed + shipped mid-cycle)` section (create it once if absent, between "Deferred from Cycle N" and "Capacity guidance"). Row format: `| **ROK-XXXX** | <title> | <why pulled in>. **Shipped YYYY-MM-DD PR #N**. |`
+3. **Strategic decision in this merge?** (architecture call, scope change, deferral, lesson learned, postmortem) — append a dated entry to the Active State Linear doc Strategic section (slug `7a4ddc5652c9`). Skip for routine bug fixes.
+4. **Derived freshness:** if main has moved >1 PR since the last Active State Derived update, run `/status-report` from main.
+
+Commit the `current-sprint.md` change inline as part of cleanup with `chore(planning): reconcile current-sprint.md post-ROK-XXXX merge` OR fold it into the existing `chore(config):` ride-along commit per operator-config rules.
+
+---
+
 ## 5f. Update State
 
 ```yaml

--- a/.claude/skills/bulk/steps/step-4-ship.md
+++ b/.claude/skills/bulk/steps/step-4-ship.md
@@ -54,6 +54,19 @@ Then retry `TeamDelete`. Only fall back to removing `~/.claude/teams/batch-YYYY-
 
 ---
 
+## 4d.5. Reconcile planning artifacts (STRICT)
+
+Per CLAUDE.md "Post-merge planning artifact reconciliation." After the merge confirms. **Run for every story in the batch.**
+
+1. **Story in `planning-artifacts/current-sprint.md`?** Strike-through the row (`~~ROK-XXXX~~ — ~~title~~`) and append `— **Shipped YYYY-MM-DD PR #N**.` to the Notes column. Preserve the row.
+2. **Story NOT in `current-sprint.md`?** Append a row to the `### Reactive shipments (filed + shipped mid-cycle)` section (create once if absent). Row format: `| **ROK-XXXX** | <title> | <why pulled in>. **Shipped YYYY-MM-DD PR #N**. |`
+3. **Strategic decision in this merge?** Append a dated entry to the Active State Linear doc Strategic section (slug `7a4ddc5652c9`). Skip for routine fixes.
+4. **Derived freshness:** if main has moved >1 PR since the last Derived update, run `/status-report` from main.
+
+Commit inline with `chore(planning): reconcile current-sprint.md post-batch-YYYY-MM-DD merge` or fold into the next `chore(config):` ride-along.
+
+---
+
 ## 4e. Final Summary
 
 ```

--- a/.claude/skills/fix-batch/steps/step-4-ship.md
+++ b/.claude/skills/fix-batch/steps/step-4-ship.md
@@ -95,6 +95,19 @@ rm -rf ~/.claude/tasks/fix-batch-YYYY-MM-DD
 
 ---
 
+## 4d.5. Reconcile planning artifacts (STRICT)
+
+Per CLAUDE.md "Post-merge planning artifact reconciliation." After `gh pr view ... --json state` confirms `MERGED`. **Run for every story in the batch.**
+
+1. **Story in `planning-artifacts/current-sprint.md`?** Strike-through the row (`~~ROK-XXXX~~ — ~~title~~`) and append `— **Shipped YYYY-MM-DD PR #N**.` to the Notes column. Preserve the row — don't delete.
+2. **Story NOT in `current-sprint.md`?** Append a row to the `### Reactive shipments (filed + shipped mid-cycle)` section (create once if absent, between "Deferred from Cycle N" and "Capacity guidance"). Row format: `| **ROK-XXXX** | <title> | <why pulled in>. **Shipped YYYY-MM-DD PR #N**. |`
+3. **Strategic decision in this merge?** (architecture call, scope change, lesson learned, postmortem) — append a dated entry to the Active State Linear doc Strategic section (slug `7a4ddc5652c9`). Skip for routine bug fixes.
+4. **Derived freshness:** if main has moved >1 PR since the last Active State Derived update, run `/status-report` from main.
+
+Commit the `current-sprint.md` change inline with `chore(planning): reconcile current-sprint.md post-batch-YYYY-MM-DD merge` OR fold into the `chore(config):` ride-along commit per operator-config rules. The reconciliation commit can ride along with the NEXT PR — it does not need its own PR.
+
+---
+
 ## 4e. Final Summary
 
 Present to the operator:

--- a/.claude/skills/handover/SKILL.md
+++ b/.claude/skills/handover/SKILL.md
@@ -96,7 +96,9 @@ Delete any found with `git branch -d`.
 
 ---
 
-## Step 4: Sync Linear
+## Step 4: Sync Linear + Reconcile Planning Artifacts
+
+### 4a. Linear status
 
 For each story identified in Step 2:
 1. `mcp__linear__get_issue` — check current status
@@ -104,6 +106,19 @@ For each story identified in Step 2:
 3. If different, `mcp__linear__update_issue` to set new status
 
 Agents should have already posted summary comments during their work. If a story is missing a summary comment (committed code but no Linear comment), flag it in the report.
+
+### 4b. Planning artifact reconciliation (STRICT)
+
+Per CLAUDE.md "Post-merge planning artifact reconciliation." For each PR that merged this session:
+
+1. **Story in `planning-artifacts/current-sprint.md`?** Strike-through the row (`~~ROK-XXXX~~ — ~~title~~`) and append `— **Shipped YYYY-MM-DD PR #N**.` to the Notes column. Preserve the row.
+2. **Story NOT in `current-sprint.md`?** Append a row to the `### Reactive shipments (filed + shipped mid-cycle)` section (create once if absent, between "Deferred from Cycle N" and "Capacity guidance"). Row format: `| **ROK-XXXX** | <title> | <why pulled in>. **Shipped YYYY-MM-DD PR #N**. |`
+3. **Strategic decisions this session?** Append a dated entry to the Active State Linear doc Strategic section (slug `7a4ddc5652c9`).
+4. **Derived freshness:** if main moved >1 PR since the last Active State Derived update, run `/status-report` from main as part of this step.
+
+`/handover` is the final-mile reconciler — even if individual skills missed Step 4d.5 (build) or 4d.5 (fix-batch/bulk), this step catches the gap. Treat it as belt-and-suspenders, not redundant.
+
+Commit the `current-sprint.md` change inline with `chore(planning): reconcile current-sprint.md` if uncommitted at session-end.
 
 ---
 

--- a/.claude/skills/janitor/SKILL.md
+++ b/.claude/skills/janitor/SKILL.md
@@ -36,7 +36,6 @@ Run in parallel:
 git fetch origin main
 git worktree list
 ls -1d ../Raid-Ledger--* 2>/dev/null
-gh pr list --state merged --limit 100 --json number,title,headRefName,mergedAt
 ```
 
 Also fetch:
@@ -45,15 +44,31 @@ Also fetch:
 
 If `git fetch origin main` fails (non-zero exit), **STOP** and tell the operator. Do not proceed.
 
-### Step 2: Classify each entry
+**Do NOT pull a flat `gh pr list --state merged --limit N`.** That list is capped — anything older than the most recent N PRs (or filtered out by labels/authors/etc.) won't appear, and the skill will misclassify a merged worktree as "not merged" and skip it forever. Step 2 verifies each branch with a per-branch `gh pr list --search` query instead.
 
-For every `Raid-Ledger--*` dir AND every registered worktree:
+### Step 2: Classify each entry — per-branch verification (STRICT)
+
+For every `Raid-Ledger--*` dir AND every registered worktree, run the **rigorous per-branch merge check** before any classification:
+
+```bash
+# Resolve the branch this dir was tracking (don't parse the dir name — read git state)
+BRANCH=$(git -C <path> rev-parse --abbrev-ref HEAD 2>/dev/null)
+
+# Did this branch ship via a merged PR? Returns JSON array, empty if no merged PR exists.
+gh pr list --search "head:${BRANCH}" --state merged --json number,mergedAt,title,headRefName
+
+# Belt-and-suspenders: if the merged query is empty, check ALL states for this branch.
+# Helps distinguish "merged via different mechanism" from "PR open/closed-without-merge"
+# from "no PR ever existed."
+gh pr list --search "head:${BRANCH}" --state all --json state,number,title
+```
+
+**Rule:** a branch is `MERGED` ONLY if the per-branch `--state merged` query returns ≥1 entry. **Do not infer merge status from a flat top-N list, from `git branch --merged main` alone, or from the absence of the branch on origin.** The per-branch search is the only authoritative signal.
 
 **Registered worktree:**
 
 ```bash
 cd <worktree_path>
-BRANCH=$(git branch --show-current)
 git status --porcelain          # any output = dirty
 git log @{u}..HEAD --oneline    # any output = unpushed (may be squash ghosts — see below)
 ```
@@ -64,10 +79,11 @@ git log @{u}..HEAD --oneline    # any output = unpushed (may be squash ghosts �
 | Branch holds env lock | SKIP — env-lock holder |
 | Branch listed in Active State "In flight" | SKIP — in flight |
 | `git status --porcelain` non-empty | SKIP — uncommitted changes |
-| Branch is `MERGED` per `gh pr list`, working tree clean, no unpushed commits | REMOVE |
-| Branch is `MERGED` per `gh pr list`, working tree clean, unpushed commits exist but the diff is squash-equivalent to the merged PR (verify with `git log @{u}..HEAD` lines correspond to the merged PR title) | REMOVE — flag as squash-ghost |
-| Branch NOT merged, last commit > 14 days old | SURFACE — possible abandoned work |
-| Branch NOT merged, recent activity | SKIP — likely active |
+| Per-branch `gh pr list --state merged` returns ≥1 entry, working tree clean, no unpushed commits | REMOVE |
+| Per-branch `gh pr list --state merged` returns ≥1 entry, working tree clean, unpushed commits exist but diff is squash-equivalent to the merged PR (verify `git log @{u}..HEAD` subjects match the merged PR title) | REMOVE — flag as squash-ghost |
+| Per-branch `gh pr list --state merged` returns 0 entries (no merged PR for this branch) | SURFACE — do NOT remove even if branch looks abandoned. Operator decides. |
+| Per-branch open/closed-without-merge PR exists, last commit > 14 days old | SURFACE — possible abandoned work |
+| Per-branch open PR exists, recent activity | SKIP — likely active |
 
 **Orphaned dir (filesystem only, NOT in `git worktree list`):**
 
@@ -75,14 +91,20 @@ git log @{u}..HEAD --oneline    # any output = unpushed (may be squash ghosts �
 cd <dir>
 git status 2>&1               # may say "fatal: ... .git file ... gitdir invalid"
 git log -1 --oneline 2>&1
+BRANCH=$(git -C <dir> rev-parse --abbrev-ref HEAD 2>/dev/null)
+# Same per-branch check as above:
+gh pr list --search "head:${BRANCH}" --state merged --json number,mergedAt,title
 ```
 
 | Condition | Bucket |
 |---|---|
-| Has `.git` file pointing at a NUKED gitdir (registered worktree was removed but dir persisted) | REMOVE — orphan |
+| Has `.git` file pointing at a NUKED gitdir (registered worktree was removed but dir persisted) AND per-branch query confirms a merged PR | REMOVE — orphan |
+| Has `.git` file pointing at a NUKED gitdir, per-branch query returns 0 merged PRs | SURFACE — branch wasn't shipped via PR; operator decides |
 | Has `.git` dir (full clone, not a worktree) with uncommitted changes | SURFACE — operator decides |
-| Has `.git` dir, clean, branch is merged on origin | REMOVE — operator confirms |
+| Has `.git` dir, clean, per-branch query confirms a merged PR | REMOVE — operator confirms |
 | No `.git` at all, just files | SURFACE — operator decides (probably not a worktree-related artifact) |
+
+**Why the per-branch query is non-negotiable:** a flat `gh pr list --state merged --limit N` is capped at N most-recent PRs. Project history > N means older worktrees get misclassified as "not merged" and skipped forever — the dir then lingers and the next /janitor pass repeats the mistake. Caught 2026-05-14 on the first /janitor invocation.
 
 ### Step 3: Propose plan (STOP HERE)
 

--- a/.claude/skills/janitor/SKILL.md
+++ b/.claude/skills/janitor/SKILL.md
@@ -1,0 +1,190 @@
+---
+name: janitor
+description: "Clean up stale local worktrees and sibling Raid-Ledger--* dirs. Always fetches origin/main first, verifies each branch actually shipped before removing anything, and appends findings to the Active State Linear doc."
+allowed-tools: "Bash(git *), Bash(gh *), Bash(ls *), Bash(rm *), Read, mcp__linear__get_document, mcp__linear__save_document, mcp__mcp-env__env_lock_status"
+---
+
+# /janitor — Worktree & directory cleanup
+
+**Purpose:** sweep the parent directory of the main Raid-Ledger checkout for stale `Raid-Ledger--*` dirs and registered worktrees. Confirm each one's work has actually shipped (PR merged on `origin/main`) and that nothing local would be lost. Propose, then — only after explicit operator approval — execute the cleanup. Update the Active State Linear doc with what happened.
+
+## Why this exists
+
+`git worktree add` and parallel `/build` / `/fix-batch` / `/bulk` sessions accumulate sibling dirs. Cleanup at the end of each session is often skipped or partial. After a few weeks the parent directory has 20+ orphaned dirs from work that already shipped — confusing for the operator and surface-area for foot-guns (a stale dir on a deleted branch can be mistaken for current state).
+
+## Hard safety rules (STRICT)
+
+These rules NEVER bend, regardless of how confident the cleanup looks:
+
+1. **ALWAYS fetch first.** `git fetch origin main` is the first action. If the fetch fails (network, auth) → **ABORT** the whole skill. No removals.
+2. **NEVER delete the main worktree** (`/Users/sdodge/Documents/Projects/Raid-Ledger`).
+3. **NEVER delete a worktree currently holding the env lock.** Check via `mcp__mcp-env__env_lock_status` and cross-reference the holder's `branch` field.
+4. **NEVER delete a worktree mentioned in the Active State doc's "In flight" section** without explicit operator override.
+5. **NEVER delete a dir with uncommitted changes**, untracked authored files, OR commits not represented on `origin/main` by a merged PR. Squash-merge "ghost commits" (local branch ahead but the squashed diff is on main) are the ONLY exception — and only if the corresponding PR is `state=MERGED`.
+6. **NEVER bypass the propose-then-confirm gate.** Present the plan, wait for operator "go", then execute. No autonomous removals.
+7. **Removals are sequential, not parallel.** One worktree at a time, log each result, stop on first unexpected failure.
+
+If any rule trips for a given entry, the entry goes into the SKIPPED bucket with a one-line reason — it does NOT get removed.
+
+## Steps
+
+### Step 1: Sync state
+
+Run in parallel:
+
+```bash
+git fetch origin main
+git worktree list
+ls -1d ../Raid-Ledger--* 2>/dev/null
+gh pr list --state merged --limit 100 --json number,title,headRefName,mergedAt
+```
+
+Also fetch:
+- `mcp__mcp-env__env_lock_status` — current env-lock holder
+- Active State doc "In flight" section via `mcp__linear__get_document(id: "7a4ddc5652c9")`
+
+If `git fetch origin main` fails (non-zero exit), **STOP** and tell the operator. Do not proceed.
+
+### Step 2: Classify each entry
+
+For every `Raid-Ledger--*` dir AND every registered worktree:
+
+**Registered worktree:**
+
+```bash
+cd <worktree_path>
+BRANCH=$(git branch --show-current)
+git status --porcelain          # any output = dirty
+git log @{u}..HEAD --oneline    # any output = unpushed (may be squash ghosts — see below)
+```
+
+| Condition | Bucket |
+|---|---|
+| `BRANCH == main` AND path is the canonical main worktree | KEEP (this is home) |
+| Branch holds env lock | SKIP — env-lock holder |
+| Branch listed in Active State "In flight" | SKIP — in flight |
+| `git status --porcelain` non-empty | SKIP — uncommitted changes |
+| Branch is `MERGED` per `gh pr list`, working tree clean, no unpushed commits | REMOVE |
+| Branch is `MERGED` per `gh pr list`, working tree clean, unpushed commits exist but the diff is squash-equivalent to the merged PR (verify with `git log @{u}..HEAD` lines correspond to the merged PR title) | REMOVE — flag as squash-ghost |
+| Branch NOT merged, last commit > 14 days old | SURFACE — possible abandoned work |
+| Branch NOT merged, recent activity | SKIP — likely active |
+
+**Orphaned dir (filesystem only, NOT in `git worktree list`):**
+
+```bash
+cd <dir>
+git status 2>&1               # may say "fatal: ... .git file ... gitdir invalid"
+git log -1 --oneline 2>&1
+```
+
+| Condition | Bucket |
+|---|---|
+| Has `.git` file pointing at a NUKED gitdir (registered worktree was removed but dir persisted) | REMOVE — orphan |
+| Has `.git` dir (full clone, not a worktree) with uncommitted changes | SURFACE — operator decides |
+| Has `.git` dir, clean, branch is merged on origin | REMOVE — operator confirms |
+| No `.git` at all, just files | SURFACE — operator decides (probably not a worktree-related artifact) |
+
+### Step 3: Propose plan (STOP HERE)
+
+Print a table grouped by bucket. **Do not execute anything yet.** Wait for explicit "go" from operator.
+
+```
+═══ /janitor PROPOSED CLEANUP ═══
+
+KEEP (N):
+  /Users/sdodge/Documents/Projects/Raid-Ledger — main worktree
+
+SKIP (M):
+  Raid-Ledger--rok-XXXX — in flight (Active State)
+  Raid-Ledger--rok-YYYY — env-lock holder
+  Raid-Ledger--rok-ZZZZ — uncommitted changes: <files>
+
+REMOVE — registered worktrees (P):
+  Raid-Ledger--rok-AAAA — PR #N merged YYYY-MM-DD, clean, no unpushed
+  Raid-Ledger--rok-BBBB — PR #N merged YYYY-MM-DD, squash-ghost commits OK
+
+REMOVE — orphaned dirs (Q):
+  Raid-Ledger--rok-CCCC — orphan (gitdir invalid), would `rm -rf`
+  Raid-Ledger--rok-DDDD — clean clone, branch merged via PR #N, would `rm -rf`
+
+SURFACE — operator decides (R):
+  Raid-Ledger--rok-EEEE — branch not merged, last commit 21 days ago — abandoned?
+  Raid-Ledger--FFFF      — no .git, no idea what this is
+
+Proceed? (go / cancel / drop:<name> / hold)
+```
+
+Operator inputs:
+- `go` → execute REMOVE buckets (registered + orphaned) in sequence
+- `cancel` → exit, change nothing
+- `drop:<name>` → move that entry from REMOVE → SKIP, re-print, ask again
+- `hold` → exit; operator wants to think about it
+
+### Step 4: Execute (only after "go")
+
+For each REMOVE-registered worktree, sequentially:
+
+```bash
+git worktree remove <path>
+# if the local branch still exists post-squash-merge:
+git branch -D <branch_name> 2>/dev/null || true
+```
+
+If `git worktree remove` errors mid-flight (e.g. detects dirty state we missed), **STOP** — do not pass `--force`. Print the error, mark this entry as failed, ask operator before continuing to next.
+
+For each REMOVE-orphaned dir:
+
+```bash
+rm -rf <path>
+```
+
+After all removals, run `git worktree prune` to clean any registry orphans.
+
+### Step 5: Update Active State doc
+
+Append a dated entry to the Active State Linear doc Strategic section (slug `7a4ddc5652c9`) per CLAUDE.md "Post-merge planning artifact reconciliation" — this counts as a strategic cleanup worth recording so future sessions know when the last sweep happened.
+
+Entry format:
+
+```
+**YYYY-MM-DD — /janitor sweep**
+
+* Removed N registered worktrees: <ROK list with PR refs>.
+* Removed M orphaned dirs: <ROK list>.
+* Skipped K: <one-line reason each, grouped by reason>.
+* Surfaced L for operator review: <list with one-line reason>.
+* Active worktrees remaining: <count + names>.
+```
+
+Use `mcp__linear__save_document` to update the doc. Get the current content via `mcp__linear__get_document` first, splice the new entry in at the TOP of "### Recent decisions" (newest first per the doc's convention), and save.
+
+### Step 6: Final report
+
+```
+═══ JANITOR SWEEP COMPLETE ═══
+Removed: <P registered + Q orphaned> = <total> dirs
+Skipped: M (see above)
+Surfaced: L (need operator review)
+Active worktrees remaining: <list>
+Active State updated: ✓ (or ✗ + reason)
+```
+
+## When NOT to invoke
+
+- During an active `/build`, `/fix-batch`, or `/bulk` session — wait for that batch to ship its PR first. The skill respects in-flight markers but accidentally racing against an active batch wastes everyone's time.
+- When `git fetch` would error (offline, auth expired) — STOP cleanly rather than guessing.
+- When the operator says "leave my old experiments" — those usually live as orphaned dirs without merged PRs. The skill's SURFACE bucket exists for exactly this case; treat the operator's preferences as override.
+
+## Halts
+
+- `git fetch origin main` fails → ABORT, no cleanup, surface error to operator.
+- Active State doc inaccessible at Step 5 → still complete Steps 1-4, skip Step 5, FLAG the gap in the final report. Don't block the cleanup on doc availability.
+- More than 3 entries land in SURFACE → present them all and ask operator to triage before executing the REMOVE buckets. The point of /janitor is reducing operator friction, not increasing it; if half the dirs need decisions, batch the conversation.
+- Mid-execution removal error → STOP, surface the entry, ask operator before continuing.
+
+## Notes on edge cases
+
+- **Squash-ghost commits:** when a PR squash-merges, the local branch typically has the pre-squash commits + a divergent hash from origin/main. Detection: `gh pr list --search "head:<branch>" --state merged --json mergedAt,title` returns a result; `git log @{u}..HEAD` shows commits whose subjects appear in the merged PR description. Safe to remove if both hold.
+- **`Raid-Ledger--batch` and `Raid-Ledger--rok-1156-feature` style names:** the dir-name → branch-name mapping isn't always `rok-NNNN`. Look at the dir's actual git state (via `git -C <dir> branch --show-current`) rather than parsing the dir name.
+- **`Raid-Ledger--fix-batch-YYYY-MM-DD`:** these are batch integration worktrees. Same classification rules — if the batch PR merged and tree is clean, REMOVE.
+- **Non-Raid-Ledger sibling dirs** (e.g. `sjdodge123.github.io`): out of scope. The skill globs only `../Raid-Ledger--*`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -268,6 +268,22 @@ Backups exclude the `drizzle` schema (migration metadata is code, not data) to p
 - `deploy_dev.sh` calls reconcile automatically after an auto-restore from `api/backups/daily/`.
 - **Symptom that means you need reconcile:** `drizzle-kit migrate` fails with `column/relation X already exists` on a migration whose hash isn't in `drizzle.__drizzle_migrations`.
 
+### Games-table INSERT paths must use the name-dedup guard (STRICT — ROK-1113 / ROK-1283)
+
+Postgres UNIQUE constraints treat NULL as never-equal, so `ON CONFLICT (igdb_id)` does NOT fire when an existing row has `igdb_id IS NULL`. Any new code that inserts into `games` MUST first call `findGameByNormalizedName(db, name)` (or the batch variant `findGameIdsByNormalizedName`) and merge into the existing row when one matches. Otherwise the next migration that collapses dups will be silently undone on the next deploy.
+
+The 5 current INSERT-into-`games` paths, all of which use the name-dedup guard:
+
+1. `api/src/steam/steam-itad-discovery.helpers.ts` — steam-itad discovery (ROK-1113).
+2. `api/src/igdb/igdb-itad-upsert.helpers.ts` — IGDB+ITAD upsert path (ROK-1113).
+3. `api/src/igdb/igdb-upsert.helpers.ts::upsertSingleGameRow` — single-row IGDB upsert (ROK-1113; canonical pattern).
+4. `api/src/igdb/igdb-upsert.helpers.ts::upsertGamesFromApi` — batch IGDB upsert (ROK-1113).
+5. `api/scripts/seed-igdb-games.ts::upsertSeedGames` — boot-time IGDB seed (ROK-1283).
+
+A 6th path exists at `api/scripts/seed-games.ts` (boot-time game-registry seed) and uses `ON CONFLICT (slug) DO NOTHING`. It is theoretically vulnerable to the same NULL-as-distinct trap but practically safe: its slugs match the IGDB seed and prod data has no surviving name dups post-ROK-1278. The same fix should be applied when next touching that file — tracked in TECH-DEBT-BACKLOG.md under 2026-05-14 / ROK-1283.
+
+When adding a NEW INSERT-into-`games` path, append it to this list. The reproduction that motivates the rule: prod 2026-05-14 — migration 0140 merged 21 BG3-like dups, then `seed-igdb-games.ts` immediately re-created the BG3 dup on the same boot because its `ON CONFLICT (igdb_id)` target ignored the NULL-keyed survivor row.
+
 ## Testing
 
 - **Backend:** `npm run test -w api` (Jest). Coverage: `npm run test:cov -w api`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -375,6 +375,18 @@ npx playwright test
   - API-only changes → Integration test (Jest, real DB)
   - Pure logic → Unit test
 
+## Discord User Deactivation (ROK-1260, ROK-1282)
+
+When a user leaves the Discord guild we must flip `users.deactivated_at` so they stop receiving DMs, get cancelled from upcoming signups, and disappear from the Players list. There is **no `GuildMemberRemove` listener** — ROK-1260's spec mentioned one but it was never shipped. Three layers cover the gap instead. Before adding a fourth, confirm one of the existing three is insufficient.
+
+| Layer | Trigger | Where | Misses |
+|-------|---------|-------|--------|
+| 1. Reactive 50278 classifier | DM send fails with `DiscordAPIError[50278]` | `api/src/notifications/discord-notification.processor.ts` (~line 117) | Quiet users who never receive a notification |
+| 2. `GuildMemberAdd` listener | User joins/rejoins the guild | `api/src/discord-bot/listeners/guild-member-add.listener.ts` | Only re-enables; nothing on the leave side |
+| 3. Daily reconciliation cron | `@Cron('0 0 7 * * *')` — 07:00 UTC daily | `api/src/users/guild-reconciliation.service.ts` | Users gone for <24h (rare; layer 1 usually catches first DM) |
+
+All three call into `DiscordNotificationService.deactivateUser(userId)` so the cancel cascade + admin notification path is identical. `deactivateUser` is idempotent (RETURNING-guarded UPDATE), so overlap between layers is safe.
+
 ## Discord Testing (tools/)
 
 Two tools exist for testing Discord bot functionality. **Use these when testing any Discord-related feature** (events, attendance, notifications, embeds, voice).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,46 @@ If you encounter a failure (TypeScript error, lint error, test failure, smoke fl
 
 **Scope guard:** documenting a pre-existing failure is NOT the same as fixing it. Don't expand your story to fix unrelated tech debt unless the operator approves. The doc entry is the deliverable.
 
+## Post-merge planning artifact reconciliation (STRICT — applies to ALL agents)
+
+When a PR merges, Linear flips to `Done` but the cycle plan at `planning-artifacts/current-sprint.md` does NOT auto-update — it rots silently until cycle rollover. The operator reads this file at session start to understand cycle state; a stale plan steers the next session toward already-shipped work. Caught 2026-05-14 during `/sprint-planning` when three Highs shown "open" had shipped 2 days prior.
+
+Every agent (Lead) that merges a PR — single-story or batched — MUST reconcile the planning artifacts as the last step of the ship phase, BEFORE ending the session. Run AFTER `gh pr view ... --json state` confirms `MERGED` (so the PR # and merge date are real).
+
+**Three reconciliation cases:**
+
+1. **Merged story IS listed in `planning-artifacts/current-sprint.md`** (any Wave / batch / table row):
+   - Strike-through the title in place (`~~ROK-XXXX~~ — ~~original title~~`) and append `— **Shipped YYYY-MM-DD PR #N**.` to the Notes column (or trailing text).
+   - Do NOT delete the row — the strike-through preserves the cycle's original commitment for sprint-end review. Deletion erases context for the retrospective.
+
+2. **Merged story is NOT in `current-sprint.md`** (out-of-cycle hotfix, reactive bug filed mid-cycle, unplanned follow-up):
+   - Append a row to the `### Reactive shipments (filed + shipped mid-cycle)` section near the bottom of the file (between "Deferred from Cycle N" and "Capacity guidance"). Create the section once if it doesn't exist; subsequent merges just append.
+   - Row format: `| **ROK-XXXX** | <title> | <1-line why this got pulled in / what prompted it>. **Shipped YYYY-MM-DD PR #N**. |`
+   - This is the part the operator specifically asked for ("I want a good picture of what was actually built during each sprint"). Without it, the sprint review undercounts what shipped.
+
+3. **The merge represents a strategic decision** (architecture call, scope change, deferral, lesson learned, new STRICT rule, dependency reversal, prod-incident postmortem):
+   - Append a dated entry to the **Active State Linear doc's Strategic section** (slug `7a4ddc5652c9`). Format matches existing entries: `**YYYY-MM-DD** — <headline>` followed by 1–3 bullets. The Strategic section is append-only and is NOT cleared by `/status-report`.
+   - Skip this for routine bug-fix merges with no broader implication. Don't pad the doc.
+
+**Plus: Derived freshness check.** If main has moved by >1 PR since the last Derived update on the Active State doc, run `/status-report` from main as part of cleanup. The Derived section is owned by `/status-report` — manual edits get overwritten on the next run.
+
+**Who runs it:**
+
+| Skill | Step where reconciliation lives |
+|---|---|
+| `/build` | `steps/step-5-ship.md` § 5e.5 |
+| `/fix-batch` | `steps/step-4-ship.md` § 4d.5 |
+| `/bulk` | `steps/step-4-ship.md` § 4d.5 |
+| `/handover` | `SKILL.md` Step 4 (extension) |
+
+For an operator-driven manual merge (`gh pr merge` outside any skill), the operator either updates the doc themselves OR re-invokes `/status-report` from main on the next session.
+
+**When NOT to do this:**
+
+- The PR was reverted or closed without merging — nothing to reconcile.
+- The merge is a routine `chore(release): bump version` or pure `chore(config)` operator-config ride-along — no story attached, no reconciliation needed.
+- The merge is a back-merge from main into a working branch — not a story shipment.
+
 ## Reference designs before coding (STRICT — applies to ALL agents)
 
 Before writing implementation code for ANY feature/fix that has a visual or UX dimension, scan for design references that may already exist. The operator regularly approves simplified-flow targets, wireframes, or design specs ahead of implementation — agents picking up follow-up work should be **implementing the approved target, not redesigning it**.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,43 +36,13 @@ If you encounter a failure (TypeScript error, lint error, test failure, smoke fl
 
 ## Post-merge planning artifact reconciliation (STRICT — applies to ALL agents)
 
-When a PR merges, Linear flips to `Done` but the cycle plan at `planning-artifacts/current-sprint.md` does NOT auto-update — it rots silently until cycle rollover. The operator reads this file at session start to understand cycle state; a stale plan steers the next session toward already-shipped work. Caught 2026-05-14 during `/sprint-planning` when three Highs shown "open" had shipped 2 days prior.
+After a PR merges (confirmed by `gh pr view ... --json state` = `MERGED`), the Lead reconciles `planning-artifacts/current-sprint.md` BEFORE ending the session. Linear's status flip alone is insufficient — the cycle plan rots until rollover otherwise.
 
-Every agent (Lead) that merges a PR — single-story or batched — MUST reconcile the planning artifacts as the last step of the ship phase, BEFORE ending the session. Run AFTER `gh pr view ... --json state` confirms `MERGED` (so the PR # and merge date are real).
+1. **Story IS in the cycle plan** → strike-through the row (`~~ROK-XXXX~~ — ~~title~~`) and append `— **Shipped YYYY-MM-DD PR #N**.` to Notes. Don't delete; strike-through preserves the original commitment for the sprint-end retrospective.
+2. **Story is NOT in the cycle plan** (out-of-cycle hotfix, reactive bug, unplanned follow-up) → append a row to `### Reactive shipments (filed + shipped mid-cycle)` near the file's bottom. Create the section once if absent. Row format: `| **ROK-XXXX** | <title> | <why pulled in>. **Shipped YYYY-MM-DD PR #N**. |`
+3. **Strategic decision in the merge** (architecture / scope change / postmortem / new STRICT rule) → append a dated entry to the Active State Linear doc Strategic section (slug `7a4ddc5652c9`). Skip for routine fixes.
 
-**Three reconciliation cases:**
-
-1. **Merged story IS listed in `planning-artifacts/current-sprint.md`** (any Wave / batch / table row):
-   - Strike-through the title in place (`~~ROK-XXXX~~ — ~~original title~~`) and append `— **Shipped YYYY-MM-DD PR #N**.` to the Notes column (or trailing text).
-   - Do NOT delete the row — the strike-through preserves the cycle's original commitment for sprint-end review. Deletion erases context for the retrospective.
-
-2. **Merged story is NOT in `current-sprint.md`** (out-of-cycle hotfix, reactive bug filed mid-cycle, unplanned follow-up):
-   - Append a row to the `### Reactive shipments (filed + shipped mid-cycle)` section near the bottom of the file (between "Deferred from Cycle N" and "Capacity guidance"). Create the section once if it doesn't exist; subsequent merges just append.
-   - Row format: `| **ROK-XXXX** | <title> | <1-line why this got pulled in / what prompted it>. **Shipped YYYY-MM-DD PR #N**. |`
-   - This is the part the operator specifically asked for ("I want a good picture of what was actually built during each sprint"). Without it, the sprint review undercounts what shipped.
-
-3. **The merge represents a strategic decision** (architecture call, scope change, deferral, lesson learned, new STRICT rule, dependency reversal, prod-incident postmortem):
-   - Append a dated entry to the **Active State Linear doc's Strategic section** (slug `7a4ddc5652c9`). Format matches existing entries: `**YYYY-MM-DD** — <headline>` followed by 1–3 bullets. The Strategic section is append-only and is NOT cleared by `/status-report`.
-   - Skip this for routine bug-fix merges with no broader implication. Don't pad the doc.
-
-**Plus: Derived freshness check.** If main has moved by >1 PR since the last Derived update on the Active State doc, run `/status-report` from main as part of cleanup. The Derived section is owned by `/status-report` — manual edits get overwritten on the next run.
-
-**Who runs it:**
-
-| Skill | Step where reconciliation lives |
-|---|---|
-| `/build` | `steps/step-5-ship.md` § 5e.5 |
-| `/fix-batch` | `steps/step-4-ship.md` § 4d.5 |
-| `/bulk` | `steps/step-4-ship.md` § 4d.5 |
-| `/handover` | `SKILL.md` Step 4 (extension) |
-
-For an operator-driven manual merge (`gh pr merge` outside any skill), the operator either updates the doc themselves OR re-invokes `/status-report` from main on the next session.
-
-**When NOT to do this:**
-
-- The PR was reverted or closed without merging — nothing to reconcile.
-- The merge is a routine `chore(release): bump version` or pure `chore(config)` operator-config ride-along — no story attached, no reconciliation needed.
-- The merge is a back-merge from main into a working branch — not a story shipment.
+If `origin/main` moved by >1 PR since the doc's last Derived update, run `/status-report` from main as part of cleanup. Step refs: `/build` 5e.5, `/fix-batch` + `/bulk` 4d.5, `/handover` 4b. Skip for reverted PRs, `chore(release|config)` ride-alongs, and back-merges from main.
 
 ## Reference designs before coding (STRICT — applies to ALL agents)
 

--- a/TECH-DEBT-BACKLOG.md
+++ b/TECH-DEBT-BACKLOG.md
@@ -280,3 +280,9 @@ Pre-existing TypeScript errors present on `origin/main` (bfc5e054) and untouched
 - **[low]** `api/src/users/guild-reconciliation.service.ts:93-106` — `loadActiveDbUsers` has no index on `deactivated_at` and full-scans `users` daily. Acceptable at current user volume; index becomes relevant past several thousand rows.
   Suggested: revisit if cron duration exceeds ~1s on prod.
 
+
+### 2026-05-14 — fix/batch-2026-05-14 (surfaced during ROK-1282 + ROK-1283 push validation)
+
+- **[med]** `web/src/components/admin/onboarding/secure-account-step.test.tsx` — 6/20 specs in this file flake with `Test timed out in 5000ms` when run as part of the full vitest suite (`npm run test:cov -w web`). All 20 PASS in 773ms when the file is run in isolation (`npx vitest run src/components/admin/onboarding/secure-account-step.test.tsx`). The failing assertions are synchronous DOM class lookups (`toHaveClass('min-h-[44px]')`), so the 5000ms timeout is concurrency starvation, not test logic. Last touched in #379 (months ago); independent of fix/batch-2026-05-14 (zero web/ changes in the batch).
+  Suggested: bump this file's `testTimeout` to 15000ms in vitest.config.ts (the FTE wizard tests do heavier jsdom setup than typical) OR move it to its own project shard. The cheap-experiment plan: run `npx vitest run secure-account-step` 50× to characterise the flake rate, then either bump the timeout or shard the file.
+

--- a/TECH-DEBT-BACKLOG.md
+++ b/TECH-DEBT-BACKLOG.md
@@ -252,3 +252,21 @@ Findings from senior-code-review on the batch diff. Critical + high were fixed i
   Suggested: replace `runMigrations` in `api/src/backup/backup.helpers.ts:124` with a call to `runBootMigrations(databaseUrl)` from the new runner. Restore flows benefit from the audit refresh + Sentry capture for free.
 - **[med]** Prod recovery required manually marking 0140 as applied in `drizzle.__drizzle_migrations` before the new image could boot. This pattern (insert hash row to skip a failed migration) is not documented anywhere — operator had to derive it. Add a `scripts/recover-stuck-migration.sh` runbook.
   Suggested: a script that takes a migration tag, looks up its hash from `meta/_journal.json`, inserts the journal row, and prints next-steps. Idempotent.
+
+### 2026-05-14 — fix/rok-1283 (ROK-1283 follow-up)
+
+- **[low]** `api/scripts/seed-games.ts` — sibling of `seed-igdb-games.ts` audited as part of ROK-1283. Same shape (`ON CONFLICT (slug) DO NOTHING`), same NULL-distinct vulnerability in principle. Practically dormant in prod: its slugs match `seed-igdb-games.ts` AND post-ROK-1278 cleanup left no name dups for this seed's names to collide with. Was NOT fixed in ROK-1283 because the file already exceeds `max-lines` (302/300) on `origin/main` and applying the same fix would push it further over; CI lint would fail. Apply the name-dedup guard the next time this file is touched, alongside breaking up the `GAMES_SEED` constant (move to a sibling `seed-games.data.ts`) to bring the file back under 300 effective lines.
+  Suggested: extract `GAMES_SEED` to `api/scripts/seed-games.data.ts` (no logic, just data) and apply the same `findGameByNormalizedName` pre-check pattern used in `seed-igdb-games.ts::upsertSeedGames`.
+
+### 2026-05-14 — fix/rok-1283 (surfaced during ROK-1283 typecheck)
+
+Pre-existing TypeScript errors present on `origin/main` (bfc5e054) and untouched by this story. Re-verified by stashing the ROK-1283 changes and re-running `npx tsc --noEmit -p api/tsconfig.json`. All four exist verbatim on main.
+
+- **[med]** `api/src/admin/games-dedup-merge.integration.spec.ts:139,149,160` — Three `TS2352` errors from postgres-js `RowList<…>` ↔ snake_case struct casts (e.g., `RowList<{ totalSeconds: number; }[]>` → `{ total_seconds: number; }[]`). Drizzle returns camelCase, the cast assumes snake_case.
+  Suggested: cast through `unknown` first (as the compiler error suggests) or fix the destination shape to match Drizzle's camelCase output.
+- **[med]** `api/src/lineups/lineup-deadline-vote-race.integration.spec.ts:186` — `TS2345`: Argument of type `SQL<unknown>` is not assignable to parameter of type `string | SQLWrapper`. Two copies of drizzle-orm types are visible (separate declarations of `shouldInlineParams`). Looks like hoisting / peer-dep dedup drift.
+  Suggested: `npm dedupe` to remove the duplicate `drizzle-orm/sql/sql` instance, or pin a single drizzle-orm version across workspaces.
+- **[med]** `api/src/lineups/lineup-notification.service.private-visibility.spec.ts:108,114,120,126` — Four `TS2556` "spread argument must either have a tuple type or be passed to a rest parameter". Test uses `fn(...args)` where `args` is inferred as `unknown[]` instead of a tuple.
+  Suggested: add `as const` to the array literals or annotate the helper parameter as a rest tuple.
+- **[med]** `api/src/admin/games-dedup-audit.integration.spec.ts:386` — `TS2769`: No overload matches this call. Likely the same drizzle-orm dedup drift as the lineup-deadline-vote-race error above.
+  Suggested: `npm dedupe` (paired with the lineup-deadline fix).

--- a/TECH-DEBT-BACKLOG.md
+++ b/TECH-DEBT-BACKLOG.md
@@ -270,3 +270,13 @@ Pre-existing TypeScript errors present on `origin/main` (bfc5e054) and untouched
   Suggested: add `as const` to the array literals or annotate the helper parameter as a rest tuple.
 - **[med]** `api/src/admin/games-dedup-audit.integration.spec.ts:386` — `TS2769`: No overload matches this call. Likely the same drizzle-orm dedup drift as the lineup-deadline-vote-race error above.
   Suggested: `npm dedupe` (paired with the lineup-deadline fix).
+
+### 2026-05-14 — fix/batch-2026-05-14 (PR pending — ROK-1282 + ROK-1283)
+
+- **[low]** `api/src/users/guild-reconciliation.service.ts:107-109` — dead-code `rows.filter((r): r is { id: number; discordId: string } => r.discordId !== null)`. SQL already guarantees `isNotNull(discordId)` so the filter never drops a row.
+  Suggested: drop the filter and tighten the return type via a non-null assertion or Drizzle column-level non-null inference.
+- **[low]** `api/src/users/guild-reconciliation.service.ts:113-123` — `deactivateGap` runs deactivations sequentially. Fine at current scale (~5–10 leavers per run on a 500-user guild), but a post-outage run with hundreds of leavers serialises per-row cascades (cancel signups + admin notification).
+  Suggested: keep sequential for now (audit-trail simplicity); revisit if a single run ever exceeds ~50 deactivations.
+- **[low]** `api/src/users/guild-reconciliation.service.ts:93-106` — `loadActiveDbUsers` has no index on `deactivated_at` and full-scans `users` daily. Acceptable at current user volume; index becomes relevant past several thousand rows.
+  Suggested: revisit if cron duration exceeds ~1s on prod.
+

--- a/TECH-DEBT-BACKLOG.md
+++ b/TECH-DEBT-BACKLOG.md
@@ -286,3 +286,13 @@ Pre-existing TypeScript errors present on `origin/main` (bfc5e054) and untouched
 - **[med]** `web/src/components/admin/onboarding/secure-account-step.test.tsx` — 6/20 specs in this file flake with `Test timed out in 5000ms` when run as part of the full vitest suite (`npm run test:cov -w web`). All 20 PASS in 773ms when the file is run in isolation (`npx vitest run src/components/admin/onboarding/secure-account-step.test.tsx`). The failing assertions are synchronous DOM class lookups (`toHaveClass('min-h-[44px]')`), so the 5000ms timeout is concurrency starvation, not test logic. Last touched in #379 (months ago); independent of fix/batch-2026-05-14 (zero web/ changes in the batch).
   Suggested: bump this file's `testTimeout` to 15000ms in vitest.config.ts (the FTE wizard tests do heavier jsdom setup than typical) OR move it to its own project shard. The cheap-experiment plan: run `npx vitest run secure-account-step` 50× to characterise the flake rate, then either bump the timeout or shard the file.
 
+
+### 2026-05-14 — fix/batch-2026-05-14 (post-Codex reviewer pass)
+
+- **[low]** `api/src/common/testing/test-app.ts:122` vs `api/src/common/testing/integration-setup.ts:64` — inconsistent CI gating. `test-app.ts` uses strict `process.env.CI === 'true'` after the post-clone audit fix; `integration-setup.ts` uses loose `!process.env.CI`. Both behave correctly under GitHub Actions (`CI=true`) but a developer setting `CI=1` locally would get DATABASE_URL deleted by integration-setup yet ignored anyway by test-app (Testcontainers fires).
+  Suggested: align both to `process.env.CI === 'true'`. ~5-line change in `integration-setup.ts`.
+- **[low]** `api/scripts/seed-igdb-games.ts:181-194` — extra DB roundtrip via `rowExistsWithIgdbId` per orphan-match row. Acceptable at boot-time (~hundreds of rows, single-threaded). Could fold into a single SQL CTE if seed counts grow into the thousands.
+  Suggested: no action unless seed perf becomes a bottleneck.
+- **[low]** `api/src/users/guild-reconciliation.service.integration.spec.ts:137-146` — the "Discord API errors bubble up" test calls `runReconciliation()` directly, not via `CronJobService.executeWithTracking`. Confirms the throw bubbles but doesn't assert the cron wrapper records a failed run vs. healthy heartbeat (which is the actual P2 motivation). Integration with `executeWithTracking` is likely already covered by existing cron-service tests but not explicitly asserted in this regression spec.
+  Suggested: add one spec that mocks `cronJobService.executeWithTracking` and asserts `failedRun` was recorded when `listAllGuildMemberIds` throws.
+

--- a/api/scripts/seed-igdb-games.ts
+++ b/api/scripts/seed-igdb-games.ts
@@ -145,12 +145,32 @@ async function mergeSeedIntoExistingRow(
     .where(eq(schema.games.id, existingId));
 }
 
+/** Does any row already own this igdb_id? Codex P1 (2026-05-14) guard. */
+async function rowExistsWithIgdbId(
+  db: Db,
+  igdbId: number,
+): Promise<boolean> {
+  const rows = await db
+    .select({ id: schema.games.id })
+    .from(schema.games)
+    .where(eq(schema.games.igdbId, igdbId))
+    .limit(1);
+  return rows.length > 0;
+}
+
 /**
  * Upsert a batch of seed rows into `games`. For each row:
  *   1. Look up an existing row by normalized name (ROK-1113 guard).
- *      If found AND its igdbId is null OR matches the seed's igdbId → merge.
- *      Mismatched non-null igdbIds (sequels/variants) are left alone.
- *   2. Otherwise fall back to INSERT ... ON CONFLICT (igdb_id) DO UPDATE.
+ *      Two safe-merge cases:
+ *        (a) Existing row's igdbId already matches the seed → idempotent merge.
+ *        (b) Existing row's igdbId is null AND no other row already owns the
+ *            seed's igdbId → safe merge (back-fills the orphan).
+ *      Codex P1 (2026-05-14): merging a null-igdb_id orphan when a canonical
+ *      row already owns the seed's igdb_id would crash on the UNIQUE index,
+ *      aborting boot. In that case, fall through to ON CONFLICT (igdb_id) so
+ *      the canonical row is updated and the orphan is left for the next
+ *      dedup audit (ROK-1277/1278) to merge.
+ *   2. Otherwise INSERT ... ON CONFLICT (igdb_id) DO UPDATE.
  * Returns the count of rows touched.
  */
 export async function upsertSeedGames(
@@ -161,13 +181,16 @@ export async function upsertSeedGames(
   for (const seed of seeds) {
     const values = mapGameToValues(seed);
     const nameMatch = await findGameByNormalizedName(db, seed.name);
-    if (
-      nameMatch &&
-      (nameMatch.igdbId == null || nameMatch.igdbId === seed.igdbId)
-    ) {
-      await mergeSeedIntoExistingRow(db, nameMatch.id, values);
-      touched++;
-      continue;
+    if (nameMatch) {
+      const sameIgdbId = nameMatch.igdbId === seed.igdbId;
+      const orphanSafe =
+        nameMatch.igdbId == null &&
+        !(await rowExistsWithIgdbId(db, seed.igdbId));
+      if (sameIgdbId || orphanSafe) {
+        await mergeSeedIntoExistingRow(db, nameMatch.id, values);
+        touched++;
+        continue;
+      }
     }
     await db
       .insert(schema.games)

--- a/api/scripts/seed-igdb-games.ts
+++ b/api/scripts/seed-igdb-games.ts
@@ -1,13 +1,14 @@
 import { NestFactory } from '@nestjs/core';
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
-import { sql } from 'drizzle-orm';
+import { eq, sql } from 'drizzle-orm';
 import {
   DrizzleModule,
   DrizzleAsyncProvider,
 } from '../src/drizzle/drizzle.module';
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import * as schema from '../src/drizzle/schema';
+import { findGameByNormalizedName } from '../src/igdb/igdb-name-dedup.helpers';
 import * as dotenv from 'dotenv';
 import * as fs from 'fs';
 import * as path from 'path';
@@ -19,11 +20,15 @@ dotenv.config();
  * This populates the `games` table (IGDB cache) with pre-seeded games,
  * enabling game search and discovery to work without requiring IGDB API keys.
  *
- * Uses upsert (ON CONFLICT DO UPDATE) to safely re-run without duplicates.
- * Writes all expanded fields (summary, rating, gameModes, screenshots, etc.)
+ * ROK-1283: Before inserting, each seed row is checked against existing rows
+ * by normalized canonical name (the same guard that production INSERT paths
+ * use in `upsertSingleGameRow`). Without this, a row with `igdb_id IS NULL`
+ * but the same name would NOT trigger ON CONFLICT (igdb_id) — PG treats NULL
+ * as never-equal — and the seeder would re-create the dup that migration
+ * 0140 just merged. See the ROK-1283 spec for the BG3 reproduction.
  */
 
-interface GameSeed {
+export interface GameSeed {
   igdbId: number;
   name: string;
   slug: string;
@@ -59,7 +64,7 @@ interface GamesSeedFile {
 })
 class SeedModule {}
 
-function mapGameToValues(game: GameSeed) {
+export function mapGameToValues(game: GameSeed) {
   return {
     igdbId: game.igdbId,
     name: game.name,
@@ -84,7 +89,10 @@ function mapGameToValues(game: GameSeed) {
   };
 }
 
-/** Column references for the excluded row in ON CONFLICT DO UPDATE */
+type GameValues = ReturnType<typeof mapGameToValues>;
+type Db = PostgresJsDatabase<typeof schema>;
+
+/** Column references for the excluded row in ON CONFLICT DO UPDATE. */
 const excludedCol = {
   name: sql`excluded.name`,
   slug: sql`excluded.slug`,
@@ -114,6 +122,65 @@ function loadSeedData(): GamesSeedFile {
   return JSON.parse(fs.readFileSync(seedPath, 'utf-8')) as GamesSeedFile;
 }
 
+/**
+ * Apply seed data onto an existing row identified by id. Mirrors
+ * `applyIgdbMergeToRow` in `igdb-upsert.helpers.ts`: writes seed columns,
+ * sets igdbId from the seed, marks the row enriched. Does NOT touch
+ * `steamAppId` / `itadGameId` — those were set by upstream discovery and
+ * the seed bundle has no values for them.
+ */
+async function mergeSeedIntoExistingRow(
+  db: Db,
+  existingId: number,
+  values: GameValues,
+): Promise<void> {
+  await db
+    .update(schema.games)
+    .set({
+      ...values,
+      cachedAt: new Date(),
+      igdbEnrichmentStatus: 'enriched',
+      igdbEnrichmentRetryCount: 0,
+    })
+    .where(eq(schema.games.id, existingId));
+}
+
+/**
+ * Upsert a batch of seed rows into `games`. For each row:
+ *   1. Look up an existing row by normalized name (ROK-1113 guard).
+ *      If found AND its igdbId is null OR matches the seed's igdbId → merge.
+ *      Mismatched non-null igdbIds (sequels/variants) are left alone.
+ *   2. Otherwise fall back to INSERT ... ON CONFLICT (igdb_id) DO UPDATE.
+ * Returns the count of rows touched.
+ */
+export async function upsertSeedGames(
+  db: Db,
+  seeds: GameSeed[],
+): Promise<number> {
+  let touched = 0;
+  for (const seed of seeds) {
+    const values = mapGameToValues(seed);
+    const nameMatch = await findGameByNormalizedName(db, seed.name);
+    if (
+      nameMatch &&
+      (nameMatch.igdbId == null || nameMatch.igdbId === seed.igdbId)
+    ) {
+      await mergeSeedIntoExistingRow(db, nameMatch.id, values);
+      touched++;
+      continue;
+    }
+    await db
+      .insert(schema.games)
+      .values(values)
+      .onConflictDoUpdate({
+        target: schema.games.igdbId,
+        set: { ...excludedCol, cachedAt: new Date() },
+      });
+    touched++;
+  }
+  return touched;
+}
+
 async function bootstrap() {
   console.log('🎮 Seeding IGDB games cache...\n');
 
@@ -126,20 +193,9 @@ async function bootstrap() {
   const db = app.get<PostgresJsDatabase<typeof schema>>(DrizzleAsyncProvider);
 
   try {
-    const rows = seedData.games.map(mapGameToValues);
-
-    // Batch upsert: insert all games in a single query
-    const result = await db
-      .insert(schema.games)
-      .values(rows)
-      .onConflictDoUpdate({
-        target: schema.games.igdbId,
-        set: { ...excludedCol, cachedAt: new Date() },
-      })
-      .returning();
-
+    const processed = await upsertSeedGames(db, seedData.games);
     console.log('📊 Seeding Summary:');
-    console.log(`  ✅ Processed: ${result.length} games`);
+    console.log(`  ✅ Processed: ${processed} games`);
     console.log(`\n🎉 IGDB games cache seeding complete!`);
   } catch (err) {
     console.error('❌ Seeding failed:', err);
@@ -151,4 +207,6 @@ async function bootstrap() {
   process.exit(0);
 }
 
-void bootstrap();
+if (require.main === module) {
+  void bootstrap();
+}

--- a/api/src/common/testing/test-app.ts
+++ b/api/src/common/testing/test-app.ts
@@ -6,9 +6,16 @@
  * reused across all integration test suites for performance.
  *
  * Dual-mode:
- *   - Local dev: Testcontainers spins up a fresh PostgreSQL container.
- *   - CI: Detects DATABASE_URL env var and connects to the existing
- *     CI postgres service (no Docker-in-Docker needed).
+ *   - Local dev: Testcontainers spins up a fresh `pgvector/pgvector:pg16`
+ *     container (same image as prod / CI / `raid-ledger-db`). Ephemeral —
+ *     dies with the suite, never touches the operator's live local DB.
+ *   - CI: Honors `DATABASE_URL` only when `CI=true` (GitHub Actions sets
+ *     this) so the service container is reused. Locally, `DATABASE_URL`
+ *     pointing at the live `raid-ledger-db` is IGNORED — otherwise
+ *     `truncateAllTables` would wipe operator-restored app_settings,
+ *     local_credentials, etc. on every `npm run test:integration` run,
+ *     breaking the clone-prod-to-local recovery flow. (Surfaced by the
+ *     fix/batch-2026-05-14 post-clone audit.)
  *
  * Usage:
  *   const { app, request } = await getTestApp();
@@ -108,7 +115,11 @@ async function provisionDatabase(): Promise<{
   connectionString: string;
   container: StartedPostgreSqlContainer | null;
 }> {
-  if (process.env.DATABASE_URL) {
+  // Honor DATABASE_URL ONLY in CI. Locally this env var points at the
+  // operator's live `raid-ledger-db` and truncateAllTables would erase
+  // app_settings / local_credentials / etc., breaking the clone-prod-to-local
+  // recovery flow. See file-level comment + fix/batch-2026-05-14 audit.
+  if (process.env.CI === 'true' && process.env.DATABASE_URL) {
     return { connectionString: process.env.DATABASE_URL, container: null };
   }
   const container = await new PostgreSqlContainer('pgvector/pgvector:pg16')

--- a/api/src/cron-jobs/cron-job.constants.ts
+++ b/api/src/cron-jobs/cron-job.constants.ts
@@ -220,4 +220,9 @@ export const CORE_JOB_METADATA: Record<string, CoreJobMetadata> = {
       'Force-finalizes orphaned Quick Play (ad-hoc) events whose end time passed >30 min ago every 5 minutes',
     category: 'Events',
   },
+  GuildReconciliationService_reconcileGuildMembers: {
+    description:
+      'Cross-references DB users against Discord guild membership and deactivates users no longer in the guild — daily at 07:00 UTC (ROK-1282)',
+    category: 'Maintenance',
+  },
 };

--- a/api/src/discord-bot/discord-bot-client.guild.helpers.ts
+++ b/api/src/discord-bot/discord-bot-client.guild.helpers.ts
@@ -66,3 +66,17 @@ export async function isGuildMember(
     return false;
   }
 }
+
+/**
+ * Fetch every member of the guild and return their Discord IDs as a Set
+ * (ROK-1282). Used by GuildReconciliationService to diff DB users against
+ * actual guild membership. Returns null when the bot is disconnected
+ * (caller should treat as a no-op, not an error).
+ */
+export async function listAllGuildMemberIds(
+  guild: Guild | null,
+): Promise<Set<string> | null> {
+  if (!guild) return null;
+  const members = await guild.members.fetch();
+  return new Set(members.map((m) => m.user.id));
+}

--- a/api/src/discord-bot/discord-bot-client.service.ts
+++ b/api/src/discord-bot/discord-bot-client.service.ts
@@ -24,6 +24,7 @@ import {
   searchGuildMembers as searchGuildMembersHelper,
   listGuildMembers as listGuildMembersHelper,
   isGuildMember as isGuildMemberHelper,
+  listAllGuildMemberIds as listAllGuildMemberIdsHelper,
 } from './discord-bot-client.guild.helpers';
 
 export type {
@@ -260,6 +261,15 @@ export class DiscordBotClientService {
   /** Check if a Discord user is in the guild (ROK-403). */
   async isGuildMember(discordUserId: string): Promise<boolean> {
     return isGuildMemberHelper(this.getGuild(), discordUserId);
+  }
+
+  /**
+   * Fetch every member of the guild and return their Discord IDs as a
+   * Set (ROK-1282). Returns null when the bot is disconnected — caller
+   * (`GuildReconciliationService`) treats null as a no-op.
+   */
+  async listAllGuildMemberIds(): Promise<Set<string> | null> {
+    return listAllGuildMemberIdsHelper(this.getGuild());
   }
 
   /** Check bot permissions in the guild. */

--- a/api/src/scripts/seed-igdb-games.integration.spec.ts
+++ b/api/src/scripts/seed-igdb-games.integration.spec.ts
@@ -93,6 +93,50 @@ describe('Regression: ROK-1283 — seed-igdb-games name-dedup', () => {
     expect(rows[0].igdbId).toBe(119171);
   });
 
+  // Codex P1 (2026-05-14): when BOTH a canonical row (igdb_id=X) AND a leftover
+  // orphan (igdb_id=NULL) exist for the same name, findGameByNormalizedName may
+  // return either. Returning the orphan and trying to UPDATE its igdb_id to X
+  // would crash on the UNIQUE index — aborting boot. The guard must detect this
+  // and fall through to ON CONFLICT (igdb_id) so the canonical row is updated.
+  it('does NOT crash when a canonical row already owns the seed igdb_id alongside a null-igdb_id orphan', async () => {
+    // Canonical row: already enriched by IGDB.
+    const [canonical] = await testApp.db
+      .insert(schema.games)
+      .values({
+        name: "Baldur's Gate 3",
+        slug: 'baldurs-gate-iii-canonical',
+        igdbId: 119171,
+        steamAppId: null,
+      })
+      .returning();
+    // Leftover orphan: same name, null igdb_id, different slug.
+    const [orphan] = await testApp.db
+      .insert(schema.games)
+      .values({
+        name: "Baldur's Gate 3",
+        slug: 'baldurs-gate-3-orphan',
+        igdbId: null,
+        steamAppId: 1086940,
+      })
+      .returning();
+
+    // Must not throw — would crash the entire deploy at container boot.
+    const touched = await upsertSeedGames(testApp.db, [BG3_SEED]);
+    expect(touched).toBe(1);
+
+    // Both rows still exist; canonical retains its igdb_id, orphan untouched.
+    const survivors = await testApp.db
+      .select()
+      .from(schema.games)
+      .where(ne(schema.games.slug, FIXTURE_GAME_SLUG));
+    expect(survivors).toHaveLength(2);
+    const canonicalRow = survivors.find((r) => r.id === canonical.id);
+    const orphanRow = survivors.find((r) => r.id === orphan.id);
+    expect(canonicalRow?.igdbId).toBe(119171);
+    expect(orphanRow?.igdbId).toBeNull();
+    expect(orphanRow?.steamAppId).toBe(1086940);
+  });
+
   it('does NOT collapse sequels: existing row with different non-null igdb_id is left alone', async () => {
     // A row that legitimately represents a different IGDB entity. A
     // normalize() collision (e.g. unusual title) must not overwrite it.

--- a/api/src/scripts/seed-igdb-games.integration.spec.ts
+++ b/api/src/scripts/seed-igdb-games.integration.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * ROK-1283: integration spec for the seed-igdb-games name-dedup guard.
+ *
+ * Reproduces the witnessed BG3 incident (2026-05-14): a pre-existing
+ * row with `igdb_id IS NULL` but matching name does NOT conflict on
+ * `ON CONFLICT (igdb_id)` because PG UNIQUE treats NULL as distinct,
+ * so the seeder re-inserts a duplicate the migration just merged.
+ *
+ * The fix routes each seed row through `findGameByNormalizedName`
+ * before inserting; this spec asserts the merge replaces the INSERT.
+ */
+import { eq } from 'drizzle-orm';
+import { getTestApp, type TestApp } from '../common/testing/test-app';
+import { truncateAllTables } from '../common/testing/integration-helpers';
+import * as schema from '../drizzle/schema';
+import { upsertSeedGames, type GameSeed } from '../../scripts/seed-igdb-games';
+
+const BG3_SEED: GameSeed = {
+  igdbId: 119171,
+  name: "Baldur's Gate 3",
+  slug: 'baldurs-gate-iii',
+  coverUrl: 'https://example.invalid/bg3.jpg',
+};
+
+describe('Regression: ROK-1283 — seed-igdb-games name-dedup', () => {
+  let testApp: TestApp;
+
+  beforeAll(async () => {
+    testApp = await getTestApp();
+  });
+
+  afterEach(async () => {
+    testApp.seed = await truncateAllTables(testApp.db);
+  });
+
+  it('merges seed into existing row when igdb_id is NULL but name matches (BG3 prod reproduction)', async () => {
+    // Pre-existing row: discovered via steam, never enriched by IGDB.
+    const [existing] = await testApp.db
+      .insert(schema.games)
+      .values({
+        name: "Baldur's Gate 3",
+        slug: 'baldurs-gate-3',
+        steamAppId: 1086940,
+        igdbId: null,
+      })
+      .returning();
+
+    const touched = await upsertSeedGames(testApp.db, [BG3_SEED]);
+    expect(touched).toBe(1);
+
+    const rows = await testApp.db
+      .select()
+      .from(schema.games)
+      .where(eq(schema.games.id, existing.id));
+    const survivors = await testApp.db.select().from(schema.games);
+
+    // Exactly one BG3 row — the existing one — now carries the seed's igdb_id
+    // AND retains the steam_app_id from upstream discovery.
+    expect(survivors).toHaveLength(1);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe(existing.id);
+    expect(rows[0].igdbId).toBe(119171);
+    expect(rows[0].steamAppId).toBe(1086940);
+    expect(rows[0].name).toBe("Baldur's Gate 3");
+  });
+
+  it('falls through to INSERT when no name match exists', async () => {
+    const touched = await upsertSeedGames(testApp.db, [BG3_SEED]);
+    expect(touched).toBe(1);
+
+    const rows = await testApp.db.select().from(schema.games);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].igdbId).toBe(119171);
+    expect(rows[0].slug).toBe('baldurs-gate-iii');
+  });
+
+  it('is idempotent: re-running the seed against its own output does not duplicate', async () => {
+    await upsertSeedGames(testApp.db, [BG3_SEED]);
+    await upsertSeedGames(testApp.db, [BG3_SEED]);
+    const rows = await testApp.db.select().from(schema.games);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].igdbId).toBe(119171);
+  });
+
+  it('does NOT collapse sequels: existing row with different non-null igdb_id is left alone', async () => {
+    // A row that legitimately represents a different IGDB entity. A
+    // normalize() collision (e.g. unusual title) must not overwrite it.
+    const seedSequel: GameSeed = {
+      igdbId: 200001,
+      name: 'TestSequel Alpha',
+      slug: 'testsequel-alpha-v2',
+      coverUrl: null,
+    };
+    await testApp.db.insert(schema.games).values({
+      name: 'TestSequel Alpha',
+      slug: 'testsequel-alpha-v1',
+      igdbId: 100001,
+    });
+
+    await upsertSeedGames(testApp.db, [seedSequel]);
+
+    const rows = await testApp.db
+      .select()
+      .from(schema.games)
+      .orderBy(schema.games.igdbId);
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.igdbId).sort()).toEqual([100001, 200001]);
+  });
+});

--- a/api/src/scripts/seed-igdb-games.integration.spec.ts
+++ b/api/src/scripts/seed-igdb-games.integration.spec.ts
@@ -9,11 +9,13 @@
  * The fix routes each seed row through `findGameByNormalizedName`
  * before inserting; this spec asserts the merge replaces the INSERT.
  */
-import { eq } from 'drizzle-orm';
+import { eq, ne } from 'drizzle-orm';
 import { getTestApp, type TestApp } from '../common/testing/test-app';
 import { truncateAllTables } from '../common/testing/integration-helpers';
 import * as schema from '../drizzle/schema';
 import { upsertSeedGames, type GameSeed } from '../../scripts/seed-igdb-games';
+
+const FIXTURE_GAME_SLUG = 'test-game';
 
 const BG3_SEED: GameSeed = {
   igdbId: 119171,
@@ -52,7 +54,10 @@ describe('Regression: ROK-1283 — seed-igdb-games name-dedup', () => {
       .select()
       .from(schema.games)
       .where(eq(schema.games.id, existing.id));
-    const survivors = await testApp.db.select().from(schema.games);
+    const survivors = await testApp.db
+      .select()
+      .from(schema.games)
+      .where(ne(schema.games.slug, FIXTURE_GAME_SLUG));
 
     // Exactly one BG3 row — the existing one — now carries the seed's igdb_id
     // AND retains the steam_app_id from upstream discovery.
@@ -68,7 +73,10 @@ describe('Regression: ROK-1283 — seed-igdb-games name-dedup', () => {
     const touched = await upsertSeedGames(testApp.db, [BG3_SEED]);
     expect(touched).toBe(1);
 
-    const rows = await testApp.db.select().from(schema.games);
+    const rows = await testApp.db
+      .select()
+      .from(schema.games)
+      .where(ne(schema.games.slug, FIXTURE_GAME_SLUG));
     expect(rows).toHaveLength(1);
     expect(rows[0].igdbId).toBe(119171);
     expect(rows[0].slug).toBe('baldurs-gate-iii');
@@ -77,7 +85,10 @@ describe('Regression: ROK-1283 — seed-igdb-games name-dedup', () => {
   it('is idempotent: re-running the seed against its own output does not duplicate', async () => {
     await upsertSeedGames(testApp.db, [BG3_SEED]);
     await upsertSeedGames(testApp.db, [BG3_SEED]);
-    const rows = await testApp.db.select().from(schema.games);
+    const rows = await testApp.db
+      .select()
+      .from(schema.games)
+      .where(ne(schema.games.slug, FIXTURE_GAME_SLUG));
     expect(rows).toHaveLength(1);
     expect(rows[0].igdbId).toBe(119171);
   });
@@ -102,6 +113,7 @@ describe('Regression: ROK-1283 — seed-igdb-games name-dedup', () => {
     const rows = await testApp.db
       .select()
       .from(schema.games)
+      .where(ne(schema.games.slug, FIXTURE_GAME_SLUG))
       .orderBy(schema.games.igdbId);
     expect(rows).toHaveLength(2);
     expect(rows.map((r) => r.igdbId).sort()).toEqual([100001, 200001]);

--- a/api/src/users/guild-reconciliation.service.integration.spec.ts
+++ b/api/src/users/guild-reconciliation.service.integration.spec.ts
@@ -1,0 +1,133 @@
+/**
+ * ROK-1282 — GuildReconciliationService integration tests.
+ *
+ * Verifies the daily reconciliation cron's core behaviour:
+ *   - users whose `discord_id` is missing from the live guild get
+ *     deactivated via the shared notification path,
+ *   - already-deactivated users are not re-touched,
+ *   - users with `local:%` / `unlinked:%` placeholder ids are skipped
+ *     (they were never guild-tracked),
+ *   - bot disconnected → no-op (returns false).
+ */
+import { getTestApp, type TestApp } from '../common/testing/test-app';
+import { truncateAllTables } from '../common/testing/integration-helpers';
+import * as schema from '../drizzle/schema';
+import { eq } from 'drizzle-orm';
+import { GuildReconciliationService } from './guild-reconciliation.service';
+import { DiscordBotClientService } from '../discord-bot/discord-bot-client.service';
+
+let testApp: TestApp;
+let service: GuildReconciliationService;
+let botClient: DiscordBotClientService;
+let listSpy: jest.SpyInstance;
+
+beforeAll(async () => {
+  testApp = await getTestApp();
+  service = testApp.app.get(GuildReconciliationService);
+  botClient = testApp.app.get(DiscordBotClientService);
+});
+
+afterEach(async () => {
+  if (listSpy) listSpy.mockRestore();
+  testApp.seed = await truncateAllTables(testApp.db);
+});
+
+async function createUserWithDiscordId(
+  username: string,
+  discordId: string,
+): Promise<typeof schema.users.$inferSelect> {
+  const [user] = await testApp.db
+    .insert(schema.users)
+    .values({ discordId, username, role: 'member' })
+    .returning();
+  return user;
+}
+
+async function getDeactivatedAt(userId: number): Promise<Date | string | null> {
+  const [row] = await testApp.db
+    .select({ deactivatedAt: schema.users.deactivatedAt })
+    .from(schema.users)
+    .where(eq(schema.users.id, userId))
+    .limit(1);
+  return row?.deactivatedAt ?? null;
+}
+
+function mockGuildMembers(ids: string[]): void {
+  listSpy = jest
+    .spyOn(botClient, 'listAllGuildMemberIds')
+    .mockResolvedValue(new Set(ids));
+}
+
+function mockBotDisconnected(): void {
+  listSpy = jest
+    .spyOn(botClient, 'listAllGuildMemberIds')
+    .mockResolvedValue(null);
+}
+
+describe('GuildReconciliationService.runReconciliation (ROK-1282)', () => {
+  it('deactivates users whose discord_id is no longer in the guild', async () => {
+    const inGuild1 = await createUserWithDiscordId('alpha', '111111');
+    const inGuild2 = await createUserWithDiscordId('beta', '222222');
+    const gone1 = await createUserWithDiscordId('gamma', '333333');
+    const gone2 = await createUserWithDiscordId('delta', '444444');
+
+    mockGuildMembers(['111111', '222222']);
+
+    await service.runReconciliation();
+
+    expect(await getDeactivatedAt(inGuild1.id)).toBeNull();
+    expect(await getDeactivatedAt(inGuild2.id)).toBeNull();
+    expect(await getDeactivatedAt(gone1.id)).not.toBeNull();
+    expect(await getDeactivatedAt(gone2.id)).not.toBeNull();
+  });
+
+  it('skips users with local: discord_id (email-only accounts)', async () => {
+    const local = await createUserWithDiscordId(
+      'localonly',
+      'local:localonly@test.local',
+    );
+
+    mockGuildMembers([]);
+
+    await service.runReconciliation();
+
+    expect(await getDeactivatedAt(local.id)).toBeNull();
+  });
+
+  it('skips users with unlinked: discord_id (previously unlinked accounts)', async () => {
+    const unlinked = await createUserWithDiscordId(
+      'unlinkedacct',
+      'unlinked:555555',
+    );
+
+    mockGuildMembers([]);
+
+    await service.runReconciliation();
+
+    expect(await getDeactivatedAt(unlinked.id)).toBeNull();
+  });
+
+  it('does not re-touch users that are already deactivated', async () => {
+    const alreadyOff = await createUserWithDiscordId('zombie', '666666');
+    await testApp.db.execute(
+      /* sql */ `UPDATE users SET deactivated_at = '2025-01-01T00:00:00Z' WHERE id = ${alreadyOff.id}`,
+    );
+    const before = await getDeactivatedAt(alreadyOff.id);
+
+    mockGuildMembers([]);
+
+    await service.runReconciliation();
+
+    expect(await getDeactivatedAt(alreadyOff.id)).toStrictEqual(before);
+  });
+
+  it('returns false (no-op) when the Discord bot is disconnected', async () => {
+    const lonely = await createUserWithDiscordId('lonely', '777777');
+    mockBotDisconnected();
+
+    const result = await service.runReconciliation();
+
+    expect(result).toBe(false);
+    expect(await getDeactivatedAt(lonely.id)).toBeNull();
+  });
+});

--- a/api/src/users/guild-reconciliation.service.integration.spec.ts
+++ b/api/src/users/guild-reconciliation.service.integration.spec.ts
@@ -130,4 +130,18 @@ describe('GuildReconciliationService.runReconciliation (ROK-1282)', () => {
     expect(result).toBe(false);
     expect(await getDeactivatedAt(lonely.id)).toBeNull();
   });
+
+  // Codex P2 (2026-05-14): only the disconnected case is a no-op; any Discord
+  // API fault must bubble so CronJobService records a real failure instead of
+  // a silent healthy heartbeat.
+  it('lets Discord API errors bubble up (not swallowed as a no-op)', async () => {
+    const survivor = await createUserWithDiscordId('survivor', '888888');
+    const apiFault = new Error('DiscordAPIError: Missing Permissions');
+    listSpy = jest
+      .spyOn(botClient, 'listAllGuildMemberIds')
+      .mockRejectedValue(apiFault);
+
+    await expect(service.runReconciliation()).rejects.toBe(apiFault);
+    expect(await getDeactivatedAt(survivor.id)).toBeNull();
+  });
 });

--- a/api/src/users/guild-reconciliation.service.ts
+++ b/api/src/users/guild-reconciliation.service.ts
@@ -1,0 +1,124 @@
+/**
+ * GuildReconciliationService (ROK-1282) — daily sweep that diffs the
+ * Discord guild's member list against DB users and deactivates anyone
+ * whose `discord_id` is no longer present.
+ *
+ * Layer 3 of the user-deactivation stack:
+ *   1. Reactive: 50278 classifier in discord-notification.processor.ts
+ *      — fires when a DM fails; misses users who never get a DM.
+ *   2. Reactive: GuildMemberAddListener — re-enables on rejoin; nothing
+ *      on the leave side (ROK-1260 spec mentioned a `GuildMemberRemove`
+ *      listener that was never shipped).
+ *   3. Proactive: this service — fills both gaps with a daily 07:00 UTC
+ *      reconciliation that runs even when the bot was offline during
+ *      a `GuildMemberRemove` event.
+ *
+ * The actual deactivation goes through `DiscordNotificationService.deactivateUser`
+ * (idempotent), so audit-trail and cascade behaviour matches the reactive path.
+ */
+import { Inject, Injectable, Logger, forwardRef } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { and, isNotNull, isNull, not, like } from 'drizzle-orm';
+import { DrizzleAsyncProvider } from '../drizzle/drizzle.module';
+import * as schema from '../drizzle/schema';
+import { CronJobService } from '../cron-jobs/cron-job.service';
+import { DiscordBotClientService } from '../discord-bot/discord-bot-client.service';
+import { DiscordNotificationService } from '../notifications/discord-notification.service';
+
+const JOB_NAME = 'GuildReconciliationService_reconcileGuildMembers';
+
+@Injectable()
+export class GuildReconciliationService {
+  private readonly logger = new Logger(GuildReconciliationService.name);
+
+  constructor(
+    @Inject(DrizzleAsyncProvider)
+    private readonly db: PostgresJsDatabase<typeof schema>,
+    private readonly cronJobService: CronJobService,
+    private readonly botClient: DiscordBotClientService,
+    @Inject(forwardRef(() => DiscordNotificationService))
+    private readonly discordNotificationService: DiscordNotificationService,
+  ) {}
+
+  @Cron('0 0 7 * * *', { name: JOB_NAME })
+  async reconcileCron(): Promise<void> {
+    await this.cronJobService.executeWithTracking(JOB_NAME, () =>
+      this.runReconciliation(),
+    );
+  }
+
+  /**
+   * Run a single reconciliation pass. Returns `false` when the bot is
+   * disconnected so CronJobService records a no-op + heartbeat (not a
+   * failure). Public so the integration test can call it directly.
+   */
+  async runReconciliation(): Promise<void | false> {
+    const guildIds = await this.fetchCurrentGuildMemberIds();
+    if (!guildIds) {
+      this.logger.warn(
+        '[ROK-1282] Reconciliation skipped — Discord bot disconnected',
+      );
+      return false;
+    }
+    const candidates = await this.loadActiveDbUsers();
+    const gaps = candidates.filter((u) => !guildIds.has(u.discordId));
+    await this.deactivateGap(gaps);
+    this.logger.log(
+      `[ROK-1282] Reconciliation deactivated ${gaps.length} user(s) ` +
+        `(checked ${candidates.length} active DB user(s) against ${guildIds.size} guild member(s))`,
+    );
+  }
+
+  /** Pull the current guild member list; returns null when bot offline. */
+  private async fetchCurrentGuildMemberIds(): Promise<Set<string> | null> {
+    try {
+      return await this.botClient.listAllGuildMemberIds();
+    } catch (err: unknown) {
+      this.logger.error(
+        `[ROK-1282] Failed to fetch guild members: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return null;
+    }
+  }
+
+  /**
+   * Active (not-yet-deactivated) users with a real Discord snowflake.
+   * Excludes both `local:%` (email-only accounts) and `unlinked:%`
+   * (previously linked users who unlinked) — neither is guild-trackable.
+   */
+  private async loadActiveDbUsers(): Promise<
+    { id: number; discordId: string }[]
+  > {
+    const rows = await this.db
+      .select({
+        id: schema.users.id,
+        discordId: schema.users.discordId,
+      })
+      .from(schema.users)
+      .where(
+        and(
+          isNull(schema.users.deactivatedAt),
+          isNotNull(schema.users.discordId),
+          not(like(schema.users.discordId, 'local:%')),
+          not(like(schema.users.discordId, 'unlinked:%')),
+        ),
+      );
+    return rows.filter(
+      (r): r is { id: number; discordId: string } => r.discordId !== null,
+    );
+  }
+
+  /** Deactivate each gap via the shared notification path (idempotent). */
+  private async deactivateGap(gaps: { id: number }[]): Promise<void> {
+    for (const u of gaps) {
+      try {
+        await this.discordNotificationService.deactivateUser(u.id);
+      } catch (err: unknown) {
+        this.logger.warn(
+          `[ROK-1282] Failed to deactivate user ${u.id}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+  }
+}

--- a/api/src/users/guild-reconciliation.service.ts
+++ b/api/src/users/guild-reconciliation.service.ts
@@ -70,16 +70,18 @@ export class GuildReconciliationService {
     );
   }
 
-  /** Pull the current guild member list; returns null when bot offline. */
+  /**
+   * Pull the current guild member list.
+   *
+   * Returns null ONLY when the bot is disconnected (`getGuild()` returned
+   * null inside the helper) — that's a benign no-op heartbeat. Discord API
+   * errors (403, missing GuildMembers intent, network, rate-limit) bubble up
+   * so `CronJobService` records a real failure instead of a healthy no-op.
+   * Codex P2 (2026-05-14): the previous blanket catch hid every fault as
+   * "bot disconnected", masking silent breakage.
+   */
   private async fetchCurrentGuildMemberIds(): Promise<Set<string> | null> {
-    try {
-      return await this.botClient.listAllGuildMemberIds();
-    } catch (err: unknown) {
-      this.logger.error(
-        `[ROK-1282] Failed to fetch guild members: ${err instanceof Error ? err.message : String(err)}`,
-      );
-      return null;
-    }
+    return this.botClient.listAllGuildMemberIds();
   }
 
   /**

--- a/api/src/users/users.integration.spec.ts
+++ b/api/src/users/users.integration.spec.ts
@@ -438,3 +438,36 @@ describe('Discord link/unlink (integration)', () => {
   it('findByDiscordIdIncludingUnlinked finds exact and prefixed', () =>
     testFindByDiscordIdIncludingUnlinked());
 });
+
+// ─── ROK-1282: Players list excludes deactivated users ───────────────────────
+
+/**
+ * Regression test pinning the behaviour ROK-1260 already shipped: the
+ * `GET /users` listing must filter `deactivated_at IS NOT NULL` rows.
+ * If a future refactor strips the `activeUsersFilter()` call from
+ * `findAllUsers`, this test catches it.
+ */
+async function testPlayersListExcludesDeactivatedUsers() {
+  const active = await createDiscordUser('rok1282-active', '1282-active-id');
+  const deactivated = await createDiscordUser(
+    'rok1282-deactivated',
+    '1282-deact-id',
+  );
+  await testApp.db.execute(
+    /* sql */ `UPDATE users SET deactivated_at = NOW() WHERE id = ${deactivated.id}`,
+  );
+
+  const res = await testApp.request
+    .get('/users')
+    .set('Authorization', `Bearer ${adminToken}`);
+  expect(res.status).toBe(200);
+
+  const ids = (res.body.data as { id: number }[]).map((u) => u.id);
+  expect(ids).toContain(active.id);
+  expect(ids).not.toContain(deactivated.id);
+}
+
+describe('Regression: ROK-1282 — Players list excludes deactivated users', () => {
+  it('GET /users does not return users with deactivated_at set', () =>
+    testPlayersListExcludesDeactivatedUsers());
+});

--- a/api/src/users/users.module.ts
+++ b/api/src/users/users.module.ts
@@ -5,12 +5,15 @@ import { UsersService } from './users.service';
 import { AvatarService } from './avatar.service';
 import { PreferencesService } from './preferences.service';
 import { GameTimeService } from './game-time.service';
+import { GuildReconciliationService } from './guild-reconciliation.service';
 import { UsersController } from './users.controller';
 import { UsersMeController } from './users-me.controller';
 import { UsersManagementController } from './users-management.controller';
 import { CharactersModule } from '../characters/characters.module';
 import { EventsModule } from '../events/events.module';
 import { DiscordBotModule } from '../discord-bot/discord-bot.module';
+import { NotificationModule } from '../notifications/notification.module';
+import { CronJobModule } from '../cron-jobs/cron-job.module';
 import { TokenBlocklistService } from '../auth/token-blocklist.service';
 
 @Module({
@@ -18,6 +21,8 @@ import { TokenBlocklistService } from '../auth/token-blocklist.service';
     forwardRef(() => CharactersModule),
     EventsModule,
     forwardRef(() => DiscordBotModule),
+    forwardRef(() => NotificationModule),
+    CronJobModule,
     MulterModule.register({ storage: multer.memoryStorage() }),
   ],
   controllers: [UsersMeController, UsersManagementController, UsersController],
@@ -26,6 +31,7 @@ import { TokenBlocklistService } from '../auth/token-blocklist.service';
     AvatarService,
     PreferencesService,
     GameTimeService,
+    GuildReconciliationService,
     TokenBlocklistService,
   ],
   exports: [UsersService, AvatarService, PreferencesService, GameTimeService],

--- a/web/TECH-DEBT-BACKLOG.md
+++ b/web/TECH-DEBT-BACKLOG.md
@@ -1,0 +1,6 @@
+
+### 2026-05-14 — fix/batch-2026-05-14 (surfaced during ROK-1282 + ROK-1283 push validation)
+
+- **[med]** `web/src/components/admin/onboarding/secure-account-step.test.tsx` — 6/20 specs in this file flake with `Test timed out in 5000ms` when run as part of the full vitest suite (`npm run test:cov -w web`). All 20 PASS in 773ms when the file is run in isolation (`npx vitest run src/components/admin/onboarding/secure-account-step.test.tsx`). The failing assertions are synchronous DOM class lookups (`toHaveClass('min-h-[44px]')`), so the 5000ms timeout is concurrency starvation, not test logic. Last touched in #379 (months ago); independent of fix/batch-2026-05-14 (zero web/ changes in the batch).
+  Suggested: bump this file's `testTimeout` to 15000ms in vitest.config.ts (the FTE wizard tests do heavier jsdom setup than typical) OR move it to its own project shard. The cheap-experiment plan: run `npx vitest run secure-account-step` 50× to characterise the flake rate, then either bump the timeout or shard the file.
+

--- a/web/TECH-DEBT-BACKLOG.md
+++ b/web/TECH-DEBT-BACKLOG.md
@@ -1,6 +1,0 @@
-
-### 2026-05-14 — fix/batch-2026-05-14 (surfaced during ROK-1282 + ROK-1283 push validation)
-
-- **[med]** `web/src/components/admin/onboarding/secure-account-step.test.tsx` — 6/20 specs in this file flake with `Test timed out in 5000ms` when run as part of the full vitest suite (`npm run test:cov -w web`). All 20 PASS in 773ms when the file is run in isolation (`npx vitest run src/components/admin/onboarding/secure-account-step.test.tsx`). The failing assertions are synchronous DOM class lookups (`toHaveClass('min-h-[44px]')`), so the 5000ms timeout is concurrency starvation, not test logic. Last touched in #379 (months ago); independent of fix/batch-2026-05-14 (zero web/ changes in the batch).
-  Suggested: bump this file's `testTimeout` to 15000ms in vitest.config.ts (the FTE wizard tests do heavier jsdom setup than typical) OR move it to its own project shard. The cheap-experiment plan: run `npx vitest run secure-account-step` 50× to characterise the flake rate, then either bump the timeout or shard the file.
-


### PR DESCRIPTION
## Summary

Fix batch landing two Bug stories plus a test-infra fix surfaced during the post-clone audit.

| Story | Label | Description |
|-------|-------|-------------|
| **ROK-1282** | Bug, Discord Bot | New daily guild reconciliation cron (`GuildReconciliationService`) — cross-references DB users against actual Discord guild membership and deactivates anyone whose `discord_id` is no longer present. Closes the gap between the reactive 50278 classifier and the rejoin listener (users who left during bot downtime AND have no fresh DM attempts). Adds a Players-list regression test pinning the existing `activeUsersFilter()` filter that was shipped in ROK-1260. |
| **ROK-1283** | Bug, Database | `api/scripts/seed-igdb-games.ts` was using `ON CONFLICT (igdb_id) DO UPDATE` which doesn't fire on pre-existing rows with `igdb_id IS NULL` (PG treats NULL as never-equal). On every container boot AFTER the ROK-1278 merge migration, the seed re-created duplicates the migration had just collapsed (BG3 specifically). Now routes each seed row through `findGameByNormalizedName` like the 4 production INSERT paths from ROK-1113. |
| **Test infra fix** | (out of original scope, surfaced by post-clone audit) | `provisionDatabase` in `api/src/common/testing/test-app.ts` was using `DATABASE_URL` whenever set, which locally pointed at the live `raid-ledger-db` container. Every `npm run test:integration` then wiped every public-schema table via `truncateAllTables` — including `app_settings`, `local_credentials`, `events`, etc. — silently breaking the clone-prod-to-local recovery flow. Now honors `DATABASE_URL` only when `CI === 'true'`; locally always Testcontainers (same `pgvector/pgvector:pg16` image, identical SQL semantics). |

Additional commits include Codex pre-push review fixes (P1: seed-igdb-games orphan-collision guard; P2: cron error bubbling instead of silent heartbeat suppression), 7 `TECH-DEBT-BACKLOG.md` entries from both reviewer passes, and operator-config ride-alongs.

## Reviewer status

- Sonnet reviewer pass #1 (post-merge): PASS WITH NOTES, 0 blockers, 3 low findings appended to backlog
- Codex pre-push: 2 findings (P1 + P2) — **fixed inline** with regression tests
- Sonnet reviewer pass #2 (post-Codex): PASS WITH NOTES, 0 blockers, 3 low findings appended to backlog
- Chrome MCP e2e (via Playwright MCP fallback — claude-in-chrome was extension-blocked): PASS. `/players` excludes deactivated user (103 vs 104 with seeded GhostBane deactivation); `/admin/settings/general/roles` shows deactivated user with `Deactivated` badge (admin escape hatch); `/admin/settings/general/cron-jobs` registers the new `Reconcile Guild Members` job (Daily 07:00 UTC, Maintenance, Active, ROK-1282 attribution). Console clean, no 4xx/5xx, no React errors. Summary: `planning-artifacts/chrome-mcp-summary-fix-batch-2026-05-14.md`.

## Validation

- [x] Build (contract + api + web) passes
- [x] TypeScript clean across all workspaces
- [x] Lint clean (api + web) — 0 errors
- [x] Unit tests pass (api + web; coverage thresholds met)
- [x] Integration tests pass (91 suites / 1027 tests; verified app_settings preserved 52→52 after the test-infra fix)
- [x] Playwright smoke (desktop + mobile) — 628 passed; 5 flakes in unrelated lineup features documented in `TECH-DEBT-BACKLOG.md`, retries clean
- [x] Chrome MCP e2e (changed flows; via Playwright MCP fallback)
- [x] Two reviewer passes + Codex pre-push review

## Regression tests

- `Regression: ROK-1282 — Players list excludes deactivated users` in `api/src/users/users.integration.spec.ts`
- `Regression: ROK-1283 — seed-igdb-games name-dedup` in `api/src/scripts/seed-igdb-games.integration.spec.ts` (includes the post-Codex BG3 dup-state crash reproduction)
- `Discord API errors bubble up` in `api/src/users/guild-reconciliation.service.integration.spec.ts` (post-Codex P2 regression)

## Tech debt observed (not auto-filed)

7 low/medium findings appended to `TECH-DEBT-BACKLOG.md` across two dated sections:

- `guild-reconciliation.service.ts` — dead-code filter, sequential deactivation loop, missing index on `users.deactivated_at` (low)
- `secure-account-step.test.tsx` — vitest concurrency flake (6/20 specs time out in full suite, 20/20 in 773ms isolated) (med)
- `CI` gating inconsistency between `test-app.ts` (strict ===) and `integration-setup.ts` (loose !) (low)
- Extra DB roundtrip in seed orphan path (low)
- Coverage gap on the P2 bubble-up test (doesn't exercise the executeWithTracking wrapper) (low)

## Sibling deferral

`api/scripts/seed-games.ts` has the same vulnerability shape as the file fixed by ROK-1283 but is already at 302 lines (over the 300-line max-lines CI limit on `origin/main`). Applying the same guard adds ~16 lines → 318, which would hard-fail CI lint. Proper fix requires extracting the 233-line `GAMES_SEED` constant to `api/scripts/seed-games.data.ts` first — out of fix-batch scope. Deferred to `TECH-DEBT-BACKLOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)