### PR TITLE
ROK-1338 PR-3 — error-hint hardening + classifier + runbook (lockdown DEFERRED pending MCP transport redesign)

### DIFF
--- a/.claude/skills/_shared/rl-infra-fleet.md
+++ b/.claude/skills/_shared/rl-infra-fleet.md
@@ -52,8 +52,10 @@ rl release                                        # destroy child envs, prune, d
 2. **Don't `cd` into the worktree manually** — Mutagen mirrors files into the
    runner's `/workspace`. Edit on the laptop, the runner sees changes within ~1s.
 3. **Shell out to the runner for compute-heavy commands**:
-   - `npm run build -w api` → `rl validate-ci` (or
-     `ssh proxmox-vm /srv/rl-infra/orchestrator/bin/run-on-runner -- npm run build -w api`)
+   - `npm run build -w api` → `rl validate-ci`, or
+     `mcp__mcp-rl-fleet__rl_run_on_runner({ command: 'npm run build -w api', worktree_path: '<abs>' })`
+     for a single targeted invocation. Agents MUST use the MCP path — direct
+     SSH as `rl-agent` is closed (ROK-1338 PR-3).
    - `./scripts/deploy_dev.sh` → `rl env spin <slug>` (built artifacts, prod-like)
    - `npm run test:integration` → wrap with `rl validate-ci --no-e2e`
    - `npx playwright test` → wrap with `rl validate-ci --only-e2e`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,6 +79,8 @@ Playwright-over-CDP tools for UI-level verification: `discord_screenshot`, `disc
 
 ### `mcp-rl-fleet` — rl-infra Remote Test Fleet (`tools/mcp-rl-fleet/`)
 
+**STRICT — agent-side SSH to the rl-infra VM as `rl-agent` is closed (ROK-1338 PR-3).** Agents reach the fleet only through the `mcp__mcp-rl-fleet__*` tools below. The operator's `rl` CLI (which SSHes as the operator user) is operator-only and is NOT an agent fallback. If a debug path requires direct SSH, that's an agent-side capability gap — append it to the no-SSH umbrella list (see [[project_rok_1338_no_ssh_umbrella]]) rather than asking the operator to re-open SSH.
+
 **STRICT — worktree_path:** every rl_* tool that touches a claimed slot (`rl_claim`, `rl_release`, `rl_env_spin`, `rl_env_destroy`, `rl_env_deploy`, `rl_env_build_image_from_runner`, `rl_run_on_runner`, `rl_validate_ci`) accepts a `worktree_path` parameter. **If you're operating from a git worktree, you MUST pass `worktree_path: "<absolute path to your worktree>"` on every call.** Without it, the MCP server uses its own cwd (where Claude was started — usually the main repo) which (a) Mutagen-syncs the wrong branch's files and (b) hashes to a different `RL_AGENT_ID` so subsequent calls can't find your slot. Use the same value on every call — e.g. `/Users/sdodge/Documents/Projects/Raid-Ledger--rok-1297`.
 
 | Tool | Use When |
@@ -182,7 +184,7 @@ This rule exists because parallel agents kept seeing these commits, assuming "no
 
 The `rl-infra` Proxmox VM hosts a 4-slot runner fleet so heavy compute (build, jest, vitest, playwright, allinone builds, per-env stacks) runs on the VM instead of the laptop, and multiple agents work in parallel without env-lock contention. Full design + runbook: `rl-infra/README.md`. Operator-facing summary: `.claude/skills/_shared/rl-infra-fleet.md`.
 
-**Default behavior:** `RL_TARGET=auto` (the default) probes `RL_PROXMOX_HOST` over SSH. Reachable → remote mode. Unreachable / `RL_TARGET=local` → fall through to the legacy local section below.
+**Default behavior:** `RL_TARGET=auto` (the default — operator CLI only; agents don't probe SSH) makes the `rl` CLI probe `RL_PROXMOX_HOST` over SSH. Reachable → remote mode. Unreachable / `RL_TARGET=local` → fall through to the legacy local section below.
 
 In remote mode, prefer the `rl` CLI over today's equivalents:
 

--- a/TECH-DEBT-BACKLOG.md
+++ b/TECH-DEBT-BACKLOG.md
@@ -642,3 +642,14 @@ Six failures resolved by ROK-1298's fixes (AC3 a11y, AC9 keyboard, vote-toggle k
 
 - **[low]** `tools/mcp-rl-fleet/src/tools/__tests__/test-plan.spec.ts:112` — `AC6 — curlOnVM rejects CR/LF/NUL in header values > throws when a header value contains \0 (NUL byte)` fails on this branch's base (confirmed via `git stash && npx vitest run src/tools/__tests__/test-plan.spec.ts` from a clean tree — 1 failed, 4 passed). The test calls `executeStatus({ slug: 'aaa' })` and expects `{ok: false}` to be returned, but gets `{}` instead. Likely the `executeStatus` function in `test-plan.ts` short-circuits on a missing curl-on-vm path and returns `{}` rather than an error envelope. Not caused by PR-2 — db-query.ts is a brand-new file with no shared state with test-plan.ts. Pre-existing.
   Suggested: read `test-plan.ts::executeStatus` against the AC6 assertions; either the executor needs to surface `{ok: false, error: 'invalid_header'}` for NUL-byte rejection, OR the test should assert on whatever shape is actually returned (likely an unhandled-rejection path).
+
+### 2026-05-22 — rok-1338-pr3-ssh-lockdown (reviewer follow-ups for next cycle)
+
+- **[low]** `tools/mcp-rl-fleet/src/exec.ts:492-501` — `UNREACHABLE_RE` would false-positive on psql-side `Connection refused` if a future write-mode `rl_db_query` (or similar) emits psql stderr that reaches the classifier. Today's tools' postgres-specific matchers run first in `db-query.ts::classifyError`, so this is latent.
+  Suggested: anchor unreachable patterns with an `ssh:` prefix where feasible — `(?:ssh:\s+connect to host \S+ port \d+:\s+)?(?:Connection refused|Connection timed out|...)`. OR add a `psql:` head-exclusion in `classifySshFailure`. Reviewer flagged 2026-05-22; defer to a hardening cycle.
+- **[low]** `tools/mcp-rl-fleet/src/exec.ts:475-486` — `DENIED_RE` could theoretically match `permission denied (some context)` postgres errors. Real-world postgres uses `permission denied for <object>` (no parens) so collision is unlikely; consumer-side classifier ordering keeps it safe today.
+  Suggested: tighten to require a publickey/password/gssapi/hostbased context inside the parens — `\bPermission denied \([^)]*(?:publickey|password|gssapi|hostbased|keyboard-interactive)`. Reviewer flagged 2026-05-22.
+- **[low]** `tools/mcp-rl-fleet/src/tools/__tests__/task.spec.ts` — `executeWait` watch-side classifier (inside the wait loop, not the probe-side branch) has no direct test. Probe-side is tested; in-loop is covered indirectly.
+  Suggested: add `execFileOk(probe-success), execFileOk(status-running), execFileFail(255, 'Permission denied (publickey)')` test asserting immediate `ssh_denied` return.
+- **[nit]** `tools/mcp-rl-fleet/src/tools/db-url.ts` — `psql_exec_cmd` alias kept for one cycle (`@deprecated`); needs a removal tracked.
+  Suggested: add to the next cycle's removal list. Look for callers via grep before dropping.

--- a/rl-infra/README.md
+++ b/rl-infra/README.md
@@ -69,9 +69,14 @@ the operator laptop or when external chain is broken.
 
 ## The CLI
 
+> **Agents:** prefer the `mcp__mcp-rl-fleet__*` MCP tools (see CLAUDE.md
+> "`mcp-rl-fleet`"). Direct SSH as `rl-agent` is closed (ROK-1338 PR-3); the
+> CLI below is the operator-facing path that uses the operator SSH user.
+
 All operator interaction goes through `rl-infra/cli/rl` on the laptop. It SSHes
-to the VM and dispatches to shell scripts in `/srv/rl-infra/orchestrator/bin/`. There is no daemon,
-no HTTP service — just SSH + flock + jq.
+to the VM as the operator user (`rl`) and dispatches to shell scripts in
+`/srv/rl-infra/orchestrator/bin/`. There is no daemon, no HTTP service — just
+SSH + flock + jq.
 
 ```bash
 rl claim [--branch foo]          # acquire a runner slot
@@ -98,7 +103,8 @@ rl validate-ci [...args]         # run validate-ci.sh inside your runner
    `dist`, `coverage`, `.git/objects`.
 3. Operator/agent works on the laptop. Saves trigger Mutagen → ~1s to runner.
 4. Heavy commands (`validate-ci`, `env spin`, jest) ship to the runner via
-   `rl <cmd>` or VSCode Remote-SSH terminal.
+   `rl <cmd>` or operator-only VSCode Remote-SSH terminal. Agents use
+   `mcp__mcp-rl-fleet__rl_run_on_runner` / `rl_validate_ci` instead.
 5. Local CLI heartbeats every 60s. Missed for 5min → slot auto-released.
 6. `rl release` → destroys child envs, prunes scoped to slot label, resets
    worktree dir, drops the claim.
@@ -122,7 +128,10 @@ rl validate-ci [...args]         # run validate-ci.sh inside your runner
 
 Long-running orchestrator commands (validate-ci, image builds, env spins) are
 tracked as **tasks** with persistent VM-side state. State survives MCP-server
-restart on the laptop and is independently observable via SSH.
+restart on the laptop and is independently observable by the operator via
+SSH. Agents observe task state via `mcp__mcp-rl-fleet__rl_task_inspect` /
+`rl_task_status` / `rl_task_logs` — direct SSH as `rl-agent` is closed
+(ROK-1338 PR-3).
 
 **Directory layout** — `/srv/rl-infra/state/tasks/`:
 
@@ -188,18 +197,27 @@ sweeper handles size at end-of-life. `task-status` caps its returned `log_tail`
 
 ## Strong debugging
 
