### PR TITLE
ROK-1292 PR1: harden local docker-compose env + extend allinone JWT guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -545,11 +545,49 @@ jobs:
             exit 1
           fi
 
+      - name: Verify JWT guard rejects known dev defaults (ROK-1292)
+        # Negative-path test: start a fresh container with each banned literal
+        # as JWT_SECRET and assert start-api.sh logs the FATAL guard message.
+        # Uses a separate container per literal so prior cached state (e.g.
+        # /data/.jwt_secret) from the previous step doesn't influence the
+        # guard's env-var-priority branch.
+        run: |
+          for SECRET in "raid-ledger-default-secret-change-in-production" "dev-secret-change-in-prod"; do
+            CONTAINER="rl-jwt-guard-$(echo "$SECRET" | tr -c 'a-z0-9' '-' | head -c 30)"
+            echo "── Testing JWT_SECRET=$SECRET should be rejected ──"
+            docker run -d --name "$CONTAINER" \
+              -e JWT_SECRET="$SECRET" \
+              -e ADMIN_PASSWORD=ci-test-password \
+              raid-ledger:ci-test
+            FOUND=0
+            for i in $(seq 1 30); do
+              if docker logs "$CONTAINER" 2>&1 | grep -q "FATAL: JWT_SECRET is still an insecure hardcoded default"; then
+                echo "✅ Guard rejected '$SECRET' after ${i}s"
+                FOUND=1
+                break
+              fi
+              sleep 1
+            done
+            docker stop "$CONTAINER" 2>/dev/null || true
+            docker rm -f "$CONTAINER" 2>/dev/null || true
+            if [ "$FOUND" != "1" ]; then
+              echo "❌ Guard did NOT reject '$SECRET' within 30s"
+              exit 1
+            fi
+          done
+
       - name: Cleanup
         if: always()
         run: |
           docker stop rl-ci-test 2>/dev/null || true
           docker rm rl-ci-test 2>/dev/null || true
+          # Defensive: the JWT-guard step cleans up its own containers, but
+          # if it errored mid-loop one might still be around.
+          for SECRET in "raid-ledger-default-secret-change-in-production" "dev-secret-change-in-prod"; do
+            CONTAINER="rl-jwt-guard-$(echo "$SECRET" | tr -c 'a-z0-9' '-' | head -c 30)"
+            docker stop "$CONTAINER" 2>/dev/null || true
+            docker rm -f "$CONTAINER" 2>/dev/null || true
+          done
 
   # ─── Synthetic Production Volume Gate (ROK-1036) ───────────────────
   # Boots the allinone image against a pre-populated volume that mimics a

--- a/Dockerfile.allinone
+++ b/Dockerfile.allinone
@@ -298,13 +298,22 @@ until redis-cli -s /tmp/redis.sock ping > /dev/null 2>&1; do
 done
 echo "✅ Redis is ready"
 
-# ── JWT_SECRET resolution (ROK-1035) ──────────────────────────────
-# Priority: 1) env var (if set and not the old default) → use it
+# ── JWT_SECRET resolution (ROK-1035, ROK-1292) ────────────────────
+# Priority: 1) env var (if set and not a known dev default) → use it
 #           2) /data/.jwt_secret file exists → read it
 #           3) generate new secret, persist to /data/.jwt_secret
-HARDCODED_DEFAULT="raid-ledger-default-secret-change-in-production"
+# Known dev defaults rejected by the guard below — keep in sync with
+# api/scripts/docker-entrypoint.sh and docker-compose.yml.
+HARDCODED_DEFAULTS="raid-ledger-default-secret-change-in-production dev-secret-change-in-prod"
 
-if [ -n "$JWT_SECRET" ] && [ "$JWT_SECRET" != "$HARDCODED_DEFAULT" ]; then
+is_known_default() {
+  for d in $HARDCODED_DEFAULTS; do
+    [ "$1" = "$d" ] && return 0
+  done
+  return 1
+}
+
+if [ -n "$JWT_SECRET" ] && ! is_known_default "$JWT_SECRET"; then
   echo "🔑 JWT_SECRET: using explicit env var"
 elif [ -s /data/.jwt_secret ]; then
   # ROK-1036: `-s` instead of `-f` because entrypoint.sh pre-touches the
