### PR TITLE
fix: Discord OAuth callback hot-reload doesn't propagate to passport-discord (ROK-1325)

### DIFF
--- a/Dockerfile.allinone
+++ b/Dockerfile.allinone
@@ -171,6 +171,14 @@ COPY --from=builder /app/packages/contract/package.json ./node_modules/@raid-led
 COPY --from=builder /app/api/dist/scripts ./dist/scripts
 COPY --from=builder /app/api/seeds ./dist/seeds
 
+# Same Mutagen perm-drift class bug as the chmod 0755 lines below — under
+# fleet builds the source files arrive at 600 (instead of laptop's 644), so
+# the unprivileged `app` user (uid 1001) cannot read drizzle migrations
+# (meta/_journal.json), the JS bundle, seed JSON, or static assets at boot.
+# a+rX adds read for everyone, plus execute on directories only (so they
+# stay traversable). No-op on CI builds where perms are already 644.
+RUN chmod -R a+rX ./drizzle/migrations ./dist ./assets ./seeds ./node_modules
+
 # Copy entrypoint
 COPY api/scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 # Use absolute mode (0755) not `+x`. The Mutagen sync that feeds the

--- a/Dockerfile.allinone
+++ b/Dockerfile.allinone
@@ -177,7 +177,7 @@ COPY --from=builder /app/api/seeds ./dist/seeds
 # (meta/_journal.json), the JS bundle, seed JSON, or static assets at boot.
 # a+rX adds read for everyone, plus execute on directories only (so they
 # stay traversable). No-op on CI builds where perms are already 644.
-RUN chmod -R a+rX ./drizzle/migrations ./dist ./assets ./seeds ./node_modules
+RUN chmod -R a+rX ./drizzle/migrations ./dist ./assets ./node_modules
 
 # Copy entrypoint
 COPY api/scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh

--- a/Dockerfile.allinone
+++ b/Dockerfile.allinone
@@ -177,7 +177,7 @@ COPY --from=builder /app/api/seeds ./dist/seeds
 # (meta/_journal.json), the JS bundle, seed JSON, or static assets at boot.
 # a+rX adds read for everyone, plus execute on directories only (so they
 # stay traversable). No-op on CI builds where perms are already 644.
-RUN chmod -R a+rX ./drizzle/migrations ./dist ./assets ./node_modules
+RUN chmod -R a+rX ./drizzle/migrations ./dist ./assets ./node_modules ./packages
 
 # Copy entrypoint
 COPY api/scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh

--- a/api/src/plugins/discord/discord-auth.strategy.spec.ts
+++ b/api/src/plugins/discord/discord-auth.strategy.spec.ts
@@ -217,11 +217,11 @@ describe('DiscordAuthStrategy', () => {
 
       // Spy on the inherited authenticate (OAuth2Strategy.prototype.authenticate
       // is reached via Strategy.prototype → OAuth2Strategy.prototype).
+      const superProto = Object.getPrototypeOf(
+        DiscordPassportStrategy.prototype,
+      ) as { authenticate: (req: unknown, options?: object) => void };
       const superAuth = jest
-        .spyOn(
-          Object.getPrototypeOf(DiscordPassportStrategy.prototype) as object,
-          'authenticate',
-        )
+        .spyOn(superProto, 'authenticate')
         .mockImplementation(() => undefined);
 
       const req = { query: {}, headers: {}, url: '/auth/discord' } as never;
@@ -243,11 +243,11 @@ describe('DiscordAuthStrategy', () => {
       await strategy.reloadConfig();
       expect(strategy.isEnabled()).toBe(false);
 
+      const superProto = Object.getPrototypeOf(
+        DiscordPassportStrategy.prototype,
+      ) as { authenticate: (req: unknown, options?: object) => void };
       const superAuth = jest
-        .spyOn(
-          Object.getPrototypeOf(DiscordPassportStrategy.prototype) as object,
-          'authenticate',
-        )
+        .spyOn(superProto, 'authenticate')
         .mockImplementation(() => undefined);
 
       const req = { query: {}, headers: {}, url: '/auth/discord' } as never;
@@ -322,10 +322,13 @@ describe('DiscordAuthStrategy', () => {
         'tester',
         'abc.png',
       );
-      expect(done).toHaveBeenCalledWith(null, expect.objectContaining({
-        id: 42,
-        username: 'tester',
-      }));
+      expect(done).toHaveBeenCalledWith(
+        null,
+        expect.objectContaining({
+          id: 42,
+          username: 'tester',
+        }),
+      );
     });
 
     it('AC7 — the freshly-registered bare Strategy rejects with "Failed to validate Discord user" when authService returns null', async () => {

--- a/api/src/plugins/discord/discord-auth.strategy.spec.ts
+++ b/api/src/plugins/discord/discord-auth.strategy.spec.ts
@@ -1,4 +1,19 @@
+// Mock the passport singleton so we can spy on `passport.use(...)` calls
+// made by the NestJS PassportStrategy mixin AND by any Fix-2
+// re-registration in reloadConfig. Keep the surface minimal — just enough
+// for the mixin's `passportInstance.use(name, this)` line not to throw.
+jest.mock('passport', () => ({
+  use: jest.fn(),
+  unuse: jest.fn(),
+}));
+
 import { Logger } from '@nestjs/common';
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const passport = require('passport') as {
+  use: jest.Mock;
+  unuse: jest.Mock;
+};
+import { Strategy as DiscordPassportStrategy } from 'passport-discord';
 import { DiscordAuthStrategy } from './discord-auth.strategy';
 import * as lifecycleUtil from '../../common/lifecycle.util';
 
@@ -12,6 +27,9 @@ describe('DiscordAuthStrategy', () => {
   let mockAuthService: { validateDiscordUser: jest.Mock };
 
   beforeEach(() => {
+    passport.use.mockClear();
+    passport.unuse.mockClear();
+
     mockSettingsService = {
       getDiscordOAuthConfig: jest.fn(),
     };
@@ -114,6 +132,238 @@ describe('DiscordAuthStrategy', () => {
       // direct arrow returning the promise (consistent with other hooks)
       const fnString = callback.toString();
       expect(fnString).not.toContain('await');
+    });
+
+    // AC8 (regression assertion) — locks in that invoking the callback
+    // passed to bestEffortInit actually calls reloadConfig. Today this
+    // passes; the goal is to detect any future refactor that decouples
+    // onModuleInit from reloadConfig and breaks the boot path.
+    it('AC8 — invoking the bestEffortInit callback calls reloadConfig (boot path unchanged)', async () => {
+      const bestEffortSpy = jest
+        .spyOn(lifecycleUtil, 'bestEffortInit')
+        .mockResolvedValue(undefined);
+      const reloadSpy = jest
+        .spyOn(strategy, 'reloadConfig')
+        .mockResolvedValue(undefined);
+
+      await strategy.onModuleInit();
+
+      expect(bestEffortSpy).toHaveBeenCalledTimes(1);
+      const callback = bestEffortSpy.mock.calls[0][2];
+      await callback();
+
+      expect(reloadSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // ROK-1325 — hot-reload propagation tests (Fix 2 + Fix 3)
+  // -------------------------------------------------------------------------
+  describe('reloadConfig — re-registers strategy on passport (Fix 2, AC4)', () => {
+    it('AC4 — calls passport.use("discord", <fresh Strategy>) reflecting new callbackUrl', async () => {
+      mockSettingsService.getDiscordOAuthConfig.mockResolvedValue({
+        clientId: 'new-client-id',
+        clientSecret: 'new-client-secret',
+        callbackUrl: 'https://slot-1.gamernight.net/api/auth/discord/callback',
+      });
+
+      // Construction (via NestJS PassportStrategy mixin) already invoked
+      // passport.use once with the placeholder. Clear so we only see the
+      // re-registration triggered by reloadConfig.
+      passport.use.mockClear();
+
+      await strategy.reloadConfig();
+
+      // Find any reload-driven registration under the 'discord' name.
+      const reloadCalls = passport.use.mock.calls.filter(
+        (args) => args[0] === 'discord',
+      );
+      expect(reloadCalls.length).toBeGreaterThanOrEqual(1);
+
+      const [, registeredStrategy] = reloadCalls[reloadCalls.length - 1] as [
+        string,
+        unknown,
+      ];
+      expect(registeredStrategy).toBeDefined();
+
+      // The freshly-registered strategy should be a bare passport-discord
+      // Strategy whose internal callbackURL reflects the new config — not
+      // a placeholder, not the original constructed instance.
+      const internal = registeredStrategy as {
+        _callbackURL?: string;
+        _oauth2?: { _clientId?: string; _clientSecret?: string };
+      };
+      expect(internal._callbackURL).toBe(
+        'https://slot-1.gamernight.net/api/auth/discord/callback',
+      );
+      expect(internal._oauth2?._clientId).toBe('new-client-id');
+      expect(internal._oauth2?._clientSecret).toBe('new-client-secret');
+    });
+  });
+
+  describe('authenticate — per-request callbackURL injection (Fix 3, AC5/AC6)', () => {
+    it('AC5 — injects latestConfig.callbackUrl into super.authenticate options even when _callbackURL is stale', async () => {
+      mockSettingsService.getDiscordOAuthConfig.mockResolvedValue({
+        clientId: 'cid',
+        clientSecret: 'csec',
+        callbackUrl: 'https://new.example/cb',
+      });
+      await strategy.reloadConfig();
+
+      // Deliberately desync the legacy internal state to prove the
+      // injection path is what's load-bearing — NOT _callbackURL.
+      (strategy as unknown as { _callbackURL: string })._callbackURL =
+        'http://stale.localhost:3000/wrong';
+
+      // Spy on the inherited authenticate (OAuth2Strategy.prototype.authenticate
+      // is reached via Strategy.prototype → OAuth2Strategy.prototype).
+      const superAuth = jest
+        .spyOn(
+          Object.getPrototypeOf(DiscordPassportStrategy.prototype) as object,
+          'authenticate',
+        )
+        .mockImplementation(() => undefined);
+
+      const req = { query: {}, headers: {}, url: '/auth/discord' } as never;
+      strategy.authenticate(req, { state: 'abc' });
+
+      expect(superAuth).toHaveBeenCalledTimes(1);
+      const [, forwardedOptions] = superAuth.mock.calls[0] as [
+        unknown,
+        Record<string, unknown>,
+      ];
+      expect(forwardedOptions).toBeDefined();
+      expect(forwardedOptions.callbackURL).toBe('https://new.example/cb');
+      // Caller-provided options preserved.
+      expect(forwardedOptions.state).toBe('abc');
+    });
+
+    it('AC6 — when strategy is NOT configured, does NOT inject callbackURL and forwards original options unchanged', async () => {
+      mockSettingsService.getDiscordOAuthConfig.mockResolvedValue(null);
+      await strategy.reloadConfig();
+      expect(strategy.isEnabled()).toBe(false);
+
+      const superAuth = jest
+        .spyOn(
+          Object.getPrototypeOf(DiscordPassportStrategy.prototype) as object,
+          'authenticate',
+        )
+        .mockImplementation(() => undefined);
+
+      const req = { query: {}, headers: {}, url: '/auth/discord' } as never;
+      const originalOptions = { state: 'xyz' };
+      strategy.authenticate(req, originalOptions);
+
+      expect(superAuth).toHaveBeenCalledTimes(1);
+      const [, forwardedOptions] = superAuth.mock.calls[0] as [
+        unknown,
+        Record<string, unknown> | undefined,
+      ];
+      // No callbackURL injection in the disabled passthrough path.
+      expect(forwardedOptions?.callbackURL).toBeUndefined();
+      // Original options are forwarded (either the same reference or
+      // structurally equivalent — both shapes are acceptable, the assertion
+      // that matters is "no callbackURL key added").
+      expect(forwardedOptions?.state).toBe('xyz');
+    });
+  });
+
+  describe('verify callback shared between code paths (AC7)', () => {
+    it('AC7 — the freshly-registered bare Strategy (Fix 2) ultimately delegates to authService.validateDiscordUser', async () => {
+      mockSettingsService.getDiscordOAuthConfig.mockResolvedValue({
+        clientId: 'cid',
+        clientSecret: 'csec',
+        callbackUrl: 'https://new.example/cb',
+      });
+      mockAuthService.validateDiscordUser.mockResolvedValue({
+        id: 42,
+        username: 'tester',
+        role: 'user',
+      });
+
+      passport.use.mockClear();
+      await strategy.reloadConfig();
+
+      const reloadCalls = passport.use.mock.calls.filter(
+        (args) => args[0] === 'discord',
+      );
+      expect(reloadCalls.length).toBeGreaterThanOrEqual(1);
+
+      const registeredStrategy = reloadCalls[
+        reloadCalls.length - 1
+      ][1] as object;
+
+      // The bare Strategy stores its verify callback as `_verify` (inherited
+      // from passport-oauth2). Invoke it with a synthetic profile and
+      // assert it routes to authService.validateDiscordUser.
+      const internal = registeredStrategy as {
+        _verify?: (
+          accessToken: string,
+          refreshToken: string,
+          profile: { id: string; username: string; avatar?: string | null },
+          done: (err: unknown, user?: unknown) => void,
+        ) => void | Promise<void>;
+      };
+      expect(typeof internal._verify).toBe('function');
+
+      const profile = {
+        id: 'discord-id-123',
+        username: 'tester',
+        avatar: 'abc.png',
+      };
+      const done = jest.fn();
+      await new Promise<void>((resolve) => {
+        done.mockImplementation(() => resolve());
+        internal._verify!('access', 'refresh', profile, done);
+      });
+
+      expect(mockAuthService.validateDiscordUser).toHaveBeenCalledWith(
+        'discord-id-123',
+        'tester',
+        'abc.png',
+      );
+      expect(done).toHaveBeenCalledWith(null, expect.objectContaining({
+        id: 42,
+        username: 'tester',
+      }));
+    });
+
+    it('AC7 — the freshly-registered bare Strategy rejects with "Failed to validate Discord user" when authService returns null', async () => {
+      mockSettingsService.getDiscordOAuthConfig.mockResolvedValue({
+        clientId: 'cid',
+        clientSecret: 'csec',
+        callbackUrl: 'https://new.example/cb',
+      });
+      mockAuthService.validateDiscordUser.mockResolvedValue(null);
+
+      passport.use.mockClear();
+      await strategy.reloadConfig();
+
+      const reloadCalls = passport.use.mock.calls.filter(
+        (args) => args[0] === 'discord',
+      );
+      const registeredStrategy = reloadCalls[
+        reloadCalls.length - 1
+      ][1] as object;
+      const internal = registeredStrategy as {
+        _verify?: (
+          accessToken: string,
+          refreshToken: string,
+          profile: { id: string; username: string; avatar?: string | null },
+          done: (err: unknown, user?: unknown) => void,
+        ) => void | Promise<void>;
+      };
+
+      const profile = { id: 'discord-id-999', username: 'ghost', avatar: null };
+      const done = jest.fn();
+      await new Promise<void>((resolve) => {
+        done.mockImplementation(() => resolve());
+        internal._verify!('access', 'refresh', profile, done);
+      });
+
+      const [err] = done.mock.calls[0];
+      expect(err).toBeInstanceOf(Error);
+      expect((err as Error).message).toBe('Failed to validate Discord user');
     });
   });
 });

--- a/api/src/plugins/discord/discord-auth.strategy.ts
+++ b/api/src/plugins/discord/discord-auth.strategy.ts
@@ -1,4 +1,6 @@
-import { Strategy, Profile } from 'passport-discord';
+import passport from 'passport';
+import { Strategy as DiscordStrategy, Profile } from 'passport-discord';
+import type { VerifyCallback } from 'passport-oauth2';
 import { PassportStrategy } from '@nestjs/passport';
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { bestEffortInit } from '../../common/lifecycle.util';
@@ -16,17 +18,19 @@ import type { DiscordOAuthConfig } from '../../settings/settings.types';
  */
 @Injectable()
 export class DiscordAuthStrategy
-  extends PassportStrategy(Strategy, 'discord')
+  extends PassportStrategy(DiscordStrategy, 'discord')
   implements OnModuleInit
 {
   private readonly logger = new Logger(DiscordAuthStrategy.name);
   private isStrategyConfigured = false;
+  private latestConfig: DiscordOAuthConfig | null = null;
 
   constructor(
     private authService: AuthService,
     private settingsService: SettingsService,
   ) {
-    // Initialize with placeholder config - will be updated in onModuleInit
+    // Placeholder config — overwritten on first reloadConfig().
+    // DI requires super() to run so the NestJS class can be constructed.
     super({
       clientID: 'placeholder',
       clientSecret: 'placeholder',
@@ -42,21 +46,21 @@ export class DiscordAuthStrategy
   }
 
   /**
-   * Reload OAuth configuration from database.
-   * Called on startup and when settings are updated.
+   * Reload OAuth configuration from database. Re-registers a fresh bare
+   * passport-discord Strategy under the 'discord' name so the constructor —
+   * not post-construction mutation — installs the current callbackURL.
    */
   async reloadConfig(): Promise<void> {
     try {
       const config = await this.settingsService.getDiscordOAuthConfig();
-
       if (!config) {
         this.logger.warn('Discord OAuth not configured - strategy disabled');
         this.isStrategyConfigured = false;
+        this.latestConfig = null;
         return;
       }
-
-      // Update the passport strategy options
-      this.updateStrategyOptions(config);
+      passport.use('discord', this.buildBareStrategy(config));
+      this.latestConfig = config;
       this.isStrategyConfigured = true;
       this.logger.log('Discord OAuth strategy reloaded with new configuration');
     } catch (error) {
@@ -65,28 +69,23 @@ export class DiscordAuthStrategy
     }
   }
 
-  /**
-   * Update passport strategy options dynamically.
-   * This is a workaround since passport doesn't officially support hot-reload.
-   * We update the internal OAuth2 client directly since the strategy is already registered.
-   */
-  private updateStrategyOptions(config: DiscordOAuthConfig): void {
-    // Access the internal strategy and update its options
-    const strategy = this as unknown as {
-      _oauth2: { _clientId: string; _clientSecret: string } | undefined;
-      _callbackURL: string;
-    };
-
-    this.logger.debug(`Updating callback URL to: ${config.callbackUrl}`);
-
-    if (strategy._oauth2) {
-      strategy._oauth2._clientId = config.clientId;
-      strategy._oauth2._clientSecret = config.clientSecret;
-      this.logger.debug(`Updated OAuth2 client credentials`);
-    }
-
-    strategy._callbackURL = config.callbackUrl;
-    this.logger.debug(`_callbackURL is now: ${strategy._callbackURL}`);
+  private buildBareStrategy(config: DiscordOAuthConfig): DiscordStrategy {
+    return new DiscordStrategy(
+      {
+        clientID: config.clientId,
+        clientSecret: config.clientSecret,
+        callbackURL: config.callbackUrl,
+        scope: ['identify'],
+      },
+      (accessToken, refreshToken, profile, done) => {
+        void this.verifyDiscordProfile(
+          accessToken,
+          refreshToken,
+          profile,
+          done,
+        );
+      },
+    );
   }
 
   /**
@@ -106,16 +105,18 @@ export class DiscordAuthStrategy
   }
 
   /**
-   * Override authenticate to ensure we have the latest callback URL.
-   * Passport caches options, so we need to force-update before each attempt.
+   * Override authenticate to inject the freshest callbackURL per request.
+   * `passport-oauth2` honors `options.callbackURL` over its cached
+   * `this._callbackURL`, so this is the load-bearing override even if the
+   * registered strategy somehow drifts.
    */
   authenticate(req: Request, options?: object): void {
-    // Ensure callback URL is current before authenticating
-    if (this.isStrategyConfigured) {
-      const strategy = this as unknown as { _callbackURL: string };
-      this.logger.debug(
-        `Authenticating with callback URL: ${strategy._callbackURL}`,
-      );
+    if (this.isStrategyConfigured && this.latestConfig?.callbackUrl) {
+      super.authenticate(req, {
+        ...(options ?? {}),
+        callbackURL: this.latestConfig.callbackUrl,
+      });
+      return;
     }
     super.authenticate(req, options);
   }
@@ -128,16 +129,43 @@ export class DiscordAuthStrategy
     if (!this.isStrategyConfigured) {
       throw new Error('Discord OAuth is not configured');
     }
-
-    const { id, username, avatar } = profile;
-    const user = await this.authService.validateDiscordUser(
-      id,
-      username,
-      avatar ?? undefined,
-    );
+    const user = await this.runValidate(profile);
     if (!user) {
       throw new Error('Failed to validate Discord user');
     }
     return user;
+  }
+
+  /**
+   * Shared verify path used by both the NestJS-wrapped `validate()` and the
+   * bare Strategy registered in `reloadConfig`. Routes through
+   * `authService.validateDiscordUser` and calls back with the appropriate
+   * error/user shape passport-oauth2 expects.
+   */
+  private async verifyDiscordProfile(
+    _accessToken: string,
+    _refreshToken: string,
+    profile: Profile,
+    done: VerifyCallback,
+  ): Promise<void> {
+    try {
+      const user = await this.runValidate(profile);
+      if (!user) {
+        done(new Error('Failed to validate Discord user'));
+        return;
+      }
+      done(null, user);
+    } catch (err) {
+      done(err);
+    }
+  }
+
+  private async runValidate(profile: Profile) {
+    const { id, username, avatar } = profile;
+    return this.authService.validateDiscordUser(
+      id,
+      username,
+      avatar ?? undefined,
+    );
   }
 }

--- a/api/src/settings/settings-bot.helpers.spec.ts
+++ b/api/src/settings/settings-bot.helpers.spec.ts
@@ -1,5 +1,6 @@
 import {
   getClientUrl,
+  getDiscordOAuthConfig,
   DEFAULT_CLIENT_URL,
   type SettingsCore,
 } from './settings-bot.helpers';
@@ -82,5 +83,68 @@ describe('getClientUrl', () => {
 describe('DEFAULT_CLIENT_URL', () => {
   it('should be the standard localhost dev URL', () => {
     expect(DEFAULT_CLIENT_URL).toBe('http://localhost:5173');
+  });
+});
+
+describe('getDiscordOAuthConfig — callbackUrl fallback chain (ROK-1325)', () => {
+  const originalEnv = process.env.DISCORD_CALLBACK_URL;
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.DISCORD_CALLBACK_URL = originalEnv;
+    } else {
+      delete process.env.DISCORD_CALLBACK_URL;
+    }
+  });
+
+  it('AC1 — falls back to process.env.DISCORD_CALLBACK_URL when setting is null', async () => {
+    process.env.DISCORD_CALLBACK_URL =
+      'https://slot-1.gamernight.net/api/auth/discord/callback';
+    const svc = mockSettingsCore({
+      [SETTING_KEYS.DISCORD_CLIENT_ID]: 'client-id',
+      [SETTING_KEYS.DISCORD_CLIENT_SECRET]: 'client-secret',
+      // DISCORD_CALLBACK_URL setting NOT set → SettingsCore.get returns null
+    });
+
+    const config = await getDiscordOAuthConfig(svc);
+
+    expect(config).not.toBeNull();
+    expect(config!.callbackUrl).toBe(
+      'https://slot-1.gamernight.net/api/auth/discord/callback',
+    );
+  });
+
+  it('AC2 — setting wins over env var when both present', async () => {
+    process.env.DISCORD_CALLBACK_URL =
+      'https://env-var.example/api/auth/discord/callback';
+    const svc = mockSettingsCore({
+      [SETTING_KEYS.DISCORD_CLIENT_ID]: 'client-id',
+      [SETTING_KEYS.DISCORD_CLIENT_SECRET]: 'client-secret',
+      [SETTING_KEYS.DISCORD_CALLBACK_URL]:
+        'https://from-setting.example/api/auth/discord/callback',
+    });
+
+    const config = await getDiscordOAuthConfig(svc);
+
+    expect(config).not.toBeNull();
+    expect(config!.callbackUrl).toBe(
+      'https://from-setting.example/api/auth/discord/callback',
+    );
+  });
+
+  it('AC3 — hardcoded localhost is the last-resort default when neither setting nor env is set', async () => {
+    delete process.env.DISCORD_CALLBACK_URL;
+    const svc = mockSettingsCore({
+      [SETTING_KEYS.DISCORD_CLIENT_ID]: 'client-id',
+      [SETTING_KEYS.DISCORD_CLIENT_SECRET]: 'client-secret',
+      // DISCORD_CALLBACK_URL setting NOT set, env var deleted above
+    });
+
+    const config = await getDiscordOAuthConfig(svc);
+
+    expect(config).not.toBeNull();
+    expect(config!.callbackUrl).toBe(
+      'http://localhost:3000/auth/discord/callback',
+    );
   });
 });

--- a/api/src/settings/settings-bot.helpers.ts
+++ b/api/src/settings/settings-bot.helpers.ts
@@ -34,7 +34,10 @@ export async function getDiscordOAuthConfig(
   return {
     clientId,
     clientSecret,
-    callbackUrl: callbackUrl || 'http://localhost:3000/auth/discord/callback',
+    callbackUrl:
+      callbackUrl ||
+      process.env.DISCORD_CALLBACK_URL ||
+      'http://localhost:3000/auth/discord/callback',
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes the bug where clicking "Continue with Discord" on a fleet preview env sent the user to Discord with `redirect_uri=http://localhost:3000/auth/discord/callback` instead of the env's slot URL. Operator picked **defense-in-depth: fixes (1) + (2) + (3)** from the spec.

Fix (4) — rl-fleet `sync_settings` JWT re-encrypt + URL substitution — was delivered separately in PR #827.

## Workspace breakdown

### api

- **Fix (1)** — `api/src/settings/settings-bot.helpers.ts`: three-tier callback URL fallback (`setting → process.env.DISCORD_CALLBACK_URL → hardcoded localhost`). One-line change. Closes Theory A (`SettingsService` cache returns null for `discord_callback_url`).
- **Fix (2)** — `api/src/plugins/discord/discord-auth.strategy.ts`: re-register the Discord strategy via `passport.use('discord', new DiscordStrategy(...))` on each `reloadConfig`, instead of mutating `_callbackURL` on the live instance. Dropped the broken `updateStrategyOptions` method. Closes Theory B (`_callbackURL` writes don't propagate through the @nestjs/passport mixin).
- **Fix (3)** — same file: override `authenticate(req, options)` to inject `latestConfig.callbackUrl` into super's options each request, so even a stale `_callbackURL` can't win. Reviewer notes this is effectively defense-in-depth on top of Fix 2 (the bare Strategy registered by Fix 2 is what handles requests, not the NestJS wrapper). Operator chose to keep it.
- Shared verify path via `verifyDiscordProfile` + `runValidate` so both the NestJS-wrapped `validate()` and the bare Strategy route through identical `authService.validateDiscordUser` logic.
- 9 new unit tests covering all 8 ACs from the spec, plus 23/23 targeted green + 6065/6065 full api suite green.

### Operator-config (rides along per CLAUDE.md)

- `Dockerfile.allinone`: `RUN chmod -R a+rX ./drizzle/migrations ./dist ./assets ./node_modules ./packages` before `USER app`. Plugs the broader Mutagen perm-strip class bug that the parallel `chmod 0755` fix in #827 didn't cover — same issue, hits drizzle `_journal.json` + npm-workspaces symlink targets (`/app/packages/contract/package.json`).

## Validation

- **Unit:** 23/23 targeted + 6065/6065 full api suite green, tsc + eslint clean on touched files.
- **Fleet e2e (4/4 PASS):** test plan on `https://fleet.gamernight.net` slug `rok-1325`. Discord OAuth round-trip works end-to-end on `https://slot-1.gamernight.net`. Curl proof:
  ```
  redirect_uri=https%3A%2F%2Fslot-1.gamernight.net%2Fapi%2Fauth%2Fdiscord%2Fcallback
  client_id=1468423433569439838
  ```
  vs pre-fix:
  ```
  redirect_uri=http%3A%2F%2Flocalhost%3A3000%2Fauth%2Fdiscord%2Fcallback
  client_id=placeholder
  ```

## Test plan

- [x] `npm run test -w api -- --testPathPatterns='settings-bot.helpers|discord-auth.strategy'` — 23/23 green
- [x] `npm run test -w api` — 6065/6065 green
- [x] `npx tsc --noEmit` clean on touched files
- [x] Fleet test plan 4/4 PASS (operator browser-tested on phone)
- [x] Reviewer: APPROVED, 0 blocking, 0 auto-fixes
- [ ] CI green
- [ ] Auto-merge enabled

## Tech debt surfaced (NOT auto-filed)

Per `feedback_no_auto_tech_debt` — captured for operator triage:

- **Fix (3) is effectively dead code under current request routing.** `AuthGuard('discord')` resolves to `passport._strategies['discord']` which is the BARE Strategy installed by Fix 2 — never reaches the NestJS-wrapped `authenticate` override. Fix 2 alone suffices; Fix 3 is a defense-in-depth nicety the operator chose. Either drop it OR add an explanatory comment in a future cleanup. See `planning-artifacts/review-ROK-1325.md` §6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)