-| Need                        | How                                                       |
-| --------------------------- | --------------------------------------------------------- |
-| Live log search             | Grafana → Loki: `{slot="1"} \|= "ECONNRESET"`             |
-| VSCode debugger from laptop | Remote-SSH into runner, `launch.json` attaches to 9229    |
-| Live REPL                   | `rl shell` → tmux session, persists across disconnects    |
-| Postgres                    | `rl db <slug>` (psql) or `rl db <slug> --web` (pgweb)     |
-| Resource live view          | `rl top` → ctop inside the VM                             |
-| Profiling                   | `clinic doctor` etc. pre-installed in runner image        |
-| Network capture             | `rl tcpdump <slot>` → tcpdump in the runner               |
-| Stack-trace clickable paths | VSCode Remote-SSH session uses the runner's filesystem    |
-| "What did agent X do?"      | `cat /srv/rl-infra/state/audit.log \| grep <agent-id>`    |
-| Snapshot before risky run   | `rl snapshot create pre-experiment` → ZFS-backed          |
+Agent-side paths first, operator-only paths labelled. Direct SSH as `rl-agent`
+is closed (ROK-1338 PR-3) — anything below that requires an SSH session is
+intentionally operator-only.
+
+| Need                        | How                                                                          |
+| --------------------------- | ---------------------------------------------------------------------------- |
+| Live log search (agents)    | `mcp__mcp-rl-fleet__rl_logs_url` → Grafana/Loki link (`{slot="1"} \|= "..."`) |
+| Read service logs (agents)  | `mcp__mcp-rl-fleet__rl_infra_logs` (`gc-sweeper`, `dashboard`, `traefik`, `loki`, `registry`, `promtail`, `docker-proxy`) |
+| Read task log (agents)      | `mcp__mcp-rl-fleet__rl_task_logs` (full ANSI-stripped stdout/stderr)         |
+| Read task JSON (agents)     | `mcp__mcp-rl-fleet__rl_task_inspect`                                         |
+| Read env config (agents)    | `mcp__mcp-rl-fleet__rl_env_inspect` (nginx-conf / supervisor-conf)           |
+| Run query against env DB    | `mcp__mcp-rl-fleet__rl_db_query` (read-only, JSON-mode, 5s timeout)          |
+| Postgres (operator-only)    | `rl db <slug>` (psql) or `rl db <slug> --web` (pgweb)                        |
+| Live REPL (operator-only)   | `rl shell` → tmux session, persists across disconnects                       |
+| Resource live view (op.)    | `rl top` → ctop inside the VM                                                |
+| VSCode debugger (operator-only) | Remote-SSH into runner, `launch.json` attaches to 9229                   |
+| Profiling (operator-only)   | `clinic doctor` etc. pre-installed in runner image                           |
+| Network capture (op.)       | `rl tcpdump <slot>` → tcpdump in the runner                                  |
+| Stack-trace clickable paths (op.) | VSCode Remote-SSH session uses the runner's filesystem                 |
+| "What did agent X do?" (op.)| `cat /srv/rl-infra/state/audit.log \| grep <agent-id>`                       |
+| Snapshot before risky run (op.) | `rl snapshot create pre-experiment` → ZFS-backed                         |
 
 ## DR — airplane mode
 
@@ -215,19 +233,21 @@ not the daily flow.
 
 ## What stays on the laptop
 
-- VSCode editor (connects to the runner via Remote-SSH for terminal/debugger).
+- VSCode editor — operator only, connects to the runner via Remote-SSH for
+  terminal/debugger using the operator SSH user.
 - Mutagen daemon (file sync agent).
-- The `rl-infra/cli/rl` CLI.
+- The `rl-infra/cli/rl` CLI (operator-only; agents use the MCP tools instead).
 - `git` operations on the worktree (refs/HEAD sync, but objects stay local).
 - Discord MCP + Chrome MCP (need local Electron / Chrome with CDP).
 - Sentry, Linear, GitHub clients (network, not compute-heavy).
 
-## First-time setup
+## First-time setup (operator-only)
 
-See `proxmox/cloud-init.yaml` for VM provisioning. After the VM is up:
+See `proxmox/cloud-init.yaml` for VM provisioning. After the VM is up, the
+operator (NOT an agent) runs:
 
 ```bash
-ssh proxmox-vm
+ssh proxmox-vm    # operator-only SSH as the `rl` user
 cd /srv/rl-infra
 docker compose up -d
 ./bin/init-state    # creates claims.json, env-registry.json, audit.log
@@ -237,11 +257,14 @@ From the laptop:
 
 ```bash
 echo 'export RL_PROXMOX_HOST=rl-infra.lan' >> ~/.zshrc
-echo 'export RL_PROXMOX_USER=rl' >> ~/.zshrc
+echo 'export RL_PROXMOX_USER=rl' >> ~/.zshrc                # operator user
 ln -s "$PWD/rl-infra/cli/rl" /usr/local/bin/rl   # or add rl-infra/cli to PATH
 rl doctor                                    # verifies SSH, Mutagen, orchestrator
 rl claim --branch $(git branch --show-current)
 ```
+
+Agents do not bootstrap the fleet — they use `mcp__mcp-rl-fleet__*` against
+the already-running stack.
 
 ## VM dependencies
 
@@ -271,3 +294,200 @@ docker compose up -d
 
 (This is an operator-action: agents don't have permission to restart
 compose-managed services.)
+
+## Operator override — temporarily enabling rl-agent SSH
+
+> **Audience:** operator only. This runbook is informational for agents but
+> not actionable by them — there is no agent path back to direct SSH and
+> there shouldn't be. Per ROK-1338 PR-3, agent-side SSH as `rl-agent` is
+> closed by default; the full agent surface lives in `mcp__mcp-rl-fleet__*`.
+
+### Why this exists
+
+Closing direct SSH for `rl-agent` removes a lateral-movement vector but also
+removes a break-glass debug path the operator may occasionally need (e.g. to
+investigate why an MCP tool is itself broken, or to interactively inspect
+fleet state during a postmortem). The mechanism below is an **operator-side
+toggle**: SSH is denied by default; a single operator command flips it back
+on; another command re-locks.
+
+The toggle is a file on the VM, not a config edit, so:
+
+- Re-locking after debugging is one command — hard to leave it open by mistake.
+- Auditing "was rl-agent SSH on?" is `ls -l /etc/ssh/.agent-allow` plus the
+  sshd_config audit trail.
+- Re-running provisioning won't accidentally re-enable SSH.
+
+### Mechanism (A — toggle file + AuthorizedKeysCommand gate)
+
+The lockdown sources rl-agent's authorized keys from a small script that
+returns empty unless a toggle file exists. sshd has no key to match against,
+so authentication fails — no `DenyUsers`/`AllowUsers` juggling needed, and
+`~rl-agent/.ssh/authorized_keys` becomes irrelevant (sshd ignores it inside
+the Match block).
+
+**The escrow file `/etc/ssh/rl-agent.authorized_keys.escrow` is the
+canonical source of truth for the laptop-side public key.** It stays in
+place permanently; only the `/etc/ssh/.agent-allow` toggle gates whether
+the key is offered to sshd. Mode `0644 root:root` — public keys are not
+secret data, and the `AuthorizedKeysCommand` runs as `nobody` which must be
+able to read it.
+
+#### Files to create on the VM
+
+`/etc/ssh/rl-agent-gated-keys.sh` (mode 0755, root:root):
+
+```bash
+#!/bin/bash
+# Returns the rl-agent authorized_keys ONLY when the toggle file exists.
+# Toggle file: /etc/ssh/.agent-allow (operator creates to break-glass).
+# Escrow:      /etc/ssh/rl-agent.authorized_keys.escrow (canonical key,
+#              0644 root:root — public key is not secret data; runs as nobody).
+set -euo pipefail
+if [ -f /etc/ssh/.agent-allow ] && [ -r /etc/ssh/rl-agent.authorized_keys.escrow ]; then
+    cat /etc/ssh/rl-agent.authorized_keys.escrow
+fi
+exit 0
+```
+
+Append to `/etc/ssh/sshd_config` (after the global `AuthorizedKeysFile`
+directive, NOT replacing it — the Match block is scoped to rl-agent only):
+
+```
+# ROK-1338 PR-3: rl-agent SSH gated on /etc/ssh/.agent-allow toggle.
+# When the file is absent the key lookup script returns empty and auth fails.
+Match User rl-agent
+    AuthorizedKeysFile none
+    AuthorizedKeysCommand /etc/ssh/rl-agent-gated-keys.sh
+    AuthorizedKeysCommandUser nobody
+```
+
+`AuthorizedKeysCommand` is re-executed per connection, so flipping the toggle
+takes effect on the next ssh attempt — no sshd reload required AFTER the
+initial sshd_config edit.
+
+### Apply the lockdown (post-merge, operator-only)
+
+1. **Back up the existing sshd_config:**
+   ```bash
+   sudo cp /etc/ssh/sshd_config /root/sshd_config.pre-rok-1338-pr3
+   ```
+2. **Escrow the rl-agent public key** (canonical store; never deleted while
+   the lockdown is in force — mode 0644 because public keys are not secret
+   and `nobody` must read it). Guard against an empty source — without a
+   non-empty escrow, break-glass would silently fail later:
+   ```bash
+   sudo test -s ~rl-agent/.ssh/authorized_keys || \
+       { echo "ABORT: ~rl-agent/.ssh/authorized_keys is missing or empty — escrow would be a no-op"; exit 1; }
+   sudo install -m 0644 -o root -g root ~rl-agent/.ssh/authorized_keys \
+        /etc/ssh/rl-agent.authorized_keys.escrow
+   ```
+3. **Install the gated-keys script:**
+   ```bash
+   sudo tee /etc/ssh/rl-agent-gated-keys.sh > /dev/null <<'SH'
+   #!/bin/bash
+   set -euo pipefail
+   if [ -f /etc/ssh/.agent-allow ] && [ -r /etc/ssh/rl-agent.authorized_keys.escrow ]; then
+       cat /etc/ssh/rl-agent.authorized_keys.escrow
+   fi
+   exit 0
+   SH
+   sudo chown root:root /etc/ssh/rl-agent-gated-keys.sh
+   sudo chmod 0755 /etc/ssh/rl-agent-gated-keys.sh
+   ```
+4. **Append the Match block** to `/etc/ssh/sshd_config` (copy-paste verbatim):
+   ```bash
+   sudo tee -a /etc/ssh/sshd_config > /dev/null <<'CFG'
+
+   # ROK-1338 PR-3: rl-agent SSH gated on /etc/ssh/.agent-allow toggle.
+   # When the file is absent the key lookup script returns empty and auth fails.
+   Match User rl-agent
+       AuthorizedKeysFile none
+       AuthorizedKeysCommand /etc/ssh/rl-agent-gated-keys.sh
+       AuthorizedKeysCommandUser nobody
+   CFG
+   ```
+5. **Validate the syntax before reloading** — a broken sshd_config will lock
+   the operator out too if the active session drops:
+   ```bash
+   sudo sshd -t      # exits 0 silent on success, prints offending line on failure
+   ```
+6. **Clear `~rl-agent/.ssh/authorized_keys`** so even the legacy path is empty
+   (defense-in-depth — `AuthorizedKeysFile none` in the Match block already
+   means sshd won't read it, but an empty file rules out accidental rollback
+   via `cp escrow ~/.ssh/authorized_keys`):
+   ```bash
+   sudo truncate -s 0 ~rl-agent/.ssh/authorized_keys
+   ```
+7. **Confirm the toggle file is absent** (lockdown active by default):
+   ```bash
+   ls -l /etc/ssh/.agent-allow   # expect: No such file or directory
+   ```
+8. **Reload sshd** (do NOT restart — reload preserves the current operator
+   session):
+   ```bash
+   sudo systemctl reload sshd
+   ```
+9. **Confirm from the laptop:**
+   ```bash
+   ssh rl-agent@rl-infra echo ok      # expect: Permission denied (publickey)
+   ```
+
+### Break-glass — re-open rl-agent SSH temporarily
+
+```bash
+# On the VM, as operator:
+sudo touch /etc/ssh/.agent-allow
+
+# That's it. Next ssh attempt as rl-agent succeeds.
+# No sshd reload needed (AuthorizedKeysCommand is per-connection).
+```
+
+### Re-lock after debugging
+
+```bash
+sudo rm -f /etc/ssh/.agent-allow
+
+# Verify from the laptop:
+ssh rl-agent@rl-infra echo ok      # expect: Permission denied (publickey)
+```
+
+### Full revert (if PR-3's premise turns out wrong)
+
+```bash
+sudo cp /root/sshd_config.pre-rok-1338-pr3 /etc/ssh/sshd_config
+sudo install -m 0600 -o rl-agent -g rl-agent \
+     /etc/ssh/rl-agent.authorized_keys.escrow \
+     ~rl-agent/.ssh/authorized_keys
+sudo systemctl reload sshd
+```
+
+Then file a follow-up explaining which agent debug path forced the revert —
+the right answer is almost always "add an MCP tool", not "permanently
+re-open SSH". The umbrella prerequisite-list in [[project-rok-1338-no-ssh-umbrella]]
+is the catch-all for those gaps.
+
+### Audit checklist
+
+- `ls -l /etc/ssh/.agent-allow` — present only during a break-glass window;
+  absent in steady state.
+- `ls -l /etc/ssh/rl-agent.authorized_keys.escrow` — must exist
+  (mode 0644 root:root, world-readable so `nobody` can serve it via the
+  AuthorizedKeysCommand). If missing, even break-glass won't work — the
+  key was never escrowed.
+- `wc -l ~rl-agent/.ssh/authorized_keys` — should always be 0 lines. Non-zero
+  is a defense-in-depth violation (it doesn't itself open SSH — `AuthorizedKeysFile none`
+  in the Match block neutralizes this file — but it suggests someone reverted
+  step 6 by hand).
+- `sudo journalctl -u sshd --since '1 hour ago' | grep rl-agent` — every
+  rl-agent SSH attempt (allowed or denied) lands in the systemd journal.
+- `sudo grep -c '/etc/ssh/.agent-allow' /var/log/auth.log` — count of recent
+  toggle-gate evaluations (every connection attempt triggers the script).
+
+### Out of scope
+
+- This runbook does NOT manage the operator (`rl`/`sdodge`) SSH user.
+  Operator SSH stays open by design — it's the legitimate path for
+  break-glass and for the `rl-infra/cli/rl` CLI's own SSH calls.
+- The runner-internal SSH path (`docker exec runner-N sshd`) is not affected;
+  agents reach runners via Mutagen + the MCP tools, not direct SSH.

--- a/rl-infra/README.md
+++ b/rl-infra/README.md
@@ -368,6 +368,33 @@ initial sshd_config edit.
 
 ### Apply the lockdown (post-merge, operator-only)
 
+**Step 0 (preflight — DO NOT skip).** Confirm every agent that will work the
+fleet has a fresh MCP surface that includes the PR-2 tools (`rl_task_logs`,
+`rl_env_inspect`, `rl_db_query`). Two parts:
+
+   1. **From the main repo (laptop):**
+      ```bash
+      cd /Users/sdodge/Documents/Projects/Raid-Ledger
+      git pull --rebase origin main
+      npm install        # MANDATORY — PR-2 added json-bigint; without npm install the MCP server fails to load at all
+      ```
+      Verify: `ls node_modules/json-bigint/package.json` exists. Without this,
+      ANY Claude session will start with a dead `mcp-rl-fleet` server (module
+      load error) and the lockdown becomes unrecoverable for agents.
+   2. **Restart any open Claude sessions.** MCP servers load their tool
+      registry at session start; sessions that predate PR-2's merge will be
+      missing `rl_task_logs` / `rl_env_inspect` / `rl_db_query` even after
+      step 1. Restart fully (exit Claude and relaunch — `/exit` from inside a
+      session is sufficient for the interactive client; background agents
+      must be stopped from the agents panel).
+   3. **Verify** by asking the agent to call `mcp__mcp-rl-fleet__rl_status`
+      and then `ToolSearch select:mcp__mcp-rl-fleet__rl_task_logs`. If the
+      latter returns "No matching deferred tools found", the agent is still
+      stale — DO NOT proceed with the lockdown. Loop back to step 2.
+
+Only proceed once every active agent session reports `rl_task_logs` /
+`rl_env_inspect` / `rl_db_query` as PRESENT in its MCP surface.
+
 1. **Back up the existing sshd_config:**
    ```bash
    sudo cp /etc/ssh/sshd_config /root/sshd_config.pre-rok-1338-pr3