@@ -320,9 +329,9 @@ else
   echo "🔑 JWT_SECRET: generated new secret → /data/.jwt_secret"
 fi
 
-# Guard: refuse to start with the old hardcoded default
-if [ "$JWT_SECRET" = "$HARDCODED_DEFAULT" ]; then
-  echo "❌ FATAL: JWT_SECRET is still the insecure hardcoded default."
+# Guard: refuse to start with any known insecure default
+if is_known_default "$JWT_SECRET"; then
+  echo "❌ FATAL: JWT_SECRET is still an insecure hardcoded default ($JWT_SECRET)."
   echo "   Remove the env var override or set a real secret."
   exit 1
 fi

--- a/TECH-DEBT-BACKLOG.md
+++ b/TECH-DEBT-BACKLOG.md
@@ -288,3 +288,8 @@ ROK-1292 ships in 3 PRs per its body. **PR 1 (this PR) lands the 4 docker-compos
 
 **ROK-1292 AC reconciliation:** the story body's AC line "Backlog section '2026-05-14 — fix/batch-2026-05-14 (surfaced during operator-triggered /security-review on whole repo + local env)' pruned from `TECH-DEBT-BACKLOG.md`" is N/A — that section was never added; operator filed direct to Linear. Strike that AC bullet when ROK-1292 closes.
 
+### 2026-05-15 — rok-1292-pr1-local-env-hardening (surfaced during validate-ci.sh typecheck)
+
+- **[low]** `api/src/version/version.controller.spec.ts:15+` and `api/test/app.e2e-spec.ts:7+` — `npx tsc --noEmit -p api/tsconfig.json` fails with `TS2593: Cannot find name 'describe'/'it'/'beforeEach'` and `TS2304: Cannot find name 'expect'/'jest'`. Reproduces on a clean `origin/main` checkout (verified via `git stash` + retry). Jest types resolve fine when running the specs (`npm run test -w api -- <spec>` works), so the issue is config-only — these spec files aren't picked up by the same `types: ['jest']` resolution that other specs use. CI doesn't catch this because GitHub Actions uses `tsconfig.build.json` (which excludes specs), but `scripts/validate-ci.sh::run_typecheck` (line 112) uses the full `tsconfig.json` and trips. Result: anyone running `./scripts/validate-ci.sh --full` locally sees a noisy "regression" that isn't theirs.
+  Suggested: add `"types": ["jest", "node"]` to `api/tsconfig.json` (or move the spec includes into a tsconfig that picks up `@types/jest`). One-line fix per file once the right tsconfig is identified.
+

--- a/TECH-DEBT-BACKLOG.md
+++ b/TECH-DEBT-BACKLOG.md
@@ -247,3 +247,44 @@ Findings from senior-code-review on the batch diff. Critical + high were fixed i
 
 - **[nit]** `tools/test-bot/scripts/no-sleep-lint.sh` still flags the comment on `tools/test-bot/src/smoke/tests/lineup-abort.test.ts:26` (same entry under fix/rok-1243 worktree) — reproduces on origin/main, still unresolved.
 
