### PR TITLE
ROK-1294: feat: JourneyHero component (U1+U3 Cycle 4 foundation) + ROK-1292 regression fix

### DIFF
--- a/TECH-DEBT-BACKLOG.md
+++ b/TECH-DEBT-BACKLOG.md
@@ -297,6 +297,15 @@ ROK-1292 closed 2026-05-16. PR 1 (Group A — 4 docker-compose / allinone JWT-gu
 - **[low]** `scripts/smoke/lineup-confirmation-pills-invitee.smoke.spec.ts:127` (mobile only) — `Building phase — invitee hero variants › invitee-acted: hero flips to waiting tone after nomination` fails with `data-tone` returning `"action"` after 14 polls instead of expected `"waiting"` (5s timeout). Hero-tone state is derived from the lineup's invitee snapshot — likely the same cross-worker bleedover. Desktop passes.
   Suggested: poll for the underlying nomination state via API before asserting the derived `data-tone`, OR isolate the invitee fixture per worker so the snapshot isn't racing the global lineup state.
 
+### 2026-05-16 — rok-1294-journey-hero (surfaced while fixing the ROK-1292 PR 2 branding regression)
+
+The ROK-1292 PR 2 regression was patched in this PR (commit `55475fb1`) by adding a `RAID_LEDGER_BRANDING_DIR` env override and sandboxing the integration spec to `os.tmpdir()`. Two related foot-guns remain in the codebase — not blocking, worth filing.
+
+- **[med]** `api/src/users/avatar.service.ts:44` and `api/src/main.ts:53-58` — same `process.cwd()/uploads/avatars` anti-pattern as the pre-fix branding code. Currently SAFE because no existing avatar spec writes/unlinks against that dir. If a future avatar integration spec copies the pre-fix branding pattern (`path.join(process.cwd(), 'uploads', 'avatars')` + `unlinkSync` in `afterEach`), it will wipe the operator's real local avatar webps in main repo `api/uploads/avatars/`.
+  Suggested: harden defensively — either (a) rename the existing `AVATAR_UPLOAD_DIR` override to match the new `RAID_LEDGER_*` convention and document both, OR (b) make the dev default for both branding + avatars resolve to a non-`process.cwd()`-anchored path so `npm run test -w api` cwd assumptions can't collide with the dev-served dir.
+- **[low]** Root-cause-vs-symptom: the production `getBrandingDir()` still returns `process.cwd()/uploads/branding` in dev. Any future spec / seed / script that doesn't honor `RAID_LEDGER_BRANDING_DIR` can re-introduce the wipe. A real fix would either anchor the dev path off something non-`process.cwd()`-relative (e.g. a fixed `~/.raid-ledger/dev-uploads/` location) OR refuse destructive writes when `NODE_ENV !== 'production'` and the target path matches the static-asset-served dir.
+  Suggested: defer until/unless another team member's spec re-trips the same bug. The env-var override + new regression test (added in this PR) is the minimum-effective fix.
+
 ### 2026-05-16 — rok-1294-journey-hero (surfaced during npx tsc --noEmit -p api/tsconfig.json)
 
 10 pre-existing TypeScript errors in `api/src` test files. None caused by ROK-1294's diff. The dev's CI proof for ROK-1294 ran `npx tsc --noEmit -p web/tsconfig.json` (web only) + `npm run build -w api` (which uses `nest build` and excludes `*.spec.ts` per `tsconfig.build.json`), so these never surfaced — they only appear when typechecking the full `api/tsconfig.json` including specs. Worth deciding whether the api/CI step should compile specs.

--- a/TECH-DEBT-BACKLOG.md
+++ b/TECH-DEBT-BACKLOG.md
@@ -297,6 +297,16 @@ ROK-1292 closed 2026-05-16. PR 1 (Group A — 4 docker-compose / allinone JWT-gu
 - **[low]** `scripts/smoke/lineup-confirmation-pills-invitee.smoke.spec.ts:127` (mobile only) — `Building phase — invitee hero variants › invitee-acted: hero flips to waiting tone after nomination` fails with `data-tone` returning `"action"` after 14 polls instead of expected `"waiting"` (5s timeout). Hero-tone state is derived from the lineup's invitee snapshot — likely the same cross-worker bleedover. Desktop passes.
   Suggested: poll for the underlying nomination state via API before asserting the derived `data-tone`, OR isolate the invitee fixture per worker so the snapshot isn't racing the global lineup state.
 
+### 2026-05-16 — rok-1294-journey-hero (surfaced during npx tsc --noEmit -p api/tsconfig.json)
+
+10 pre-existing TypeScript errors in `api/src` test files. None caused by ROK-1294's diff. The dev's CI proof for ROK-1294 ran `npx tsc --noEmit -p web/tsconfig.json` (web only) + `npm run build -w api` (which uses `nest build` and excludes `*.spec.ts` per `tsconfig.build.json`), so these never surfaced — they only appear when typechecking the full `api/tsconfig.json` including specs. Worth deciding whether the api/CI step should compile specs.
+
+- **[low]** `api/src/admin/games-dedup-audit.integration.spec.ts:386` — `TS2769: No overload matches this call`. Drizzle query builder type mismatch.
+- **[low]** `api/src/admin/games-dedup-audit.service.spec.ts:432` — `TS2502: 'tx' is referenced directly or indirectly in its own type annotation`. Recursive type in transaction mock.
+- **[low]** `api/src/admin/games-dedup-merge.integration.spec.ts:139,149,160` (3 errors) — `TS2352: Conversion of type 'RowList<{...}>' to type '{...}' may be a mistake`. Test-side type assertion mismatches between Drizzle's camelCase result and snake_case fixture shape.
+- **[low]** `api/src/lineups/lineup-deadline-vote-race.integration.spec.ts:186` — `TS2345: Argument of type 'SQL<unknown>' is not assignable to parameter of type 'string | SQLWrapper'`. Cross-package drizzle-orm version mismatch in private types (`shouldInlineParams`).
+- **[low]** `api/src/lineups/lineup-notification.service.private-visibility.spec.ts:108,114,120,126` (4 errors) — `TS2556: A spread argument must either have a tuple type or be passed to a rest parameter`. Type narrowing failure on a generic mock.
+  Suggested: most are 1-2 line fixes (add `as { ... }[]` cast or narrow the mock signature). The drizzle-orm cross-package mismatch may be a workspace nohoist issue.
 
 ### 2026-05-16 — fix/batch-2026-05-16 (surfaced during Playwright sweep on batch)
 

--- a/api/src/admin/branding.controller.integration.spec.ts
+++ b/api/src/admin/branding.controller.integration.spec.ts
@@ -166,4 +166,30 @@ describe('ROK-1292 PR 2 — branding logo SVG XSS rejection', () => {
       communityLogoUrl: expect.stringMatching(/\.png$/),
     });
   });
+
+  // Regression guard for ROK-1292 PR 2 follow-up: an uploaded logo's
+  // on-disk path MUST resolve under the sandboxed BRANDING_DIR, not
+  // process.cwd()/uploads/branding. If this test ever fails, the
+  // env-var override is broken and `npm run test -w api` will resume
+  // wiping the operator's real dev logo.
+  it('upload lands under the sandboxed BRANDING_DIR, never under process.cwd()', async () => {
+    const png = makeTinyPngBuffer();
+    await testApp.request
+      .post('/admin/branding/logo')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .attach('logo', png, {
+        filename: 'logo.png',
+        contentType: 'image/png',
+      })
+      .expect(201);
+
+    const settings = testApp.app.get(SettingsService);
+    const branding = await settings.getBranding();
+    expect(branding.communityLogoPath).toBeTruthy();
+    expect(branding.communityLogoPath?.startsWith(BRANDING_DIR)).toBe(true);
+    expect(branding.communityLogoPath).not.toContain(
+      path.join(process.cwd(), 'uploads', 'branding'),
+    );
+    expect(fs.existsSync(branding.communityLogoPath!)).toBe(true);
+  });
 });