--- a/rl-infra/README.md
+++ b/rl-infra/README.md
@@ -297,6 +297,35 @@ compose-managed services.)
 
 ## Operator override — temporarily enabling rl-agent SSH
 
+> ⛔ **BLOCKED — DO NOT APPLY YET (2026-05-22).** The Codex `/security-review`
+> on ROK-1338 PR-3 (`planning-artifacts/security-review-223dfedd.md`) caught
+> a design gap: the MCP server itself authenticates to the VM **as
+> `rl-agent`** via `buildSshArgs` in `tools/mcp-rl-fleet/src/exec.ts:199`.
+> Same key, same user, same authentication path as the agent ad-hoc SSH this
+> runbook intends to deny. **Applying the apply sequence below would brick
+> the MCP transport for every tool** (`rl_claim`, `rl_status`, `rl_env_spin`,
+> `rl_db_query`, …) and leave agents with no remaining path to the fleet.
+>
+> The runbook is preserved as the *target end-state*. Before it can be
+> applied, one of these must land:
+>
+> 1. **MCP transport identity separation.** Issue a separate SSH user (e.g.
+>    `rl-mcp`) for the MCP server, with its own authorized_keys and its own
+>    sudoers/docker-group memberships that mirror today's `rl-agent`. Wire
+>    `buildSshArgs` to use the new user. Then this lockdown only denies
+>    `rl-agent` interactive SSH — MCP keeps working.
+> 2. **MCP transport off SSH.** Replace the SSH-based transport with an
+>    HTTPS service running on the VM (mTLS or HMAC-authenticated). The MCP
+>    server calls that service; the orchestrator binaries become handlers
+>    instead of SSH targets. No `rl-agent` SSH at all.
+>
+> Either path is a meaningful piece of work — tracked as a new prerequisite
+> on ROK-1338's umbrella checklist.
+>
+> Below this callout, every step is correct for the *post-fix* state. Leaving
+> it in place so the work is ready to apply the moment the design gap is
+> closed.
+
 > **Audience:** operator only. This runbook is informational for agents but
 > not actionable by them — there is no agent path back to direct SSH and
 > there shouldn't be. Per ROK-1338 PR-3, agent-side SSH as `rl-agent` is

--- a/rl-infra/orchestrator/bin/claim-wait
+++ b/rl-infra/orchestrator/bin/claim-wait
@@ -42,7 +42,7 @@ fi
 
 # Step 2 — long-poll. Pre-flight: inotifywait must be installed.
 if ! command -v inotifywait >/dev/null 2>&1; then
-    jq -nc '{ok:false, error:"inotifywait_not_installed", hint:"sudo apt-get install -y inotify-tools"}'
+    jq -nc '{ok:false, error:"inotifywait_not_installed", operator_only:true, hint:"inotify-tools is missing on the rl-infra VM. This is operator-only to install (apt-get install -y inotify-tools); agents cannot self-remediate. File a ticket or message the operator."}'
     exit 0
 fi
 

--- a/rl-infra/orchestrator/bin/env-spin
+++ b/rl-infra/orchestrator/bin/env-spin
@@ -28,7 +28,7 @@ _env_spin_trap_on_abort() {
         jq -nc --argjson rc "$rc" --arg slug "${SLUG:-}" --arg phase "${LAST_PHASE:-unknown}" \
             '{ok:false, error:"env_spin_aborted_unexpectedly", exit_code:$rc, slug:$slug,
               last_phase:$phase,
-              hint:("env-spin aborted with rc=" + ($rc|tostring) + " after completing phase \"" + $phase + "\". The failing line is between the marker for that phase and the next. Re-run with bash -x on the VM if more detail is needed: ssh rl@vm bash -x /srv/rl-infra/orchestrator/bin/env-spin --slug " + $slug)}' \
+              hint:("env-spin aborted with rc=" + ($rc|tostring) + " after completing phase \"" + $phase + "\". The failing line is between the marker for that phase and the next. Read /srv/rl-infra/audit.log for the matching env-spin err entry, then call rl_infra_logs(service=gc-sweeper, tail=200) for sweeper-side context. If deeper bash -x tracing is required, escalate to the operator — rl-agent does not have shell on the VM.")}' \
         2>/dev/null || echo '{"ok":false,"error":"env_spin_aborted_unexpectedly","exit_code":'"$rc"',"last_phase":"'"${LAST_PHASE:-unknown}"'"}'
     fi
 }

--- a/rl-infra/orchestrator/bin/env-spin
+++ b/rl-infra/orchestrator/bin/env-spin
@@ -28,7 +28,7 @@ _env_spin_trap_on_abort() {
         jq -nc --argjson rc "$rc" --arg slug "${SLUG:-}" --arg phase "${LAST_PHASE:-unknown}" \
             '{ok:false, error:"env_spin_aborted_unexpectedly", exit_code:$rc, slug:$slug,
               last_phase:$phase,
-              hint:("env-spin aborted with rc=" + ($rc|tostring) + " after completing phase \"" + $phase + "\". The failing line is between the marker for that phase and the next. Read /srv/rl-infra/audit.log for the matching env-spin err entry, then call rl_infra_logs(service=gc-sweeper, tail=200) for sweeper-side context. If deeper bash -x tracing is required, escalate to the operator — rl-agent does not have shell on the VM.")}' \
+              hint:("env-spin aborted with rc=" + ($rc|tostring) + " after completing phase \"" + $phase + "\". The failing line is between the marker for that phase and the next. Agents: call rl_infra_logs(service=gc-sweeper, tail=200) for sweeper-side context. Operator-only follow-ups (rl-agent does not have shell on the VM): read /srv/rl-infra/audit.log for the matching env-spin err entry; run bash -x for deeper tracing.")}' \
         2>/dev/null || echo '{"ok":false,"error":"env_spin_aborted_unexpectedly","exit_code":'"$rc"',"last_phase":"'"${LAST_PHASE:-unknown}"'"}'
     fi
 }