+### 2026-05-15 — rok-1292-pr1-local-env-hardening (deferred PR 2 + PR 3 from ROK-1292 /security-review)
+
+ROK-1292 ships in 3 PRs per its body. **PR 1 (this PR) lands the 4 docker-compose / allinone JWT-guard items + 2 validation-pass follow-ups (BANNED_SECRETS symmetry + CI negative-path test).** The remaining 9-10 original findings + 2 new completeness/reviewer findings stay tracked here so the parent Linear story (ROK-1292) and TECH-DEBT-BACKLOG agree. Source reports preserved at `planning-artifacts/security-review-7bec0fb2-fullrepo.md` + `planning-artifacts/security-review-7bec0fb2-summary.md`.
+
+**Group B — App-code HIGH severity (PR 2 of ROK-1292):**
+
+- **[high]** `api/src/admin/branding.controller.ts:25, 152-164` + `api/src/main.ts:59-65` — SVG entry in `ALLOWED_TYPES` declares `magic: [0x3c]` (single `<` byte). Any text file beginning with `<` passes the magic-byte check; uploaded SVG is written as `logo.svg` and served same-origin from `/uploads/branding/logo.svg`. Helmet's app-wide CSP doesn't extend per-asset. Admin-only upload limits to admin-trojan / social-engineering, but a logo SVG with `<script>` executes JS in the API origin when navigated directly. (Avatar upload is hardened via `sharp` re-encode; branding intentionally preserves SVG.)
+  Suggested: drop SVG from `ALLOWED_TYPES`. If SVG required: server-side sanitize (`svg-sanitizer` / `DOMPurify`), serve with `Content-Disposition: attachment` AND per-static-asset CSP `default-src 'none'; style-src 'unsafe-inline'`, consider a sandboxed subdomain for branding. Ship with a regression test that uploads `<svg><script>...</script></svg>` and asserts rejection.
+
+**Group C — App-code defense-in-depth (PR 3 of ROK-1292):**
+
+- **[med]** `api/src/ai/ai-providers.controller.ts:60-73, 234-250` — `@Body() body: AiProviderConfigDto` is a TS type alias only; no `ValidationPipe`, no Zod parse. `body.apiKey` / `body.url` / `body.model` persisted via `settings.set()` as-is. Admin-gated so external impact is low, but data-integrity / settings-cache corruption / log tampering possible from inside an admin session.
+  Suggested: add `AiProviderConfigSchema` to `packages/contract` and `.parse(body)` at controller, OR convert DTO to class-validator with paired `ValidationPipe`.
+- **[med]** `api/src/main.ts:23-46` (`installAutoClientUrlDetection`) — When `CORS_ORIGIN === 'auto'` and `CLIENT_URL` unset, first request writes `process.env.CLIENT_URL` from unverified `Host` + `X-Forwarded-Proto` headers. No allow-list. In direct-access deployment (no nginx normalization), one crafted request poisons `CLIENT_URL` for process lifetime — flows into OG-embed redirects, OAuth callbacks, Discord magic-link bodies. Synology + nginx mitigates in practice; code doesn't enforce the contract.
+  Suggested: in `auto` mode, require `ALLOWED_HOSTS` env var (comma-separated allow-list) and reject non-matching `Host` headers before mutating env. Better: derive `CLIENT_URL` per-request via request-scoped helper instead of mutating `process.env`.
+- **[med]** `api/src/auth/magic-link.service.ts:36-49` + `web/src/App.tsx:42-56` — 15-min JWT shipped as `?token=` in URL sent to Discord. Frontend strips query AFTER page load (already too late — Discord link-tracker, browser history, HTTPS proxies, Referer headers may have logged it). `magicLink: true` claim NOT enforced downstream — JWT interchangeable with a normal login token. No single-use enforcement: captured magic link grants 15 min of full account impersonation.
+  Suggested: store `jti` in Redis at issue (`setex(jti, 900, '1')`), `getdel` on consumption, reject if absent. Add magic-link-only guard requiring `magicLink === true` and refusing write endpoints. Best long-term: server-side `/auth/redeem-magic-link` POST instead of GET-with-query.
+- **[med]** `api/src/settings/encryption.util.ts:32-37` (`deriveKey`) — Salt built as `Buffer.from(secret.slice(0, 32).padEnd(32, '0'))`. Salt derived deterministically from the secret defeats the salt's purpose. Acceptable for per-process JWT_SECRET use-case in isolation; dangerous if reused for password hashing. Short JWT_SECRET values get padded with literal `'0'` chars, weakening entropy.
+  Suggested: persist a process-local random 32-byte salt in `app_settings` (`encryption_salt`), pass explicitly. At minimum add a code comment marking this pattern as JWT-secret-only and forbidding reuse for password storage.
+- **[low]** `api/src/steam/steam-auth.controller.ts:233-255` + `api/src/steam/steam-http.util.ts:49-81` — Steam-OpenID nonce replay protection currently relies on Steam (`mode=check_authentication`). We don't cache `openid.response_nonce` ourselves. Replay risk low (only re-links the same Steam ID to the same user); layered-defense story missing.
+  Suggested: after successful link, `redis.setex(`steam-openid:${nonce}`, 86400, '1')` and reject if already present.
+- **[low]** `api/src/auth/jwt.strategy.ts:28` — `process.env.JWT_SECRET!` non-null assertion at construction. If env var missing in prod, passport-jwt receives `undefined` as `secretOrKey` and may either crash at boot or accept tokens signed with an empty key.
+  Suggested: throw at module init if `JWT_SECRET` missing or < 32 chars (fail-closed).
+- **[low]** `api/src/auth/auth.controller.ts:48-67` (`exchangeCode`) — `redis.get` then `redis.del` is not atomic. Two simultaneous requests with the same code could both retrieve, both `del`, both succeed. Single-use semantics claimed in code comment but not enforced.
+  Suggested: replace with `redis.getdel(key)` (Redis 6.2+) or wrap in `MULTI/EXEC`.
+- **[low]** `api/src/csp-report/csp-report.controller.ts:14-32` — Logs full CSP report payload to structured logger. 64kb body limit caps abuse but an attacker producing CSP violations can spam logs with arbitrary content reaching the configured log sink.
+  Suggested: cap and redact (`JSON.stringify(report).slice(0, 4096)`), or rely on Sentry tags + sampling and skip the second log line.
+- **[low]** `api/src/plugins/wow-common/blizzard-equipment.helpers.ts:25-52` (`fetchSingleIconUrl`) — Sends `Bearer ${token}` Authorization header to a URL pulled from parent Blizzard JSON response (`equipped_items[].media.key.href`) without host validation. If a future Blizzard endpoint returns a non-Blizzard URL (or MITM injects one), bearer leaks to third-party host.
+  Suggested: assert `new URL(mediaHref).hostname.endsWith('blizzard.com') || .endsWith('battle.net')` before fetch.
+- **[low]** `api/src/version/version-check.service.ts:144` → `web/src/components/admin/UpdateBanner.tsx:48` — `latestReleaseUrl` flows from GitHub's `body.html_url` through `app_settings` to a JSX `<a href={href}>`. Zod's `z.string().url()` allows `javascript:` URLs (uses URL constructor which accepts them), so contract doesn't block scheme-based XSS. Trusted source today; defense-in-depth one-liner.
+  Suggested: validate `href.startsWith('https://github.com/')` either at storage step in `storeVersionCheckResults` (reject otherwise, store empty) OR at render time in `BannerContent`.
+
+**Sibling/completeness findings (surfaced by `/validate` + `/code-review` over PR 1):**
+
+- **[low]** `docker-compose.test.yml` (sibling to `docker-compose.yml`) binds `5433:5432` for the test Postgres — same wide-open `0.0.0.0` exposure as the main compose file before PR 1. Out of scope for the PR1 framing but the obvious sibling to harden.
+  Suggested: change to `"127.0.0.1:5433:5432"`. Same risk profile, same one-line fix.
+- **[nit]** `api/scripts/reencrypt-settings.ts:116` — recovery-instructions help text bakes the literal `raid-ledger-default-secret-change-in-production` into a `console.log` example. Not in `BANNED_SECRETS` scope (it's documentation), but if the literal naming is ever rotated this is a 4th replication site to update (alongside `Dockerfile.allinone`, `docker-entrypoint.sh`, `encryption.util.ts`).
+  Suggested: leave for now; flag if anyone proposes renaming the legacy literal.
+
+**ROK-1292 AC reconciliation:** the story body's AC line "Backlog section '2026-05-14 — fix/batch-2026-05-14 (surfaced during operator-triggered /security-review on whole repo + local env)' pruned from `TECH-DEBT-BACKLOG.md`" is N/A — that section was never added; operator filed direct to Linear. Strike that AC bullet when ROK-1292 closes.
+

--- a/api/scripts/docker-entrypoint.sh
+++ b/api/scripts/docker-entrypoint.sh
@@ -28,16 +28,20 @@ if [ -n "$DATABASE_URL" ]; then
     MIGRATIONS_FOLDER=/app/drizzle/migrations \
       node /app/dist/scripts/run-migrations-with-sentry.js 2>&1
 
-    # Re-encrypt app_settings if migrating from default JWT_SECRET (ROK-1035)
+    # Re-encrypt app_settings if migrating from a known dev JWT_SECRET (ROK-1035, ROK-1292)
+    # Keep this list in sync with Dockerfile.allinone HARDCODED_DEFAULTS and the
+    # docker-compose.yml JWT_SECRET fallback.
     if [ ! -f /data/.jwt_secret_migrated ]; then
-        HARDCODED_DEFAULT="raid-ledger-default-secret-change-in-production"
+        HARDCODED_DEFAULTS="raid-ledger-default-secret-change-in-production dev-secret-change-in-prod"
         echo "🔄 Checking if app_settings re-encryption is needed..."
         if [ -f /app/dist/scripts/reencrypt-settings.js ]; then
-            node /app/dist/scripts/reencrypt-settings.js \
-                --old-secret "$HARDCODED_DEFAULT" \
-                --new-secret "$JWT_SECRET" 2>&1 || {
-                echo "⚠️ Re-encryption failed (non-fatal — settings may already use new key)"
-            }
+            for OLD_SECRET in $HARDCODED_DEFAULTS; do
+                node /app/dist/scripts/reencrypt-settings.js \
+                    --old-secret "$OLD_SECRET" \
+                    --new-secret "$JWT_SECRET" 2>&1 || {
+                    echo "⚠️ Re-encryption attempt with default '$OLD_SECRET' failed (non-fatal — settings may already use new key)"
+                }
+            done
         fi
         touch /data/.jwt_secret_migrated
         echo "✅ Re-encryption migration marker created"

--- a/api/src/settings/encryption.util.spec.ts
+++ b/api/src/settings/encryption.util.spec.ts
@@ -190,9 +190,10 @@ function describeEncryptionUtil() {
     });
   });
 
