### PR TITLE
ROK-1355: recover-orphans includeStale — fingerprint-only reclaim of stale RL duplicates

### DIFF
--- a/api/src/admin/admin.controller.ts
+++ b/api/src/admin/admin.controller.ts
@@ -30,6 +30,7 @@ import {
   type NameDedupDryRunResult,
 } from '../igdb/igdb-dedup-cleanup.helpers';
 import { DiscordBotClientService } from '../discord-bot/discord-bot-client.service';
+import { SettingsService } from '../settings/settings.service';
 import {
   recoverOrphanScheduledEvents,
   type RecoveryResult,
@@ -46,6 +47,7 @@ export class AdminController {
     @Inject(DrizzleAsyncProvider)
     private readonly db: PostgresJsDatabase<typeof schema>,
     private readonly discordClient: DiscordBotClientService,
+    private readonly settingsService: SettingsService,
   ) {}
 
   @Get('check')
@@ -90,11 +92,16 @@ export class AdminController {
    * duplicate Discord scheduled events that pin the guild at its 100-SE cap.
    * Defaults to dry-run; pass `?dryRun=false` to execute. Never deletes
    * operator-owned SEs. Re-runnable until `reclaimableDuplicates` is empty.
+   * ROK-1355: `?includeStale=true` additionally reclaims untracked SEs whose
+   * description carries the configured CLIENT_URL `/events/<id>` fingerprint —
+   * stale RL duplicates of already-ended events that the live-match pass can
+   * never pair.
    */
   @Post('scheduled-events/recover-orphans')
   @HttpCode(HttpStatus.OK)
   async recoverOrphanScheduledEvents(
     @Query('dryRun') dryRunParam?: string,
+    @Query('includeStale') includeStaleParam?: string,
   ): Promise<RecoveryResult> {
     const dryRun = dryRunParam !== 'false';
     const guild = this.discordClient.getGuild();
@@ -104,13 +111,19 @@ export class AdminController {
         guildSeCount: 0,
         rlBound: 0,
         reclaimableDuplicates: [],
+        staleReclaimable: [],
         operatorOrphans: 0,
         deleted: 0,
         failures: [],
       };
     }
+    const staleClientUrl =
+      includeStaleParam === 'true'
+        ? await this.settingsService.getClientUrl()
+        : null;
     return recoverOrphanScheduledEvents(guild, this.db, this.logger, {
       dryRun,
+      staleClientUrl,
     });
   }
 }