--- a/tools/mcp-rl-fleet/src/__tests__/classify-ssh-failure.spec.ts
+++ b/tools/mcp-rl-fleet/src/__tests__/classify-ssh-failure.spec.ts
@@ -1,0 +1,88 @@
+// ROK-1338 PR-3 — classifySshFailure helper unit tests.
+//
+// Pure-function classifier — pins the regex bucketing across:
+//   - denied: Permission denied (publickey | publickey,password | try again),
+//             Host key verification failed
+//   - unreachable: Connection refused / timed out / closed by host port 22 /
+//             No route to host / ssh: connect to host... / Could not resolve
+//   - null: empty stderr, postgres errors, docker errors, exit 0
+//
+// Spec: planning-artifacts/specs/ROK-1338-error-hints.md §B0.
+
+import { describe, it, expect } from 'vitest';
+import { classifySshFailure } from '../exec.js';
+
+describe('classifySshFailure — denied bucket', () => {
+  it('matches Permission denied (publickey)', () => {
+    const r = classifySshFailure(255, 'rl-agent@rl-infra: Permission denied (publickey).');
+    expect(r?.error).toBe('ssh_denied');
+    expect(r?.hint).toMatch(/post-ROK-1338|MCP tools/);
+  });
+  it('matches Permission denied (publickey,password)', () => {
+    const r = classifySshFailure(255, 'Permission denied (publickey,password).');
+    expect(r?.error).toBe('ssh_denied');
+  });
+  it('matches Permission denied, please try again', () => {
+    const r = classifySshFailure(255, 'Permission denied, please try again.');
+    expect(r?.error).toBe('ssh_denied');
+  });
+  it('matches Host key verification failed', () => {
+    const r = classifySshFailure(255, 'Host key verification failed.');
+    expect(r?.error).toBe('ssh_denied');
+  });
+});
+
+describe('classifySshFailure — unreachable bucket', () => {
+  it('matches Connection refused', () => {
+    const r = classifySshFailure(
+      255,
+      'ssh: connect to host rl-infra port 22: Connection refused',
+    );
+    expect(r?.error).toBe('ssh_unreachable');
+  });
+  it('matches Connection timed out', () => {
+    const r = classifySshFailure(
+      255,
+      'ssh: connect to host 192.168.0.132 port 22: Connection timed out',
+    );
+    expect(r?.error).toBe('ssh_unreachable');
+  });
+  it('matches Connection closed by host port 22', () => {
+    const r = classifySshFailure(255, 'Connection closed by 192.168.0.132 port 22');
+    expect(r?.error).toBe('ssh_unreachable');
+  });
+  it('matches No route to host', () => {
+    const r = classifySshFailure(
+      255,
+      'ssh: connect to host rl-infra port 22: No route to host',
+    );
+    expect(r?.error).toBe('ssh_unreachable');
+  });
+  it('matches Could not resolve hostname', () => {
+    const r = classifySshFailure(
+      255,
+      'ssh: Could not resolve hostname rl-infra: nodename nor servname provided',
+    );
+    expect(r?.error).toBe('ssh_unreachable');
+  });
+});
+
+describe('classifySshFailure — null bucket', () => {
+  it('returns null on empty stderr', () => {
+    expect(classifySshFailure(255, '')).toBeNull();
+  });
+  it('returns null on postgres syntax error', () => {
+    expect(classifySshFailure(3, 'ERROR:  syntax error at or near "FOO"')).toBeNull();
+  });
+  it('returns null on docker no-such-container error', () => {
+    expect(
+      classifySshFailure(
+        1,
+        'Error response from daemon: No such container: rl-env-x-allinone',
+      ),
+    ).toBeNull();
+  });
+  it('returns null on exit 0 with any stderr', () => {
+    expect(classifySshFailure(0, 'irrelevant')).toBeNull();
+  });
+});

