### PR TITLE
ROK-1372: variety-series voice bind no longer locks quick-plays to one game (gamernight → HELLCARD)

### DIFF
--- a/api/src/discord-bot/commands/bind.command.ts
+++ b/api/src/discord-bot/commands/bind.command.ts
@@ -26,6 +26,7 @@ import {
   applyEventChanges,
   findSeriesEventIds,
   findSeriesGame,
+  shouldDeriveSeriesGame,
   type OtherSlotState,
 } from './bind.helpers';
 import {
@@ -134,7 +135,13 @@ export class BindCommand
     if (game === false) return;
     const series = await resolveSeries(this.db, interaction);
     if (series === false) return;
-    if (!game && series) {
+    // ROK-1372: voice binds must NOT auto-derive a series game — a variety
+    // series would get locked to one arbitrary game (game-voice-monitor) and
+    // mislabel every quick-play. See shouldDeriveSeriesGame.
+    if (
+      series &&
+      shouldDeriveSeriesGame(resolved.bindingChannelType, game !== null)
+    ) {
       game = await findSeriesGame(this.db, series.id);
     }
     await this.tryBindChannel(

--- a/api/src/discord-bot/commands/bind.helpers.spec.ts
+++ b/api/src/discord-bot/commands/bind.helpers.spec.ts
@@ -1,0 +1,23 @@
+import { shouldDeriveSeriesGame } from './bind.helpers';
+
+/**
+ * ROK-1372: a variety-series VOICE bind must not auto-derive a single game
+ * (which would lock the channel to game-voice-monitor and mislabel every
+ * quick-play, e.g. gamernight → HELLCARD). Text/announce binds still derive.
+ */
+describe('shouldDeriveSeriesGame (ROK-1372)', () => {
+  it('does NOT derive a game for a voice bind with no explicit game', () => {
+    // → gameId stays null → general-lobby (presence auto-detect)
+    expect(shouldDeriveSeriesGame('voice', false)).toBe(false);
+  });
+
+  it('derives a game for a text/announce bind with no explicit game', () => {
+    // announcements route by game, so derivation is intended
+    expect(shouldDeriveSeriesGame('text', false)).toBe(true);
+  });
+
+  it('never derives when an explicit game was supplied (voice or text)', () => {
+    expect(shouldDeriveSeriesGame('voice', true)).toBe(false);
+    expect(shouldDeriveSeriesGame('text', true)).toBe(false);
+  });
+});

--- a/api/src/discord-bot/commands/bind.helpers.ts
+++ b/api/src/discord-bot/commands/bind.helpers.ts
@@ -244,6 +244,24 @@ export async function applyGameChange(
   return { change: `Game reassigned to **${gameMatch.name}**` };
 }
 
+/**
+ * Whether a `/bind` should auto-derive the series' representative game.
+ *
+ * Voice binds must NOT derive a game: a variety series (e.g. gamernight, whose
+ * game changes each occurrence) would get locked to one arbitrary game
+ * (`findSeriesGame` is innerJoin + LIMIT 1, no ORDER BY), flipping the channel
+ * to game-voice-monitor and mislabeling every quick-play (ROK-1372). Leaving the
+ * game null makes a variety voice bind a general-lobby (presence auto-detect).
+ * Text/announce binds DO derive it (announcements route by game). An explicit
+ * `game:` option always wins and skips derivation.
+ */
+export function shouldDeriveSeriesGame(
+  bindingChannelType: 'text' | 'voice',
+  hasExplicitGame: boolean,
+): boolean {
+  return !hasExplicitGame && bindingChannelType !== 'voice';
+}
+
 /** Derives the game from the first event in a series (if any). */
 export async function findSeriesGame(
   db: PostgresJsDatabase<typeof schemaType>,

--- a/api/src/discord-bot/services/voice-attendance-flush.helpers.spec.ts
+++ b/api/src/discord-bot/services/voice-attendance-flush.helpers.spec.ts
@@ -60,10 +60,7 @@ describe('findActiveEventsForChannel — diagnostic logging (ROK-842)', () => {
       );
 
       expect(logger.warn).toHaveBeenCalledWith(
-        expect.stringContaining('[voice-pipe]'),
-        'unknown-channel',
-        expect.any(Number),
-        expect.any(Number),
+        expect.stringContaining('channel=unknown-channel'),
       );
       expect(logger.debug).not.toHaveBeenCalled();
     });
@@ -84,12 +81,10 @@ describe('findActiveEventsForChannel — diagnostic logging (ROK-842)', () => {
         logger,
       );
 
-      expect(logger.warn).toHaveBeenCalledWith(
-        expect.any(String),
-        'different-channel',
-        3, // total bindings
-        2, // voice bindings only (game-voice-monitor + general-lobby)
-      );
+      const warnArg = (logger.warn as jest.Mock).mock.calls[0][0] as string;
+      expect(warnArg).toContain('channel=different-channel');
+      expect(warnArg).toContain('bindings=3'); // total bindings
+      expect(warnArg).toContain('voiceBindings=2'); // game-voice-monitor + general-lobby
     });
 
     it('returns empty array for unrecognized channel', async () => {
@@ -115,12 +110,10 @@ describe('findActiveEventsForChannel — diagnostic logging (ROK-842)', () => {
         logger,
       );
 
-      expect(logger.warn).toHaveBeenCalledWith(
-        expect.any(String),
-        'any-channel',
-        0,
-        0,
-      );
+      const warnArg = (logger.warn as jest.Mock).mock.calls[0][0] as string;
+      expect(warnArg).toContain('channel=any-channel');
+      expect(warnArg).toContain('bindings=0');
+      expect(warnArg).toContain('voiceBindings=0');
     });
 
     it('WARN is not emitted when defaultVoiceChannelId matches', async () => {

--- a/api/src/discord-bot/services/voice-attendance-flush.helpers.ts
+++ b/api/src/discord-bot/services/voice-attendance-flush.helpers.ts
@@ -281,11 +281,10 @@ function logUnrecognizedChannel(
   const voiceBindingCount = bindings.filter((b) =>
     voiceBindingPurposes.includes(b.bindingPurpose),
   ).length;
+  // NestJS Logger does not printf-substitute %s/%d — interpolate directly so the
+  // channel id + counts land on one line instead of four orphan WARN lines.
   logger.warn(
-    '[voice-pipe] findActive: unrecognized channel=%s, bindings=%d, voiceBindings=%d',
-    channelId,
-    bindings.length,
-    voiceBindingCount,
+    `[voice-pipe] findActive: unrecognized channel=${channelId}, bindings=${bindings.length}, voiceBindings=${voiceBindingCount}`,
   );
 }
 


### PR DESCRIPTION
## Summary
Binding a **voice** channel to a series with no explicit game called `findSeriesGame` (innerJoin + `LIMIT 1`, no `ORDER BY` → arbitrary occurrence's game), which locked the binding to `game-voice-monitor` and mislabeled every quick-play of a variety series — **gamernight → HELLCARD**. Now only **text/announce** binds derive a series game; a series **voice** bind with no `game:` stays `general-lobby` (presence auto-detect). Operators wanting a game-locked voice monitor pass `game:` explicitly.

- Extract `shouldDeriveSeriesGame` (pure, unit-tested) + guard the derivation.
- Drive-by: fix the broken `%s/%d` printf logger at `voice-attendance-flush.helpers.ts` (NestJS Logger doesn't substitute) — the unrecognized-channel diagnostic now lands on one line.

## ⚠️ Operator action after merge
The **existing gamernight binding** is likely already `gameId=HELLCARD` / `game-voice-monitor` — the code fix won't retro-fix it. **Re-run `/bind <voice> series:gamernight`** after deploy (or null `gameId` on series voice bindings) to fix the live binding.

## Test plan
- [x] `validate-ci.sh --static` (build, tsc, lint)
- [x] Unit test: `shouldDeriveSeriesGame` (voice→skip, text→derive, explicit-game→skip)
- [x] All 7 existing bind suites pass (61 tests)
- [ ] Discord smoke: GitHub CI (triggers on discord-bot changes)

**⛔ Auto-merge intentionally OFF** — Discord blast radius; please review + run the re-bind after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)