### PR TITLE
tech-debt(zod): migrate from zod 3.25 to 4.4.3 (ROK-1330)

### DIFF
--- a/TECH-DEBT-BACKLOG.md
+++ b/TECH-DEBT-BACKLOG.md
@@ -501,3 +501,9 @@ Two Codex-review findings deferred because they're MEDIUM/correctness-non-blocke
   Suggested: same fix as 525 — explicit poll on `/lineups/:id` until `myVotes` updates before asserting.
 - **[low]** `scripts/smoke/notifications.smoke.spec.ts:20` — mobile: `Notifications › dropdown opens and shows content` flake. Notifications dropdown not visible at 7s on mobile. Not touched by ROK-1297.
   Suggested: bump the open-animation timeout or assert against an inner element instead of the container.
+
+### 2026-05-19 — rok-1330-zod-4-migration (surfaced during `npx tsc --noEmit -p api/tsconfig.json`)
+
+- **[high]** `api/src/lineups/common-ground-query.helpers.spec.ts:49` and `:88` — `error TS2741: Property 'itadLowestPrice' is missing in type ... but required in type 'CommonGroundRow'`. ROK-1297 (#823) added `itadLowestPrice: number | null` to the `CommonGroundRow` interface (`api/src/lineups/common-ground-query.helpers.ts:55`) but did not update the two `CommonGroundRow` fixtures in the spec file. Pre-existing on origin/main; confirmed by reverting my zod 4 changes and re-running tsc. `nest build` (api workspace) does not catch this because `api/tsconfig.build.json` excludes `**/*.spec*.ts`, but `validate-ci.sh::run_typecheck` uses `api/tsconfig.json` which DOES include spec files — so this fails CI on the typecheck step.
+  Suggested: add `itadLowestPrice: 1234` (or `null`) to both fixtures at lines 49 and 88 in `common-ground-query.helpers.spec.ts`. One-line each; trivial.
+

--- a/api/package.json
+++ b/api/package.json
@@ -65,7 +65,7 @@
     "rxjs": "^7.8.1",
     "sharp": "^0.34.5",
     "socket.io": "^4.8.3",
-    "zod": "^3.24.0"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",

--- a/api/src/admin/ai-chat-test.controller.ts
+++ b/api/src/admin/ai-chat-test.controller.ts
@@ -74,7 +74,7 @@ export class AiChatTestController {
   private parseBody<T>(schema: z.ZodSchema<T>, body: unknown): T {
     const result = schema.safeParse(body);
     if (!result.success) {
-      const messages = result.error.errors
+      const messages = result.error.issues
         .map((e) => `${e.path.join('.')}: ${e.message}`)
         .join('; ');
       throw new BadRequestException(`Validation failed: ${messages}`);

--- a/api/src/admin/demo-test.utils.ts
+++ b/api/src/admin/demo-test.utils.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 export function parseDemoBody<T>(schema: z.ZodSchema<T>, body: unknown): T {
   const result = schema.safeParse(body);
   if (!result.success) {
-    const messages = result.error.errors
+    const messages = result.error.issues
       .map((e) => `${e.path.join('.')}: ${e.message}`)
       .join('; ');
     throw new BadRequestException(`Validation failed: ${messages}`);

--- a/api/src/admin/onboarding.controller.ts
+++ b/api/src/admin/onboarding.controller.ts
@@ -147,7 +147,7 @@ export class OnboardingController {
     const parsed = UpdateStepSchema.safeParse(body);
     if (!parsed.success) {
       throw new BadRequestException(
-        parsed.error.errors.map((e) => e.message).join(', '),
+        parsed.error.issues.map((e) => e.message).join(', '),
       );
     }
 
@@ -176,7 +176,7 @@ export class OnboardingController {
     const parsed = ChangePasswordSchema.safeParse(body);
     if (!parsed.success) {
       throw new BadRequestException(
-        parsed.error.errors.map((e) => e.message).join(', '),
+        parsed.error.issues.map((e) => e.message).join(', '),
       );
     }
 
@@ -237,7 +237,7 @@ export class OnboardingController {
     const parsed = CommunityIdentitySchema.safeParse(body);
     if (!parsed.success) {
       throw new BadRequestException(
-        parsed.error.errors.map((e) => e.message).join(', '),
+        parsed.error.issues.map((e) => e.message).join(', '),
       );
     }
 

--- a/api/src/admin/slash-command-test.controller.ts
+++ b/api/src/admin/slash-command-test.controller.ts
@@ -17,7 +17,7 @@ import type { CapturedResponse } from './fake-interaction';
 const SlashCommandSchema = z.object({
   commandName: z.string().min(1),
   subcommand: z.string().optional(),
-  options: z.record(z.unknown()).optional(),
+  options: z.record(z.string(), z.unknown()).optional(),
   discordUserId: z.string().optional(),
   guildId: z.string().optional(),
   channelId: z.string().optional(),
@@ -79,7 +79,7 @@ export class SlashCommandTestController {
   private parseBody<T>(schema: z.ZodSchema<T>, body: unknown): T {
     const result = schema.safeParse(body);
     if (!result.success) {
-      const messages = result.error.errors
+      const messages = result.error.issues
         .map((e) => `${e.path.join('.')}: ${e.message}`)
         .join('; ');
       throw new BadRequestException(`Validation failed: ${messages}`);

--- a/api/src/discovery-categories/demo-test-discovery-categories.controller.ts
+++ b/api/src/discovery-categories/demo-test-discovery-categories.controller.ts
@@ -71,7 +71,7 @@ export class DemoTestDiscoveryCategoriesController {
     const parsed = SeedBodySchema.safeParse(body ?? {});
     if (!parsed.success) {
       throw new BadRequestException(
-        parsed.error.errors[0]?.message ?? 'Invalid body',
+        parsed.error.issues[0]?.message ?? 'Invalid body',
       );
     }
     const input = parsed.data;

--- a/api/src/discovery-categories/discovery-categories.admin.controller.ts
+++ b/api/src/discovery-categories/discovery-categories.admin.controller.ts
@@ -147,7 +147,7 @@ export class DiscoveryCategoriesAdminController {
     const parsed = AdminCategoryPatchSchema.safeParse(body);
     if (!parsed.success) {
       throw new BadRequestException(
-        parsed.error.errors[0]?.message ?? 'Invalid patch body',
+        parsed.error.issues[0]?.message ?? 'Invalid patch body',
       );
     }
     const patch = parsed.data;
@@ -189,7 +189,7 @@ export class DiscoveryCategoriesAdminController {
     const parsed = AdminRejectBodySchema.safeParse(body ?? {});
     if (!parsed.success) {
       throw new BadRequestException(
-        parsed.error.errors[0]?.message ?? 'Invalid reject body',
+        parsed.error.issues[0]?.message ?? 'Invalid reject body',
       );
     }
     // v1 does not persist reason; the column isn't in the schema yet.

--- a/api/src/discovery-categories/llm-output.helpers.ts
+++ b/api/src/discovery-categories/llm-output.helpers.ts
@@ -144,7 +144,7 @@ function parseOnce(content: string): ParseResult {
     if (parsed.success) {
       validated.push(parsed.data);
     } else {
-      const first = parsed.error.errors[0];
+      const first = parsed.error.issues[0];
       if (first) {
         zodIssues.push(`${first.path.join('.')}: ${first.message}`);
       }

--- a/api/src/events/event-plans.controller.ts
+++ b/api/src/events/event-plans.controller.ts
@@ -22,17 +22,14 @@ import {
   PollResultsResponse,
 } from '@raid-ledger/contract';
 import { EventPlansService } from './event-plans.service';
-import { type ZodType, type ZodTypeDef, ZodError } from 'zod';
+import { type ZodType, ZodError } from 'zod';
 
 import type { AuthenticatedRequest } from '../auth/types';
 
 /**
  * Parse data with a Zod schema, converting ZodError to BadRequestException.
  */
-function parseOrThrow<TOut, TDef extends ZodTypeDef, TIn>(
-  schema: ZodType<TOut, TDef, TIn>,
-  data: unknown,
-): TOut {
+function parseOrThrow<TOut>(schema: ZodType<TOut>, data: unknown): TOut {
   try {
     return schema.parse(data);
   } catch (error) {

--- a/api/src/events/recurrence-schema.spec.ts
+++ b/api/src/events/recurrence-schema.spec.ts
@@ -67,7 +67,7 @@ function testRejectsPlainDate() {
   });
   expect(result.success).toBe(false);
   if (!result.success) {
-    const paths = result.error.errors.map((e) => e.path.join('.'));
+    const paths = result.error.issues.map((e) => e.path.join('.'));
     expect(paths).toContain('until');
   }
 }
@@ -176,7 +176,7 @@ function testRejectsBareDateIntegration() {
   });
   expect(result.success).toBe(false);
   if (!result.success) {
-    const allPaths = result.error.errors.map((e) => e.path.join('.'));
+    const allPaths = result.error.issues.map((e) => e.path.join('.'));
     expect(allPaths.some((p) => p.includes('until'))).toBe(true);
   }
 }
@@ -197,7 +197,7 @@ function testRejectsEndBeforeStart() {
   });
   expect(result.success).toBe(false);
   if (!result.success) {
-    const paths = result.error.errors.map((e) => e.path.join('.'));
+    const paths = result.error.issues.map((e) => e.path.join('.'));
     expect(paths).toContain('endTime');
   }
 }

--- a/api/src/users/preferences-schema-zod4.spec.ts
+++ b/api/src/users/preferences-schema-zod4.spec.ts
@@ -1,0 +1,124 @@
+/**
+ * ROK-1330 carrier spec — exercises the contract schemas most likely to
+ * change behavior across the zod 3 → 4 migration:
+ *
+ *  - `z.record(z.string(), z.unknown())` — outer batch shape (was `z.record(value)` in zod 3)
+ *  - `z.record(z.unknown())` inside the value union (nested record)
+ *  - `.refine()` rejection — the at-least-one-key rule
+ *  - `.safeParse()` error shape — `.issues` vs `.errors` access
+ *
+ * If any of these break shape across the migration the API responses
+ * change (clients consume `.flatten().fieldErrors`).
+ */
+import {
+  UpdatePreferenceBatchSchema,
+  UpdatePreferenceSchema,
+} from '@raid-ledger/contract';
+
+describe('preferences schema — zod 3/4 round-trip', () => {
+  describe('UpdatePreferenceBatchSchema', () => {
+    it('accepts a record of string keys with mixed primitive values', () => {
+      const payload = {
+        preferences: {
+          theme: 'dark',
+          fontSize: 14,
+          notifications: true,
+        },
+      };
+      const parsed = UpdatePreferenceBatchSchema.parse(payload);
+      expect(parsed.preferences).toEqual(payload.preferences);
+    });
+
+    it('accepts nested JSON objects as values (nested z.record(z.unknown()))', () => {
+      const payload = {
+        preferences: {
+          dashboardLayout: {
+            columns: ['recent', 'pinned'],
+            density: 'compact',
+            extra: { nested: { deeply: true } },
+          },
+        },
+      };
+      const parsed = UpdatePreferenceBatchSchema.parse(payload);
+      expect(parsed.preferences.dashboardLayout).toEqual(
+        payload.preferences.dashboardLayout,
+      );
+    });
+
+    it('accepts arrays as values', () => {
+      const payload = {
+        preferences: {
+          pinnedGames: [101, 202, 303],
+        },
+      };
+      const parsed = UpdatePreferenceBatchSchema.parse(payload);
+      expect(parsed.preferences.pinnedGames).toEqual([101, 202, 303]);
+    });
+
+    it('rejects empty preferences via .refine()', () => {
+      const result = UpdatePreferenceBatchSchema.safeParse({
+        preferences: {},
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        const messages = result.error.issues.map((i) => i.message);
+        expect(messages).toContain('At least one preference is required');
+      }
+    });
+
+    it('rejects keys that exceed max length', () => {
+      const tooLong = 'x'.repeat(101);
+      const result = UpdatePreferenceBatchSchema.safeParse({
+        preferences: { [tooLong]: 'value' },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects values that are not primitives, records, or arrays', () => {
+      // null is not in the union; we want it to be rejected so we catch any
+      // accidental loosening of the value schema across migration.
+      const result = UpdatePreferenceBatchSchema.safeParse({
+        preferences: { theme: null },
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('produces a flatten-able error shape consumed by the API layer', () => {
+      const result = UpdatePreferenceBatchSchema.safeParse({
+        preferences: {},
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        // The lineups + many other controllers do
+        // `throw new BadRequestException(parsed.error.flatten().fieldErrors)`
+        // — guard the shape so a zod upgrade doesn't silently change it.
+        const flattened = result.error.flatten();
+        expect(flattened).toHaveProperty('fieldErrors');
+        expect(flattened).toHaveProperty('formErrors');
+      }
+    });
+  });
+
+  describe('UpdatePreferenceSchema (single)', () => {
+    it('accepts a primitive value', () => {
+      const parsed = UpdatePreferenceSchema.parse({
+        key: 'theme',
+        value: 'dark',
+      });
+      expect(parsed.value).toBe('dark');
+    });
+
+    it('accepts a record value', () => {
+      const parsed = UpdatePreferenceSchema.parse({
+        key: 'layout',
+        value: { columns: 2, density: 'compact' },
+      });
+      expect(parsed.value).toEqual({ columns: 2, density: 'compact' });
+    });
+
+    it('rejects an empty key', () => {
+      const result = UpdatePreferenceSchema.safeParse({ key: '', value: 'x' });
+      expect(result.success).toBe(false);
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
                 "rxjs": "^7.8.1",
                 "sharp": "^0.34.5",
                 "socket.io": "^4.8.3",
-                "zod": "^3.24.0"
+                "zod": "^4.4.3"
             },
             "devDependencies": {
                 "@eslint/js": "^10.0.1",
@@ -21589,9 +21589,9 @@
             }
         },
         "node_modules/zod": {
-            "version": "3.25.76",
-            "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-            "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+            "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
@@ -21652,11 +21652,11 @@
             "name": "@raid-ledger/contract",
             "version": "0.0.1",
             "dependencies": {
-                "zod": "^3.22.4"
+                "zod": "^4.4.3"
             },
             "devDependencies": {
                 "typescript": "^6.0.3",
-                "zod": "^3.22.4"
+                "zod": "^4.4.3"
             }
         },
         "packages/contract/node_modules/typescript": {
@@ -21719,7 +21719,7 @@
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.11.0",
                 "tsx": "^4.19.3",
-                "zod": "^3.24.2"
+                "zod": "^4.4.3"
             },
             "devDependencies": {
                 "typescript": "^6.0.3",

--- a/packages/contract/package.json
+++ b/packages/contract/package.json
@@ -17,9 +17,9 @@
     },
     "devDependencies": {
         "typescript": "^6.0.3",
-        "zod": "^3.22.4"
+        "zod": "^4.4.3"
     },
     "dependencies": {
-        "zod": "^3.22.4"
+        "zod": "^4.4.3"
     }
 }

--- a/packages/contract/src/activity-log.schema.ts
+++ b/packages/contract/src/activity-log.schema.ts
@@ -55,7 +55,7 @@ export const ActivityEntrySchema = z.object({
     id: z.number(),
     action: ActivityActionSchema,
     actor: ActivityActorSchema.nullable(),
-    metadata: z.record(z.unknown()).nullable(),
+    metadata: z.record(z.string(), z.unknown()).nullable(),
     createdAt: z.string(),
 });
 

--- a/packages/contract/src/preferences.schema.ts
+++ b/packages/contract/src/preferences.schema.ts
@@ -10,7 +10,7 @@ export const UpdatePreferenceSchema = z.object({
         z.string(),
         z.number(),
         z.boolean(),
-        z.record(z.unknown()),
+        z.record(z.string(), z.unknown()),
         z.array(z.unknown()),
     ]),
 });
@@ -28,7 +28,7 @@ export const UpdatePreferenceBatchSchema = z.object({
             z.string(),
             z.number(),
             z.boolean(),
-            z.record(z.unknown()),
+            z.record(z.string(), z.unknown()),
             z.array(z.unknown()),
         ]),
     ).refine((obj) => Object.keys(obj).length > 0, {

--- a/tools/mcp-env/package.json
+++ b/tools/mcp-env/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.11.0",
     "tsx": "^4.19.3",
-    "zod": "^3.24.2"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "typescript": "^6.0.3",

--- a/tools/mcp-rl-fleet/package.json
+++ b/tools/mcp-rl-fleet/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.11.0",
     "tsx": "^4.19.3",
-    "zod": "^3.24.2"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "typescript": "^6.0.3",

--- a/web/src/components/admin/DynamicCategoryEditModal.tsx
+++ b/web/src/components/admin/DynamicCategoryEditModal.tsx
@@ -67,7 +67,7 @@ function EditFormBody({
     const handleSave = async () => {
         const parsed = EditSchema.safeParse({ name, description });
         if (!parsed.success) {
-            setErrors(parseFieldErrors(parsed.error.errors));
+            setErrors(parseFieldErrors(parsed.error.issues));
             return;
         }
         await onSave(suggestion.id, parsed.data);


### PR DESCRIPTION
## Summary

Migrates `zod` from `^3.25` to `^4.4.3` across the monorepo, replacing dependabot PR #815 which lint-failed on the major bump.

- Bumps `zod` to `^4.4.3` in `packages/contract`, `api`, `tools/mcp-env`, `tools/mcp-rl-fleet` + regenerated `package-lock.json`.
- Applies the three concrete zod 4 breaking-change classes the codebase actually uses:
  - `z.record(value)` → `z.record(z.string(), value)` at 4 sites (preferences ×2, activity-log, slash-command-test).
  - `ZodError.errors` → `ZodError.issues` at 13 sites (admin controllers, discovery categories, recurrence-schema.spec, DynamicCategoryEditModal).
  - `ZodTypeDef` removed → simpler `ZodType<TOut>` signature in `event-plans.controller.ts::parseOrThrow`.
- New carrier spec `api/src/users/preferences-schema-zod4.spec.ts` (10 tests) exercises `z.record()`, nested `z.record()`, `.refine()` rejection, and `.flatten()` shape preservation — the at-risk surfaces with downstream API consumers.

**Deferred** (intentionally, to limit blast radius): `z.string().email()/url()/uuid()/datetime()` and `.flatten().fieldErrors` calls remain — both deprecated in zod 4 but functional. ~128 sites; tracked for a future tech-debt cycle.

Closes ROK-1330. After merge, PR #815 will be closed with a reference comment.

## Validation

| Check | Result |
| --- | --- |
| `npm run build -w packages/contract` | clean |
| `npm run build -w api` (nest build) | clean |
| `npm run build -w web` | clean |
| `npm run test -w api` | **6092 / 6092** |
| `npm run test -w web` | **3472 / 3472** |
| `npm run lint -w api && -w web` | clean |
| `npm run test -w api -- --testPathPatterns=preferences-schema-zod4` | **10 / 10** |
| Codex-style devedup-rl reviewer | **APPROVED** (0 critical, 0 warning, 3 suggestion, 1 nitpick) |

`npx tsc --noEmit -p api/tsconfig.json` surfaces 2 pre-existing errors in `common-ground-query.helpers.spec.ts` (missing `itadLowestPrice` in test fixtures) — introduced by ROK-1297 (#823), masked by the validate-ci `run_typecheck` masking bug already documented 2026-05-17. Documented in `TECH-DEBT-BACKLOG.md` per CLAUDE.md "Document pre-existing failures" rule. **Zero new errors** from the zod 4 migration.

## Risk

- Migration touches one web component (`DynamicCategoryEditModal.tsx`) as a single-token rename; covered by vitest 3472/3472.
- Migration is mechanical (lib bump + property rename + signature simplification). Reviewer confirmed runtime equivalence at every site (JSON object keys are strings → 2-arg `z.record` is a no-op; `.issues` carries identical `ZodIssue[]` shape; `parseOrThrow` infers `TOut` cleanly from `z.object` schemas).

## Test plan

- [x] Local CI green across all workspaces.
- [x] Carrier spec exercises round-trip on `z.record` + `.refine` + `.flatten`.
- [x] Reviewer (devedup-rl:reviewer) APPROVED.
- [ ] CI green on this PR.
- [ ] Watchtower picks up next nightly with no runtime errors (post-merge observation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)