--- a/tools/mcp-rl-fleet/src/exec.ts
+++ b/tools/mcp-rl-fleet/src/exec.ts
@@ -409,11 +409,103 @@ function sanitizeExtra(opts: RlEnv): Record<string, string> {
  */
 export function synthesizeEmptyStderrDiagnostic(exitCode: number | undefined): string {
   const code = typeof exitCode === 'number' ? String(exitCode) : 'unknown';
+  // ROK-1338 PR-3 (C1): include `permission denied (publickey, post-ROK-1338
+  // lockdown)` in the causes list so an agent who hits the empty-stderr fall-
+  // through path knows the lockdown is a plausible cause. The wording is
+  // INFORMATIONAL — the classifier's DENIED_RE matches the literal
+  // `Permission denied (publickey)` form (capitalized + uppercase regex),
+  // not this lowercase variant, so the synth string never accidentally
+  // re-enters the classifier as a false positive.
   return (
     `[mcp-rl-fleet: ssh returned exit ${code} with no output — ` +
-    `possible causes: command not found, shell init failure, ` +
-    `git dubious-ownership, stdin pipeline error, ssh connection drop]`
+    `possible causes: permission denied (publickey, post-ROK-1338 lockdown), ` +
+    `command not found, shell init failure, git dubious-ownership, ` +
+    `stdin pipeline error, ssh connection drop]`
   );
+}
+
+/**
+ * Classify an OpenSSH-client-level failure (auth denied, host unreachable)
+ * from the (exitCode, stderr) pair of a failed `execFile('ssh', ...)` call.
+ *
+ * Returns:
+ *   - `{error: 'ssh_denied', hint: <text>}` when sshd rejected the identity.
+ *     Expected post-ROK-1338 lockdown for rl-agent; agents should STOP
+ *     retrying and surface the structured envelope so the operator triages.
+ *   - `{error: 'ssh_unreachable', hint: <text>}` when the SSH client could
+ *     not reach sshd at all (network down, fleet VM off, DNS, fail2ban).
+ *   - `null` when stderr is not recognizably an SSH-client error. The
+ *     caller falls through to its own classifier (postgres syntax, docker
+ *     "no such container", etc).
+ *
+ * Pure: no side effects, no async, no I/O. Trivial to unit test.
+ *
+ * Exit codes: OpenSSH uses 255 as the catch-all "ssh itself failed" code.
+ * We accept any exit code — the stderr regex is the source of truth (many
+ * real failures land on exit 1/2 when wrapped via `timeout` or `Promise.race`).
+ */
+export function classifySshFailure(
+  exitCode: number | undefined,
+  stderr: string,
+):
+  | { error: 'ssh_denied'; hint: string }
+  | { error: 'ssh_unreachable'; hint: string }
+  | null {
+  // exitCode currently unused for classification (the stderr regex is
+  // authoritative); kept in the signature so callers can pass it without
+  // a discard variable, and so future heuristics can add code-aware logic.
+  void exitCode;
+
+  // Empty stderr → caller already substituted synthesized diagnostic.
+  // Don't try to classify from synth text; let the caller's existing
+  // logic handle it (the *_unreachable / exit-code fall-through paths).
+  if (!stderr) return null;
+
+  // Synth diagnostic (C1) is informational only — it lists "permission denied
+  // (publickey, post-ROK-1338 lockdown)" as a *possible cause*, not real
+  // OpenSSH output. Skip classification so the caller's exit-code fall-
+  // through (`*_unreachable` on exit 255 + empty stderr) keeps its
+  // pre-PR-3 semantics. AC-C1 + the db-query "exit-255 with empty stderr
+  // as db_unreachable" regression test pin this contract.
+  if (stderr.startsWith('[mcp-rl-fleet:')) return null;
+
+  // Denied patterns. Host-key verification failure is classified as DENIED
+  // (not unreachable) — it's a sshd-side identity decision; "retry won't
+  // help" matches the ssh_denied UX.
+  const DENIED_RE =
+    /(?:Permission denied(?:,? please try again| \([^)]+\))|Host key verification failed)/i;
+  if (DENIED_RE.test(stderr)) {
+    return {
+      error: 'ssh_denied',
+      hint:
+        'MCP transport failed at sshd: rl-agent SSH is denied. This is the ' +
+        'expected post-ROK-1338 behavior — use the MCP tools (which run ' +
+        "inside the server's already-authenticated transport) rather than " +
+        "retrying. If you're an operator, see the rl-agent break-glass " +
+        'runbook in rl-infra/README.md.',
+    };
+  }
+
+  // Unreachable patterns. `Connection closed by ... port 22` (sshd hung up
+  // before banner) is treated as unreachable — it usually means sshd is up
+  // but refused before authentication started (fail2ban, MaxStartups).
+  const UNREACHABLE_RE =
+    /(?:Connection refused|Connection timed out|Connection closed by [^\n]* port 22|No route to host|ssh: connect to host [^\s]+ port \d+:|ssh: Could not resolve hostname)/i;
+  if (UNREACHABLE_RE.test(stderr)) {
+    return {
+      error: 'ssh_unreachable',
+      hint:
+        'MCP transport failed: the rl-infra VM is not reachable. Check ' +
+        "rl_status first; if that also fails, the fleet is down or you're " +
+        'off the network.',
+    };
+  }
+
+  // Exit 255 with stderr that doesn't match either bucket — usually a local
+  // SSH config issue (`unknown option`, `bad configuration`) or signal-on-
+  // shutdown. Don't claim either bucket; let the caller's existing path
+  // classify so message context is preserved.
+  return null;
 }
 
 /**

--- a/tools/mcp-rl-fleet/src/index.ts
+++ b/tools/mcp-rl-fleet/src/index.ts
@@ -302,7 +302,7 @@ registerTool('rl_task_status', TASK_STATUS_DESC, taskStatusSchema, async (p) =>
 );
 
 const TASK_WAIT_DESC =
-  "Long-poll via SSH inotifywait on the task's JSON file. Blocks until the task transitions to a terminal state OR the timeout expires (default 600s). Returns the same shape as rl_task_status on transition; returns {ok:false, error:'timed_out', task_id, waited_seconds} on timeout (resume polling via rl_task_status or another rl_task_wait). Returns {ok:false, error:'inotifywait_not_installed'} when the VM doesn't have inotify-tools.";
+  "Long-poll via SSH inotifywait on the task's JSON file. Blocks until the task transitions to a terminal state OR the timeout expires (default 600s). Returns the same shape as rl_task_status on transition; returns {ok:false, error:'timed_out', task_id, waited_seconds} on timeout (resume polling via rl_task_status or another rl_task_wait). Returns {ok:false, error:'inotifywait_not_installed', operator_only:true} when the VM is missing inotify-tools (operator-only to install). Returns {ok:false, error:'ssh_denied'|'ssh_unreachable', hint:...} when the SSH transport itself fails (e.g. post-ROK-1338 lockdown).";
 const taskWaitSchema: Shape = {
   task_id: taskIdSchema,
   timeout_seconds: z.number().int().min(5).max(3600).optional(),

--- a/tools/mcp-rl-fleet/src/tools/__tests__/db-query.spec.ts
+++ b/tools/mcp-rl-fleet/src/tools/__tests__/db-query.spec.ts
@@ -505,7 +505,7 @@ describe('rl_db_query — error classification (architect §D layers + spec §6)
     expect(result.error).toBe('statement_timeout');
   });
 
-  it('returns db_unreachable on ssh connection refused', async () => {
+  it('returns ssh_unreachable on ssh connection refused (ROK-1338 PR-3)', async () => {
     execFileFail(
       255,
       'ssh: connect to host rl-infra port 22: Connection refused',
@@ -516,7 +516,25 @@ describe('rl_db_query — error classification (architect §D layers + spec §6)
       read_only: true,
     });
     expect(result.ok).toBe(false);
-    expect(result.error).toBe('db_unreachable');
+    expect(result.error).toBe('ssh_unreachable');
+  });
+
+  // ROK-1338 PR-3: shared classifier — Permission denied (publickey) is the
+  // expected post-lockdown shape. Distinguished from db_unreachable so
+  // agents stop retrying and surface the lockdown context to operators.
+  it('returns ssh_denied on Permission denied (publickey) (ROK-1338 PR-3)', async () => {
+    execFileFail(
+      255,
+      'rl-agent@rl-infra: Permission denied (publickey).',
+    );
+    const result = await execute({
+      slug: 'myslug',
+      sql: 'SELECT 1',
+      read_only: true,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('ssh_denied');
+    expect(result.hint).toMatch(/post-ROK-1338|MCP tools/);
   });
 
   it('returns db_query_failed for unknown errors with stderr verbatim', async () => {

--- a/tools/mcp-rl-fleet/src/tools/__tests__/db-url.spec.ts
+++ b/tools/mcp-rl-fleet/src/tools/__tests__/db-url.spec.ts
@@ -1,0 +1,48 @@
+// ROK-1338 PR-3 (A4) — rl_db_url result-shape regression.
+//
+// Pure metadata tool — no SSH stubbing required. Pins the post-PR-3 shape:
+//   - back-compat `psql_exec_cmd` still emitted (will be removed next cycle).
+//   - new `psql_exec_cmd_operator` mirrors the legacy field exactly.
+//   - new `mcp_query_hint` advertises rl_db_query for agent-side reads.
+//   - third notes[] entry mentions operator-only + rl_db_query.
+
+import { describe, it, expect } from 'vitest';
+import { execute } from '../db-url.js';
+
+describe('rl_db_url — ROK-1338 PR-3 A4 surface', () => {
+  it('returns both psql_exec_cmd (back-compat) and psql_exec_cmd_operator', async () => {
+    const r = await execute({ slug: 'myslug' });
+    expect(r.ok).toBe(true);
+    expect(r.psql_exec_cmd).toBeDefined();
+    expect(r.psql_exec_cmd_operator).toBeDefined();
+    // The two fields are aliases for one cycle — exact-equal value.
+    expect(r.psql_exec_cmd).toBe(r.psql_exec_cmd_operator);
+    // Both still encode the literal SSH command the operator runs from
+    // their shell. Agents do not invoke this string.
+    expect(r.psql_exec_cmd_operator).toContain('ssh rl-infra docker exec');
+    expect(r.psql_exec_cmd_operator).toContain('rl-env-myslug-pg');
+  });
+
+  it('returns mcp_query_hint pointing at rl_db_query', async () => {
+    const r = await execute({ slug: 'myslug' });
+    expect(r.mcp_query_hint).toBeDefined();
+    expect(r.mcp_query_hint).toMatch(/rl_db_query/);
+    expect(r.mcp_query_hint).toMatch(/read-only/i);
+  });
+
+  it('third notes[] entry mentions operator-only AND rl_db_query', async () => {
+    const r = await execute({ slug: 'myslug' });
+    expect(r.notes.length).toBeGreaterThanOrEqual(3);
+    const third = r.notes[2];
+    expect(third).toMatch(/operator-only/);
+    expect(third).toMatch(/rl_db_query/);
+  });
+
+  it('does not still advertise psql_exec_cmd as agent-runnable in notes', async () => {
+    const r = await execute({ slug: 'myslug' });
+    // The legacy "Run it from a terminal" note implied the agent runs it.
+    // Now the third note explicitly says operator-only.
+    const joined = r.notes.join(' | ');
+    expect(joined).not.toMatch(/the psql_exec_cmd opens an interactive prompt on the VM\. Run it from a terminal\./);
+  });
+});

--- a/tools/mcp-rl-fleet/src/tools/__tests__/env-inspect.spec.ts
+++ b/tools/mcp-rl-fleet/src/tools/__tests__/env-inspect.spec.ts
@@ -248,12 +248,20 @@ describe('rl_env_inspect — execute()', () => {
     expect(result.message).toContain('255');
   });
 
-  it('surfaces generic SSH failure stderr verbatim under env_inspect_failed', async () => {
+  it('returns ssh_unreachable on Connection refused (ROK-1338 PR-3)', async () => {
     execFileFail('ssh: connect to host rl-infra port 22: Connection refused', 255);
     const result = await execute({ slug: 'myenv', what: 'supervisor-conf' });
     expect(result.ok).toBe(false);
-    expect(result.error).toBe('env_inspect_failed');
+    expect(result.error).toBe('ssh_unreachable');
     expect(result.message).toContain('Connection refused');
+  });
+
+  it('returns ssh_denied on Permission denied (publickey) (ROK-1338 PR-3)', async () => {
+    execFileFail('rl-agent@rl-infra: Permission denied (publickey).', 255);
+    const result = await execute({ slug: 'myenv', what: 'supervisor-conf' });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('ssh_denied');
+    expect(result.hint).toMatch(/post-ROK-1338|MCP tools/);
   });
 });
 

--- a/tools/mcp-rl-fleet/src/tools/__tests__/infra-logs.spec.ts
+++ b/tools/mcp-rl-fleet/src/tools/__tests__/infra-logs.spec.ts
@@ -203,12 +203,22 @@ describe('rl_infra_logs — execute()', () => {
     expect(result.lines).toEqual(['partial-line1', 'partial-line2']);
   });
 
-  it('surfaces other SSH failure stderr under infra_logs_failed', async () => {
-    execFileFail('ssh: connect to host rl-infra: Connection refused', 255);
+  it('returns ssh_unreachable on Connection refused (ROK-1338 PR-3)', async () => {
+    execFileFail(
+      'ssh: connect to host rl-infra port 22: Connection refused',
+      255,
+    );
     const result = await execute({ service: 'registry', tail: 50 });
     expect(result.ok).toBe(false);
-    expect(result.error).toBe('infra_logs_failed');
+    expect(result.error).toBe('ssh_unreachable');
     expect(result.message).toContain('Connection refused');
+  });
+
+  it('returns ssh_denied on Permission denied (publickey) (ROK-1338 PR-3)', async () => {
+    execFileFail('rl-agent@rl-infra: Permission denied (publickey).', 255);
+    const result = await execute({ service: 'registry', tail: 50 });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('ssh_denied');
   });
 
   it('maps docker-proxy → rl-docker-proxy (the dashed name)', async () => {

--- a/tools/mcp-rl-fleet/src/tools/__tests__/task-inspect.spec.ts
+++ b/tools/mcp-rl-fleet/src/tools/__tests__/task-inspect.spec.ts
@@ -141,11 +141,18 @@ describe('rl_task_inspect — execute()', () => {
     expect(result.message).toContain('not json');
   });
 
-  it('surfaces SSH failure stderr verbatim under task_inspect_failed', async () => {
+  it('returns ssh_unreachable on Connection refused (ROK-1338 PR-3)', async () => {
     execFileFail(255, 'ssh: connect to host rl-infra port 22: Connection refused');
     const result = await execute({ task_id: 'abc123def' });
     expect(result.ok).toBe(false);
-    expect(result.error).toBe('task_inspect_failed');
+    expect(result.error).toBe('ssh_unreachable');
     expect(result.message).toContain('Connection refused');
+  });
+
+  it('returns ssh_denied on Permission denied (publickey) (ROK-1338 PR-3)', async () => {
+    execFileFail(255, 'rl-agent@rl-infra: Permission denied (publickey).');
+    const result = await execute({ task_id: 'abc123def' });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('ssh_denied');
   });
 });

--- a/tools/mcp-rl-fleet/src/tools/__tests__/task-logs.spec.ts
+++ b/tools/mcp-rl-fleet/src/tools/__tests__/task-logs.spec.ts
@@ -224,12 +224,23 @@ describe('rl_task_logs — structural error paths', () => {
     expect(result.error).toBe('task_log_not_found');
   });
 
-  it('surfaces other SSH failure stderr under task_logs_failed', async () => {
-    execFileFail('ssh: connect to host rl-infra: Connection refused', 255);
+  it('returns ssh_unreachable on Connection refused (ROK-1338 PR-3)', async () => {
+    execFileFail(
+      'ssh: connect to host rl-infra port 22: Connection refused',
+      255,
+    );
     const result = await execute({ task_id: 'abc123def', lines: 100 });
     expect(result.ok).toBe(false);
-    expect(result.error).toBe('task_logs_failed');
+    expect(result.error).toBe('ssh_unreachable');
     expect(result.message).toContain('Connection refused');
+  });
+
+  it('returns ssh_denied on Permission denied (publickey) (ROK-1338 PR-3)', async () => {
+    execFileFail('rl-agent@rl-infra: Permission denied (publickey).', 255);
+    const result = await execute({ task_id: 'abc123def', lines: 100 });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('ssh_denied');
+    expect(result.hint).toMatch(/post-ROK-1338|MCP tools/);
   });
 
   it('synthesizes a diagnostic when SSH exits non-zero with empty stderr', async () => {

--- a/tools/mcp-rl-fleet/src/tools/__tests__/task.spec.ts
+++ b/tools/mcp-rl-fleet/src/tools/__tests__/task.spec.ts
@@ -260,6 +260,20 @@ describe('rl_task_cancel — executeCancel()', () => {
     const result = await executeCancel({ task_id: 'abc123def', reason: 'cleanup' });
     expect(result.ok).toBe(true);
   });
+
+  // Regression: ROK-1338 PR-3 dogfood caught this shim passing `--reason <r>`
+  // which task-cancel (positional <task_id> <reason>) recorded as the literal
+  // string "--reason" in cancel_reason. Lock the positional contract.
+  it('passes task_id + reason as positional argv to the orchestrator binary (no --reason flag)', async () => {
+    execFileOk({ ok: true, task_id: 'abc123def', mcp_runtime_status: 'cancelled' });
+    await executeCancel({ task_id: 'abc123def', reason: 'dogfood done' });
+    const firstCall = mockExecFile.mock.calls[0];
+    const argv = JSON.stringify(firstCall.slice(0, 2));
+    expect(argv).toContain('/srv/rl-infra/orchestrator/bin/task-cancel');
+    expect(argv).toContain('abc123def');
+    expect(argv).toContain('dogfood done');
+    expect(argv).not.toContain('--reason');
+  });
 });
 
 describe('rl_task_list — executeList()', () => {

--- a/tools/mcp-rl-fleet/src/tools/__tests__/task.spec.ts
+++ b/tools/mcp-rl-fleet/src/tools/__tests__/task.spec.ts
@@ -276,6 +276,132 @@ describe('rl_task_cancel — executeCancel()', () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// ROK-1338 PR-3 — shared SSH classifier wiring for the four task tools.
+// ---------------------------------------------------------------------------
+//
+// Each catch-block in task.ts now routes through classifySshFailure BEFORE
+// falling back to its generic *_failed envelope. Tests pin both buckets
+// (denied + unreachable) for status / cancel / list, plus the executeWait
+// inotifywait-probe guard that stops a tight retry loop on ssh_denied.
+
+describe('rl_task_status — ROK-1338 PR-3 SSH classifier', () => {
+  it('returns ssh_denied on Permission denied (publickey)', async () => {
+    execFileFail(255, 'rl-agent@rl-infra: Permission denied (publickey).');
+    const result = await executeStatus({ task_id: 'abc123def' });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('ssh_denied');
+    expect((result as { hint?: string }).hint).toMatch(/post-ROK-1338|MCP tools/);
+  });
+
+  it('returns ssh_unreachable on Connection refused', async () => {
+    execFileFail(
+      255,
+      'ssh: connect to host rl-infra port 22: Connection refused',
+    );
+    const result = await executeStatus({ task_id: 'abc123def' });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('ssh_unreachable');
+  });
+});
+
+describe('rl_task_cancel — ROK-1338 PR-3 SSH classifier', () => {
+  it('returns ssh_denied on Permission denied (publickey)', async () => {
+    execFileFail(255, 'rl-agent@rl-infra: Permission denied (publickey).');
+    const result = await executeCancel({
+      task_id: 'abc123def',
+      reason: 'test',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('ssh_denied');
+  });
+
+  it('returns ssh_unreachable on Connection refused', async () => {
+    execFileFail(
+      255,
+      'ssh: connect to host rl-infra port 22: Connection refused',
+    );
+    const result = await executeCancel({
+      task_id: 'abc123def',
+      reason: 'test',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('ssh_unreachable');
+  });
+});
+
+describe('rl_task_wait — ROK-1338 PR-3 SSH classifier', () => {
+  // Without the probe-side classifier, a Permission denied (publickey) at the
+  // inotifywait `command -v` probe would mis-classify as inotifywait_not_installed.
+  it('returns ssh_denied immediately when inotifywait probe gets Permission denied', async () => {
+    // Probe call returns Permission denied — must short-circuit BEFORE
+    // status pre-check, BEFORE attaching inotifywait. ssh_denied
+    // envelope returned to caller; the otherwise-misleading
+    // inotifywait_not_installed envelope is NOT returned.
+    execFileFail(255, 'rl-agent@rl-infra: Permission denied (publickey).');
+    const result = await executeWait({
+      task_id: 'abc123def',
+      timeout_seconds: 5,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('ssh_denied');
+    // No follow-on status/inotify calls — single probe + immediate return.
+    expect(mockExecFile.mock.calls.length).toBe(1);
+  });
+
+  it('returns ssh_unreachable when inotifywait probe gets Connection refused', async () => {
+    execFileFail(
+      255,
+      'ssh: connect to host rl-infra port 22: Connection refused',
+    );
+    const result = await executeWait({
+      task_id: 'abc123def',
+      timeout_seconds: 5,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('ssh_unreachable');
+    expect(mockExecFile.mock.calls.length).toBe(1);
+  });
+});
+
+describe('rl_task_wait — ROK-1338 PR-3 A3 hint rewrite', () => {
+  it('returns operator_only:true with operator-only hint on inotifywait_not_installed', async () => {
+    // Probe fails with a non-SSH reason (e.g. command not found inside the
+    // shell session). The classifier returns null → fall through to the
+    // inotifywait_not_installed envelope, now decorated with operator_only.
+    execFileFail(127, 'bash: inotifywait: command not found');
+    const result = await executeWait({
+      task_id: 'abc123def',
+      timeout_seconds: 5,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('inotifywait_not_installed');
+    expect((result as { operator_only?: boolean }).operator_only).toBe(true);
+    expect(result.hint).toMatch(/operator-only/);
+    // The pre-PR-3 `apt-get install inotify-tools on the VM` literal is gone.
+    expect(result.hint).not.toContain('apt-get install inotify-tools on the VM');
+  });
+});
+
+describe('rl_task_list — ROK-1338 PR-3 SSH classifier', () => {
+  it('returns ssh_denied on Permission denied (publickey)', async () => {
+    execFileFail(255, 'rl-agent@rl-infra: Permission denied (publickey).');
+    const result = await executeList({});
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('ssh_denied');
+  });
+
+  it('returns ssh_unreachable on Connection refused', async () => {
+    execFileFail(
+      255,
+      'ssh: connect to host rl-infra port 22: Connection refused',
+    );
+    const result = await executeList({});
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('ssh_unreachable');
+  });
+});
+
 describe('rl_task_list — executeList()', () => {
   it('filters by slot/status/limit and returns the array', async () => {
     execFileOk({

--- a/tools/mcp-rl-fleet/src/tools/db-query.ts
+++ b/tools/mcp-rl-fleet/src/tools/db-query.ts
@@ -61,6 +61,7 @@ import JSONbigFactory from 'json-bigint';
 const JSONbig = JSONbigFactory({ storeAsString: true });
 import {
   buildSshArgs,
+  classifySshFailure,
   execFileP,
   shellQuote,
   synthesizeEmptyStderrDiagnostic,
@@ -113,6 +114,13 @@ export interface DbQueryResult {
   row_count?: number;
   truncated?: boolean;
   elapsed_ms?: number;
+  /**
+   * Tool-specific codes: env_not_found | read_only_violation |
+   * statement_timeout | syntax_error | db_unreachable | db_query_failed |
+   * response_too_large | blocked_keyword | unknown_param | invalid_params.
+   * SSH-transport codes (shared classifier, ROK-1338 PR-3):
+   *   ssh_denied | ssh_unreachable.
+   */
   error?: string;
   message?: string;
   hint?: string;