--- a/api/src/discord-bot/services/scheduled-event.recovery.spec.ts
+++ b/api/src/discord-bot/services/scheduled-event.recovery.spec.ts
@@ -113,6 +113,110 @@ describe('recoverOrphanScheduledEvents', () => {
     return guild;
   }
 
+  describe('includeStale (ROK-1355)', () => {
+    const CLIENT_URL = 'https://rl.example';
+
+    it('classifies a fingerprinted SE with NO live match as staleReclaimable (dry-run)', async () => {
+      // Event 77 has ended — no live row, no tracked binding. Its duplicate
+      // outlived it but still carries the RL /events/77 fingerprint.
+      const guild = makeGuild([
+        { id: 'stale-se', name: 'Old Gamernight', ts: START, desc: rlDesc(77) },
+        { id: 'op-se', name: 'Operator Party', ts: START, desc: 'hand-made' },
+      ]);
+
+      const result = await recoverOrphanScheduledEvents(
+        guild,
+        makeDb(),
+        logger,
+        { dryRun: true, staleClientUrl: CLIENT_URL },
+      );
+
+      expect(result.staleReclaimable).toEqual([
+        {
+          eventId: 77,
+          seId: 'stale-se',
+          title: 'Old Gamernight',
+          start: new Date(START).toISOString(),
+        },
+      ]);
+      // The hand-made SE stays an operator orphan; the stale one moved out.
+      expect(result.operatorOrphans).toBe(1);
+      expect(tryDeleteEvent).not.toHaveBeenCalled();
+    });
+
+    it('returns empty staleReclaimable and unchanged counts when staleClientUrl is not provided', async () => {
+      const guild = makeGuild([
+        { id: 'stale-se', name: 'Old Gamernight', ts: START, desc: rlDesc(77) },
+      ]);
+
+      const result = await recoverOrphanScheduledEvents(
+        guild,
+        makeDb(),
+        logger,
+        { dryRun: true },
+      );
+
+      expect(result.staleReclaimable).toEqual([]);
+      expect(result.operatorOrphans).toBe(1);
+    });
+
+    it('requires the CONFIGURED client url — a foreign /events/ URL is never reclaimed', async () => {
+      const guild = makeGuild([
+        {
+          id: 'foreign-se',
+          name: 'Other Community Event',
+          ts: START,
+          desc: 'View event: https://other.example/events/123',
+        },
+      ]);
+
+      const result = await recoverOrphanScheduledEvents(
+        guild,
+        makeDb(),
+        logger,
+        { dryRun: true, staleClientUrl: CLIENT_URL },
+      );
+
+      expect(result.staleReclaimable).toEqual([]);
+      expect(result.operatorOrphans).toBe(1);
+    });
+
+    it('dryRun=false deletes stale SEs alongside live duplicates', async () => {
+      const guild = makeGuild([
+        { id: 'bound-se', name: 'Palworld Event', ts: START },
+        { id: 'dup-se', name: 'Palworld Event', ts: START, desc: rlDesc(9) },
+        { id: 'stale-se', name: 'Old Gamernight', ts: START, desc: rlDesc(77) },
+      ]);
+      findRLTrackedSEs.mockResolvedValue([
+        { id: 9, discordScheduledEventId: 'bound-se', isStale: false },
+      ]);
+      findLiveRLEventsForDedup.mockResolvedValue([
+        {
+          id: 9,
+          discordScheduledEventId: 'bound-se',
+          title: 'Palworld Event',
+          startIso: new Date(START).toISOString(),
+        },
+      ]);
+
+      const result = await recoverOrphanScheduledEvents(
+        guild,
+        makeDb(),
+        logger,
+        { dryRun: false, staleClientUrl: CLIENT_URL },
+      );
+
+      expect(result.deleted).toBe(2);
+      expect(tryDeleteEvent).toHaveBeenCalledWith(guild, 9, 'dup-se');
+      expect(tryDeleteEvent).toHaveBeenCalledWith(guild, 77, 'stale-se');
+      expect(tryDeleteEvent).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        'bound-se',
+      );
+    });
+  });
+
   it('dry-run returns reclaimable duplicates and deletes nothing', async () => {
     const guild = withOneDuplicate();
 

--- a/api/src/discord-bot/services/scheduled-event.recovery.ts
+++ b/api/src/discord-bot/services/scheduled-event.recovery.ts
@@ -31,6 +31,13 @@ export interface RecoveryResult {
   guildSeCount: number;
   rlBound: number;
   reclaimableDuplicates: RecoveryDuplicate[];
+  /**
+   * ROK-1355: untracked SEs whose description carries the configured
+   * CLIENT_URL's `/events/<id>` fingerprint but match NO live RL event —
+   * stale RL-created duplicates of already-ended events. Populated (and
+   * deleted on dryRun=false) only when `includeStale` is requested.
+   */
+  staleReclaimable: RecoveryDuplicate[];
   operatorOrphans: number;
   deleted: number;
   failures: Array<{ seId: string; code?: number; retryAfter?: number }>;
@@ -50,7 +57,7 @@ export async function recoverOrphanScheduledEvents(
   guild: Guild,
   db: PostgresJsDatabase<typeof schema>,
   logger: Logger,
-  opts: { dryRun: boolean },
+  opts: { dryRun: boolean; staleClientUrl?: string | null },
 ): Promise<RecoveryResult> {
   const all = await guild.scheduledEvents.fetch();
   const seValues = [...all.values()] as GuildSEShape[];
@@ -66,18 +73,60 @@ export async function recoverOrphanScheduledEvents(
   );
   const duplicates = toRecoveryDuplicates(reclaimable, seValues);
 
+  // ROK-1355: stale pass — fingerprint-only reclaim of RL-created SEs whose
+  // event has already ended (no live match possible). Gated on the caller
+  // providing the configured CLIENT_URL.
+  const reclaimedIds = new Set(reclaimable.map((r) => r.seId));
+  const stale = opts.staleClientUrl
+    ? classifyStaleRLSEs(untracked, reclaimedIds, opts.staleClientUrl)
+    : [];
+
   const base: RecoveryResult = {
     dryRun: opts.dryRun,
     guildSeCount: seIds.length,
     rlBound: rlIds.size,
     reclaimableDuplicates: duplicates,
-    operatorOrphans: operatorOrphanCount,
+    staleReclaimable: stale,
+    operatorOrphans: operatorOrphanCount - stale.length,
     deleted: 0,
     failures: [],
   };
   if (opts.dryRun) return base;
 
-  return executeRecovery(guild, db, logger, base, duplicates);
+  return executeRecovery(guild, db, logger, base, [...duplicates, ...stale]);
+}
+
+/**
+ * ROK-1355: classify untracked SEs (already excluded: tracked + live-match
+ * reclaimable) whose description carries `{clientUrl}/events/<id>` — the
+ * fingerprint ONLY RL-created SEs have. Operator-created Discord events never
+ * contain the app's event URL, so this is safe to delete even without a live
+ * RL event to pair against (the event ended; its duplicate outlived it).
+ */
+function classifyStaleRLSEs(
+  untracked: GuildSEShape[],
+  alreadyReclaimedIds: Set<string>,
+  clientUrl: string,
+): RecoveryDuplicate[] {
+  const prefix = `${clientUrl.replace(/\/+$/, '')}/events/`;
+  const out: RecoveryDuplicate[] = [];
+  for (const se of untracked) {
+    if (alreadyReclaimedIds.has(se.id)) continue;
+    const desc = se.description ?? '';
+    const idx = desc.indexOf(prefix);
+    if (idx === -1) continue;
+    const m = /^(\d+)/.exec(desc.slice(idx + prefix.length));
+    if (!m) continue;
+    const startMs =
+      se.scheduledStartTimestamp ?? se.scheduledStartAt?.getTime() ?? null;
+    out.push({
+      eventId: Number(m[1]),
+      seId: se.id,
+      title: se.name ?? '',
+      start: startMs != null ? new Date(startMs).toISOString() : '',
+    });
+  }
+  return out;
 }
 
 function toRecoveryDuplicates(


### PR DESCRIPTION
## Summary
- ROK-1347's recovery cleared 27 live-matched duplicates but left 53 untracked SEs in prod: stale RL-created duplicates of already-**ended** events, which the live-match pass can never pair (verified 2026-06-07: guildSeCount 73, operatorOrphans 53).
- Adds `?includeStale=true` to `POST /admin/scheduled-events/recover-orphans`: a second pass reclaims untracked SEs whose description carries the **configured CLIENT_URL** `/events/<id>` fingerprint — written by RL on every SE it creates; operator-made Discord events never contain it. Foreign-host `/events/` URLs are rejected.
- Same rails: dry-run default, 25-per-call batch cap, candidates listed (`staleReclaimable`) for operator review before `dryRun=false`. Default behavior (no param) unchanged.

## Linear
ROK-1355 (follow-up to ROK-1347 / PR #879)

## Test plan
- [x] `validate-ci` lite gate locally (build, typecheck, lint clean)
- [x] Unit: 4 new cases — stale fingerprinted SE listed only with flag; absent without; foreign client-url never reclaimed; dryRun=false deletes stale alongside live dups (9/9 recovery spec, 367/367 SE+admin suites)
- [ ] Unit + integration: deferred to GitHub CI
- [x] Prod runbook staged: dry-run with includeStale → operator reviews 53-item list → execute

🤖 Generated with [Claude Code](https://claude.com/claude-code)