### PR TITLE
fix(events): 'ended X ago' rolled the unit over ~11h early

### DIFF
--- a/web/src/lib/__tests__/event-utils.test.ts
+++ b/web/src/lib/__tests__/event-utils.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { getRelativeTime } from '../event-utils';
+
+/**
+ * Regression: getEndedRelativeTime used Math.round, so the day/hour unit rolled
+ * over ~11h early — an event ended 13h ago read "ended 1 day ago". Now floors,
+ * matching the sibling relative-time formatters.
+ */
+describe('getRelativeTime — ended events floor the unit', () => {
+  const iso = (msAgo: number) => new Date(Date.now() - msAgo).toISOString();
+
+  it('an event ended 13h ago reads hours, not "1 day ago"', () => {
+    const label = getRelativeTime(iso(14 * 3600_000), iso(13 * 3600_000));
+    expect(label).toContain('hours ago');
+    expect(label).not.toContain('day ago');
+  });
+
+  it('an event ended 25h ago reads "1 day ago"', () => {
+    const label = getRelativeTime(iso(26 * 3600_000), iso(25 * 3600_000));
+    expect(label).toContain('1 day ago');
+  });
+});

--- a/web/src/lib/event-utils.ts
+++ b/web/src/lib/event-utils.ts
@@ -59,9 +59,12 @@ function getLiveRelativeTime(now: Date, start: Date): string {
 
 function getEndedRelativeTime(now: Date, end: Date): string {
     const diffMs = now.getTime() - end.getTime();
-    const diffMins = Math.round(diffMs / 60000);
-    const diffHours = Math.round(diffMs / 3600000);
-    const diffDays = Math.round(diffMs / 86400000);
+    // Floor (not round) so "ended" labels don't roll the unit over early — a
+    // 13h-old event must read "13 hours ago", not "1 day ago". Matches the
+    // sibling formatters getRelativeTimeAgo (activity-feed) + formatTimelineDate.
+    const diffMins = Math.floor(diffMs / 60000);
+    const diffHours = Math.floor(diffMs / 3600000);
+    const diffDays = Math.floor(diffMs / 86400000);
     if (diffDays >= 1) return `ended ${pluralize(diffDays, 'day')} ago`;
     if (diffHours >= 1) return `ended ${pluralize(diffHours, 'hour')} ago`;
     if (diffMins < 1) return 'just ended';


### PR DESCRIPTION
## Summary
`getEndedRelativeTime` used `Math.round`, so an event ended 13h ago rendered **"ended 1 day ago"** (day/hour unit rolled over at ~12h instead of 24h). Floor instead — matches the sibling formatters (`getRelativeTimeAgo`, `formatTimelineDate`). + regression test.

## Test plan
- [x] `validate-ci.sh --static` passes (build, tsc, lint)
- [x] web vitest: 13h→hours, 25h→"1 day ago"
- [ ] Playwright: deferred to GitHub CI (lite gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)