@@ -317,15 +325,24 @@ function classifyError(
         'Multi-statement queries, DDL, and explicit BEGIN/COMMIT/ROLLBACK are rejected.',
     };
   }
-  // SSH-level failures (host unreachable, auth refused, etc.) — exitCode
-  // 255 is ssh's standard "connection failed" code, but also catch the
-  // common "Connection refused" / "connect to host" patterns regardless
-  // of code.
-  if (
-    exitCode === 255 ||
-    /ssh:.*connect/i.test(stderr) ||
-    /Connection refused/i.test(stderr)
-  ) {
+  // ROK-1338 PR-3 (B1): shared SSH classifier — split sshd-side auth refusal
+  // (`ssh_denied`, the expected post-lockdown shape) from network failure
+  // (`ssh_unreachable`, fleet down). Postgres-specific classifiers above
+  // win when stderr contains BOTH an ssh:connect line AND a postgres error
+  // — pinned by the `read_only_violation when stderr contains BOTH …` test.
+  const sshClass = classifySshFailure(
+    typeof exitCode === 'number' ? exitCode : undefined,
+    stderr,
+  );
+  if (sshClass) {
+    return { ok: false, slug, ...sshClass, message: stderr.trim() };
+  }
+  // Exit 255 with stderr the classifier didn't bucket (e.g. empty stderr →
+  // synth diagnostic, which is informational only): preserve the original
+  // db_unreachable behavior so the `classifies exit-255 with empty stderr
+  // as db_unreachable via the exit-code branch` regression test keeps
+  // passing.
+  if (exitCode === 255) {
     return {
       ok: false,
       slug,

--- a/tools/mcp-rl-fleet/src/tools/db-url.ts
+++ b/tools/mcp-rl-fleet/src/tools/db-url.ts
@@ -11,7 +11,12 @@ export interface DbUrlResult {
   ok: boolean;
   slug: string;
   pg_container: string;
+  /** @deprecated alias of psql_exec_cmd_operator; will be removed next cycle (ROK-1338 PR-3 A4). */
   psql_exec_cmd: string;
+  /** Operator-only — rl-agent cannot SSH to the VM post-ROK-1338 lockdown. */
+  psql_exec_cmd_operator: string;
+  /** Agent-facing alternative for read-only inspection via rl_db_query. */
+  mcp_query_hint: string;
   database_url: string;
   pgweb_url: string;
   notes: string[];
@@ -24,17 +29,30 @@ export async function execute(params: DbUrlParams): Promise<DbUrlResult> {
   // The pgweb hostname is launched on demand by `rl db <slug> --web` (we
   // surface the URL here so it's discoverable; if pgweb isn't running yet,
   // the user can start it with that command from the operator shell).
+  //
+  // ROK-1338 PR-3 (A4): post-lockdown, rl-agent cannot run `ssh rl-infra
+  // docker exec -it …` itself. The legacy `psql_exec_cmd` field is kept
+  // as an alias to `psql_exec_cmd_operator` for one cycle (backward-compat
+  // for callers on older MCP versions); new callers should use the
+  // operator/agent pair below. For agent-side read-only inspection, the
+  // canonical path is rl_db_query, advertised via mcp_query_hint.
+  const operatorCmd = `ssh rl-infra docker exec -it rl-env-${params.slug}-pg psql -U user -d raid_ledger`;
   return {
     ok: true,
     slug: params.slug,
     pg_container: `rl-env-${params.slug}-pg`,
-    psql_exec_cmd: `ssh rl-infra docker exec -it rl-env-${params.slug}-pg psql -U user -d raid_ledger`,
+    psql_exec_cmd: operatorCmd,
+    psql_exec_cmd_operator: operatorCmd,
+    mcp_query_hint:
+      'For read-only inspection from an agent context, use rl_db_query ' +
+      '(slug=<this>, sql=<your SELECT>). The interactive psql command ' +
+      'above is operator-only.',
     database_url: `postgresql://user:password@rl-env-${params.slug}-pg:5432/raid_ledger`,
     pgweb_url: `http://db-${params.slug}.rl.lan`,
     notes: [
-      "database_url uses container-network DNS — only valid from inside rl-net (e.g. testcontainers in the runner, the allinone container itself).",
+      'database_url uses container-network DNS — only valid from inside rl-net (e.g. testcontainers in the runner, the allinone container itself).',
       "pgweb_url only resolves if you've started it via `rl db {slug} --web` from the operator shell.",
-      'For direct psql, the psql_exec_cmd opens an interactive prompt on the VM. Run it from a terminal.',
+      'psql_exec_cmd_operator is operator-only: it opens an interactive prompt and requires SSH; rl-agent cannot run it post-ROK-1338 lockdown. For read-only queries from an agent context, use rl_db_query.',
     ],
   };
 }

--- a/tools/mcp-rl-fleet/src/tools/env-inspect.ts
+++ b/tools/mcp-rl-fleet/src/tools/env-inspect.ts
@@ -12,7 +12,12 @@
 // intentional omission.
 
 import { z } from 'zod';
-import { buildSshArgs, execFileP, synthesizeEmptyStderrDiagnostic } from '../exec.js';
+import {
+  buildSshArgs,
+  classifySshFailure,
+  execFileP,
+  synthesizeEmptyStderrDiagnostic,
+} from '../exec.js';
 
 export const TOOL_NAME = 'rl_env_inspect';
 export const TOOL_DESCRIPTION =
@@ -198,6 +203,25 @@ function classifyError(err: unknown, ctx: ErrCtx): EnvInspectResult {
     captured === ''
       ? synthesizeEmptyStderrDiagnostic(typeof e.code === 'number' ? e.code : undefined)
       : captured;
+  // ROK-1338 PR-3 (B2): shared SSH classifier — must precede docker-side
+  // checks. An `ssh_denied` failure produces empty stdout+stderr like
+  // `Permission denied (publickey)` — neither No-such-container nor
+  // No-such-file matchers fire on it, so without this branch the agent
+  // sees env_inspect_failed with a generic synth message.
+  const sshClass = classifySshFailure(
+    typeof e.code === 'number' ? e.code : undefined,
+    stderr,
+  );
+  if (sshClass) {
+    return {
+      ok: false,
+      slug: ctx.slug,
+      what: ctx.what,
+      container: ctx.container,
+      ...sshClass,
+      message: stderr,
+    };
+  }
   if (/No such container/i.test(stderr)) {
     return {
       ok: false,

--- a/tools/mcp-rl-fleet/src/tools/infra-logs.ts
+++ b/tools/mcp-rl-fleet/src/tools/infra-logs.ts
@@ -5,7 +5,12 @@
 // Strict service enum + tail cap. SSH via execFile argv-array.
 
 import { z } from 'zod';
-import { buildSshArgs, execFileP, synthesizeEmptyStderrDiagnostic } from '../exec.js';
+import {
+  buildSshArgs,
+  classifySshFailure,
+  execFileP,
+  synthesizeEmptyStderrDiagnostic,
+} from '../exec.js';
 
 export const TOOL_NAME = 'rl_infra_logs';
 export const TOOL_DESCRIPTION =
@@ -55,6 +60,8 @@ export interface InfraLogsResult {
   truncated?: boolean;
   error?: string;
   message?: string;
+  /** ROK-1338 PR-3: populated when classifySshFailure returns ssh_denied/ssh_unreachable. */
+  hint?: string;
 }
 
 export async function execute(params: InfraLogsParams): Promise<InfraLogsResult> {
@@ -146,6 +153,24 @@ export async function execute(params: InfraLogsParams): Promise<InfraLogsResult>
       captured === ''
         ? synthesizeEmptyStderrDiagnostic(typeof e.code === 'number' ? e.code : undefined)
         : captured;
+    // ROK-1338 PR-3: shared SSH classifier — symmetric with rl_db_query /
+    // rl_env_inspect / rl_task_* per spec §589 (operator-approved symmetry).
+    // Runs BEFORE the No-such-container matcher so a sshd-denied response
+    // (post-lockdown) is surfaced correctly rather than mis-classified as
+    // a missing-container envelope.
+    const sshClass = classifySshFailure(
+      typeof e.code === 'number' ? e.code : undefined,
+      stderr,
+    );
+    if (sshClass) {
+      return {
+        ok: false,
+        service,
+        container,
+        ...sshClass,
+        message: stderr,
+      };
+    }
     // Common case: container missing → "Error: No such container: rl-foo".
     if (/No such container/i.test(stderr)) {
       return {

--- a/tools/mcp-rl-fleet/src/tools/task-inspect.ts
+++ b/tools/mcp-rl-fleet/src/tools/task-inspect.ts
@@ -8,6 +8,7 @@
 
 import {
   buildSshArgs,
+  classifySshFailure,
   execFileP,
   shellQuote,
   synthesizeEmptyStderrDiagnostic,
@@ -28,6 +29,8 @@ export interface ExecuteInspectResult {
   task?: Record<string, unknown>;
   error?: string;
   message?: string;
+  /** ROK-1338 PR-3: populated when classifySshFailure returns ssh_denied/ssh_unreachable. */
+  hint?: string;
 }
 
 export async function execute(params: ExecuteInspectParams): Promise<ExecuteInspectResult> {
@@ -93,6 +96,20 @@ export async function execute(params: ExecuteInspectParams): Promise<ExecuteInsp
       !e.stderr || e.stderr.trim() === ''
         ? synthesizeEmptyStderrDiagnostic(e.code)
         : e.stderr;
+    // ROK-1338 PR-3: shared SSH classifier — symmetric with rl_db_query /
+    // rl_env_inspect / rl_task_logs / rl_task_* per spec §589 (operator-
+    // approved symmetry wiring). Splits sshd-denied (post-lockdown) from
+    // network-unreachable so agents don't mis-treat either as the
+    // not-found path below.
+    const sshClass = classifySshFailure(e.code, stderr);
+    if (sshClass) {
+      return {
+        ok: false,
+        task_id: params.task_id,
+        ...sshClass,
+        message: stderr,
+      };
+    }
     // Common case: file doesn't exist — `cat` exits 1 with "No such file…".
     // Surface as a structured not-found.
     if (/No such file or directory/i.test(stderr)) {

--- a/tools/mcp-rl-fleet/src/tools/task-logs.ts
+++ b/tools/mcp-rl-fleet/src/tools/task-logs.ts
@@ -12,6 +12,7 @@
 import { z } from 'zod';
 import {
   buildSshArgs,
+  classifySshFailure,
   execFileP,
   shellQuote,
   synthesizeEmptyStderrDiagnostic,
@@ -208,6 +209,23 @@ function classifyError(
     captured === ''
       ? synthesizeEmptyStderrDiagnostic(typeof e.code === 'number' ? e.code : undefined)
       : captured;
+  // ROK-1338 PR-3 (B3): shared SSH classifier — runs BEFORE the No-such-
+  // file matcher so a `ssh_denied` failure is reported as the lockdown
+  // shape rather than masquerading as task_logs_failed with the synth
+  // diagnostic.
+  const sshClass = classifySshFailure(
+    typeof e.code === 'number' ? e.code : undefined,
+    message,
+  );
+  if (sshClass) {
+    return {
+      ok: false,
+      task_id: taskId,
+      log_path: logPath,
+      ...sshClass,
+      message,
+    };
+  }
   if (/No such file or directory/i.test(message)) {
     return {
       ok: false,

--- a/tools/mcp-rl-fleet/src/tools/task.ts
+++ b/tools/mcp-rl-fleet/src/tools/task.ts
@@ -343,9 +343,13 @@ export interface ExecuteCancelResult {
 }
 
 export async function executeCancel(params: ExecuteCancelParams): Promise<ExecuteCancelResult> {
+  // task-cancel takes positional args: <task_id> <reason>. Earlier versions of
+  // this shim passed `--reason <reason>` which the binary recorded as
+  // cancel_reason: "--reason" (the flag literal, not the value). Caught by the
+  // ROK-1338 PR-3 zero-SSH dogfood.
   const remote =
     `/srv/rl-infra/orchestrator/bin/task-cancel ` +
-    `${shellQuote(params.task_id)} --reason ${shellQuote(params.reason)}`;
+    `${shellQuote(params.task_id)} ${shellQuote(params.reason)}`;
   const [cmd, args] = sshArgs(remote);
   try {
     const { stdout } = await execFileP(cmd, args, {

--- a/tools/mcp-rl-fleet/src/tools/task.ts
+++ b/tools/mcp-rl-fleet/src/tools/task.ts
@@ -14,7 +14,12 @@
 // `steps[]` comes from M1's PASS/FAIL parser running over the log.
 
 import { z } from 'zod';
-import { execFileP, shellQuote, synthesizeEmptyStderrDiagnostic } from '../exec.js';
+import {
+  classifySshFailure,
+  execFileP,
+  shellQuote,
+  synthesizeEmptyStderrDiagnostic,
+} from '../exec.js';
 
 export const TASK_ID_RE = /^[a-z0-9]{8,32}$/;
 export const taskIdSchema = z.string().regex(TASK_ID_RE);
@@ -79,6 +84,8 @@ export interface ExecuteStatusReturn extends Partial<TaskStatusResult> {
   task_id?: string;
   error?: string;
   message?: string;
+  /** ROK-1338 PR-3: populated when classifySshFailure returns ssh_denied/ssh_unreachable. */
+  hint?: string;
   // executeStatus normalizes `steps` to [] on success-shape responses (and
   // omits it on raw error envelopes). Declared as a non-optional array so
   // callers can write `result.steps.length` without a chain of null checks.
@@ -154,6 +161,20 @@ export async function executeStatus(params: ExecuteStatusParams): Promise<Execut
       !e.stderr || e.stderr.trim() === ''
         ? synthesizeEmptyStderrDiagnostic(e.code)
         : e.stderr;
+    // ROK-1338 PR-3 (B4): shared SSH classifier — surfaces sshd-denied
+    // (post-lockdown) vs network-unreachable as structured errors so the
+    // agent sees what kind of transport failure happened rather than a
+    // generic task_status_failed envelope.
+    const sshClass = classifySshFailure(e.code, stderr);
+    if (sshClass) {
+      return {
+        ok: false,
+        task_id: params.task_id,
+        ...sshClass,
+        message: stderr,
+        steps: [],
+      };
+    }
     return {
       ok: false,
       error: 'task_status_failed',
@@ -183,6 +204,13 @@ export interface ExecuteWaitResult extends Partial<TaskStatusResult> {
   task_id?: string;
   error?: string;
   hint?: string;
+  /**
+   * ROK-1338 PR-3 (A3): true when the hint describes a step only the operator
+   * can take (e.g. `apt-get install inotify-tools` on the VM). rl-agent
+   * cannot act on it; the flag is a machine-readable marker for the
+   * dashboard / MCP layer / agents to route the failure correctly.
+   */
+  operator_only?: boolean;
   waited_seconds?: number;
   message?: string;
   /** Mirrors the executeStatus-side normalization to make property access ergonomic. */
@@ -203,11 +231,37 @@ export async function executeWait(params: ExecuteWaitParams): Promise<ExecuteWai
   const [probeCmd, probeArgs] = sshArgs(probeRemote);
   try {
     await execFileP(probeCmd, probeArgs, { timeout: 10_000 });
-  } catch {
+  } catch (probeErr) {
+    const e = probeErr as Error & { stderr?: string; code?: number };
+    const probeStderr =
+      !e.stderr || e.stderr.trim() === ''
+        ? synthesizeEmptyStderrDiagnostic(e.code)
+        : e.stderr;
+    // ROK-1338 PR-3 (B4): if the probe failed at the SSH transport (denied
+    // or unreachable), surface that — not the misleading "inotify is
+    // missing" envelope. Post-lockdown, the probe SSH call is the FIRST
+    // SSH call this tool makes; a ssh_denied here would otherwise pin the
+    // entire wait loop on a retry that can never succeed.
+    const sshClass = classifySshFailure(e.code, probeStderr);
+    if (sshClass) {
+      return {
+        ok: false,
+        task_id: params.task_id,
+        ...sshClass,
+        message: probeStderr,
+      };
+    }
     return {
       ok: false,
       error: 'inotifywait_not_installed',
-      hint: 'apt-get install inotify-tools on the VM (or whatever the runner image uses)',
+      // ROK-1338 PR-3 (A3): the operator installs inotify-tools; rl-agent
+      // cannot sudo. operator_only flags this as a machine-readable
+      // "escalate" signal so dashboards / agents don't show a self-fix path.
+      operator_only: true,
+      hint:
+        'inotify-tools is missing on the rl-infra VM. This is operator-only ' +
+        'to install (apt-get install -y inotify-tools); agents cannot ' +
+        'self-remediate.',
     };
   }
 
@@ -276,7 +330,11 @@ export async function executeWait(params: ExecuteWaitParams): Promise<ExecuteWai
         ),
       ]);
     } catch (err) {
-      const e = err as Error & { code?: string | number; signal?: string };
+      const e = err as Error & {
+        code?: string | number;
+        signal?: string;
+        stderr?: string;
+      };
       const overallElapsed = Math.round((Date.now() - (overallDeadlineMs - timeoutS * 1000)) / 1000);
       const cycleElapsedMs = Date.now() - cycleStartedMs;
       // Local-timer / SIGTERM / exceeded remaining budget → overall timeout.
@@ -298,6 +356,29 @@ export async function executeWait(params: ExecuteWaitParams): Promise<ExecuteWai
           error: 'timed_out',
           task_id: params.task_id,
           waited_seconds: overallElapsed,
+        };
+      }
+      // ROK-1338 PR-3 (B4): if the inotifywait SSH call hit sshd-denied or
+      // host-unreachable, RETURN IMMEDIATELY rather than re-looping. Without
+      // this, a Permission denied (publickey) at the watch SSH would pin
+      // the entire loop on a retry that can never succeed until the
+      // overall timeout fires.
+      const watchStderr =
+        !e.stderr || e.stderr.trim() === ''
+          ? synthesizeEmptyStderrDiagnostic(
+              typeof e.code === 'number' ? e.code : undefined,
+            )
+          : e.stderr;
+      const sshClass = classifySshFailure(
+        typeof e.code === 'number' ? e.code : undefined,
+        watchStderr,
+      );
+      if (sshClass) {
+        return {
+          ok: false,
+          task_id: params.task_id,
+          ...sshClass,
+          message: watchStderr,
         };
       }
       // Some other failure (SSH drop, grep nomatch, etc.) — surface current state.
@@ -340,6 +421,8 @@ export interface ExecuteCancelResult {
   mcp_runtime_status?: string;
   error?: string;
   message?: string;
+  /** ROK-1338 PR-3: populated when classifySshFailure returns ssh_denied/ssh_unreachable. */
+  hint?: string;
 }
 
 export async function executeCancel(params: ExecuteCancelParams): Promise<ExecuteCancelResult> {
@@ -377,6 +460,17 @@ export async function executeCancel(params: ExecuteCancelParams): Promise<Execut
       !e.stderr || e.stderr.trim() === ''
         ? synthesizeEmptyStderrDiagnostic(e.code)
         : e.stderr;
+    // ROK-1338 PR-3 (B4): shared SSH classifier — surface ssh_denied /
+    // ssh_unreachable before falling back to task_cancel_failed.
+    const sshClass = classifySshFailure(e.code, stderr);
+    if (sshClass) {
+      return {
+        ok: false,
+        task_id: params.task_id,
+        ...sshClass,
+        message: stderr,
+      };
+    }
     return {
       ok: false,
       error: 'task_cancel_failed',
@@ -401,6 +495,8 @@ export interface ExecuteListResult {
   tasks?: Array<Omit<TaskStatusResult, 'log_tail'>>;
   error?: string;
   message?: string;
+  /** ROK-1338 PR-3: populated when classifySshFailure returns ssh_denied/ssh_unreachable. */
+  hint?: string;
 }
 
 export async function executeList(params: ExecuteListParams): Promise<ExecuteListResult> {
@@ -430,6 +526,16 @@ export async function executeList(params: ExecuteListParams): Promise<ExecuteLis
       !e.stderr || e.stderr.trim() === ''
         ? synthesizeEmptyStderrDiagnostic(e.code)
         : e.stderr;
+    // ROK-1338 PR-3 (B4): shared SSH classifier — surface ssh_denied /
+    // ssh_unreachable before falling back to task_list_failed.
+    const sshClass = classifySshFailure(e.code, stderr);
+    if (sshClass) {
+      return {
+        ok: false,
+        ...sshClass,
+        message: stderr,
+      };
+    }
     return {
       ok: false,
       error: 'task_list_failed',


### PR DESCRIPTION
## Summary

Pivots ROK-1338 PR-3 away from "apply the SSH lockdown" toward **error-hint hardening + SSH-failure classifier + a parked runbook**. Codex `/security-review` caught that the MCP server itself authenticates to the rl-infra VM as `rl-agent` — applying the originally-scoped sshd lockdown would brick the MCP transport. The lockdown step is **deferred** until the MCP→VM transport identity is separated; tracked on the ROK-1338 umbrella.

### What ships in this PR

- **A1-A4 — drop / rewrite SSH-instructing hints** in:
  - `rl-infra/orchestrator/bin/env-spin` (EXIT-trap hint no longer says `ssh rl@vm bash -x ...`; agent path leads with `rl_infra_logs`, operator-only paths labelled)
  - `rl-infra/orchestrator/bin/claim-wait` (`inotifywait_not_installed` hint now `operator_only:true` + tells agent to escalate)
  - `tools/mcp-rl-fleet/src/tools/task.ts` (mirror of above for `rl_task_wait`)
  - `tools/mcp-rl-fleet/src/tools/db-url.ts` (new `psql_exec_cmd_operator` + `mcp_query_hint` fields; `psql_exec_cmd` aliased for back-compat one cycle)
- **B0-B4 — new `classifySshFailure` helper** in `tools/mcp-rl-fleet/src/exec.ts` (pure function, 13 unit fixtures). Wired into 7 tools' error paths (`db-query`, `env-inspect`, `task-logs`, `task` 4 catch-blocks + inotifywait probe, `task-inspect`, `infra-logs`). Distinguishes `ssh_denied` (post-lockdown working as designed; stop retrying) from `ssh_unreachable` (fleet down; check `rl_status`) so agents see structured envelopes instead of raw stderr leaks.
- **C1** — `synthesizeEmptyStderrDiagnostic` causes-list now includes `permission denied (publickey, post-ROK-1338 lockdown)`.
- **Runbook in `rl-infra/README.md`** with ⛔ BLOCKED preamble explaining why the apply sequence cannot be run yet, and what redesign work must land first.
- **Step 0 preflight** still in the runbook (mandatory `npm install` + Claude restart so the MCP server picks up PR-2 tools) — surfaced by the pre-merge dogfood.
- **Task-cancel `--reason` argv bug** fixed in `tools/mcp-rl-fleet/src/tools/task.ts` (previous shim passed `--reason <r>` but the orchestrator reads positional `<task_id> <reason>`, so cancel_reason got the literal string `--reason`).

### Why the lockdown is deferred

Codex's exact finding: *"Applying this Match User rl-agent gate will brick the fleet for agents, because the MCP implementation still reaches the VM as rl-agent everywhere (runRl() forces RL_PROXMOX_USER=rl-agent and buildSshArgs() hard-codes rl-agent@... in tools/mcp-rl-fleet/src/exec.ts). Once the operator follows this runbook, calls like rl_claim, rl_status, rl_env_spin, rl_db_query, etc. all degrade to ssh_denied."*

Resolution path (one of) must land first:
- **(a) Separate MCP transport identity** — dedicated `rl-mcp` user with its own authorized_keys + sudoers/docker-group memberships; rewire `buildSshArgs`. Lockdown then only denies `rl-agent` interactive SSH.
- **(b) Non-SSH transport** — HTTPS service on the VM (mTLS or HMAC); MCP server calls the service; orchestrator binaries become handlers.

Tracked as a new prerequisite on the [ROK-1338 umbrella](https://linear.app/roknua-projects/issue/ROK-1338/featrl-infra-sec-disable-ssh-access-for-agents-close-direct-vm).

## Diff scope

- 23 files / +1003 / -61
- Only `tools/mcp-rl-fleet/`, `rl-infra/orchestrator/bin/`, `rl-infra/README.md`, `CLAUDE.md`, `.claude/skills/_shared/rl-infra-fleet.md`, `TECH-DEBT-BACKLOG.md`. No api/, web/, or `packages/contract/` changes.

## Linear

[ROK-1338](https://linear.app/roknua-projects/issue/ROK-1338/featrl-infra-sec-disable-ssh-access-for-agents-close-direct-vm) — umbrella stays **In Review**. The MCP transport identity work is a new prerequisite on the checklist; PR-3 doesn't close the umbrella.

Comment threads on the issue:
- Pre-merge dogfood findings (F1a/b, F3, F4)
- Codex /security-review verdict + new prerequisite

## Test plan

- [x] `npx vitest run` from `tools/mcp-rl-fleet/`: **237 passed**, 1 pre-existing failure (`test-plan.spec.ts > AC6 — NUL byte`) documented in `TECH-DEBT-BACKLOG.md` under the 2026-05-21 PR-2 entry.
- [x] `npx tsc --noEmit` from `tools/mcp-rl-fleet/`: clean. New `operator_only?: boolean`, `hint?: string`, `psql_exec_cmd_operator`, `mcp_query_hint` fields type-check end-to-end.
- [x] `/devedup-rl:review` (devedup-rl reviewer): 0 crit / 0 high / 0 med / 4 low / 2 nit. Two nits folded in-flight (env-spin hint operator-only labelling, TASK_WAIT_DESC documents new envelope fields). Remaining 4 low findings appended to `TECH-DEBT-BACKLOG.md` under the 2026-05-22 PR-3 entry.
- [x] `/security-review` (Codex): 1 P1 finding (lockdown design gap), resolved by deferring the lockdown step + adding BLOCKED preamble + new umbrella prereq. 0 outstanding crit/high.
- [x] Live MCP dogfood: 8 tools verified end-to-end against the new classifier against a bogus SSH host (`198.51.100.42` test-net) — every tool returns the structured `ssh_unreachable` envelope with the spec-mandated hint. `ssh_denied` envelope covered by 13 unit fixtures (real-wire denied state requires the actual lockdown to be applied; that's a post-fix verification cycle).

## NOT auto-merge

Operator review required given the scope pivot from "apply the lockdown" to "harden + defer". The original PR #838 was closed for this exact reason; the new title + summary make the change of intent explicit so the operator can verify before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)