-  describe('getEncryptionKey production rejection (ROK-1035)', () => {
+  describe('getEncryptionKey production rejection (ROK-1035, ROK-1292)', () => {
     const HARDCODED_DEFAULT = 'raid-ledger-default-secret-change-in-production';
     const DEV_FALLBACK = 'dev-encryption-key-change-me';
+    const COMPOSE_DEFAULT = 'dev-secret-change-in-prod';
 
     afterEach(() => {
       // Restore non-production env and clear cache
@@ -234,6 +235,26 @@ function describeEncryptionUtil() {
     it('should NOT throw in non-production when JWT_SECRET is the dev fallback', () => {
       process.env.NODE_ENV = 'test';
       process.env.JWT_SECRET = DEV_FALLBACK;
+      _resetKeyCache();
+
+      expect(() => getEncryptionKey()).not.toThrow();
+    });
+
+    it('should throw in production when JWT_SECRET is the docker-compose default (ROK-1292)', () => {
+      expect(typeof getEncryptionKey).toBe('function');
+
+      process.env.NODE_ENV = 'production';
+      process.env.JWT_SECRET = COMPOSE_DEFAULT;
+      _resetKeyCache();
+
+      expect(() => getEncryptionKey()).toThrow(
+        /default.*secret|insecure|banned/i,
+      );
+    });
+
+    it('should NOT throw in non-production when JWT_SECRET is the docker-compose default (ROK-1292)', () => {
+      process.env.NODE_ENV = 'test';
+      process.env.JWT_SECRET = COMPOSE_DEFAULT;
       _resetKeyCache();
 
       expect(() => getEncryptionKey()).not.toThrow();

--- a/api/src/settings/encryption.util.ts
+++ b/api/src/settings/encryption.util.ts
@@ -11,10 +11,15 @@ const AUTH_TAG_LENGTH = 16;
 const SALT_LENGTH = 32;
 const KEY_LENGTH = 32;
 
-/** Secrets that must never be used in production. */
+/**
+ * Secrets that must never be used in production.
+ * Keep this in sync with the allinone JWT guard:
+ * Dockerfile.allinone (HARDCODED_DEFAULTS) and api/scripts/docker-entrypoint.sh.
+ */
 const BANNED_SECRETS = [
   'raid-ledger-default-secret-change-in-production',
   'dev-encryption-key-change-me',
+  'dev-secret-change-in-prod',
 ];
 
 /**

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,9 @@ services:
       -c shared_preload_libraries=pg_stat_statements
       -c log_min_duration_statement=200ms
       -c pg_stat_statements.track=all
+    # ROK-1292 PR1: bind to loopback only — local DB holds prod-clone data after `clone-prod-to-local.sh`.
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - db_data:/var/lib/postgresql/data
     healthcheck:
@@ -29,8 +30,9 @@ services:
     image: redis:alpine
     container_name: raid-ledger-redis
     restart: always
+    # ROK-1292 PR1: loopback-only — Redis runs without auth and carries BullMQ payloads.
     ports:
-      - "6379:6379"
+      - "127.0.0.1:6379:6379"
     healthcheck:
       test: [ "CMD", "redis-cli", "ping" ]
       interval: 5s
@@ -54,6 +56,7 @@ services:
     environment:
       DATABASE_URL: postgresql://user:password@db:5432/raid_ledger
       REDIS_URL: redis://redis:6379
+      # ROK-1292 PR1: this literal is also rejected by the allinone guard (Dockerfile.allinone + docker-entrypoint.sh) — keep them in sync.
       JWT_SECRET: "${JWT_SECRET:-dev-secret-change-in-prod}"
       CLIENT_URL: http://localhost:80
       CORS_ORIGIN: http://localhost:80
@@ -63,7 +66,6 @@ services:
       # DISABLE_TELEMETRY: "true"
     volumes:
       - avatar_data:/data
-      - /var/run/docker.sock:/var/run/docker.sock
     ports:
       - "${API_PORT:-3000}:3000"
     healthcheck:


### PR DESCRIPTION
## Summary

First of three planned PRs from ROK-1292 (`/security-review` of commit `7bec0fb2` on 2026-05-14, 13 findings total). This PR ships the 4 highest-urgency local-env / allinone-guard items + 2 validation-pass follow-ups (BANNED_SECRETS symmetry + CI negative-path test). The remaining 9-10 findings are tracked in `TECH-DEBT-BACKLOG.md` for later PRs; **the parent Linear story (ROK-1292) stays Open** until PR 2 (branding SVG) and PR 3 (defense-in-depth) ship.

## Changes

| File | Change | Why |
|------|--------|-----|
| `docker-compose.yml` | Bind Postgres `5432` and Redis `6379` to `127.0.0.1`; drop vestigial `/var/run/docker.sock` mount; add JWT_SECRET cross-ref comment | Local DB now holds prod-clone data after `clone-prod-to-local.sh`; previous `0.0.0.0` binding exposed it on LAN with hardcoded user/password. `docker.sock` mount was added with ROK-542 (Ollama) and has zero call sites in api code. |
| `Dockerfile.allinone` | Convert `HARDCODED_DEFAULT` scalar → `HARDCODED_DEFAULTS` list + `is_known_default()` helper; rejects both legacy literal AND new compose default `dev-secret-change-in-prod` | Closes a fail-open path where the compose default could accidentally leak into prod env files. |
| `api/scripts/docker-entrypoint.sh` | Re-encrypt loop tries both old defaults | Mirrors the guard list. Block is gated by `/data/.jwt_secret_migrated` so it's a no-op on existing prod (which has the marker since ROK-1035). |
| `api/src/settings/encryption.util.ts` | Add `dev-secret-change-in-prod` to `BANNED_SECRETS` | Symmetry with the new entrypoint guard — encryption layer rejects the same set of insecure defaults. |
| `api/src/settings/encryption.util.spec.ts` | Two new tests for the new banned literal | Locks the contract. **27/27 tests pass locally.** |
| `.github/workflows/ci.yml` | New `container-startup` step "Verify JWT guard rejects known dev defaults" — boots allinone with each banned literal as `JWT_SECRET`, polls logs for the FATAL message within 30s | Closes the gap where CI built the image but never exercised the guard's reject branch. |
| `TECH-DEBT-BACKLOG.md` | New `2026-05-15 — rok-1292-pr1-local-env-hardening` section: PR 2 + PR 3 deferrals + 2 sibling/completeness findings (`docker-compose.test.yml:5433` still wide-open; `reencrypt-settings.ts:116` 4th replication site) | Persistent tracking so ROK-1292 doesn't go stale before PR 2 + PR 3. |

## Prod risk

**LOW.** Only `Dockerfile.allinone` reaches prod; the change widens the fail-closed JWT guard from one literal to two. Outage triggers if and only if prod's effective `JWT_SECRET` equals one of the rejected literals — vanishingly unlikely (prod uses `/data/.jwt_secret`, not the env override). Recovery: re-tag the previous image SHA on the NAS and `docker compose up -d` (faster than git revert + Watchtower wait). `docker-compose.yml` and `TECH-DEBT-BACKLOG.md` are local/docs only. `docker-entrypoint.sh` re-encrypt change is gated by the existing migration marker — effectively a no-op on prod.

The container-startup CI job exercises the new guard's reject branch on every PR.

## Story-body AC reconciliation

- ✅ Items A.1, A.2, A.3, A.4 (Group A — local-env / docker-compose).
- ⏭ Item B.1 (branding SVG) deferred to PR 2 — tracked in `TECH-DEBT-BACKLOG.md`.
- ⏭ Items C.1–C.10 (defense-in-depth) deferred to PR 3 — tracked in `TECH-DEBT-BACKLOG.md`.
- ❌ AC line "prune backlog section '2026-05-14 — fix/batch-2026-05-14 (surfaced during ... /security-review on whole repo + local env)'" is **N/A** — that section was never added (operator filed direct to Linear, never to backlog). Strike when ROK-1292 closes.

## Test plan

- [x] `npm run test -w api -- encryption.util.spec` → 27/27 pass
- [x] `bash -n api/scripts/docker-entrypoint.sh` clean
- [x] `bash -n` clean on `start-api.sh` heredoc extracted from `Dockerfile.allinone`
- [x] `docker compose config` resolves Postgres + Redis to `host_ip: 127.0.0.1`
- [ ] CI `container-startup` job: build + boot allinone + verify nginx + verify NEW negative-path test rejects both banned literals within 30s
- [ ] (Operator) After merge + Watchtower 5AM pull: `docker port raid-ledger-db` shows `127.0.0.1:5432, [::1]:5432` only on local dev (prod allinone is unaffected — different image, doesn't use `docker-compose.yml`)

## Validation provenance

- `/validate` (4 parallel agents) over commit `26f105f6`: ACCURATE / MOSTLY SOUND / MOSTLY COMPLETE / LOW RISK
- `/code-review` (devedup-rl:reviewer) over commits `26f105f6` + `910bd936`: PASS — 0 critical, 0 warning, 1 suggestion (defer-only), 0 nitpick
- Pre-existing tsc breakage in `api/src/version/version.controller.spec.ts` + `api/test/app.e2e-spec.ts` confirmed pre-existing via `git stash` test; not addressed here. The rok-1036 entry in `TECH-DEBT-BACKLOG.md` (added by PR #794) covers a separate but related set of pre-existing tsc errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)