--- a/api/src/admin/branding.controller.integration.spec.ts
+++ b/api/src/admin/branding.controller.integration.spec.ts
@@ -10,6 +10,7 @@
  * 201) and will pass once SVG is dropped.
  */
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import { getTestApp, type TestApp } from '../common/testing/test-app';
 import {
@@ -19,7 +20,16 @@ import {
 import { SettingsService } from '../settings/settings.service';
 import { BrandingController } from './branding.controller';
 
-const BRANDING_DIR = path.join(process.cwd(), 'uploads', 'branding');
+// Sandbox to a per-run tmpdir so the spec cannot wipe the operator's real
+// dev `api/uploads/branding/` (the dev server's static-asset path). The
+// production code at `branding.controller.ts::getBrandingDir` honors
+// RAID_LEDGER_BRANDING_DIR when set. Set at module load (before any
+// `beforeAll`) so the controller's multer storage callback + onModuleInit
+// pick it up. Cleaned up entirely in `afterAll` below.
+const BRANDING_DIR = fs.mkdtempSync(
+  path.join(os.tmpdir(), 'rok-1292-branding-'),
+);
+process.env.RAID_LEDGER_BRANDING_DIR = BRANDING_DIR;
 
 function clearBrandingDir(): void {
   if (!fs.existsSync(BRANDING_DIR)) return;
@@ -71,6 +81,12 @@ describe('ROK-1292 PR 2 — branding logo SVG XSS rejection', () => {
 
   afterAll(() => {
     clearBrandingDir();
+    try {
+      fs.rmdirSync(BRANDING_DIR);
+    } catch {
+      // best-effort: removal can fail if a stray file remains
+    }
+    delete process.env.RAID_LEDGER_BRANDING_DIR;
   });
 
   it('rejects an SVG containing <script> with 400 and an error message that does not name SVG', async () => {

--- a/api/src/admin/branding.controller.ts
+++ b/api/src/admin/branding.controller.ts
@@ -34,6 +34,13 @@ const LEGACY_EXTS = ['svg'];
 const MAX_LOGO_SIZE = 2 * 1024 * 1024; // 2 MB
 
 function getBrandingDir(): string {
+  // Test-only escape hatch so integration specs can sandbox to a tmpdir
+  // instead of mutating real dev uploads. ROK-1292 PR 2's spec wiped the
+  // operator's dev logo on every CI run because it computed the same
+  // `process.cwd()/uploads/branding` path the dev server serves from.
+  if (process.env.RAID_LEDGER_BRANDING_DIR) {
+    return process.env.RAID_LEDGER_BRANDING_DIR;
+  }
   const isProduction = process.env.NODE_ENV === 'production';
   return isProduction
     ? '/data/uploads/branding'

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -56,9 +56,11 @@ function configureStaticAssets(
       ? '/data/avatars'
       : path.join(process.cwd(), 'uploads', 'avatars'));
   app.useStaticAssets(avatarDir, { prefix: '/avatars/', maxAge: '7d' });
-  const brandingDir = isProduction
-    ? '/data/uploads/branding'
-    : path.join(process.cwd(), 'uploads', 'branding');
+  const brandingDir =
+    process.env.RAID_LEDGER_BRANDING_DIR ||
+    (isProduction
+      ? '/data/uploads/branding'
+      : path.join(process.cwd(), 'uploads', 'branding'));
   app.useStaticAssets(brandingDir, {
     prefix: '/uploads/branding/',
     maxAge: '1d',

--- a/web/src/components/shared/journey-hero/JourneyHero.test.tsx
+++ b/web/src/components/shared/journey-hero/JourneyHero.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * Failing-first tests for JourneyHero component (ROK-1294).
+ * Source file does not yet exist — these MUST fail with module-not-found until dev implements.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../../../test/render-helpers';
+import { JourneyHero } from './JourneyHero';
+import type { HeroTone, JourneyPhase } from './types';
+
+const PHASES: JourneyPhase[] = ['nominating', 'voting', 'decided', 'scheduling', 'done'];
+const TONES: HeroTone[] = ['action', 'waiting', 'set'];
+
+function pillLabelFor(tone: HeroTone): string | null {
+    if (tone === 'waiting') return "✓ You're done here";
+    if (tone === 'set') return "✓ You're set";
+    return null;
+}
+
+describe('JourneyHero — 5 phases × 3 tones smoke', () => {
+    for (const phase of PHASES) {
+        for (const tone of TONES) {
+            it(`renders phase=${phase} tone=${tone} with task, badge, and correct pill`, () => {
+                const badge = `BADGE-${phase}-${tone}`;
+                const task = `Task copy for ${phase} ${tone}`;
+                renderWithProviders(
+                    <JourneyHero phase={phase} tone={tone} badge={badge} task={task} />,
+                );
+                expect(screen.getByText(task)).toBeInTheDocument();
+                expect(screen.getByText(badge)).toBeInTheDocument();
+                const expectedPill = pillLabelFor(tone);
+                if (expectedPill) {
+                    expect(screen.getByText(expectedPill)).toBeInTheDocument();
+                } else {
+                    expect(screen.queryByText("✓ You're done here")).not.toBeInTheDocument();
+                    expect(screen.queryByText("✓ You're set")).not.toBeInTheDocument();
+                }
+            });
+        }
+    }
+});
+
+describe('JourneyHero — ribbon visibility', () => {
+    it('noRibbon=true hides the phase ribbon <ol>', () => {
+        renderWithProviders(
+            <JourneyHero phase="nominating" badge="b" task="t" noRibbon />,
+        );
+        expect(screen.queryByRole('list', { name: 'Lineup progress' })).not.toBeInTheDocument();
+    });
+
+    it('noRibbon unset renders <ol aria-label="Lineup progress"> with exactly 4 phase <li> items', () => {
+        renderWithProviders(<JourneyHero phase="nominating" badge="b" task="t" />);
+        const ribbon = screen.getByRole('list', { name: 'Lineup progress' });
+        expect(ribbon).toBeInTheDocument();
+        // 4 named phases: Nominate / Vote / Decide / Schedule
+        const items = ribbon.querySelectorAll('li');
+        expect(items.length).toBe(4);
+    });
+});
+
+describe('JourneyHero — pill override', () => {
+    it('donePillLabel overrides the tone-derived default', () => {
+        renderWithProviders(
+            <JourneyHero phase="done" tone="set" badge="b" task="t" donePillLabel="✓ Custom label" />,
+        );
+        expect(screen.getByText('✓ Custom label')).toBeInTheDocument();
+        expect(screen.queryByText("✓ You're set")).not.toBeInTheDocument();
+    });
+});
+
+describe('JourneyHero — CTA', () => {
+    it('renders a real <button>; clicking calls onCtaClick', async () => {
+        const onCtaClick = vi.fn();
+        renderWithProviders(
+            <JourneyHero phase="nominating" badge="b" task="t" cta="Nominate now" onCtaClick={onCtaClick} />,
+        );
+        const btn = screen.getByRole('button', { name: 'Nominate now' });
+        expect(btn).toBeInTheDocument();
+        await userEvent.click(btn);
+        expect(onCtaClick).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders a disabled button when cta is set but onCtaClick is omitted', () => {
+        renderWithProviders(
+            <JourneyHero phase="nominating" badge="b" task="t" cta="Disabled CTA" />,
+        );
+        const btn = screen.getByRole('button', { name: 'Disabled CTA' });
+        expect(btn).toBeDisabled();
+    });
+});
+
+describe('JourneyHero — exitCondition + cue', () => {
+    it('renders exitCondition when provided', () => {
+        renderWithProviders(
+            <JourneyHero
+                phase="nominating"
+                tone="waiting"
+                badge="b"
+                task="t"
+                exitCondition="Auto-advances when 15 of 20 have nominated."
+            />,
+        );
+        expect(screen.getByText(/Auto-advances when 15 of 20 have nominated\./)).toBeInTheDocument();
+    });
+
+    it('does not render exitCondition when not provided', () => {
+        renderWithProviders(<JourneyHero phase="nominating" badge="b" task="t" />);
+        expect(screen.queryByText(/Auto-advances/)).not.toBeInTheDocument();
+    });
+
+    it('renders cue when provided (with 🔔 prefix)', () => {
+        renderWithProviders(
+            <JourneyHero
+                phase="nominating"
+                tone="waiting"
+                badge="b"
+                task="t"
+                cue="We'll DM you when voting opens."
+            />,
+        );
+        expect(screen.getByText(/We'll DM you when voting opens\./)).toBeInTheDocument();
+    });
+
+    it('does not render cue when not provided', () => {
+        renderWithProviders(<JourneyHero phase="nominating" badge="b" task="t" />);
+        expect(screen.queryByText(/DM you/)).not.toBeInTheDocument();
+    });
+});
+
+describe('JourneyHero — a11y', () => {
+    it('phase ribbon: active phase has aria-current="step"; others do not', () => {
+        renderWithProviders(<JourneyHero phase="voting" badge="b" task="t" />);
+        const ribbon = screen.getByRole('list', { name: 'Lineup progress' });
+        const items = Array.from(ribbon.querySelectorAll('li'));
+        const current = items.filter((li) => li.getAttribute('aria-current') === 'step');
+        expect(current).toHaveLength(1);
+        // voting maps to active index 1 (0-based: nominate, vote, decide, schedule)
+        expect(items.indexOf(current[0])).toBe(1);
+    });
+
+    it('outer container is role="region" with aria-labelledby pointing to badge id', () => {
+        renderWithProviders(<JourneyHero phase="nominating" badge="MY BADGE" task="t" />);
+        const region = screen.getByRole('region');
+        const labelledBy = region.getAttribute('aria-labelledby');
+        expect(labelledBy).toBeTruthy();
+        const labelEl = document.getElementById(labelledBy as string);
+        expect(labelEl).not.toBeNull();
+        expect(labelEl?.textContent).toBe('MY BADGE');
+    });
+
+    it('does NOT add role="status" or aria-live to the container or pills', () => {
+        renderWithProviders(
+            <JourneyHero phase="nominating" tone="waiting" badge="b" task="t" />,
+        );
+        expect(screen.queryByRole('status')).not.toBeInTheDocument();
+        const region = screen.getByRole('region');
+        expect(region.hasAttribute('aria-live')).toBe(false);
+    });
+});
+
+describe('JourneyHero — phase prop derivation', () => {
+    it('phase="voting" (no active) renders the same ribbon state as active={1}', () => {
+        const { unmount } = renderWithProviders(<JourneyHero phase="voting" badge="b" task="t" />);
+        const phaseCurrentIdx = Array.from(
+            screen.getByRole('list', { name: 'Lineup progress' }).querySelectorAll('li'),
+        ).findIndex((li) => li.getAttribute('aria-current') === 'step');
+        unmount();
+
+        renderWithProviders(<JourneyHero active={1} badge="b" task="t" />);
+        const activeCurrentIdx = Array.from(
+            screen.getByRole('list', { name: 'Lineup progress' }).querySelectorAll('li'),
+        ).findIndex((li) => li.getAttribute('aria-current') === 'step');
+
+        expect(phaseCurrentIdx).toBe(activeCurrentIdx);
+        expect(phaseCurrentIdx).toBe(1);
+    });
+});

--- a/web/src/components/shared/journey-hero/JourneyHero.tsx
+++ b/web/src/components/shared/journey-hero/JourneyHero.tsx
@@ -75,61 +75,43 @@ function pillLabelFor(tone: HeroTone, override?: string): string | null {
   return null;
 }
 
+function HeroHeader({ badgeId, badge, tone, pillLabel }: { badgeId: string; badge: string; tone: HeroTone; pillLabel: string | null }): JSX.Element {
+  const pillCls = tone === 'set' ? PILL_CLS.set : PILL_CLS.default;
+  return (
+    <div className="flex items-baseline justify-between mb-1">
+      <span id={badgeId} className={`text-[10px] uppercase tracking-wider ${BADGE_CLS[tone]}`}>{badge}</span>
+      {pillLabel && (
+        <span className={`inline-flex items-center gap-1 px-2 py-0.5 text-[10px] rounded-full border ${pillCls}`}>{pillLabel}</span>
+      )}
+    </div>
+  );
+}
+
+function HeroCta({ cta, onCtaClick, tone }: { cta: string; onCtaClick?: () => void; tone: HeroTone }): JSX.Element {
+  const cls = tone === 'action'
+    ? 'inline-block px-2 py-0.5 text-[10px] rounded bg-emerald-600 text-white disabled:opacity-50 disabled:cursor-not-allowed'
+    : 'inline-block px-2 py-0.5 text-[10px] rounded border border-edge text-muted disabled:opacity-50 disabled:cursor-not-allowed';
+  return (
+    <div className="text-right">
+      <button type="button" className={cls} onClick={onCtaClick} disabled={!onCtaClick}>{cta}</button>
+    </div>
+  );
+}
+
 export function JourneyHero(props: JourneyHeroProps): JSX.Element {
-  const {
-    phase,
-    active,
-    badge,
-    task,
-    sub,
-    cta,
-    onCtaClick,
-    hint,
-    tone = 'action',
-    exitCondition,
-    cue,
-    donePillLabel,
-    noRibbon,
-  } = props;
+  const { phase, active, badge, task, sub, cta, onCtaClick, hint, tone = 'action', exitCondition, cue, donePillLabel, noRibbon } = props;
   const badgeId = useId();
   const computedActive: HeroActive = active ?? PHASE_TO_ACTIVE[phase ?? 'nominating'];
   const taskCls = tone === 'action' ? 'text-foreground' : 'text-secondary';
   const pillLabel = pillLabelFor(tone, donePillLabel);
-  const pillCls = tone === 'set' ? PILL_CLS.set : PILL_CLS.default;
-  const ctaCls = tone === 'action'
-    ? 'inline-block px-2 py-0.5 text-[10px] rounded bg-emerald-600 text-white disabled:opacity-50 disabled:cursor-not-allowed'
-    : 'inline-block px-2 py-0.5 text-[10px] rounded border border-edge text-muted disabled:opacity-50 disabled:cursor-not-allowed';
-
   return (
-    <div
-      role="region"
-      aria-labelledby={badgeId}
-      className={`border rounded-lg p-3 ${BORDER_CLS[tone]}`}
-    >
+    <div role="region" aria-labelledby={badgeId} className={`border rounded-lg p-3 ${BORDER_CLS[tone]}`}>
       {!noRibbon && <PhaseRibbon active={computedActive} />}
-      <div className="flex items-baseline justify-between mb-1">
-        <span id={badgeId} className={`text-[10px] uppercase tracking-wider ${BADGE_CLS[tone]}`}>{badge}</span>
-        {pillLabel && (
-          <span className={`inline-flex items-center gap-1 px-2 py-0.5 text-[10px] rounded-full border ${pillCls}`}>
-            {pillLabel}
-          </span>
-        )}
-      </div>
+      <HeroHeader badgeId={badgeId} badge={badge} tone={tone} pillLabel={pillLabel} />
       <div className={`text-sm font-semibold mb-1 ${taskCls}`}>{task}</div>
       {sub && <div className="text-[11px] text-muted mb-1">{sub}</div>}
       {exitCondition && <div className="text-[10px] text-amber-300/80 mb-2 italic">⏱ {exitCondition}</div>}
-      {cta && (
-        <div className="text-right">
-          <button
-            type="button"
-            className={ctaCls}
-            onClick={onCtaClick}
-            disabled={!onCtaClick}
-          >
-            {cta}
-          </button>
-        </div>
-      )}
+      {cta && <HeroCta cta={cta} onCtaClick={onCtaClick} tone={tone} />}
       {cue && <div className="text-[10px] text-emerald-300/80 mt-2">🔔 {cue}</div>}
       {hint && <div className="text-[10px] text-muted mt-2 italic">{hint}</div>}
     </div>

--- a/web/src/components/shared/journey-hero/JourneyHero.tsx
+++ b/web/src/components/shared/journey-hero/JourneyHero.tsx
@@ -1,0 +1,137 @@
+import { useId, type JSX } from 'react';
+import type { HeroActive, HeroTone, JourneyHeroProps, JourneyPhase } from './types';
+
+const PHASE_TO_ACTIVE: Record<JourneyPhase, HeroActive> = {
+  nominating: 0,
+  voting: 1,
+  decided: 2,
+  scheduling: 3,
+  done: 4,
+};
+
+const PHASE_LABELS = ['Nominate', 'Vote', 'Decide', 'Schedule'] as const;
+
+const BORDER_CLS: Record<HeroTone, string> = {
+  action: 'border-emerald-500/30 bg-panel/70',
+  waiting: 'border-edge bg-overlay/40',
+  set: 'border-amber-500/30 bg-overlay/40',
+};
+
+const BADGE_CLS: Record<HeroTone, string> = {
+  action: 'text-emerald-300',
+  waiting: 'text-muted',
+  set: 'text-amber-300',
+};
+
+const PILL_CLS = {
+  set: 'bg-amber-500/15 text-amber-300 border-amber-500/30',
+  default: 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30',
+} as const;
+
+type StepState = 'done' | 'current' | 'future';
+
+function PhaseDot({ state, label }: { state: StepState; label: string }): JSX.Element {
+  const dotCls = {
+    done: 'bg-emerald-500/80 text-white',
+    current: 'bg-emerald-400 ring-2 ring-emerald-300/50 text-white',
+    future: 'bg-overlay/40 text-dim border border-edge',
+  }[state];
+  const symbol = state === 'done' ? '✓' : state === 'current' ? '●' : '○';
+  return (
+    <div className="flex flex-col items-center min-w-0 flex-1">
+      <div className={`w-5 h-5 rounded-full flex items-center justify-center text-[9px] ${dotCls}`}>{symbol}</div>
+      <div className="text-[9px] text-muted mt-1 truncate">{label}</div>
+    </div>
+  );
+}
+
+function PhaseRibbon({ active }: { active: HeroActive }): JSX.Element {
+  return (
+    <ol aria-label="Lineup progress" className="flex items-center gap-1 mb-3 list-none p-0">
+      {PHASE_LABELS.map((label, i) => {
+        const state: StepState = i < active ? 'done' : i === active ? 'current' : 'future';
+        const isCurrent = state === 'current';
+        return (
+          <li
+            key={label}
+            className="flex items-center flex-1"
+            {...(isCurrent ? { 'aria-current': 'step' as const } : {})}
+          >
+            <PhaseDot state={state} label={label} />
+            {i < PHASE_LABELS.length - 1 && (
+              <div className={`h-px flex-1 ${i < active ? 'bg-emerald-500/60' : 'bg-edge'}`} />
+            )}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+function pillLabelFor(tone: HeroTone, override?: string): string | null {
+  if (override !== undefined) return override;
+  if (tone === 'set') return "✓ You're set";
+  if (tone === 'waiting') return "✓ You're done here";
+  return null;
+}
+
+export function JourneyHero(props: JourneyHeroProps): JSX.Element {
+  const {
+    phase,
+    active,
+    badge,
+    task,
+    sub,
+    cta,
+    onCtaClick,
+    hint,
+    tone = 'action',
+    exitCondition,
+    cue,
+    donePillLabel,
+    noRibbon,
+  } = props;
+  const badgeId = useId();
+  const computedActive: HeroActive = active ?? PHASE_TO_ACTIVE[phase ?? 'nominating'];
+  const taskCls = tone === 'action' ? 'text-foreground' : 'text-secondary';
+  const pillLabel = pillLabelFor(tone, donePillLabel);
+  const pillCls = tone === 'set' ? PILL_CLS.set : PILL_CLS.default;
+  const ctaCls = tone === 'action'
+    ? 'inline-block px-2 py-0.5 text-[10px] rounded bg-emerald-600 text-white disabled:opacity-50 disabled:cursor-not-allowed'
+    : 'inline-block px-2 py-0.5 text-[10px] rounded border border-edge text-muted disabled:opacity-50 disabled:cursor-not-allowed';
+
+  return (
+    <div
+      role="region"
+      aria-labelledby={badgeId}
+      className={`border rounded-lg p-3 ${BORDER_CLS[tone]}`}
+    >
+      {!noRibbon && <PhaseRibbon active={computedActive} />}
+      <div className="flex items-baseline justify-between mb-1">
+        <span id={badgeId} className={`text-[10px] uppercase tracking-wider ${BADGE_CLS[tone]}`}>{badge}</span>
+        {pillLabel && (
+          <span className={`inline-flex items-center gap-1 px-2 py-0.5 text-[10px] rounded-full border ${pillCls}`}>
+            {pillLabel}
+          </span>
+        )}
+      </div>
+      <div className={`text-sm font-semibold mb-1 ${taskCls}`}>{task}</div>
+      {sub && <div className="text-[11px] text-muted mb-1">{sub}</div>}
+      {exitCondition && <div className="text-[10px] text-amber-300/80 mb-2 italic">⏱ {exitCondition}</div>}
+      {cta && (
+        <div className="text-right">
+          <button
+            type="button"
+            className={ctaCls}
+            onClick={onCtaClick}
+            disabled={!onCtaClick}
+          >
+            {cta}
+          </button>
+        </div>
+      )}
+      {cue && <div className="text-[10px] text-emerald-300/80 mt-2">🔔 {cue}</div>}
+      {hint && <div className="text-[10px] text-muted mt-2 italic">{hint}</div>}
+    </div>
+  );
+}

--- a/web/src/components/shared/journey-hero/get-hero-state.test.ts
+++ b/web/src/components/shared/journey-hero/get-hero-state.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Failing-first tests for getHeroState selector + lineupStatusToJourneyPhase mapper (ROK-1294).
+ * Source files do not yet exist — these MUST fail with module-not-found until dev implements.
+ */
+import { describe, it, expect } from 'vitest';
+import { getHeroState, lineupStatusToJourneyPhase } from './get-hero-state';
+import type { GroupProgress, LineupConfig, UserActions } from './types';
+
+const noNoms: UserActions = { hasSubmittedNominations: false, hasSubmittedVotes: false, scheduledMatchCount: 0, totalMatchCount: 0 };
+const submittedNoms: UserActions = { hasSubmittedNominations: true, hasSubmittedVotes: false, scheduledMatchCount: 0, totalMatchCount: 0 };
+const submittedVotes: UserActions = { hasSubmittedNominations: true, hasSubmittedVotes: true, scheduledMatchCount: 0, totalMatchCount: 0 };
+const partialSchedule: UserActions = { hasSubmittedNominations: true, hasSubmittedVotes: true, scheduledMatchCount: 1, totalMatchCount: 2 };
+const fullSchedule: UserActions = { hasSubmittedNominations: true, hasSubmittedVotes: true, scheduledMatchCount: 2, totalMatchCount: 2 };
+
+const progress: GroupProgress = { nominationsSubmitted: 3, votesSubmitted: 0, totalVoters: 20 };
+
+const deadline = new Date('2026-05-20T23:59:00Z');
+const cfgWithDeadlines: LineupConfig = {
+    nominationQuorum: 15,
+    votingQuorum: 15,
+    schedulingAgreementPct: 75,
+    nominationDeadline: deadline,
+    votingDeadline: deadline,
+    schedulingDeadline: deadline,
+};
+const cfgNoDeadlines: LineupConfig = {
+    nominationQuorum: 15,
+    votingQuorum: 15,
+    schedulingAgreementPct: 75,
+};
+
+describe('getHeroState — decision table (8 rows)', () => {
+    it('row 1: nominating + NOT submitted → action', () => {
+        const state = getHeroState({ phase: 'nominating', userActions: noNoms, groupProgress: progress, lineupConfig: cfgWithDeadlines });
+        expect(state).toEqual({ tone: 'action' });
+    });
+
+    it('row 2: nominating + submitted → waiting with exitCondition + cue', () => {
+        const state = getHeroState({ phase: 'nominating', userActions: submittedNoms, groupProgress: progress, lineupConfig: cfgWithDeadlines });
+        expect(state.tone).toBe('waiting');
+        expect(state.exitCondition).toMatch(/Auto-advances when 15 of 20 have nominated/);
+        expect(state.exitCondition).toMatch(/or at deadline /);
+        expect(state.cue).toBe("We'll DM you when voting opens.");
+    });
+
+    it('row 3: voting + NOT submitted → action', () => {
+        const state = getHeroState({ phase: 'voting', userActions: submittedNoms, groupProgress: progress, lineupConfig: cfgWithDeadlines });
+        expect(state).toEqual({ tone: 'action' });
+    });
+
+    it('row 4: voting + submitted → waiting with exitCondition + cue', () => {
+        const state = getHeroState({ phase: 'voting', userActions: submittedVotes, groupProgress: progress, lineupConfig: cfgWithDeadlines });
+        expect(state.tone).toBe('waiting');
+        expect(state.exitCondition).toMatch(/Auto-advances when 15 of 20 have voted/);
+        expect(state.exitCondition).toMatch(/or at deadline /);
+        expect(state.cue).toBe("We'll DM you when matches are decided.");
+    });
+
+    it('row 5: decided → action (always)', () => {
+        const state = getHeroState({ phase: 'decided', userActions: submittedVotes, groupProgress: progress, lineupConfig: cfgWithDeadlines });
+        expect(state).toEqual({ tone: 'action' });
+    });
+
+    it('row 6: scheduling + scheduledMatchCount < totalMatchCount → action', () => {
+        const state = getHeroState({ phase: 'scheduling', userActions: partialSchedule, groupProgress: progress, lineupConfig: cfgWithDeadlines });
+        expect(state).toEqual({ tone: 'action' });
+    });
+
+    it('row 7: scheduling + scheduledMatchCount === totalMatchCount (>0) → waiting', () => {
+        const state = getHeroState({ phase: 'scheduling', userActions: fullSchedule, groupProgress: progress, lineupConfig: cfgWithDeadlines });
+        expect(state.tone).toBe('waiting');
+        expect(state.exitCondition).toMatch(/Each match locks at 75% agreement/);
+        expect(state.exitCondition).toMatch(/or at deadline /);
+        expect(state.cue).toBe("We'll DM you when events are locked.");
+    });
+
+    it('row 8: done → set with cue, no exitCondition', () => {
+        const state = getHeroState({ phase: 'done', userActions: fullSchedule, groupProgress: progress, lineupConfig: cfgWithDeadlines });
+        expect(state.tone).toBe('set');
+        expect(state.exitCondition).toBeUndefined();
+        expect(state.cue).toBe("We'll DM you 24h, 1h, and 15min before each event.");
+    });
+});
+
+describe('getHeroState — missing deadline cleanup', () => {
+    it('nominating + submitted + no deadline → exitCondition omits "or at deadline" clause cleanly', () => {
+        const state = getHeroState({ phase: 'nominating', userActions: submittedNoms, groupProgress: progress, lineupConfig: cfgNoDeadlines });
+        expect(state.tone).toBe('waiting');
+        expect(state.exitCondition).toBeDefined();
+        expect(state.exitCondition).not.toMatch(/or at deadline/);
+        expect(state.exitCondition).not.toMatch(/undefined/);
+        expect(state.exitCondition).not.toMatch(/,\s*\.?$/); // no dangling trailing comma
+        expect(state.exitCondition).toMatch(/\.$/); // ends with a period cleanly
+    });
+
+    it('voting + submitted + no deadline → exitCondition omits "or at deadline" cleanly', () => {
+        const state = getHeroState({ phase: 'voting', userActions: submittedVotes, groupProgress: progress, lineupConfig: cfgNoDeadlines });
+        expect(state.tone).toBe('waiting');
+        expect(state.exitCondition).toBeDefined();
+        expect(state.exitCondition).not.toMatch(/or at deadline/);
+        expect(state.exitCondition).not.toMatch(/undefined/);
+        expect(state.exitCondition).not.toMatch(/,\s*\.?$/);
+        expect(state.exitCondition).toMatch(/\.$/);
+    });
+
+    it('scheduling + fully scheduled + no deadline → exitCondition omits "or at deadline" cleanly', () => {
+        const state = getHeroState({ phase: 'scheduling', userActions: fullSchedule, groupProgress: progress, lineupConfig: cfgNoDeadlines });
+        expect(state.tone).toBe('waiting');
+        expect(state.exitCondition).toBeDefined();
+        expect(state.exitCondition).not.toMatch(/or at deadline/);
+        expect(state.exitCondition).not.toMatch(/undefined/);
+        expect(state.exitCondition).not.toMatch(/,\s*\.?$/);
+        expect(state.exitCondition).toMatch(/\.$/);
+    });
+});
+
+describe('getHeroState — edge cases', () => {
+    it('scheduling + totalMatchCount === 0 → action (degenerate "all scheduled of zero")', () => {
+        const zero: UserActions = { hasSubmittedNominations: true, hasSubmittedVotes: true, scheduledMatchCount: 0, totalMatchCount: 0 };
+        const state = getHeroState({ phase: 'scheduling', userActions: zero, groupProgress: progress, lineupConfig: cfgWithDeadlines });
+        expect(state.tone).toBe('action');
+    });
+
+    it('determinism: same input invoked twice returns deeply equal output', () => {
+        const input = { phase: 'nominating' as const, userActions: submittedNoms, groupProgress: progress, lineupConfig: cfgWithDeadlines };
+        const a = getHeroState(input);
+        const b = getHeroState(input);
+        expect(a).toEqual(b);
+    });
+});
+
+// lineupStatusToJourneyPhase mapper — inputs are LineupStatusDto: 'building' | 'voting' | 'decided' | 'archived'.
+// Architect's note (architect-ROK-1294.md §3): 'building' → 'nominating', 'voting' → 'voting'.
+// 'decided' collapses two hero phases — caller passes a second arg to disambiguate (matches unlocked = scheduling).
+// 'archived' → 'done' only when the caller signals completion; otherwise mapper falls back to 'nominating' per brief §5.
+describe('lineupStatusToJourneyPhase mapper', () => {
+    it("maps 'building' → 'nominating'", () => {
+        expect(lineupStatusToJourneyPhase('building')).toBe('nominating');
+    });
+
+    it("maps 'voting' → 'voting'", () => {
+        expect(lineupStatusToJourneyPhase('voting')).toBe('voting');
+    });
+
+    it("maps 'decided' → 'decided' by default", () => {
+        expect(lineupStatusToJourneyPhase('decided')).toBe('decided');
+    });
+
+    it("maps 'archived' → 'done' (terminal state)", () => {
+        expect(lineupStatusToJourneyPhase('archived')).toBe('done');
+    });
+});

--- a/web/src/components/shared/journey-hero/get-hero-state.ts
+++ b/web/src/components/shared/journey-hero/get-hero-state.ts
@@ -1,0 +1,75 @@
+import type { GroupProgress, HeroState, JourneyPhase, LineupConfig, UserActions } from './types';
+import type { LineupStatusDto } from '@raid-ledger/contract';
+
+interface HeroSelectorInput {
+  phase: JourneyPhase;
+  userActions: UserActions;
+  groupProgress: GroupProgress;
+  lineupConfig: LineupConfig;
+}
+
+function formatHeroDeadline(date: Date): string {
+  return new Intl.DateTimeFormat(undefined, { weekday: 'short', hour: 'numeric', minute: '2-digit' }).format(date);
+}
+
+function withOptionalDeadline(prefix: string, deadline: Date | undefined): string {
+  return deadline ? `${prefix}, or at deadline ${formatHeroDeadline(deadline)}.` : `${prefix}.`;
+}
+
+function nominationExit(cfg: LineupConfig, prog: GroupProgress): string {
+  return withOptionalDeadline(
+    `Auto-advances when ${cfg.nominationQuorum} of ${prog.totalVoters} have nominated`,
+    cfg.nominationDeadline,
+  );
+}
+
+function votingExit(cfg: LineupConfig, prog: GroupProgress): string {
+  return withOptionalDeadline(
+    `Auto-advances when ${cfg.votingQuorum} of ${prog.totalVoters} have voted`,
+    cfg.votingDeadline,
+  );
+}
+
+function schedulingExit(cfg: LineupConfig): string {
+  return withOptionalDeadline(
+    `Each match locks at ${cfg.schedulingAgreementPct}% agreement`,
+    cfg.schedulingDeadline,
+  );
+}
+
+export function getHeroState({ phase, userActions, groupProgress, lineupConfig }: HeroSelectorInput): HeroState {
+  if (phase === 'nominating') {
+    if (!userActions.hasSubmittedNominations) return { tone: 'action' };
+    return { tone: 'waiting', exitCondition: nominationExit(lineupConfig, groupProgress), cue: "We'll DM you when voting opens." };
+  }
+  if (phase === 'voting') {
+    if (!userActions.hasSubmittedVotes) return { tone: 'action' };
+    return { tone: 'waiting', exitCondition: votingExit(lineupConfig, groupProgress), cue: "We'll DM you when matches are decided." };
+  }
+  if (phase === 'decided') return { tone: 'action' };
+  if (phase === 'scheduling') {
+    const { scheduledMatchCount, totalMatchCount } = userActions;
+    if (totalMatchCount === 0 || scheduledMatchCount < totalMatchCount) return { tone: 'action' };
+    return { tone: 'waiting', exitCondition: schedulingExit(lineupConfig), cue: "We'll DM you when events are locked." };
+  }
+  return { tone: 'set', cue: "We'll DM you 24h, 1h, and 15min before each event." };
+}
+
+/**
+ * Maps the server-returned `LineupStatusDto` enum to the hero's `JourneyPhase`.
+ * Note: 'decided' collapses two hero phases (decided + scheduling) — callers with
+ * match-lock context should disambiguate downstream. 'archived' maps to 'done' as
+ * the terminal state per brief §5.
+ */
+export function lineupStatusToJourneyPhase(status: LineupStatusDto): JourneyPhase {
+  switch (status) {
+    case 'building':
+      return 'nominating';
+    case 'voting':
+      return 'voting';
+    case 'decided':
+      return 'decided';
+    case 'archived':
+      return 'done';
+  }
+}

--- a/web/src/components/shared/journey-hero/index.ts
+++ b/web/src/components/shared/journey-hero/index.ts
@@ -1,0 +1,12 @@
+export { JourneyHero } from './JourneyHero';
+export { getHeroState, lineupStatusToJourneyPhase } from './get-hero-state';
+export type {
+  HeroTone,
+  HeroActive,
+  JourneyPhase,
+  UserActions,
+  GroupProgress,
+  LineupConfig,
+  HeroState,
+  JourneyHeroProps,
+} from './types';

--- a/web/src/components/shared/journey-hero/types.ts
+++ b/web/src/components/shared/journey-hero/types.ts
@@ -1,0 +1,56 @@
+/**
+ * Public types for the JourneyHero component (ROK-1294).
+ * `phase` is the primary input; `active` is an optional override.
+ */
+export type HeroTone = 'action' | 'waiting' | 'set';
+export type HeroActive = 0 | 1 | 2 | 3 | 4;
+export type JourneyPhase = 'nominating' | 'voting' | 'decided' | 'scheduling' | 'done';
+
+export interface UserActions {
+  /** nominations_submitted_at IS NOT NULL — ships in U4 (ROK-1296); pass `false` until then */
+  hasSubmittedNominations: boolean;
+  /** votes_submitted_at IS NOT NULL — ships in U4 (ROK-1296); pass `false` until then */
+  hasSubmittedVotes: boolean;
+  scheduledMatchCount: number;
+  totalMatchCount: number;
+}
+
+export interface GroupProgress {
+  nominationsSubmitted: number;
+  votesSubmitted: number;
+  totalVoters: number;
+}
+
+export interface LineupConfig {
+  nominationQuorum: number;
+  votingQuorum: number;
+  schedulingAgreementPct: number;
+  nominationDeadline?: Date;
+  votingDeadline?: Date;
+  schedulingDeadline?: Date;
+}
+
+export interface HeroState {
+  tone: HeroTone;
+  exitCondition?: string;
+  cue?: string;
+}
+
+export interface JourneyHeroProps {
+  /** Primary input — drives `active` internally if `active` not supplied */
+  phase?: JourneyPhase;
+  /** Explicit override / Sx escape hatch — derived from `phase` when omitted */
+  active?: HeroActive;
+  badge: string;
+  task: string;
+  sub?: string;
+  cta?: string;
+  /** Real button handler — wired by consumers. When omitted with `cta` set, button renders disabled. */
+  onCtaClick?: () => void;
+  hint?: string;
+  tone?: HeroTone;
+  exitCondition?: string;
+  cue?: string;
+  donePillLabel?: string;
+  noRibbon?: boolean;
+}

--- a/web/src/dev/simplify-wireframes/README.md
+++ b/web/src/dev/simplify-wireframes/README.md
@@ -225,7 +225,48 @@ File reference: see `walk-2026-05-15` notes in chat history.
 
 ## Where this doc lives + how to find it
 
-- **This doc:** `planning-artifacts/specs/cycle-4-unify-lineup.md`
+- **Tracked copy (this file):** `web/src/dev/simplify-wireframes/README.md` — committed, available to all agents on `main`
+- **Operator-local copy:** `planning-artifacts/specs/cycle-4-unify-lineup.md` (gitignored)
 - **Wireframe source:** `web/src/dev/simplify-wireframes/*`
 - **Operator memory pointer:** [`reference_cycle_4_unify_design.md`](`~/.claude/projects/-Users-sdodge-Documents-Projects-Raid-Ledger/memory/`)
-- **Indexed in:** `planning-artifacts/next-sprint.md` (cycle plan) and the per-story Linear issue bodies (once filed)
+- **Indexed in:** `planning-artifacts/next-sprint.md` (cycle plan) and the per-story Linear issue bodies
+
+---
+
+## Linear ledger (filed 2026-05-16, Cycle 4)
+
+| Slot | ID | Status |
+|---|---|---|
+| U1+U3 | ROK-1294 | Todo |
+| U2 | ROK-1295 | Todo |
+| U4 | ROK-1296 | Todo |
+| S1 | ROK-1297 | Todo |
+| Sv | ROK-1298 | Todo |
+| S3 | ROK-1299 | Todo |
+| Ss+Sx | ROK-1300 | Todo |
+| S5 | ROK-1301 | Todo |
+| S4 | ROK-1302 | Todo (closes ROK-1265) |
+| S6 | ROK-1303 | Todo |
+| S7 | ROK-1304 | Todo |
+| S9 | ROK-1305 | Todo |
+| Bug — lineup→scheduling routing | ROK-1306 | Todo |
+| Bug — voting auto-advance | ROK-1258 | Todo (reassigned to Cycle 4) |
+
+### Pre-existing in Cycle 4 (not new from this design pass, but still in cycle)
+
+- **ROK-1212** — `feat: lineups index page with Active/Past/Mine tabs` (HIGH, ROK-1193 → Page 1). Not subsumed by S1's per-page tab switcher (which is All/Yours/Trending). Still needed.
+- **ROK-1215** — `feat: public-lineup join CTA for uninvited users` (HIGH, ROK-1193 → F-27). Recruiting funnel via public share links. Independent of foundation; can ride Wave 4.
+- **ROK-1208** — `feat: decided-view "your next step" rollup with single-CTA hierarchy` (ROK-1193 → F-19, F-21). Partial overlap with S3 (ROK-1299) which provides "Your matches" + per-match CTAs. Implementer should check if S3 already satisfies this before doing extra work.
+- **ROK-1210, ROK-1211, ROK-1213, ROK-1214, ROK-1219, ROK-1220** — other ROK-1193 audit items. None subsumed by Cycle 4 foundation; keep open.
+- **ROK-1122** (Share/Rally button silent failure), **ROK-1032** (scheduling conflict warnings), **ROK-1201** (perf), **ROK-1204** (Radix Colors + shadcn/ui), **ROK-1203** (light-mode contrast audit) — independent stories.
+- **~20 tech-debt + bug-fix items** (ROK-1284–1290, ROK-1287, ROK-1164, ROK-1165, ROK-1160, ROK-1293) — ride-along carry items.
+
+### Cancellations from this audit (subsumed by new stories)
+
+| Cancelled | Subsumed by | Reason |
+|---|---|---|
+| ROK-1254 | ROK-1302 (S4) | Configurable lineup sliders — folded into S4's preset chooser + match-shape settings |
+| ROK-1256 | ROK-1295 (U2) | Research-during-voting — solved by universal game-research drawer |
+| ROK-1265 | ROK-1302 (S4) | Lineup template presets — IS the S4 preset chooser |
+| ROK-1216 | ROK-1300 (Ss+Sx) | "Unify scheduling inside lineup detail" — exactly what Ss composite does |
+| ROK-1009 | ROK-1303 (S6) | "Scheduling poll Create Event navigates with pre-filled data" — confirm card is this pattern improved |

--- a/web/src/dev/simplify-wireframes/simplify-composite-mocks.tsx
+++ b/web/src/dev/simplify-wireframes/simplify-composite-mocks.tsx
@@ -4,7 +4,7 @@
  * and U2 game-research drawer affordances on every game reference.
  */
 import type { JSX, ReactNode } from 'react';
-import { JourneyHero } from './simplify-unify-mocks';
+import { JourneyHero } from '../../components/shared/journey-hero';
 
 function Btn({ children, variant = 'ghost' }: { children: ReactNode; variant?: 'primary' | 'secondary' | 'ghost' }): JSX.Element {
   const cls = {

--- a/web/src/dev/simplify-wireframes/simplify-unify-mocks.tsx
+++ b/web/src/dev/simplify-wireframes/simplify-unify-mocks.tsx
@@ -3,6 +3,7 @@
  * DEV-ONLY. Static mocks; no behavior wired up.
  */
 import type { JSX, ReactNode } from 'react';
+import { JourneyHero } from '../../components/shared/journey-hero';
 
 function Btn({ children, variant = 'ghost' }: { children: ReactNode; variant?: 'primary' | 'secondary' | 'ghost' }): JSX.Element {
   const cls = {
@@ -11,72 +12,6 @@ function Btn({ children, variant = 'ghost' }: { children: ReactNode; variant?: '
     ghost: 'border border-edge text-muted',
   }[variant];
   return <span className={`inline-block px-2 py-0.5 text-[10px] rounded ${cls}`}>{children}</span>;
-}
-
-type StepState = 'done' | 'current' | 'future';
-function PhaseDot({ state, label }: { state: StepState; label: string }): JSX.Element {
-  const dotCls = {
-    done: 'bg-emerald-500/80 text-white',
-    current: 'bg-emerald-400 ring-2 ring-emerald-300/50 text-white',
-    future: 'bg-overlay/40 text-dim border border-edge',
-  }[state];
-  const symbol = state === 'done' ? '✓' : state === 'current' ? '●' : '○';
-  return (
-    <div className="flex flex-col items-center min-w-0 flex-1">
-      <div className={`w-5 h-5 rounded-full flex items-center justify-center text-[9px] ${dotCls}`}>{symbol}</div>
-      <div className="text-[9px] text-muted mt-1 truncate">{label}</div>
-    </div>
-  );
-}
-
-function PhaseRibbon({ active }: { active: 0 | 1 | 2 | 3 | 4 }): JSX.Element {
-  const phases = ['Nominate', 'Vote', 'Decide', 'Schedule'];
-  return (
-    <div className="flex items-center gap-1 mb-3">
-      {phases.map((label, i) => {
-        const state: StepState = i < active ? 'done' : i === active ? 'current' : 'future';
-        return (
-          <div key={label} className="flex items-center flex-1">
-            <PhaseDot state={state} label={label} />
-            {i < phases.length - 1 && <div className={`h-px flex-1 ${i < active ? 'bg-emerald-500/60' : 'bg-edge'}`} />}
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
-type HeroTone = 'action' | 'waiting' | 'set';
-export function JourneyHero({ active, badge, task, sub, cta, hint, tone = 'action', exitCondition, cue, donePillLabel, noRibbon }: {
-  active: 0 | 1 | 2 | 3 | 4; badge: string; task: string; sub?: string; cta?: string; hint?: string;
-  tone?: HeroTone; exitCondition?: string; cue?: string; donePillLabel?: string; noRibbon?: boolean;
-}): JSX.Element {
-  const borderCls = {
-    action: 'border-emerald-500/30 bg-panel/70',
-    waiting: 'border-edge bg-overlay/40',
-    set: 'border-amber-500/30 bg-overlay/40',
-  }[tone];
-  const badgeCls = { action: 'text-emerald-300', waiting: 'text-muted', set: 'text-amber-300' }[tone];
-  const taskCls = tone === 'action' ? 'text-foreground' : 'text-secondary';
-  const pillLabel = donePillLabel ?? (tone === 'set' ? "✓ You're set" : tone === 'waiting' ? "✓ You're done here" : null);
-  const pillCls = tone === 'set'
-    ? 'bg-amber-500/15 text-amber-300 border-amber-500/30'
-    : 'bg-emerald-500/15 text-emerald-300 border-emerald-500/30';
-  return (
-    <div className={`border rounded-lg p-3 ${borderCls}`}>
-      {!noRibbon && <PhaseRibbon active={active} />}
-      <div className="flex items-baseline justify-between mb-1">
-        <span className={`text-[10px] uppercase tracking-wider ${badgeCls}`}>{badge}</span>
-        {pillLabel && <span className={`inline-flex items-center gap-1 px-2 py-0.5 text-[10px] rounded-full border ${pillCls}`}>{pillLabel}</span>}
-      </div>
-      <div className={`text-sm font-semibold mb-1 ${taskCls}`}>{task}</div>
-      {sub && <div className="text-[11px] text-muted mb-1">{sub}</div>}
-      {exitCondition && <div className="text-[10px] text-amber-300/80 mb-2 italic">⏱ {exitCondition}</div>}
-      {cta && <div className="text-right">{tone === 'action' ? <Btn variant="primary">{cta}</Btn> : <span className="inline-block px-2 py-0.5 text-[10px] rounded border border-edge text-muted">{cta}</span>}</div>}
-      {cue && <div className="text-[10px] text-emerald-300/80 mt-2">🔔 {cue}</div>}
-      {hint && <div className="text-[10px] text-muted mt-2 italic">{hint}</div>}
-    </div>
-  );
 }
 
 function StateGroup({ label, kicker, children }: { label: string; kicker: string; children: ReactNode }): JSX.Element {


### PR DESCRIPTION
## Summary

### ROK-1294 — Cycle 4 foundation: JourneyHero (U1+U3)

New shared component + pure selector that replace 4 inconsistent banner shapes (\"Advance to Voting\" / \"Open voting\" / \"Sit tight\" / \"Open scheduling\") with one persistent component that morphs across phases.

**Element-count delta: 4 inconsistent banners → 1 morphing component.**

- `web/src/components/shared/journey-hero/` — new 6-file module: `types.ts`, `get-hero-state.ts` (pure selector + `lineupStatusToJourneyPhase()` mapper), `JourneyHero.tsx` (with `HeroHeader` + `HeroCta` subcomponents to keep functions ≤30 lines), `index.ts` barrel, plus selector + component test files.
- 5 phase morphs (`active: 0..4`), 3 tones (`action` / `waiting` / `set`), `noRibbon` mode for Sx, accessibility primitives (`role=\"region\"` + `aria-labelledby`, `<ol aria-label=\"Lineup progress\">` + `aria-current=\"step\"`, real `<button>` CTA with disabled-when-no-handler).
- `phase` is the primary input; `active` is an optional escape hatch derived via `PHASE_TO_ACTIVE`.
- Both wireframe consumers (`simplify-unify-mocks.tsx`, `simplify-composite-mocks.tsx`) re-targeted to import from the production location.

Wave 2 stories (S1/Sv/S3/Ss/Sx) will consume this component when they wire it into production lineup pages — explicitly OUT of scope for this PR. Production `LineupBanner.tsx` / `LineupVoteBanner.tsx` remain untouched.

### ROK-1292 PR 2 regression (folded in by operator request)

The integration spec introduced by #797 computed `BRANDING_DIR = path.join(process.cwd(), 'uploads', 'branding')` — the same path the dev server serves from — and `clearBrandingDir()` in `afterEach` + `afterAll` `fs.unlinkSync`d every entry. Every \`npm run test -w api\` run wiped the operator's real local `logo.png` while leaving the encrypted `community_logo_path` DB row in place, producing the broken-image header (`/uploads/branding/logo.png` → 404).

**Fix:**
- `branding.controller.ts::getBrandingDir` and `main.ts::configureStaticAssets` honor a new `RAID_LEDGER_BRANDING_DIR` env override. Production defaults unchanged.
- The integration spec creates a per-run `os.tmpdir()` sandbox at module load (before `beforeAll`), sets the env var, and cleans up + clears it in `afterAll`.
- Added a regression-guard test asserting every uploaded logo lands under the sandboxed dir, never under `process.cwd()/uploads/branding`.

## Linear

- ROK-1294 (the main story)
- Carries a fix for the ROK-1292 PR 2 regression

## Tech debt observed (not auto-filed)

Three dated sections appended to `TECH-DEBT-BACKLOG.md` (2026-05-16):

- **Avatar parallel risk + root-cause foot-gun** — `api/src/users/avatar.service.ts:44` shares the `process.cwd()/uploads/avatars` anti-pattern. Currently SAFE (no existing avatar spec writes/unlinks there) but worth defensive hardening or a consistent rename of the existing `AVATAR_UPLOAD_DIR` to match the new convention. The deeper root cause is that the dev default path remains `process.cwd()`-anchored — env override is a symptom-level fix.
- **10 pre-existing TS errors in `api/src` test files** — surfaced by `npx tsc --noEmit -p api/tsconfig.json` against the full project. `nest build` excludes specs so these never blocked CI before. Worth deciding whether the api CI typecheck step should compile specs.
- **Pre-existing smoke-test flakes** — entry was dropped during rebase because batch PR #798 (just merged) already documented the same flake class with a fuller analysis. No duplication needed.

## Test plan

- [x] TDD: 31 failing tests committed FIRST (`0e9a2d3f`), then made green by subsequent commits.
- [x] Targeted vitest on the new module: **45/45 pass** (17 selector + 28 component), coverage 100% stmts / 100% lines / 100% fns / 94% branches.
- [x] Workspace web CI (dev's self-scope): `npm run build -w web`, `npx tsc --noEmit -p web/tsconfig.json`, `npm run lint -w web`, full Vitest (`290 files / 3388 tests pass`) — all green.
- [x] Branding integration spec (ROK-1292 fix verified): 6/6 pass, canary file in `api/uploads/branding/` survives the run (same inode + mtime + size).
- [x] Playwright (desktop + mobile, 855 specs): 628 passed, 201 skipped, 4 did not run, 11 failed — all match documented cross-worker bleedover flake classes (see `TECH-DEBT-BACKLOG.md` lines 97, 236, 297, 304, and batch #798's 2026-05-16 entry). Verified to also fail on `origin/main` per batch #798's reproduction.
- [x] Chrome MCP e2e gate: U1 / U3 / Sx flows exercised on `/dev/wireframes/simplify`. DOM audit confirmed `<ol aria-label=\"Lineup progress\">` × 15, `aria-current=\"step\"` × 13 (one per ribbon), `role=\"region\"` + `aria-labelledby` × 16, NO `role=\"status\"` on any hero, 11 real `<button>` CTAs. Console clean (React DevTools INFO only); no network errors (static wireframe).
- [x] Operator visual verification on the locally-deployed env.
- [x] Code review: APPROVED, no auto-fixes (see `planning-artifacts/review-ROK-1294.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)