### PR TITLE
fix(fleet): 30min claim grace + runner Playwright v1.60 (pipeline-stall fixes)

### DIFF
--- a/rl-infra/docker-compose.yml
+++ b/rl-infra/docker-compose.yml
@@ -268,7 +268,13 @@ services:
       - ./traefik/conf.d:/traefik-conf.d
     environment:
       SWEEP_INTERVAL_SECONDS: "900"   # 15min
-      CLAIM_HEARTBEAT_TIMEOUT_SECONDS: "300"  # 5min
+      # 30min — MCP agents are request-driven: the server can only heartbeat a
+      # claim while a fleet *task* runs, so legitimate local-work gaps (edits,
+      # commits, investigation) between fleet calls leave the claim un-pinged.
+      # A 5min grace reclaimed live slots mid-build; 30min covers normal gaps.
+      # Dead slots are still bounded by MAX_CLAIM_AGE (8h hoarding cap) +
+      # operator /opt preemption. (raised from 300 — fleet-grace fix)
+      CLAIM_HEARTBEAT_TIMEOUT_SECONDS: "1800"  # 30min
       DEFAULT_ENV_TTL_HOURS: "24"
     labels:
       rl.role: infra

--- a/rl-infra/gc-sweeper/sweep.sh
+++ b/rl-infra/gc-sweeper/sweep.sh
@@ -27,7 +27,10 @@ QUEUE_TTL_SECONDS="${QUEUE_TTL_SECONDS:-1800}"   # 30 min — stale waiters
 MAX_CLAIM_AGE_SECONDS="${MAX_CLAIM_AGE_SECONDS:-28800}"   # 8 hr — slot hoarding
 # ROK-1331 M1: default so the task-retention block (added below) can be
 # exercised by tests that don't supply the Dockerfile-provided env vars.
-CLAIM_HEARTBEAT_TIMEOUT_SECONDS="${CLAIM_HEARTBEAT_TIMEOUT_SECONDS:-300}"
+# Default 30min (matches docker-compose). MCP agents can't heartbeat a held
+# claim during local-work gaps between fleet tasks; a 5min grace reclaimed live
+# slots mid-build. Dead slots still bounded by MAX_CLAIM_AGE + /opt preemption.
+CLAIM_HEARTBEAT_TIMEOUT_SECONDS="${CLAIM_HEARTBEAT_TIMEOUT_SECONDS:-1800}"
 mkdir -p "$LOCK_DIR"
 NOW_EPOCH=$(date -u +%s)
 NOW_ISO=$(date -u +%FT%TZ)

--- a/rl-infra/runner/Dockerfile
+++ b/rl-infra/runner/Dockerfile
@@ -3,7 +3,10 @@
 # Built once on the VM (docker compose build runner-1). Mutagen syncs the
 # worktree from the laptop into /workspace; node_modules + cache live in
 # named volumes that survive rebuilds.
-FROM mcr.microsoft.com/playwright:v1.50.0-jammy
+# Pin matches the repo's playwright devDependency. When package.json bumps
+# Playwright, bump this base image in lockstep and rebuild the runner image,
+# or globalSetup fails fleet-wide with a missing chromium binary.
+FROM mcr.microsoft.com/playwright:v1.60.0-jammy
 
 ENV DEBIAN_FRONTEND=noninteractive \
     LANG=C.UTF-8 \


### PR DESCRIPTION
Two recurring rl-infra pipeline stalls surfaced during the ROK-1351 build:

## 1. gc-sweeper reclaimed live slots mid-build (heartbeat grace 5min → 30min)
The MCP server is request-driven — it can only heartbeat a claim while a fleet *task* runs. Normal local-work gaps (edits, commits, investigation) between fleet calls left the claim un-pinged, and the 5-min `CLAIM_HEARTBEAT_TIMEOUT_SECONDS` reclaimed it. During one build this forced ~4 re-claims. Raised to 30min in `docker-compose.yml` + `sweep.sh` default. Dead slots are still bounded by `MAX_CLAIM_AGE` (8h hoarding cap) and operator `/opt` preemption.

## 2. Runner Playwright image lag (v1.50 → v1.60)
The runner image shipped `playwright:v1.50.0-jammy` while the repo needs `@playwright/test ^1.60.0`, so the chromium binary was missing and `globalSetup` failed fleet-wide for every branch's Playwright step. Bumped `runner/Dockerfile` base to `v1.60.0-jammy`.

**Requires VM redeploy:** sweeper change → recreate `rl-gc-sweeper`; Playwright change → rebuild the runner image. Applied live on the VM as part of this change (both slots were idle).

Not addressed here: dashboard `/api/tasks/<id>/log` 502 — that's a traefik/gateway routing issue, diagnosed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)