### PR TITLE
fix: low-hanging batch — scheduling banner refresh + no-sleep-lint + cleanups

### DIFF
--- a/api/src/admin/games-dedup-extra-counts.helpers.ts
+++ b/api/src/admin/games-dedup-extra-counts.helpers.ts
@@ -4,9 +4,9 @@
  * `games-dedup-audit.helpers.ts` under the 300-line ESLint cap.
  *
  * Order here is the contract: callers spread this array into
- * `buildDirectCountQueries` and destructure the result in lockstep with the
- * `extendedBlastRadiusKeys` order below. If you reorder either list, update
- * both together — the destructure swap is a silent bug.
+ * `buildDirectCountQueries`, whose combined results are destructured in
+ * lockstep at the call site (see `games-dedup-audit.helpers.ts`). If you
+ * reorder this list, update that destructure together — a swap is a silent bug.
  */
 import { count, eq } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
@@ -18,7 +18,7 @@ function takeCount(rows: { c: number }[]): number {
   return Number(rows[0]?.c ?? 0);
 }
 
-/** 6 new direct-count promises in the same order as `extendedBlastRadiusKeys`. */
+/** 6 new direct-count promises, in the lockstep order consumed by buildDirectCountQueries. */
 export function buildExtraCountQueries(db: Db, id: number): Promise<number>[] {
   const c = () => count();
   return [

--- a/api/src/feedback/feedback.controller.ts
+++ b/api/src/feedback/feedback.controller.ts
@@ -78,7 +78,11 @@ export class FeedbackController {
     this.logger.log(
       `Feedback submitted: id=${inserted.id} category=${category} user=${userId}`,
     );
-    await this.attachSlowQueryContext(inserted.id, req.user.role, clientLogs);
+    await this.attachSlowQueryContext(
+      inserted.id,
+      req.user.role,
+      truncatedClientLogs,
+    );
     return {
       id: inserted.id,
       category: inserted.category as FeedbackResponseDto['category'],
@@ -99,7 +103,7 @@ export class FeedbackController {
   private async attachSlowQueryContext(
     feedbackId: number,
     role: UserRole,
-    clientLogs: string | undefined,
+    clientLogs: string | null | undefined,
   ): Promise<void> {
     if (role !== 'admin' || !clientLogs) return;
     try {

--- a/tools/test-bot/src/smoke/tests/lineup-abort.test.ts
+++ b/tools/test-bot/src/smoke/tests/lineup-abort.test.ts
@@ -23,7 +23,7 @@
  *   - Create a fresh public lineup via the API.
  *   - POST the new abort endpoint.
  *   - Drain BullMQ queues with `awaitProcessing` + `flushEmbedQueue`.
- *   - Use `pollForEmbed` (NEVER `sleep()`) to look for the channel
+ *   - Use `pollForEmbed` (never a fixed delay) to look for the channel
  *     embed.
  */
 import { pollForEmbed } from '../../helpers/polling.js';

--- a/web/src/hooks/__tests__/use-standalone-poll.test.ts
+++ b/web/src/hooks/__tests__/use-standalone-poll.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Regression: scheduling-banner queryKey mismatch (TECH-DEBT 2026-05-13).
+ *
+ * useCreateSchedulingPoll invalidated ['scheduling-banner'] — a single-element
+ * key that matches nothing — instead of the real banner key ['scheduling',
+ * 'banner'] declared in use-scheduling.ts (BANNER_KEY). TanStack matches by
+ * prefix-array equality, so the events-page scheduling banner never refreshed
+ * after a standalone poll was created. This asserts the canonical key is
+ * invalidated and the dead key is not.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createElement, type ReactNode } from 'react';
+
+const mockCreateSchedulingPoll = vi.fn();
+
+vi.mock('../../lib/api-client', () => ({
+  createSchedulingPoll: (...args: unknown[]) =>
+    mockCreateSchedulingPoll(...args),
+  getActiveStandalonePolls: vi.fn(),
+}));
+
+vi.mock('../../lib/toast', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { useCreateSchedulingPoll } from '../use-standalone-poll';
+
+describe('useCreateSchedulingPoll — invalidates the scheduling banner', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    mockCreateSchedulingPoll.mockReset();
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+  });
+
+  function wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: queryClient }, children);
+  }
+
+  it('invalidates the canonical key ["scheduling","banner"] on success, not the dead key', async () => {
+    mockCreateSchedulingPoll.mockResolvedValue({ matchId: 1, lineupId: 2 });
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    const { result } = renderHook(() => useCreateSchedulingPoll(), { wrapper });
+
+    await act(async () => {
+      await result.current.mutateAsync({} as never);
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['scheduling', 'banner'],
+    });
+    expect(invalidateSpy).not.toHaveBeenCalledWith({
+      queryKey: ['scheduling-banner'],
+    });
+  });
+});

--- a/web/src/hooks/use-standalone-poll.ts
+++ b/web/src/hooks/use-standalone-poll.ts
@@ -26,7 +26,7 @@ export function useCreateSchedulingPoll() {
     mutationFn: (dto: CreateSchedulingPollDto) => createSchedulingPoll(dto),
     onSuccess: () => {
       toast.success('Scheduling poll created!');
-      void queryClient.invalidateQueries({ queryKey: ['scheduling-banner'] });
+      void queryClient.invalidateQueries({ queryKey: ['scheduling', 'banner'] });
       void queryClient.invalidateQueries({ queryKey: ['standalone-polls'] });
       void queryClient.invalidateQueries({ queryKey: ['lineups'] });
       void queryClient.invalidateQueries({ queryKey: ['events'] });


### PR DESCRIPTION
## Summary
Trivial-lane batch clearing 4 TECH-DEBT-BACKLOG entries (operator-triaged):
- **fix(scheduling):** the events-page scheduling banner never refreshed after creating a standalone poll — `useCreateSchedulingPoll` invalidated a dead key `['scheduling-banner']` instead of the real `['scheduling','banner']`. Fixed + regression test.
- **chore(test-bot):** reworded a JSDoc comment so `npm run lint:no-sleep` stops false-failing on a clean tree (re-discovered 6+ times).
- **chore(feedback):** pass trimmed `clientLogs` into `attachSlowQueryContext` for consistency; widened its param to accept null. Behavior-neutral (presence gate only).
- **chore(admin):** fixed a misleading comment referencing the non-existent `extendedBlastRadiusKeys`.

## Test plan
- [x] `validate-ci.sh --static` (build all, typecheck, lint) passes
- [x] web vitest: `use-standalone-poll` banner regression test passes
- [x] `npm run lint:no-sleep` exits 0
- [ ] Unit / integration / Playwright: deferred to GitHub CI (lite gate)

First batch shipped via the new trivial-fix fast lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)