### PR TITLE
fix(rok-1292): JWT guard fail-fast on env-var known default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,7 +560,7 @@ jobs:
               -e ADMIN_PASSWORD=ci-test-password \
               raid-ledger:ci-test
             FOUND=0
-            for i in $(seq 1 30); do
+            for i in $(seq 1 60); do
               if docker logs "$CONTAINER" 2>&1 | grep -q "FATAL: JWT_SECRET is still an insecure hardcoded default"; then
                 echo "✅ Guard rejected '$SECRET' after ${i}s"
                 FOUND=1
@@ -568,12 +568,18 @@ jobs:
               fi
               sleep 1
             done
-            docker stop "$CONTAINER" 2>/dev/null || true
-            docker rm -f "$CONTAINER" 2>/dev/null || true
             if [ "$FOUND" != "1" ]; then
-              echo "❌ Guard did NOT reject '$SECRET' within 30s"
+              echo "❌ Guard did NOT reject '$SECRET' within 60s — dumping diagnostics:"
+              echo "─── docker inspect ───"
+              docker inspect "$CONTAINER" --format '{{.State.Status}} (exit {{.State.ExitCode}})' 2>&1 || true
+              echo "─── docker logs (tail 200) ───"
+              docker logs "$CONTAINER" --tail 200 2>&1 || true
+              docker stop "$CONTAINER" 2>/dev/null || true
+              docker rm -f "$CONTAINER" 2>/dev/null || true
               exit 1
             fi
+            docker stop "$CONTAINER" 2>/dev/null || true
+            docker rm -f "$CONTAINER" 2>/dev/null || true
           done
 
       - name: Cleanup

--- a/Dockerfile.allinone
+++ b/Dockerfile.allinone
@@ -299,10 +299,10 @@ done
 echo "✅ Redis is ready"
 
 # ── JWT_SECRET resolution (ROK-1035, ROK-1292) ────────────────────
-# Priority: 1) env var (if set and not a known dev default) → use it
-#           2) /data/.jwt_secret file exists → read it
+# Priority: 1) env var (must NOT be a known dev default — fail fast)
+#           2) /data/.jwt_secret file exists & non-empty → read it
 #           3) generate new secret, persist to /data/.jwt_secret
-# Known dev defaults rejected by the guard below — keep in sync with
+# Known dev defaults rejected by both guards below — keep in sync with
 # api/scripts/docker-entrypoint.sh and docker-compose.yml.
 HARDCODED_DEFAULTS="raid-ledger-default-secret-change-in-production dev-secret-change-in-prod"
 
@@ -313,7 +313,18 @@ is_known_default() {
   return 1
 }
 
-if [ -n "$JWT_SECRET" ] && ! is_known_default "$JWT_SECRET"; then
+# ROK-1292: fail fast if env var is explicitly a known default.
+# (Original ROK-1035 code fell through to file/generate which silently
+# overwrote JWT_SECRET — the post-resolution guard then checked the *new*
+# random value and never fired. Net effect pre-ROK-1292: known-bad env
+# var was accepted in practice.)
+if [ -n "$JWT_SECRET" ] && is_known_default "$JWT_SECRET"; then
+  echo "❌ FATAL: JWT_SECRET is still an insecure hardcoded default ($JWT_SECRET)."
+  echo "   Remove the env var override or set a real secret."
+  exit 1
+fi
+
+if [ -n "$JWT_SECRET" ]; then
   echo "🔑 JWT_SECRET: using explicit env var"
 elif [ -s /data/.jwt_secret ]; then
   # ROK-1036: `-s` instead of `-f` because entrypoint.sh pre-touches the
@@ -329,10 +340,11 @@ else
   echo "🔑 JWT_SECRET: generated new secret → /data/.jwt_secret"
 fi
 
-# Guard: refuse to start with any known insecure default
+# Guard: catch a /data/.jwt_secret file that was pre-populated with an
+# insecure historical literal (legacy install before ROK-1035).
 if is_known_default "$JWT_SECRET"; then
-  echo "❌ FATAL: JWT_SECRET is still an insecure hardcoded default ($JWT_SECRET)."
-  echo "   Remove the env var override or set a real secret."
+  echo "❌ FATAL: JWT_SECRET loaded from /data/.jwt_secret is an insecure hardcoded default."
+  echo "   Delete /data/.jwt_secret and restart to generate a new one."
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Follow-up to PR #795 (ROK-1292 PR1, merged as `bb7784ed`). The new container-startup CI step added in #795 caught a **pre-existing logic bug** in `start-api.sh`'s JWT guard. PR #795 itself merged with the bug because container-startup wasn't a required check.

## The bug (existed since ROK-1035, PR #616)

```bash
if [ -n "$JWT_SECRET" ] && ! is_known_default "$JWT_SECRET"; then
  use env var
elif [ -s /data/.jwt_secret ]; then
  export JWT_SECRET=$(cat ...)        # overwrites env var
else
  export JWT_SECRET=$(node -e ...)    # overwrites env var with random
fi

if is_known_default "$JWT_SECRET"; then exit 1; fi   # checks the new value
```

If env `JWT_SECRET` was set to a known default, the script silently fell through to file/generate which **overwrote `$JWT_SECRET`**. The post-resolution guard then checked the new (random) value and never fired. Net effect: a known-bad env var was accepted in practice. The TS-side `BANNED_SECRETS` check in `encryption.util.ts` caught this for the encryption layer, but `start-api.sh` never enforced it for JWT signing.

## The fix

Move the env-var check BEFORE resolution (fail fast on known-bad env). Keep a second post-resolution guard for the legacy-install case where `/data/.jwt_secret` was historically populated with the bad literal.

```bash
# NEW: fail fast at the top
if [ -n "$JWT_SECRET" ] && is_known_default "$JWT_SECRET"; then
  echo "❌ FATAL: ..."
  exit 1
fi

# Resolution stays the same (without the now-redundant env-var check in branch 1)
if [ -n "$JWT_SECRET" ]; then
  use env var
elif [ -s /data/.jwt_secret ]; then
  load from file
else
  generate
fi

# OLD guard kept — catches legacy /data/.jwt_secret with bad literal
if is_known_default "$JWT_SECRET"; then exit 1; fi
```

## Also

CI step's per-literal poll bumped 30s → 60s, and adds `docker inspect` + `docker logs --tail 200` on failure so future failures are debuggable from CI logs alone.

## Prod risk

**LOW.** Same envelope as PR #795. Only `start-api.sh` reaches prod. The fix tightens an existing guard that was effectively no-op for the env-var case. Outage trigger remains: only if prod's effective `JWT_SECRET` matches one of the rejected literals (vanishingly unlikely; prod uses `/data/.jwt_secret`, not env).

The container-startup CI step will exercise the fixed guard's reject branch on this PR.

## Test plan

- [ ] CI `container-startup`: build + boot allinone + verify nginx + verify NEW negative-path test rejects both banned literals within 60s
- [x] `bash -n` clean on `start-api.sh` heredoc (extracted from `Dockerfile.allinone`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)