### PR TITLE
ROK-1332: fix Discord 100-scheduled-event cap blocks reconciliation forever

### DIFF
--- a/api/src/discord-bot/services/scheduled-event.capacity-recovery.integration.spec.ts
+++ b/api/src/discord-bot/services/scheduled-event.capacity-recovery.integration.spec.ts
@@ -1,0 +1,380 @@
+/**
+ * Capacity-recovery integration tests (ROK-1332).
+ *
+ * Covers AC6 (real DB + mocked guild.scheduledEvents): 5 stale RL-tracked
+ * scheduled events get GC'd when the reconciliation cron hits a 30038
+ * (MAX_SCHEDULED_EVENTS_REACHED) error; the candidate retry succeeds after
+ * GC frees capacity. Also extends to AC3 (single WARN per tick) and AC4
+ * (scheduled_event_reconcile_backoff_until gates the next tick).
+ *
+ * These tests MUST FAIL before dev implementation lands because:
+ *   1. `./scheduled-event.gc` module does not yet exist.
+ *   2. `scheduled_event_reconcile_backoff_until` column does not yet exist
+ *      in `events` — seeding step throws "column does not exist".
+ *   3. `withCapacityRecovery` is not wired into `doCreate`, so a 30038
+ *      bubbles up unhandled and the retry call never fires.
+ */
+import { DiscordAPIError } from 'discord.js';
+import { eq, inArray } from 'drizzle-orm';
+import { getTestApp, type TestApp } from '../../common/testing/test-app';
+import {
+  truncateAllTables,
+  loginAsAdmin,
+} from '../../common/testing/integration-helpers';
+import * as schema from '../../drizzle/schema';
+import { DiscordBotClientService } from '../discord-bot-client.service';
+import { ChannelResolverService } from './channel-resolver.service';
+import { ScheduledEventReconciliationService } from './scheduled-event.reconciliation';
+import { makeDiscordApiError } from './scheduled-event.service.spec-helpers';
+// AC6: the GC helper file does not exist yet — importing it here is what
+// makes the spec compile-fail until dev step c lands. The import itself is
+// the assertion that `scheduled-event.gc.ts` will exist.
+import { gcStaleRLScheduledEvents } from './scheduled-event.gc';
+
+const MAX_SCHEDULED_EVENTS_REACHED = 30038;
+const FUTURE_MS = 7 * 24 * 60 * 60 * 1000;
+
+let testApp: TestApp;
+let reconciliationService: ScheduledEventReconciliationService;
+let clientService: DiscordBotClientService;
+let channelResolver: ChannelResolverService;
+
+interface MockGuildSEMap extends Map<string, { id: string }> {}
+
+interface MockGuildShape {
+  id: string;
+  scheduledEvents: {
+    fetch: jest.Mock<Promise<MockGuildSEMap>, []>;
+    create: jest.Mock<Promise<{ id: string }>, [Record<string, unknown>]>;
+    delete: jest.Mock<Promise<void>, [string]>;
+    edit: jest.Mock<Promise<{ id: string }>, [string, Record<string, unknown>]>;
+  };
+  channels: { cache: { get: (_id: string) => undefined } };
+}
+
+let mockGuild: MockGuildShape;
+let isConnectedSpy: jest.SpyInstance;
+let getGuildSpy: jest.SpyInstance;
+let resolveVoiceSpy: jest.SpyInstance;
+
+function buildMockGuild(): MockGuildShape {
+  return {
+    id: 'guild-1332',
+    scheduledEvents: {
+      fetch: jest.fn().mockResolvedValue(new Map() as MockGuildSEMap),
+      create: jest.fn().mockResolvedValue({ id: 'new-se-default' }),
+      delete: jest.fn().mockResolvedValue(undefined),
+      edit: jest.fn().mockResolvedValue({ id: 'edited-default' }),
+    },
+    channels: { cache: { get: () => undefined } },
+  };
+}
+
+beforeAll(async () => {
+  testApp = await getTestApp();
+  await loginAsAdmin(testApp.request, testApp.seed);
+  reconciliationService = testApp.app.get(ScheduledEventReconciliationService);
+  clientService = testApp.app.get(DiscordBotClientService);
+  channelResolver = testApp.app.get(ChannelResolverService);
+
+  // R7 (plan §7): spy in beforeAll, restore in afterAll. NEVER beforeEach/afterEach
+  // — DiscordBotClientService is a singleton and per-test restore leaks across
+  // sibling integration suites because the testApp persists.
+  mockGuild = buildMockGuild();
+  isConnectedSpy = jest
+    .spyOn(clientService, 'isConnected')
+    .mockReturnValue(true);
+  getGuildSpy = jest
+    .spyOn(clientService, 'getGuild')
+    .mockReturnValue(mockGuild as unknown as ReturnType<
+      DiscordBotClientService['getGuild']
+    >);
+  resolveVoiceSpy = jest
+    .spyOn(channelResolver, 'resolveVoiceChannelForScheduledEvent')
+    .mockResolvedValue('voice-channel-1332');
+});
+
+afterEach(async () => {
+  testApp.seed = await truncateAllTables(testApp.db);
+  // Reset spy call counts WITHOUT restoring (per R7) — and rebuild the mock
+  // guild's scheduledEvents methods so per-test mockResolvedValueOnce setups
+  // don't bleed into the next test.
+  mockGuild = buildMockGuild();
+  getGuildSpy.mockReturnValue(
+    mockGuild as unknown as ReturnType<DiscordBotClientService['getGuild']>,
+  );
+  isConnectedSpy.mockReturnValue(true);
+  resolveVoiceSpy.mockResolvedValue('voice-channel-1332');
+});
+
+afterAll(() => {
+  isConnectedSpy?.mockRestore();
+  getGuildSpy?.mockRestore();
+  resolveVoiceSpy?.mockRestore();
+});
+
+interface SeededEvent {
+  id: number;
+  discordScheduledEventId: string | null;
+}
+
+/** Seed 5 stale RL-tracked events (cancelled_at SET, discord_scheduled_event_id SET). */
+async function seedStaleRLEvents(count = 5): Promise<SeededEvent[]> {
+  const now = new Date();
+  const start = new Date(now.getTime() - 3 * 60 * 60 * 1000); // 3h ago
+  const end = new Date(now.getTime() - 2 * 60 * 60 * 1000); // 2h ago
+  const rows = await testApp.db
+    .insert(schema.events)
+    .values(
+      Array.from({ length: count }, (_, i) => ({
+        title: `Stale Event ${i + 1}`,
+        creatorId: testApp.seed.adminUser.id,
+        gameId: testApp.seed.game.id,
+        duration: [start, end] as [Date, Date],
+        discordScheduledEventId: `stale-se-${i + 1}`,
+        cancelledAt: new Date(now.getTime() - 60 * 60 * 1000),
+      })),
+    )
+    .returning({
+      id: schema.events.id,
+      discordScheduledEventId: schema.events.discordScheduledEventId,
+    });
+  return rows;
+}
+
+/** Seed a single fresh reconciliation candidate (no SE id, future, not ad-hoc, not cancelled). */
+async function seedCandidate(): Promise<number> {
+  const futureStart = new Date(Date.now() + FUTURE_MS);
+  const futureEnd = new Date(futureStart.getTime() + 3 * 60 * 60 * 1000);
+  const [row] = await testApp.db
+    .insert(schema.events)
+    .values({
+      title: 'New Raid Night',
+      creatorId: testApp.seed.adminUser.id,
+      gameId: testApp.seed.game.id,
+      duration: [futureStart, futureEnd] as [Date, Date],
+      isAdHoc: false,
+    })
+    .returning({ id: schema.events.id });
+  return row.id;
+}
+
+describe('ROK-1332 — capacity-recovery integration', () => {
+  it('AC6 — reconciliation hits 30038, GC frees 5 stale RL SEs, retry succeeds', async () => {
+    const stale = await seedStaleRLEvents(5);
+    const candidateId = await seedCandidate();
+
+    // Mock guild.scheduledEvents.fetch() → returns a Map of all SEs visible
+    // to the bot (the 5 stale RL ones). discord.js Collection is Map-shaped,
+    // so a plain Map is sufficient for `[...all.keys()]` iteration in GC.
+    const seIdsOnDiscord = stale.map((s) => s.discordScheduledEventId!);
+    mockGuild.scheduledEvents.fetch.mockResolvedValue(
+      new Map(seIdsOnDiscord.map((id) => [id, { id }])) as MockGuildSEMap,
+    );
+
+    // First create() fails with 30038 (capacity full); after GC, second
+    // create() resolves with a new SE id (retry succeeded).
+    mockGuild.scheduledEvents.create
+      .mockRejectedValueOnce(
+        makeDiscordApiError(
+          MAX_SCHEDULED_EVENTS_REACHED,
+          'Maximum number of guild scheduled events reached (100)',
+        ),
+      )
+      .mockResolvedValueOnce({ id: 'new-se-after-gc' });
+
+    await reconciliationService.reconcileMissingScheduledEvents();
+
+    // GC deleted all 5 stale SEs via tryDeleteEvent → guild.scheduledEvents.delete
+    expect(mockGuild.scheduledEvents.delete).toHaveBeenCalledTimes(5);
+    for (const seId of seIdsOnDiscord) {
+      expect(mockGuild.scheduledEvents.delete).toHaveBeenCalledWith(seId);
+    }
+
+    // 5 stale rows had their discord_scheduled_event_id cleared by GC.
+    const staleIds = stale.map((s) => s.id);
+    const reloadedStale = await testApp.db
+      .select({
+        id: schema.events.id,
+        discordScheduledEventId: schema.events.discordScheduledEventId,
+      })
+      .from(schema.events)
+      .where(inArray(schema.events.id, staleIds));
+    for (const row of reloadedStale) {
+      expect(row.discordScheduledEventId).toBeNull();
+    }
+
+    // The candidate retry attempt produced a new SE id and persisted it.
+    expect(mockGuild.scheduledEvents.create).toHaveBeenCalledTimes(2);
+    const [candidateRow] = await testApp.db
+      .select({
+        discordScheduledEventId: schema.events.discordScheduledEventId,
+      })
+      .from(schema.events)
+      .where(eq(schema.events.id, candidateId))
+      .limit(1);
+    expect(candidateRow.discordScheduledEventId).toBe('new-se-after-gc');
+  });
+
+  it('AC3 + AC5 — when GC frees 0, single WARN logs and remaining candidates get 1h backoff', async () => {
+    // No RL-tracked stale SEs — only operator-owned orphans (5 SEs visible to bot,
+    // none of which are in events.discord_scheduled_event_id).
+    mockGuild.scheduledEvents.fetch.mockResolvedValue(
+      new Map(
+        Array.from({ length: 5 }, (_, i) => [
+          `operator-orphan-${i}`,
+          { id: `operator-orphan-${i}` },
+        ]),
+      ) as MockGuildSEMap,
+    );
+
+    // Seed two candidates — the cron picks them both up. First create() throws
+    // 30038; GC sweeps but finds 0 RL-tracked stale; second candidate must
+    // NOT receive a create attempt because the cron stops iterating.
+    const c1 = await seedCandidate();
+    const c2 = await seedCandidate();
+
+    mockGuild.scheduledEvents.create.mockRejectedValue(
+      makeDiscordApiError(
+        MAX_SCHEDULED_EVENTS_REACHED,
+        'Maximum number of guild scheduled events reached (100)',
+      ),
+    );
+
+    // Spy on the reconciliation service logger to count WARNs.
+    const logger = (
+      reconciliationService as unknown as {
+        logger: { warn: jest.Mock; log: jest.Mock; error: jest.Mock };
+      }
+    ).logger;
+    const warnSpy = jest.spyOn(logger, 'warn');
+
+    try {
+      await reconciliationService.reconcileMissingScheduledEvents();
+
+      // Single WARN per cron tick (AC5).
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+
+      // Only ONE create attempt happened — the cron stopped after the first
+      // CapacityStillSaturatedError instead of iterating to c2 (AC3 "exactly
+      // ONE WARN per tick" requires NOT looping into per-candidate errors).
+      expect(mockGuild.scheduledEvents.create).toHaveBeenCalledTimes(1);
+
+      // Both candidates now have backoff_until set ≈1h in the future (AC4).
+      const rows = await testApp.db
+        .select({
+          id: schema.events.id,
+          backoffUntil: schema.events.scheduledEventReconcileBackoffUntil,
+        })
+        .from(schema.events)
+        .where(inArray(schema.events.id, [c1, c2]));
+
+      expect(rows).toHaveLength(2);
+      const oneHourMs = 60 * 60 * 1000;
+      const now = Date.now();
+      for (const row of rows) {
+        expect(row.backoffUntil).not.toBeNull();
+        const diff = row.backoffUntil!.getTime() - now;
+        // ±5min tolerance for clock skew + cron wall-time vs assertion wall-time.
+        expect(diff).toBeGreaterThan(oneHourMs - 5 * 60 * 1000);
+        expect(diff).toBeLessThan(oneHourMs + 5 * 60 * 1000);
+      }
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('AC4 — candidate with future backoff_until is excluded from reconciliation', async () => {
+    // Seed a candidate with backoff_until 30min in the future.
+    const futureStart = new Date(Date.now() + FUTURE_MS);
+    const futureEnd = new Date(futureStart.getTime() + 3 * 60 * 60 * 1000);
+    await testApp.db.insert(schema.events).values({
+      title: 'Backed-off Candidate',
+      creatorId: testApp.seed.adminUser.id,
+      gameId: testApp.seed.game.id,
+      duration: [futureStart, futureEnd] as [Date, Date],
+      isAdHoc: false,
+      scheduledEventReconcileBackoffUntil: new Date(
+        Date.now() + 30 * 60 * 1000,
+      ),
+    });
+
+    await reconciliationService.reconcileMissingScheduledEvents();
+
+    // findReconciliationCandidates must have excluded the backed-off row,
+    // so no create() attempt was made.
+    expect(mockGuild.scheduledEvents.create).not.toHaveBeenCalled();
+  });
+
+  it('AC2 — gcStaleRLScheduledEvents helper directly: cancelled→delete, orphan→count, active+future→skip', async () => {
+    // Seed: 2 stale RL (cancelled), 1 active+future RL (NOT stale), 0 operator orphans.
+    const now = new Date();
+    const staleStart = new Date(now.getTime() - 4 * 60 * 60 * 1000);
+    const staleEnd = new Date(now.getTime() - 3 * 60 * 60 * 1000);
+    const futureStart = new Date(now.getTime() + FUTURE_MS);
+    const futureEnd = new Date(futureStart.getTime() + 3 * 60 * 60 * 1000);
+
+    await testApp.db.insert(schema.events).values([
+      {
+        title: 'Cancelled-1',
+        creatorId: testApp.seed.adminUser.id,
+        duration: [staleStart, staleEnd] as [Date, Date],
+        discordScheduledEventId: 'stale-cx-1',
+        cancelledAt: new Date(now.getTime() - 60 * 60 * 1000),
+      },
+      {
+        title: 'Cancelled-2',
+        creatorId: testApp.seed.adminUser.id,
+        duration: [staleStart, staleEnd] as [Date, Date],
+        discordScheduledEventId: 'stale-cx-2',
+        cancelledAt: new Date(now.getTime() - 60 * 60 * 1000),
+      },
+      {
+        title: 'Active-Future',
+        creatorId: testApp.seed.adminUser.id,
+        duration: [futureStart, futureEnd] as [Date, Date],
+        discordScheduledEventId: 'active-keep-1',
+      },
+    ]);
+
+    // The guild sees 4 SEs: 2 stale RL, 1 active RL, 1 operator-owned orphan.
+    mockGuild.scheduledEvents.fetch.mockResolvedValue(
+      new Map([
+        ['stale-cx-1', { id: 'stale-cx-1' }],
+        ['stale-cx-2', { id: 'stale-cx-2' }],
+        ['active-keep-1', { id: 'active-keep-1' }],
+        ['operator-orphan-1', { id: 'operator-orphan-1' }],
+      ]) as MockGuildSEMap,
+    );
+
+    const { freed, orphanCount } = await gcStaleRLScheduledEvents(
+      mockGuild as unknown as Parameters<typeof gcStaleRLScheduledEvents>[0],
+      testApp.db,
+    );
+
+    expect(freed).toBe(2);
+    expect(orphanCount).toBe(1);
+    // Only the 2 stale SEs got deleted from Discord.
+    expect(mockGuild.scheduledEvents.delete).toHaveBeenCalledTimes(2);
+    expect(mockGuild.scheduledEvents.delete).toHaveBeenCalledWith('stale-cx-1');
+    expect(mockGuild.scheduledEvents.delete).toHaveBeenCalledWith('stale-cx-2');
+    expect(mockGuild.scheduledEvents.delete).not.toHaveBeenCalledWith(
+      'active-keep-1',
+    );
+    expect(mockGuild.scheduledEvents.delete).not.toHaveBeenCalledWith(
+      'operator-orphan-1',
+    );
+  });
+
+  it('helper integration — uses DiscordAPIError instanceof for 30038 classification', () => {
+    // Sanity: makeDiscordApiError must produce a true DiscordAPIError so the
+    // dev's `isAtScheduledEventCapacityError` (instanceof DiscordAPIError &&
+    // code === 30038) matches. This guards R2 (mock leak / wrong class).
+    const err = makeDiscordApiError(
+      MAX_SCHEDULED_EVENTS_REACHED,
+      'capacity full',
+    );
+    expect(err).toBeInstanceOf(DiscordAPIError);
+    expect(err.code).toBe(MAX_SCHEDULED_EVENTS_REACHED);
+  });
+});

--- a/api/src/discord-bot/services/scheduled-event.capacity-recovery.integration.spec.ts
+++ b/api/src/discord-bot/services/scheduled-event.capacity-recovery.integration.spec.ts
@@ -39,12 +39,10 @@ let reconciliationService: ScheduledEventReconciliationService;
 let clientService: DiscordBotClientService;
 let channelResolver: ChannelResolverService;
 
-interface MockGuildSEMap extends Map<string, { id: string }> {}
-
 interface MockGuildShape {
   id: string;
   scheduledEvents: {
-    fetch: jest.Mock<Promise<MockGuildSEMap>, []>;
+    fetch: jest.Mock<Promise<Map<string, { id: string }>>, []>;
     create: jest.Mock<Promise<{ id: string }>, [Record<string, unknown>]>;
     delete: jest.Mock<Promise<void>, [string]>;
     edit: jest.Mock<Promise<{ id: string }>, [string, Record<string, unknown>]>;
@@ -61,7 +59,7 @@ function buildMockGuild(): MockGuildShape {
   return {
     id: 'guild-1332',
     scheduledEvents: {
-      fetch: jest.fn().mockResolvedValue(new Map() as MockGuildSEMap),
+      fetch: jest.fn().mockResolvedValue(new Map<string, { id: string }>()),
       create: jest.fn().mockResolvedValue({ id: 'new-se-default' }),
       delete: jest.fn().mockResolvedValue(undefined),
       edit: jest.fn().mockResolvedValue({ id: 'edited-default' }),
@@ -86,9 +84,9 @@ beforeAll(async () => {
     .mockReturnValue(true);
   getGuildSpy = jest
     .spyOn(clientService, 'getGuild')
-    .mockReturnValue(mockGuild as unknown as ReturnType<
-      DiscordBotClientService['getGuild']
-    >);
+    .mockReturnValue(
+      mockGuild as unknown as ReturnType<DiscordBotClientService['getGuild']>,
+    );
   resolveVoiceSpy = jest
     .spyOn(channelResolver, 'resolveVoiceChannelForScheduledEvent')
     .mockResolvedValue('voice-channel-1332');
@@ -100,9 +98,7 @@ afterEach(async () => {
   // guild's scheduledEvents methods so per-test mockResolvedValueOnce setups
   // don't bleed into the next test.
   mockGuild = buildMockGuild();
-  getGuildSpy.mockReturnValue(
-    mockGuild as unknown as ReturnType<DiscordBotClientService['getGuild']>,
-  );
+  getGuildSpy.mockReturnValue(mockGuild);
   isConnectedSpy.mockReturnValue(true);
   resolveVoiceSpy.mockResolvedValue('voice-channel-1332');
 });
@@ -169,7 +165,7 @@ describe('ROK-1332 — capacity-recovery integration', () => {
     // so a plain Map is sufficient for `[...all.keys()]` iteration in GC.
     const seIdsOnDiscord = stale.map((s) => s.discordScheduledEventId!);
     mockGuild.scheduledEvents.fetch.mockResolvedValue(
-      new Map(seIdsOnDiscord.map((id) => [id, { id }])) as MockGuildSEMap,
+      new Map<string, { id: string }>(seIdsOnDiscord.map((id) => [id, { id }])),
     );
 
     // First create() fails with 30038 (capacity full); after GC, second
@@ -220,12 +216,12 @@ describe('ROK-1332 — capacity-recovery integration', () => {
     // No RL-tracked stale SEs — only operator-owned orphans (5 SEs visible to bot,
     // none of which are in events.discord_scheduled_event_id).
     mockGuild.scheduledEvents.fetch.mockResolvedValue(
-      new Map(
+      new Map<string, { id: string }>(
         Array.from({ length: 5 }, (_, i) => [
           `operator-orphan-${i}`,
           { id: `operator-orphan-${i}` },
         ]),
-      ) as MockGuildSEMap,
+      ),
     );
 
     // Seed two candidates — the cron picks them both up. First create() throws
@@ -339,12 +335,12 @@ describe('ROK-1332 — capacity-recovery integration', () => {
 
     // The guild sees 4 SEs: 2 stale RL, 1 active RL, 1 operator-owned orphan.
     mockGuild.scheduledEvents.fetch.mockResolvedValue(
-      new Map([
+      new Map<string, { id: string }>([
         ['stale-cx-1', { id: 'stale-cx-1' }],
         ['stale-cx-2', { id: 'stale-cx-2' }],
         ['active-keep-1', { id: 'active-keep-1' }],
         ['operator-orphan-1', { id: 'operator-orphan-1' }],
-      ]) as MockGuildSEMap,
+      ]),
     );
 
     const { freed, orphanCount } = await gcStaleRLScheduledEvents(

--- a/api/src/discord-bot/services/scheduled-event.capacity-recovery.integration.spec.ts
+++ b/api/src/discord-bot/services/scheduled-event.capacity-recovery.integration.spec.ts
@@ -362,6 +362,40 @@ describe('ROK-1332 — capacity-recovery integration', () => {
     );
   });
 
+  it('ROK-1332 review fix — extended-but-live event (past duration, future extendedUntil) is NOT GC-deleted', async () => {
+    // Regression guard: GC staleness uses COALESCE(extended_until, upper(duration)).
+    // An auto-extended event (members still in voice past the original end) has
+    // upper(duration) in the past but extended_until in the future → still live,
+    // so its Discord SE must be preserved.
+    const now = new Date();
+    const pastStart = new Date(now.getTime() - 4 * 60 * 60 * 1000);
+    const pastEnd = new Date(now.getTime() - 3 * 60 * 60 * 1000); // ended 3h ago
+    const futureExtension = new Date(now.getTime() + 2 * 60 * 60 * 1000); // +2h
+
+    await testApp.db.insert(schema.events).values({
+      title: 'Extended-Live',
+      creatorId: testApp.seed.adminUser.id,
+      duration: [pastStart, pastEnd] as [Date, Date],
+      extendedUntil: futureExtension,
+      discordScheduledEventId: 'extended-live-1',
+    });
+
+    mockGuild.scheduledEvents.fetch.mockResolvedValue(
+      new Map<string, { id: string }>([
+        ['extended-live-1', { id: 'extended-live-1' }],
+      ]),
+    );
+
+    const { freed, orphanCount } = await gcStaleRLScheduledEvents(
+      mockGuild as unknown as Parameters<typeof gcStaleRLScheduledEvents>[0],
+      testApp.db,
+    );
+
+    expect(freed).toBe(0);
+    expect(orphanCount).toBe(0);
+    expect(mockGuild.scheduledEvents.delete).not.toHaveBeenCalled();
+  });
+
   it('helper integration — uses DiscordAPIError instanceof for 30038 classification', () => {
     // Sanity: makeDiscordApiError must produce a true DiscordAPIError so the
     // dev's `isAtScheduledEventCapacityError` (instanceof DiscordAPIError &&

--- a/api/src/discord-bot/services/scheduled-event.capacity.ts
+++ b/api/src/discord-bot/services/scheduled-event.capacity.ts
@@ -1,0 +1,38 @@
+import type { Logger } from '@nestjs/common';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from '../../drizzle/schema';
+import type { DiscordBotClientService } from '../discord-bot-client.service';
+import { isAtScheduledEventCapacityError } from './scheduled-event.discord-ops';
+import { gcStaleRLScheduledEvents } from './scheduled-event.gc';
+import { CapacityStillSaturatedError } from './scheduled-event.helpers';
+
+type Guild = NonNullable<ReturnType<DiscordBotClientService['getGuild']>>;
+
+/**
+ * ROK-1332: Catch Discord 30038 ("guild at 100-SE cap"), sweep stale
+ * RL-tracked SEs, retry the call once. If GC freed 0 rows, throw
+ * CapacityStillSaturatedError so the reconciliation cron can apply
+ * per-event backoff and emit a single WARN per tick.
+ *
+ * Lives as a free function (not a method on ScheduledEventService) so the
+ * service file stays under the 300-line cap; the wrapper itself is pure
+ * coordination + has no service-instance dependencies beyond what's passed in.
+ */
+export async function withCapacityRecovery(
+  guild: Guild,
+  db: PostgresJsDatabase<typeof schema>,
+  logger: Logger,
+  fn: () => Promise<void>,
+): Promise<void> {
+  try {
+    await fn();
+  } catch (err) {
+    if (!isAtScheduledEventCapacityError(err)) throw err;
+    const { freed, orphanCount } = await gcStaleRLScheduledEvents(guild, db);
+    logger.log(
+      `Discord SE capacity GC freed=${freed} orphanCount=${orphanCount}`,
+    );
+    if (freed === 0) throw new CapacityStillSaturatedError(orphanCount);
+    await fn();
+  }
+}

--- a/api/src/discord-bot/services/scheduled-event.db-helpers.ts
+++ b/api/src/discord-bot/services/scheduled-event.db-helpers.ts
@@ -229,7 +229,9 @@ export async function findRLTrackedSEs(
     discordScheduledEventId: r.discordScheduledEventId!,
     cancelledAt: r.cancelledAt,
     durationUpper:
-      r.durationUpper instanceof Date ? r.durationUpper : new Date(r.durationUpper as unknown as string),
+      r.durationUpper instanceof Date
+        ? r.durationUpper
+        : new Date(r.durationUpper as unknown as string),
   }));
 }
 

--- a/api/src/discord-bot/services/scheduled-event.db-helpers.ts
+++ b/api/src/discord-bot/services/scheduled-event.db-helpers.ts
@@ -1,4 +1,4 @@
-import { eq, and, isNotNull, isNull, sql } from 'drizzle-orm';
+import { eq, and, inArray, isNotNull, isNull, sql } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import * as schema from '../../drizzle/schema';
 
@@ -176,7 +176,76 @@ export async function findReconciliationCandidates(
         isNull(schema.events.cancelledAt),
         sql`${schema.events.isAdHoc} = false`,
         sql`lower(${schema.events.duration}) > ${now.toISOString()}::timestamptz`,
+        // ROK-1332: Skip rows currently in capacity-backoff. NULL means never
+        // backed off (the common case); a past timestamp means the backoff
+        // window expired and the row is eligible again.
+        sql`(${schema.events.scheduledEventReconcileBackoffUntil} IS NULL OR ${schema.events.scheduledEventReconcileBackoffUntil} <= NOW())`,
       ),
     )
     .limit(RECONCILIATION_BATCH_SIZE);
+}
+
+/** Row shape returned by findRLTrackedSEs for GC's stale-check (ROK-1332). */
+export interface RLTrackedSERow {
+  id: number;
+  discordScheduledEventId: string;
+  cancelledAt: Date | null;
+  durationUpper: Date;
+}
+
+/**
+ * Look up RL-tracked events whose discord_scheduled_event_id is in the given
+ * seIds list. Used by gcStaleRLScheduledEvents to decide which guild SEs are
+ * candidates for stale-deletion vs operator-orphans (ROK-1332).
+ *
+ * Returns id + seId + cancelledAt + the upper bound of the duration tsrange.
+ * `durationUpper` is extracted via `upper()` so callers can compare against
+ * wall-clock without parsing the postgres range string in JS.
+ */
+export async function findRLTrackedSEs(
+  db: PostgresJsDatabase<typeof schema>,
+  seIds: string[],
+): Promise<RLTrackedSERow[]> {
+  if (seIds.length === 0) return [];
+  const rows = await db
+    .select({
+      id: schema.events.id,
+      discordScheduledEventId: schema.events.discordScheduledEventId,
+      cancelledAt: schema.events.cancelledAt,
+      durationUpper: sql<Date>`upper(${schema.events.duration})`,
+    })
+    .from(schema.events)
+    .where(
+      and(
+        isNotNull(schema.events.discordScheduledEventId),
+        inArray(schema.events.discordScheduledEventId, seIds),
+      ),
+    );
+  // Drizzle returns durationUpper as a string under postgres-js — coerce to Date.
+  // The schema typing above documents intent; the runtime value is the raw
+  // postgres timestamptz string when read via `sql<Date>`.
+  return rows.map((r) => ({
+    id: r.id,
+    discordScheduledEventId: r.discordScheduledEventId!,
+    cancelledAt: r.cancelledAt,
+    durationUpper:
+      r.durationUpper instanceof Date ? r.durationUpper : new Date(r.durationUpper as unknown as string),
+  }));
+}
+
+/**
+ * Set scheduled_event_reconcile_backoff_until on the given event rows. Used
+ * by the reconciliation cron to pause retries when Discord's guild-wide cap
+ * remains saturated after GC (ROK-1332).
+ */
+export async function setReconcileBackoff(
+  db: PostgresJsDatabase<typeof schema>,
+  eventIds: number[],
+  expiresAt: Date,
+): Promise<void> {
+  if (eventIds.length === 0) return;
+  await db
+    .update(schema.events)
+    .set({ scheduledEventReconcileBackoffUntil: expiresAt })
+    .where(inArray(schema.events.id, eventIds));
 }

--- a/api/src/discord-bot/services/scheduled-event.db-helpers.ts
+++ b/api/src/discord-bot/services/scheduled-event.db-helpers.ts
@@ -189,8 +189,10 @@ export async function findReconciliationCandidates(
 export interface RLTrackedSERow {
   id: number;
   discordScheduledEventId: string;
-  cancelledAt: Date | null;
-  durationUpper: Date;
+  /** True when the SE should have been cleaned up already: the RL row is
+   *  cancelled OR its effective end (extendedUntil ?? upper(duration)) is more
+   *  than 1h in the past. Computed server-side to avoid timezone skew. */
+  isStale: boolean;
 }
 
 /**
@@ -198,9 +200,14 @@ export interface RLTrackedSERow {
  * seIds list. Used by gcStaleRLScheduledEvents to decide which guild SEs are
  * candidates for stale-deletion vs operator-orphans (ROK-1332).
  *
- * Returns id + seId + cancelledAt + the upper bound of the duration tsrange.
- * `durationUpper` is extracted via `upper()` so callers can compare against
- * wall-clock without parsing the postgres range string in JS.
+ * Staleness is computed IN SQL (not JS) for two reasons:
+ *   1. The `duration` tsrange and `extended_until` columns are timezone-less;
+ *      pulling `upper(duration)` as a string and `new Date()`-parsing it in JS
+ *      interprets it as local time → a multi-hour skew on the 1h comparison.
+ *   2. It mirrors the sibling reconciliation/completion queries by using
+ *      `COALESCE(extended_until, upper(duration))` so an auto-extended event
+ *      that is still live (members in voice past the original end) is NOT
+ *      treated as stale and its Discord SE is preserved.
  */
 export async function findRLTrackedSEs(
   db: PostgresJsDatabase<typeof schema>,
@@ -211,8 +218,11 @@ export async function findRLTrackedSEs(
     .select({
       id: schema.events.id,
       discordScheduledEventId: schema.events.discordScheduledEventId,
-      cancelledAt: schema.events.cancelledAt,
-      durationUpper: sql<Date>`upper(${schema.events.duration})`,
+      isStale: sql<boolean>`(
+        ${schema.events.cancelledAt} IS NOT NULL
+        OR COALESCE(${schema.events.extendedUntil}, upper(${schema.events.duration}))
+             < NOW() - INTERVAL '1 hour'
+      )`,
     })
     .from(schema.events)
     .where(
@@ -221,17 +231,10 @@ export async function findRLTrackedSEs(
         inArray(schema.events.discordScheduledEventId, seIds),
       ),
     );
-  // Drizzle returns durationUpper as a string under postgres-js — coerce to Date.
-  // The schema typing above documents intent; the runtime value is the raw
-  // postgres timestamptz string when read via `sql<Date>`.
   return rows.map((r) => ({
     id: r.id,
     discordScheduledEventId: r.discordScheduledEventId!,
-    cancelledAt: r.cancelledAt,
-    durationUpper:
-      r.durationUpper instanceof Date
-        ? r.durationUpper
-        : new Date(r.durationUpper as unknown as string),
+    isStale: r.isStale,
   }));
 }
 

--- a/api/src/discord-bot/services/scheduled-event.discord-ops.spec.ts
+++ b/api/src/discord-bot/services/scheduled-event.discord-ops.spec.ts
@@ -3,7 +3,10 @@ import { makeDiscordApiError } from './scheduled-event.service.spec-helpers';
 
 describe('isAtScheduledEventCapacityError (ROK-1332 AC1)', () => {
   it('returns true for DiscordAPIError with code 30038', () => {
-    const err = makeDiscordApiError(30038, 'Max guild scheduled events reached');
+    const err = makeDiscordApiError(
+      30038,
+      'Max guild scheduled events reached',
+    );
     expect(isAtScheduledEventCapacityError(err)).toBe(true);
   });
 
@@ -13,9 +16,9 @@ describe('isAtScheduledEventCapacityError (ROK-1332 AC1)', () => {
   });
 
   it('returns false for plain Error', () => {
-    expect(isAtScheduledEventCapacityError(new Error('not a discord error'))).toBe(
-      false,
-    );
+    expect(
+      isAtScheduledEventCapacityError(new Error('not a discord error')),
+    ).toBe(false);
   });
 
   it('returns false for non-Error values', () => {

--- a/api/src/discord-bot/services/scheduled-event.discord-ops.spec.ts
+++ b/api/src/discord-bot/services/scheduled-event.discord-ops.spec.ts
@@ -1,0 +1,27 @@
+import { isAtScheduledEventCapacityError } from './scheduled-event.discord-ops';
+import { makeDiscordApiError } from './scheduled-event.service.spec-helpers';
+
+describe('isAtScheduledEventCapacityError (ROK-1332 AC1)', () => {
+  it('returns true for DiscordAPIError with code 30038', () => {
+    const err = makeDiscordApiError(30038, 'Max guild scheduled events reached');
+    expect(isAtScheduledEventCapacityError(err)).toBe(true);
+  });
+
+  it('returns false for DiscordAPIError with a different code (e.g. 10070)', () => {
+    const err = makeDiscordApiError(10070, 'Unknown Scheduled Event');
+    expect(isAtScheduledEventCapacityError(err)).toBe(false);
+  });
+
+  it('returns false for plain Error', () => {
+    expect(isAtScheduledEventCapacityError(new Error('not a discord error'))).toBe(
+      false,
+    );
+  });
+
+  it('returns false for non-Error values', () => {
+    expect(isAtScheduledEventCapacityError(undefined)).toBe(false);
+    expect(isAtScheduledEventCapacityError(null)).toBe(false);
+    expect(isAtScheduledEventCapacityError(30038)).toBe(false);
+    expect(isAtScheduledEventCapacityError({ code: 30038 })).toBe(false);
+  });
+});

--- a/api/src/discord-bot/services/scheduled-event.discord-ops.ts
+++ b/api/src/discord-bot/services/scheduled-event.discord-ops.ts
@@ -6,6 +6,7 @@ import {
 } from 'discord.js';
 import {
   UNKNOWN_SCHEDULED_EVENT,
+  MAX_SCHEDULED_EVENTS_REACHED,
   timedDiscordCall,
   type ScheduledEventData,
 } from './scheduled-event.helpers';
@@ -24,6 +25,18 @@ interface VoiceChannelResolver {
 export function isUnknownEventError(error: unknown): boolean {
   return (
     error instanceof DiscordAPIError && error.code === UNKNOWN_SCHEDULED_EVENT
+  );
+}
+
+/**
+ * Discord error 30038 — the guild is at the 100-uncompleted-scheduled-events
+ * hard cap. Used by `withCapacityRecovery` to trigger a GC sweep + single
+ * retry instead of letting the cron loop forever (ROK-1332).
+ */
+export function isAtScheduledEventCapacityError(error: unknown): boolean {
+  return (
+    error instanceof DiscordAPIError &&
+    error.code === MAX_SCHEDULED_EVENTS_REACHED
   );
 }
 

--- a/api/src/discord-bot/services/scheduled-event.gc.spec.ts
+++ b/api/src/discord-bot/services/scheduled-event.gc.spec.ts
@@ -4,7 +4,10 @@
  * Pure-mock layer: the helper takes a Guild + a Drizzle handle. We stub the
  * guild's `scheduledEvents.fetch/delete` and the two db-helpers it calls
  * (`findRLTrackedSEs` + `clearScheduledEventId`) via jest.mock so the spec
- * stays at the unit level. The integration spec covers the real-DB path.
+ * stays at the unit level. This layer asserts GC's delete/skip dispatch on the
+ * `isStale` flag; the staleness SQL itself (cancelled / past-due ≥1h /
+ * extendedUntil / active-future) is computed in `findRLTrackedSEs` and is
+ * covered against a real DB by the capacity-recovery integration spec.
  */
 import { gcStaleRLScheduledEvents } from './scheduled-event.gc';
 import * as dbHelpers from './scheduled-event.db-helpers';
@@ -50,15 +53,10 @@ beforeEach(() => {
 });
 
 describe('gcStaleRLScheduledEvents (ROK-1332 AC2)', () => {
-  it('deletes cancelled RL-tracked SEs', async () => {
+  it('deletes stale RL-tracked SEs (isStale=true)', async () => {
     const guild = makeGuild(['se-1']);
     findRLTrackedSEs.mockResolvedValue([
-      {
-        id: 101,
-        discordScheduledEventId: 'se-1',
-        cancelledAt: new Date(Date.now() - 30 * 60 * 1000),
-        durationUpper: new Date(Date.now() + 24 * 60 * 60 * 1000),
-      },
+      { id: 101, discordScheduledEventId: 'se-1', isStale: true },
     ]);
 
     const result = await gcStaleRLScheduledEvents(guild, db);
@@ -69,15 +67,10 @@ describe('gcStaleRLScheduledEvents (ROK-1332 AC2)', () => {
     expect(clearScheduledEventId).toHaveBeenCalledWith(db, 101);
   });
 
-  it('deletes past-due (>1h) RL-tracked SEs', async () => {
+  it('deletes a second stale RL-tracked SE', async () => {
     const guild = makeGuild(['se-pastdue']);
     findRLTrackedSEs.mockResolvedValue([
-      {
-        id: 202,
-        discordScheduledEventId: 'se-pastdue',
-        cancelledAt: null,
-        durationUpper: new Date(Date.now() - 2 * 60 * 60 * 1000), // 2h ago
-      },
+      { id: 202, discordScheduledEventId: 'se-pastdue', isStale: true },
     ]);
 
     const result = await gcStaleRLScheduledEvents(guild, db);
@@ -86,15 +79,10 @@ describe('gcStaleRLScheduledEvents (ROK-1332 AC2)', () => {
     expect(tryDeleteEvent).toHaveBeenCalledWith(guild, 202, 'se-pastdue');
   });
 
-  it('skips active+future RL-tracked SEs (not stale)', async () => {
+  it('skips non-stale RL-tracked SEs (isStale=false)', async () => {
     const guild = makeGuild(['se-active']);
     findRLTrackedSEs.mockResolvedValue([
-      {
-        id: 303,
-        discordScheduledEventId: 'se-active',
-        cancelledAt: null,
-        durationUpper: new Date(Date.now() + 24 * 60 * 60 * 1000),
-      },
+      { id: 303, discordScheduledEventId: 'se-active', isStale: false },
     ]);
 
     const result = await gcStaleRLScheduledEvents(guild, db);
@@ -107,12 +95,7 @@ describe('gcStaleRLScheduledEvents (ROK-1332 AC2)', () => {
   it('counts operator-owned SEs (not in DB) as orphans and never deletes them', async () => {
     const guild = makeGuild(['se-rl', 'op-orphan-1', 'op-orphan-2']);
     findRLTrackedSEs.mockResolvedValue([
-      {
-        id: 404,
-        discordScheduledEventId: 'se-rl',
-        cancelledAt: new Date(Date.now() - 60 * 60 * 1000),
-        durationUpper: new Date(Date.now() + 24 * 60 * 60 * 1000),
-      },
+      { id: 404, discordScheduledEventId: 'se-rl', isStale: true },
     ]);
 
     const result = await gcStaleRLScheduledEvents(guild, db);

--- a/api/src/discord-bot/services/scheduled-event.gc.spec.ts
+++ b/api/src/discord-bot/services/scheduled-event.gc.spec.ts
@@ -23,9 +23,10 @@ jest.mock('./scheduled-event.discord-ops', () => ({
 const findRLTrackedSEs = dbHelpers.findRLTrackedSEs as jest.MockedFunction<
   typeof dbHelpers.findRLTrackedSEs
 >;
-const clearScheduledEventId = dbHelpers.clearScheduledEventId as jest.MockedFunction<
-  typeof dbHelpers.clearScheduledEventId
->;
+const clearScheduledEventId =
+  dbHelpers.clearScheduledEventId as jest.MockedFunction<
+    typeof dbHelpers.clearScheduledEventId
+  >;
 const tryDeleteEvent = discordOps.tryDeleteEvent as jest.MockedFunction<
   typeof discordOps.tryDeleteEvent
 >;

--- a/api/src/discord-bot/services/scheduled-event.gc.spec.ts
+++ b/api/src/discord-bot/services/scheduled-event.gc.spec.ts
@@ -1,0 +1,144 @@
+/**
+ * Unit tests for gcStaleRLScheduledEvents (ROK-1332 AC2).
+ *
+ * Pure-mock layer: the helper takes a Guild + a Drizzle handle. We stub the
+ * guild's `scheduledEvents.fetch/delete` and the two db-helpers it calls
+ * (`findRLTrackedSEs` + `clearScheduledEventId`) via jest.mock so the spec
+ * stays at the unit level. The integration spec covers the real-DB path.
+ */
+import { gcStaleRLScheduledEvents } from './scheduled-event.gc';
+import * as dbHelpers from './scheduled-event.db-helpers';
+import * as discordOps from './scheduled-event.discord-ops';
+
+jest.mock('./scheduled-event.db-helpers', () => ({
+  ...jest.requireActual('./scheduled-event.db-helpers'),
+  findRLTrackedSEs: jest.fn(),
+  clearScheduledEventId: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('./scheduled-event.discord-ops', () => ({
+  ...jest.requireActual('./scheduled-event.discord-ops'),
+  tryDeleteEvent: jest.fn().mockResolvedValue(undefined),
+}));
+
+const findRLTrackedSEs = dbHelpers.findRLTrackedSEs as jest.MockedFunction<
+  typeof dbHelpers.findRLTrackedSEs
+>;
+const clearScheduledEventId = dbHelpers.clearScheduledEventId as jest.MockedFunction<
+  typeof dbHelpers.clearScheduledEventId
+>;
+const tryDeleteEvent = discordOps.tryDeleteEvent as jest.MockedFunction<
+  typeof discordOps.tryDeleteEvent
+>;
+
+function makeGuild(seIds: string[]) {
+  return {
+    scheduledEvents: {
+      fetch: jest
+        .fn()
+        .mockResolvedValue(new Map(seIds.map((id) => [id, { id }]))),
+    },
+  } as unknown as Parameters<typeof gcStaleRLScheduledEvents>[0];
+}
+
+const db = {} as Parameters<typeof gcStaleRLScheduledEvents>[1];
+
+beforeEach(() => {
+  findRLTrackedSEs.mockReset();
+  clearScheduledEventId.mockReset().mockResolvedValue(undefined);
+  tryDeleteEvent.mockReset().mockResolvedValue(undefined);
+});
+
+describe('gcStaleRLScheduledEvents (ROK-1332 AC2)', () => {
+  it('deletes cancelled RL-tracked SEs', async () => {
+    const guild = makeGuild(['se-1']);
+    findRLTrackedSEs.mockResolvedValue([
+      {
+        id: 101,
+        discordScheduledEventId: 'se-1',
+        cancelledAt: new Date(Date.now() - 30 * 60 * 1000),
+        durationUpper: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      },
+    ]);
+
+    const result = await gcStaleRLScheduledEvents(guild, db);
+
+    expect(result).toEqual({ freed: 1, orphanCount: 0 });
+    expect(tryDeleteEvent).toHaveBeenCalledTimes(1);
+    expect(tryDeleteEvent).toHaveBeenCalledWith(guild, 101, 'se-1');
+    expect(clearScheduledEventId).toHaveBeenCalledWith(db, 101);
+  });
+
+  it('deletes past-due (>1h) RL-tracked SEs', async () => {
+    const guild = makeGuild(['se-pastdue']);
+    findRLTrackedSEs.mockResolvedValue([
+      {
+        id: 202,
+        discordScheduledEventId: 'se-pastdue',
+        cancelledAt: null,
+        durationUpper: new Date(Date.now() - 2 * 60 * 60 * 1000), // 2h ago
+      },
+    ]);
+
+    const result = await gcStaleRLScheduledEvents(guild, db);
+
+    expect(result).toEqual({ freed: 1, orphanCount: 0 });
+    expect(tryDeleteEvent).toHaveBeenCalledWith(guild, 202, 'se-pastdue');
+  });
+
+  it('skips active+future RL-tracked SEs (not stale)', async () => {
+    const guild = makeGuild(['se-active']);
+    findRLTrackedSEs.mockResolvedValue([
+      {
+        id: 303,
+        discordScheduledEventId: 'se-active',
+        cancelledAt: null,
+        durationUpper: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      },
+    ]);
+
+    const result = await gcStaleRLScheduledEvents(guild, db);
+
+    expect(result).toEqual({ freed: 0, orphanCount: 0 });
+    expect(tryDeleteEvent).not.toHaveBeenCalled();
+    expect(clearScheduledEventId).not.toHaveBeenCalled();
+  });
+
+  it('counts operator-owned SEs (not in DB) as orphans and never deletes them', async () => {
+    const guild = makeGuild(['se-rl', 'op-orphan-1', 'op-orphan-2']);
+    findRLTrackedSEs.mockResolvedValue([
+      {
+        id: 404,
+        discordScheduledEventId: 'se-rl',
+        cancelledAt: new Date(Date.now() - 60 * 60 * 1000),
+        durationUpper: new Date(Date.now() + 24 * 60 * 60 * 1000),
+      },
+    ]);
+
+    const result = await gcStaleRLScheduledEvents(guild, db);
+
+    expect(result).toEqual({ freed: 1, orphanCount: 2 });
+    expect(tryDeleteEvent).toHaveBeenCalledTimes(1);
+    expect(tryDeleteEvent).toHaveBeenCalledWith(guild, 404, 'se-rl');
+    // The orphans must NEVER be deleted.
+    expect(tryDeleteEvent).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'op-orphan-1',
+    );
+    expect(tryDeleteEvent).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      'op-orphan-2',
+    );
+  });
+
+  it('short-circuits when guild has zero SEs (no DB call)', async () => {
+    const guild = makeGuild([]);
+
+    const result = await gcStaleRLScheduledEvents(guild, db);
+
+    expect(result).toEqual({ freed: 0, orphanCount: 0 });
+    expect(findRLTrackedSEs).not.toHaveBeenCalled();
+    expect(tryDeleteEvent).not.toHaveBeenCalled();
+  });
+});

--- a/api/src/discord-bot/services/scheduled-event.gc.ts
+++ b/api/src/discord-bot/services/scheduled-event.gc.ts
@@ -1,0 +1,51 @@
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import * as schema from '../../drizzle/schema';
+import type { DiscordBotClientService } from '../discord-bot-client.service';
+import {
+  clearScheduledEventId,
+  findRLTrackedSEs,
+} from './scheduled-event.db-helpers';
+import { tryDeleteEvent } from './scheduled-event.discord-ops';
+
+type Guild = NonNullable<ReturnType<DiscordBotClientService['getGuild']>>;
+
+/** Grace window before a past-due (but never cancelled) event is considered stale.
+ *  Matches the `completeScheduledEvents` cron's 5-min cadence × buffer (ROK-1332). */
+const STALE_PAST_DUE_GRACE_MS = 60 * 60 * 1000;
+
+/**
+ * Sweep the guild's uncompleted scheduled events looking for RL-tracked rows
+ * that should have been deleted/completed already (cancelled or >1h past
+ * end-time). Deletes the stale ones from Discord, nulls their event row's
+ * discord_scheduled_event_id, and returns a `{ freed, orphanCount }` tally
+ * the caller uses to decide whether to retry a 30038 (ROK-1332).
+ *
+ * orphanCount = SEs visible to the bot that RL never created — operator-owned
+ * events. NEVER deleted; just counted so the WARN can tell the operator
+ * whether the cap is RL's fault or theirs.
+ */
+export async function gcStaleRLScheduledEvents(
+  guild: Guild,
+  db: PostgresJsDatabase<typeof schema>,
+): Promise<{ freed: number; orphanCount: number }> {
+  const all = await guild.scheduledEvents.fetch();
+  const seIds = [...all.keys()];
+  if (seIds.length === 0) return { freed: 0, orphanCount: 0 };
+
+  const rlRows = await findRLTrackedSEs(db, seIds);
+  const rlIds = new Set(rlRows.map((r) => r.discordScheduledEventId));
+  const orphanCount = seIds.length - rlIds.size;
+
+  const staleThreshold = new Date(Date.now() - STALE_PAST_DUE_GRACE_MS);
+  let freed = 0;
+  for (const row of rlRows) {
+    const isStale =
+      row.cancelledAt !== null || row.durationUpper < staleThreshold;
+    if (!isStale) continue;
+    await tryDeleteEvent(guild, row.id, row.discordScheduledEventId);
+    await clearScheduledEventId(db, row.id);
+    freed++;
+  }
+
+  return { freed, orphanCount };
+}

--- a/api/src/discord-bot/services/scheduled-event.gc.ts
+++ b/api/src/discord-bot/services/scheduled-event.gc.ts
@@ -9,10 +9,6 @@ import { tryDeleteEvent } from './scheduled-event.discord-ops';
 
 type Guild = NonNullable<ReturnType<DiscordBotClientService['getGuild']>>;
 
-/** Grace window before a past-due (but never cancelled) event is considered stale.
- *  Matches the `completeScheduledEvents` cron's 5-min cadence × buffer (ROK-1332). */
-const STALE_PAST_DUE_GRACE_MS = 60 * 60 * 1000;
-
 /**
  * Sweep the guild's uncompleted scheduled events looking for RL-tracked rows
  * that should have been deleted/completed already (cancelled or >1h past
@@ -36,12 +32,9 @@ export async function gcStaleRLScheduledEvents(
   const rlIds = new Set(rlRows.map((r) => r.discordScheduledEventId));
   const orphanCount = seIds.length - rlIds.size;
 
-  const staleThreshold = new Date(Date.now() - STALE_PAST_DUE_GRACE_MS);
   let freed = 0;
   for (const row of rlRows) {
-    const isStale =
-      row.cancelledAt !== null || row.durationUpper < staleThreshold;
-    if (!isStale) continue;
+    if (!row.isStale) continue;
     await tryDeleteEvent(guild, row.id, row.discordScheduledEventId);
     await clearScheduledEventId(db, row.id);
     freed++;

--- a/api/src/discord-bot/services/scheduled-event.helpers.ts
+++ b/api/src/discord-bot/services/scheduled-event.helpers.ts
@@ -3,8 +3,29 @@ import { perfLog } from '../../common/perf-logger';
 /** Discord API error code for "Unknown Scheduled Event" (manually deleted). */
 export const UNKNOWN_SCHEDULED_EVENT = 10070;
 
+/** Discord API error code 30038 — guild has hit its 100 uncompleted scheduled
+ *  events cap (ROK-1332). */
+export const MAX_SCHEDULED_EVENTS_REACHED = 30038;
+
 /** Maximum description length for Discord Scheduled Events. */
 export const MAX_DESCRIPTION_LENGTH = 1000;
+
+/**
+ * Thrown by `withCapacityRecovery` when GC ran but freed 0 stale RL-tracked
+ * scheduled events — the cap is held by operator-owned SEs that RL can't
+ * touch. The reconciliation cron catches this to apply per-event backoff
+ * and emit a single WARN per tick instead of one per candidate (ROK-1332).
+ */
+export class CapacityStillSaturatedError extends Error {
+  readonly orphanCount: number;
+  constructor(orphanCount: number) {
+    super(
+      `Discord scheduled-event capacity still saturated after GC (orphanCount=${orphanCount})`,
+    );
+    this.name = 'CapacityStillSaturatedError';
+    this.orphanCount = orphanCount;
+  }
+}
 
 /** Timeout (ms) for individual Discord API calls (ROK-685, ROK-969). */
 const parsed = parseInt(process.env.DISCORD_API_TIMEOUT_MS ?? '5000', 10);

--- a/api/src/discord-bot/services/scheduled-event.reconciliation.spec.ts
+++ b/api/src/discord-bot/services/scheduled-event.reconciliation.spec.ts
@@ -1,5 +1,5 @@
 /**
- * Tests for ScheduledEventReconciliationService (ROK-755).
+ * Tests for ScheduledEventReconciliationService (ROK-755, ROK-1332).
  */
 import { Test, TestingModule } from '@nestjs/testing';
 import { ScheduledEventReconciliationService } from './scheduled-event.reconciliation';
@@ -7,6 +7,17 @@ import { ScheduledEventService } from './scheduled-event.service';
 import { DiscordBotClientService } from '../discord-bot-client.service';
 import { CronJobService } from '../../cron-jobs/cron-job.service';
 import { DrizzleAsyncProvider } from '../../drizzle/drizzle.module';
+import { CapacityStillSaturatedError } from './scheduled-event.helpers';
+import * as dbHelpers from './scheduled-event.db-helpers';
+
+jest.mock('./scheduled-event.db-helpers', () => ({
+  ...jest.requireActual('./scheduled-event.db-helpers'),
+  setReconcileBackoff: jest.fn().mockResolvedValue(undefined),
+}));
+
+const setReconcileBackoffMock = dbHelpers.setReconcileBackoff as jest.MockedFunction<
+  typeof dbHelpers.setReconcileBackoff
+>;
 
 function createSelectChain(rows: unknown[] = []) {
   const chain: Record<string, jest.Mock> & { then?: unknown } = {};
@@ -154,6 +165,83 @@ describe('ScheduledEventReconciliationService (ROK-755)', () => {
     expect(
       mocks.scheduledEventService.createScheduledEvent,
     ).toHaveBeenCalledWith(2, candidates[1], 2, false, null);
+  });
+
+  describe('ROK-1332 capacity-saturated path', () => {
+    const future = new Date(Date.now() + 86400000).toISOString();
+    const futureEnd = new Date(Date.now() + 90000000).toISOString();
+    const buildCandidate = (id: number) => ({
+      id,
+      title: `Event ${id}`,
+      description: null,
+      startTime: future,
+      endTime: futureEnd,
+      gameId: id,
+      isAdHoc: false,
+      notificationChannelOverride: null,
+      signupCount: 0,
+      maxAttendees: null,
+    });
+
+    beforeEach(() => {
+      setReconcileBackoffMock.mockClear();
+    });
+
+    it('on CapacityStillSaturatedError: writes 1h backoff to unprocessed candidates and stops iterating', async () => {
+      const candidates = [buildCandidate(1), buildCandidate(2), buildCandidate(3)];
+      mocks.mockDb.select.mockReturnValue(createSelectChain(candidates));
+      mocks.scheduledEventService.createScheduledEvent.mockRejectedValueOnce(
+        new CapacityStillSaturatedError(7),
+      );
+
+      await mocks.service.reconcileMissingScheduledEvents();
+
+      // Stopped after first candidate's CapacityStillSaturatedError.
+      expect(
+        mocks.scheduledEventService.createScheduledEvent,
+      ).toHaveBeenCalledTimes(1);
+      // setReconcileBackoff called once with all 3 ids (none processed) and an
+      // expiresAt ≈ now + 1h.
+      expect(setReconcileBackoffMock).toHaveBeenCalledTimes(1);
+      const [, ids, expiresAt] = setReconcileBackoffMock.mock.calls[0];
+      expect(ids).toEqual([1, 2, 3]);
+      const diff = expiresAt.getTime() - Date.now();
+      const oneHourMs = 60 * 60 * 1000;
+      expect(diff).toBeGreaterThan(oneHourMs - 5 * 60 * 1000);
+      expect(diff).toBeLessThan(oneHourMs + 5 * 60 * 1000);
+    });
+
+    it('on CapacityStillSaturatedError after some success: backs off only the remaining (unprocessed) candidates', async () => {
+      const candidates = [buildCandidate(1), buildCandidate(2), buildCandidate(3)];
+      mocks.mockDb.select.mockReturnValue(createSelectChain(candidates));
+      mocks.scheduledEventService.createScheduledEvent
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new CapacityStillSaturatedError(3));
+
+      await mocks.service.reconcileMissingScheduledEvents();
+
+      expect(
+        mocks.scheduledEventService.createScheduledEvent,
+      ).toHaveBeenCalledTimes(2);
+      const [, ids] = setReconcileBackoffMock.mock.calls[0];
+      // First candidate (id=1) was processed; remaining are [2, 3].
+      expect(ids).toEqual([2, 3]);
+    });
+
+    it('non-CapacityStillSaturatedError still allows iteration to continue (no backoff write)', async () => {
+      const candidates = [buildCandidate(1), buildCandidate(2)];
+      mocks.mockDb.select.mockReturnValue(createSelectChain(candidates));
+      mocks.scheduledEventService.createScheduledEvent
+        .mockRejectedValueOnce(new Error('Discord timeout'))
+        .mockResolvedValueOnce(undefined);
+
+      await mocks.service.reconcileMissingScheduledEvents();
+
+      expect(
+        mocks.scheduledEventService.createScheduledEvent,
+      ).toHaveBeenCalledTimes(2);
+      expect(setReconcileBackoffMock).not.toHaveBeenCalled();
+    });
   });
 
   it('processes multiple candidates', async () => {

--- a/api/src/discord-bot/services/scheduled-event.reconciliation.spec.ts
+++ b/api/src/discord-bot/services/scheduled-event.reconciliation.spec.ts
@@ -15,9 +15,10 @@ jest.mock('./scheduled-event.db-helpers', () => ({
   setReconcileBackoff: jest.fn().mockResolvedValue(undefined),
 }));
 
-const setReconcileBackoffMock = dbHelpers.setReconcileBackoff as jest.MockedFunction<
-  typeof dbHelpers.setReconcileBackoff
->;
+const setReconcileBackoffMock =
+  dbHelpers.setReconcileBackoff as jest.MockedFunction<
+    typeof dbHelpers.setReconcileBackoff
+  >;
 
 function createSelectChain(rows: unknown[] = []) {
   const chain: Record<string, jest.Mock> & { then?: unknown } = {};
@@ -188,7 +189,11 @@ describe('ScheduledEventReconciliationService (ROK-755)', () => {
     });
 
     it('on CapacityStillSaturatedError: writes 1h backoff to unprocessed candidates and stops iterating', async () => {
-      const candidates = [buildCandidate(1), buildCandidate(2), buildCandidate(3)];
+      const candidates = [
+        buildCandidate(1),
+        buildCandidate(2),
+        buildCandidate(3),
+      ];
       mocks.mockDb.select.mockReturnValue(createSelectChain(candidates));
       mocks.scheduledEventService.createScheduledEvent.mockRejectedValueOnce(
         new CapacityStillSaturatedError(7),
@@ -212,7 +217,11 @@ describe('ScheduledEventReconciliationService (ROK-755)', () => {
     });
 
     it('on CapacityStillSaturatedError after some success: backs off only the remaining (unprocessed) candidates', async () => {
-      const candidates = [buildCandidate(1), buildCandidate(2), buildCandidate(3)];
+      const candidates = [
+        buildCandidate(1),
+        buildCandidate(2),
+        buildCandidate(3),
+      ];
       mocks.mockDb.select.mockReturnValue(createSelectChain(candidates));
       mocks.scheduledEventService.createScheduledEvent
         .mockResolvedValueOnce(undefined)

--- a/api/src/discord-bot/services/scheduled-event.reconciliation.ts
+++ b/api/src/discord-bot/services/scheduled-event.reconciliation.ts
@@ -12,7 +12,17 @@ import * as schema from '../../drizzle/schema';
 import { DiscordBotClientService } from '../discord-bot-client.service';
 import { CronJobService } from '../../cron-jobs/cron-job.service';
 import { ScheduledEventService } from './scheduled-event.service';
-import { findReconciliationCandidates } from './scheduled-event.db-helpers';
+import {
+  findReconciliationCandidates,
+  setReconcileBackoff,
+  type ReconciliationCandidate,
+} from './scheduled-event.db-helpers';
+import { CapacityStillSaturatedError } from './scheduled-event.helpers';
+
+/** ROK-1332: pause-window applied to remaining candidates when Discord's
+ *  guild-wide 100-SE cap is still saturated after GC. One hour matches the
+ *  cron's 15-min cadence × 4 → next ~4 ticks skip the row. */
+const CAPACITY_BACKOFF_MS = 60 * 60 * 1000;
 
 @Injectable()
 export class ScheduledEventReconciliationService {
@@ -46,6 +56,7 @@ export class ScheduledEventReconciliationService {
     this.logger.log(
       `Reconciling ${candidates.length} events missing Discord scheduled events`,
     );
+    const processed: number[] = [];
     for (const c of candidates) {
       try {
         await this.scheduledEventService.createScheduledEvent(
@@ -55,11 +66,37 @@ export class ScheduledEventReconciliationService {
           c.isAdHoc,
           c.notificationChannelOverride,
         );
+        processed.push(c.id);
       } catch (err) {
+        if (err instanceof CapacityStillSaturatedError) {
+          await this.applyCapacityBackoff(candidates, processed, err);
+          return;
+        }
         this.logger.error(
           `Reconciliation failed for event ${c.id}: ${err instanceof Error ? err.message : 'unknown'}`,
         );
       }
     }
+  }
+
+  /** ROK-1332: write 1h backoff to every still-unprocessed candidate and log
+   *  a single WARN so the cap doesn't trigger an N-event Sentry storm. */
+  private async applyCapacityBackoff(
+    candidates: ReconciliationCandidate[],
+    processed: number[],
+    err: CapacityStillSaturatedError,
+  ): Promise<void> {
+    const processedSet = new Set(processed);
+    const remaining = candidates
+      .filter((c) => !processedSet.has(c.id))
+      .map((c) => c.id);
+    await setReconcileBackoff(
+      this.db,
+      remaining,
+      new Date(Date.now() + CAPACITY_BACKOFF_MS),
+    );
+    this.logger.warn(
+      `Discord SE capacity still saturated after GC (freed=0, orphanCount=${err.orphanCount}). Backing off ${remaining.length} events for 1h.`,
+    );
   }
 }

--- a/api/src/discord-bot/services/scheduled-event.service.ts
+++ b/api/src/discord-bot/services/scheduled-event.service.ts
@@ -11,6 +11,7 @@ import { ActiveEventCacheService } from '../../events/active-event-cache.service
 import { EmbedSyncQueueService } from '../queues/embed-sync.queue';
 import {
   buildDescriptionText,
+  CapacityStillSaturatedError,
   formatApiError,
   getCreateSkipReason,
   type ScheduledEventData,
@@ -26,6 +27,7 @@ import {
   type ScheduledEventRecord,
 } from './scheduled-event.db-helpers';
 import {
+  isAtScheduledEventCapacityError,
   isUnknownEventError,
   tryStartEvent,
   tryDeleteEvent,
@@ -36,6 +38,7 @@ import {
   tryEditFullEvent,
   resolveVoiceForEdit,
 } from './scheduled-event.discord-ops';
+import { gcStaleRLScheduledEvents } from './scheduled-event.gc';
 
 async function desc(s: SettingsService, id: number, d: ScheduledEventData) {
   return buildDescriptionText(id, d, await s.getClientUrl());
@@ -294,8 +297,39 @@ export class ScheduledEventService {
       return;
     }
     const d = await desc(this.settingsService, eventId, eventData);
-    const se = await tryCreateNewEvent(guild, eventId, eventData, vc, d);
-    await saveScheduledEventId(this.db, eventId, se.id);
+    // ROK-1332: wrap the API-create + DB-save pair so a 30038 triggers a
+    // single GC sweep + retry. Preamble (voice channel, description) is
+    // outside the wrapper so GC doesn't re-run if the retry succeeds.
+    await this.withCapacityRecovery(guild, async () => {
+      const se = await tryCreateNewEvent(guild, eventId, eventData, vc, d);
+      await saveScheduledEventId(this.db, eventId, se.id);
+    });
+  }
+
+  /**
+   * ROK-1332: Catch Discord 30038 ("guild at 100-SE cap"), sweep stale
+   * RL-tracked SEs, retry the call once. If GC freed 0 rows, throw
+   * CapacityStillSaturatedError so the reconciliation cron can apply
+   * per-event backoff and emit a single WARN per tick.
+   */
+  private async withCapacityRecovery(
+    guild: NonNullable<ReturnType<DiscordBotClientService['getGuild']>>,
+    fn: () => Promise<void>,
+  ): Promise<void> {
+    try {
+      await fn();
+    } catch (err) {
+      if (!isAtScheduledEventCapacityError(err)) throw err;
+      const { freed, orphanCount } = await gcStaleRLScheduledEvents(
+        guild,
+        this.db,
+      );
+      this.logger.log(
+        `Discord SE capacity GC freed=${freed} orphanCount=${orphanCount}`,
+      );
+      if (freed === 0) throw new CapacityStillSaturatedError(orphanCount);
+      await fn();
+    }
   }
 
   private async tryEdit(

--- a/api/src/discord-bot/services/scheduled-event.service.ts
+++ b/api/src/discord-bot/services/scheduled-event.service.ts
@@ -11,7 +11,6 @@ import { ActiveEventCacheService } from '../../events/active-event-cache.service
 import { EmbedSyncQueueService } from '../queues/embed-sync.queue';
 import {
   buildDescriptionText,
-  CapacityStillSaturatedError,
   formatApiError,
   getCreateSkipReason,
   type ScheduledEventData,
@@ -27,7 +26,6 @@ import {
   type ScheduledEventRecord,
 } from './scheduled-event.db-helpers';
 import {
-  isAtScheduledEventCapacityError,
   isUnknownEventError,
   tryStartEvent,
   tryDeleteEvent,
@@ -38,7 +36,7 @@ import {
   tryEditFullEvent,
   resolveVoiceForEdit,
 } from './scheduled-event.discord-ops';
-import { gcStaleRLScheduledEvents } from './scheduled-event.gc';
+import { withCapacityRecovery } from './scheduled-event.capacity';
 
 async function desc(s: SettingsService, id: number, d: ScheduledEventData) {
   return buildDescriptionText(id, d, await s.getClientUrl());
@@ -300,36 +298,10 @@ export class ScheduledEventService {
     // ROK-1332: wrap the API-create + DB-save pair so a 30038 triggers a
     // single GC sweep + retry. Preamble (voice channel, description) is
     // outside the wrapper so GC doesn't re-run if the retry succeeds.
-    await this.withCapacityRecovery(guild, async () => {
+    await withCapacityRecovery(guild, this.db, this.logger, async () => {
       const se = await tryCreateNewEvent(guild, eventId, eventData, vc, d);
       await saveScheduledEventId(this.db, eventId, se.id);
     });
-  }
-
-  /**
-   * ROK-1332: Catch Discord 30038 ("guild at 100-SE cap"), sweep stale
-   * RL-tracked SEs, retry the call once. If GC freed 0 rows, throw
-   * CapacityStillSaturatedError so the reconciliation cron can apply
-   * per-event backoff and emit a single WARN per tick.
-   */
-  private async withCapacityRecovery(
-    guild: NonNullable<ReturnType<DiscordBotClientService['getGuild']>>,
-    fn: () => Promise<void>,
-  ): Promise<void> {
-    try {
-      await fn();
-    } catch (err) {
-      if (!isAtScheduledEventCapacityError(err)) throw err;
-      const { freed, orphanCount } = await gcStaleRLScheduledEvents(
-        guild,
-        this.db,
-      );
-      this.logger.log(
-        `Discord SE capacity GC freed=${freed} orphanCount=${orphanCount}`,
-      );
-      if (freed === 0) throw new CapacityStillSaturatedError(orphanCount);
-      await fn();
-    }
   }
 
   private async tryEdit(

--- a/api/src/drizzle/migrations/0145_scheduled_event_reconcile_backoff.sql
+++ b/api/src/drizzle/migrations/0145_scheduled_event_reconcile_backoff.sql
@@ -1,0 +1,12 @@
+-- ROK-1332: Add per-event reconcile backoff column so the Discord-scheduled-event
+-- reconciliation cron can pause retries on rows whose previous attempt hit the
+-- guild-wide 100-SE cap (Discord error code 30038). Without this, 5 stuck events
+-- × 1 cron run per 15min × 24h = 480 30038 errors/day forever once the cap is hit.
+--
+-- Partial index: most rows are NULL (no backoff active). The reconciliation cron
+-- query joins on `IS NULL OR <= NOW()` so only the NOT-NULL branch needs the
+-- index. Drizzle DSL doesn't support partial indexes natively — the schema
+-- declaration is a plain index() and this migration hand-edits the CREATE INDEX
+-- to add the partial predicate (matches precedent in migration 0085).
+ALTER TABLE "events" ADD COLUMN "scheduled_event_reconcile_backoff_until" timestamp;--> statement-breakpoint
+CREATE INDEX "idx_events_se_reconcile_backoff" ON "events" USING btree ("scheduled_event_reconcile_backoff_until") WHERE scheduled_event_reconcile_backoff_until IS NOT NULL;

--- a/api/src/drizzle/migrations/meta/_journal.json
+++ b/api/src/drizzle/migrations/meta/_journal.json
@@ -1016,6 +1016,13 @@
       "when": 1779300000000,
       "tag": "0144_grant_pg_stat_statements_reset_execute",
       "breakpoints": true
+    },
+    {
+      "idx": 145,
+      "version": "7",
+      "when": 1779400000000,
+      "tag": "0145_scheduled_event_reconcile_backoff",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/drizzle/schema/events.ts
+++ b/api/src/drizzle/schema/events.ts
@@ -106,6 +106,12 @@ export const events = pgTable(
     cancelledAt: timestamp('cancelled_at'),
     /** Optional reason provided when the event was cancelled (ROK-374). */
     cancellationReason: text('cancellation_reason'),
+    /** ROK-1332: When set, reconciliation cron skips this row until the timestamp
+     *  passes. Set to NOW()+1h when Discord's guild-wide 100-SE cap remains
+     *  saturated after GC sweep, so the cron stops retrying in a tight loop. */
+    scheduledEventReconcileBackoffUntil: timestamp(
+      'scheduled_event_reconcile_backoff_until',
+    ),
     createdAt: timestamp('created_at').defaultNow().notNull(),
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
   },
@@ -124,6 +130,11 @@ export const events = pgTable(
     index('idx_events_cancelled_at').on(table.cancelledAt),
     index('idx_events_discord_scheduled_event_id').on(
       table.discordScheduledEventId,
+    ),
+    // ROK-1332: Actual DB index is partial (WHERE scheduled_event_reconcile_backoff_until
+    // IS NOT NULL) via migration 0143. Drizzle DSL doesn't support partial indexes natively.
+    index('idx_events_se_reconcile_backoff').on(
+      table.scheduledEventReconcileBackoffUntil,
     ),
   ],
 );

--- a/api/src/drizzle/schema/events.ts
+++ b/api/src/drizzle/schema/events.ts
@@ -132,7 +132,7 @@ export const events = pgTable(
       table.discordScheduledEventId,
     ),
     // ROK-1332: Actual DB index is partial (WHERE scheduled_event_reconcile_backoff_until
-    // IS NOT NULL) via migration 0143. Drizzle DSL doesn't support partial indexes natively.
+    // IS NOT NULL) via migration 0145. Drizzle DSL doesn't support partial indexes natively.
     index('idx_events_se_reconcile_backoff').on(
       table.scheduledEventReconcileBackoffUntil,
     ),


### PR DESCRIPTION
## Summary
- Discord guild hit the 100-uncompleted-scheduled-events cap (error 30038); RL retried 5 stuck events every 15min forever (570 ERRORs/14h). RL now self-heals.
- Adds `isAtScheduledEventCapacityError` (30038) classifier next to `isUnknownEventError`.
- `gcStaleRLScheduledEvents` sweeps RL-tracked SEs that are cancelled or past their effective end (≥1h) and deletes ONLY those — operator-created SEs are counted as orphans, never touched.
- `withCapacityRecovery` wraps `doCreate` so every create path (reconciliation cron, event-lifecycle processor, edit-recovery) gets GC + single retry on 30038 for free.
- On still-saturated-after-GC: reconciliation applies a 1h per-event backoff (new `scheduled_event_reconcile_backoff_until` column, migration 0145 + partial index) and logs exactly ONE WARN per tick — no Sentry storm. (Admin-DM AC was dropped by operator decision in favor of the WARN.)
- Review fix: GC staleness computed in SQL via `COALESCE(extended_until, upper(duration)) < NOW() - INTERVAL '1 hour'` — fixes a JS timezone-skew on the 1h check and preserves auto-extended still-live events.

## Linear
ROK-1332

## Test plan
- [x] Unit tests added/updated (gc, discord-ops classifier, reconciliation — 18 passing)
- [x] Integration spec (Jest + real DB): 6/6 incl. extended-but-live regression guard
- [x] Migration validation against real Postgres (`validate-migrations.sh`) — 146 migrations clean
- [x] CI passes (build + lint + type + unit + coverage)
- [x] Code review passed (devedup-rl — APPROVE-WITH-NITS, med finding fixed)

## Tech debt observed (not auto-filed)
- Pre-existing `[high]`: full integration suite OOMs on Node v25.5.0 macOS (~4GB heap); workaround `NODE_OPTIONS=--max-old-space-size=8192`. Already in TECH-DEBT-BACKLOG.md (2026-05-21).