### PR TITLE
chore(ci): integration-shard fast lane + scope-narrowed local gate

### DIFF
--- a/.claude/skills/build/SKILL.md
+++ b/.claude/skills/build/SKILL.md
@@ -25,7 +25,7 @@ Read `<worktree>/build-state.yaml`, follow `pipeline.next_action`. Stories with 
 
 | Scope | Criteria | E2E Test Type | Gates |
 |-------|----------|---------------|-------|
-| **light** | Config, copy, style-only, docs, single-file simple fix (typo, import order, isolated edit) — no team, no worktree, no dev agent | Fast CI on touched workspace ONLY (lint + tsc + workspace tests) | lead_direct → fast_ci → operator |
+| **light / trivial** | Config, copy, style-only, docs, OR **any single-file ≤30-line logic/copy/style/config fix touching no `packages/contract`/migration/infra/auth surface** (the `trivial` tier — see CLAUDE.md "Trivial-fix fast lane") — no team, no worktree, no dev agent | Lightest tier that covers the change (often **none** for a behavior-neutral diff); fast CI on the touched workspace ONLY (lint + tsc + workspace tests) | lead_direct → fast_ci → operator-PR-review (non-UI: no FULL STOP, no Chrome MCP) |
 | **standard** | Single-module feature, bug fix, OR straightforward cross-module add (≤10 files) — including new contract schemas with matching backend + frontend | Playwright/Discord smoke (TDD) | e2e_first → dev → ci → operator → reviewer → smoke |
 | **full** | DB migration, breaking change to existing contract schema, Dockerfile/entrypoint/nginx, OR ≥4 unrelated modules with non-trivial logic in each | Full suite (TDD) + planner + architect + phase-split dev | e2e_first → dev → ci → operator → reviewer → architect_final → smoke |
 
@@ -80,10 +80,11 @@ Both modes: light scope skips test-infra steps entirely.
 
 **Light scope bypasses team / worktree / dev-agent overhead.** For `scope: light` ONLY:
 - No team, no worktree, no `Agent()` spawn — Lead implements directly on a feature branch in the main repo.
-- No TDD test-first, no reviewer, no architect, no Lead final smoke run.
+- No TDD test-first; **lightest proportionate test only** (a unit assertion for a behavior-changing fix, none for a behavior-neutral one). No reviewer team, no architect, no Lead final smoke — a single Codex pre-push pass (`/push` Step 8.5) is the one review.
+- **Human gates tier by blast radius** (CLAUDE.md "Trivial-fix fast lane"): a **non-UI** light/trivial fix skips BOTH the Chrome MCP e2e gate and the operator FULL STOP — the operator reviews the PR diff instead. A **cosmetic-UI** fix gets one screenshot on the already-running env (no `deploy_dev.sh --rebuild`). Anything touching a rendered flow / auth / contract keeps the full gate → escalate to `standard`.
 - Fast CI only — lint + tsc + workspace tests for touched workspace; skip full `validate-ci.sh`, migration validation, container-startup, Playwright.
-- No `deploy_dev.sh` re-run.
-- Pipeline collapses to: Step 1 (setup + Linear flip) → Step 2 light fast-path → Step 3 light fast-path (Linear "In Review" + operator stop) → Step 4 (operator approval only) → Step 5 (push + PR + auto-merge).
+- No `deploy_dev.sh` re-run (except a cosmetic-UI screenshot against an already-running env).
+- Pipeline collapses to: Step 1 (setup + Linear flip) → Step 2 light fast-path → Step 3 light fast-path (Linear "In Review") → Step 4 (operator PR-diff review; FULL STOP only for cosmetic-UI fixes) → Step 5 (push + PR + auto-merge).
 - Escape hatch: if mid-implementation you find real complexity (≥3 files, cross-workspace, real architectural decision), STOP, escalate to `standard`, create a worktree, restart Step 2 from 2a.
 
 **STOP / PAUSE / halt from operator:** cease all tool calls immediately, acknowledge "Stopped.", wait.

--- a/.claude/skills/build/steps/step-1-setup.md
+++ b/.claude/skills/build/steps/step-1-setup.md
@@ -76,6 +76,8 @@ Print a one-line summary per story: `ROK-XXX: <N> comments, <0|N> triage-relevan
 
 Apply the profiling matrix from SKILL.md. Per story: scope (light/standard/full), `needs_planner` (true if full), `needs_architect` (true if full), serialization conflicts (touches `packages/contract`? migration? file overlap?).
 
+A single-file ≤30-line logic/copy/style/config fix touching no `packages/contract`/migration/infra/auth surface profiles as **light** (the `trivial` tier — Lead-direct fast path, human gates tiered by blast radius). See CLAUDE.md "Trivial-fix fast lane". Don't profile a genuine one-liner as `standard` — that's the cliff this tier exists to close. When in doubt, `standard`.
+
 Group into batches respecting serialization. Max 2-3 devs per batch.
 
 **Migration rule:** if a story adds a DB migration, it MUST be the only story in its batch. Shared Docker Postgres means deploying one worktree's migration affects all in-flight worktrees. Serialize migrations against everything — put them in their own batch.

--- a/.claude/skills/fix-batch/SKILL.md
+++ b/.claude/skills/fix-batch/SKILL.md
@@ -65,6 +65,19 @@ Step 4: Ship      → Single PR, auto-merge, Linear → Done, cleanup
 
 ---
 
+## Trivial single-story short-circuit (CLAUDE.md "Trivial-fix fast lane")
+
+When the batch resolves to a **single story** that meets the `trivial` bar (≤30 net lines, single file, no `packages/contract`/migration/infra/auth surface, pure logic/copy/style/config), collapse the pipeline — do NOT pay the multi-story batch ceremony for one tiny fix:
+
+- **Step 2:** Lead edits directly on a `fix/rok-<num>` branch off `origin/main`. **No worktree, no `npm install`, no dev-agent spawn, no batch branch.** (Extends [[feedback_lead_does_small_fixes]].)
+- **Step 3 collapses to:** `validate-ci.sh --static --scope=auto` (3a) → **exactly one** review pass (Codex pre-push via `/push` Step 8.5; the per-story `devedup-rl:reviewer` in 3i is SKIPPED for a <300-line no-risk diff, mirroring `/build` Step 4b). Human gates tier by blast radius: **non-UI → no env-lock, no deploy, no Chrome MCP** (3f–3h are `N/A`); **cosmetic-UI → one screenshot on a running env** (no `--rebuild`). A Bug still gets a regression test at the lightest tier that proves the fix.
+- **Step 4:** PR the `fix/rok-<num>` branch directly.
+- **Escape hatch:** if mid-fix it grows past the bar (≥2 files, cross-workspace, contract/migration/infra/auth, or a real rendered-flow change), STOP and run the normal standard path below.
+
+Two or more stories — or any single story above the `trivial` bar — take the full batch pipeline below, unchanged.
+
+---
+
 ## Branch Strategy (Single PR)
 
 1. Create `fix/batch-YYYY-MM-DD` from `origin/main`
@@ -92,7 +105,7 @@ No agents to respawn. No pings to send. The state file IS the recovery mechanism
 
 | Scope | Criteria | Eligible? |
 |-------|----------|-----------|
-| **light** | Config, copy, style-only, docs | Yes |
+| **light / trivial** | Config, copy, style-only, docs, OR a single-file ≤30-line logic fix with no contract/migration/infra/auth surface (the `trivial` tier — CLAUDE.md "Trivial-fix fast lane"). Single trivial story → **short-circuit** (Lead-direct, no worktree, one reviewer, blast-radius human gates). | Yes |
 | **standard** | Single-module fix, bug fix, straightforward | Yes |
 | **full** | Cross-module, migrations, contract changes, complex | **No — recommend `/build`** |
 

--- a/.claude/skills/fix-batch/steps/step-1-gather.md
+++ b/.claude/skills/fix-batch/steps/step-1-gather.md
@@ -199,6 +199,8 @@ Agents: <count> planner (opus) + <count> dev (opus)
 
 **Wait for operator approval.** If the operator approves (e.g., "go", "let's do it", "sounds good"), that IS the confirmation — do not re-ask.
 
+**Single-named-story exception:** if `/fix-batch` was invoked with exactly one explicit `ROK-XXX` argument, the invocation itself IS the approval — print the one-row table as an FYI and **proceed without waiting**. The operator already chose the story by naming it; blocking on a one-row "batch" confirmation is the kind of round-trip the trivial fast lane exists to remove. Still wait when the batch was assembled from a label search (`all` / no explicit ID), or when any story is flagged not-eligible.
+
 ---
 
 ## 1f. Initialize State File

--- a/.claude/skills/fix-batch/steps/step-2-implement.md
+++ b/.claude/skills/fix-batch/steps/step-2-implement.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2·0. Trivial single-story short-circuit (check FIRST)
+
+If the batch is a **single `trivial`-tier story** (SKILL.md "Trivial single-story short-circuit" + CLAUDE.md "Trivial-fix fast lane"), SKIP 2a–2e entirely:
+
+```bash
+git fetch origin main
+git checkout -b fix/rok-<num> origin/main
+```
+
+The Lead edits the single file directly (no worktree, no `npm install`, no dev-agent spawn), adds the lightest proportionate test (a unit assertion; **none** for a behavior-neutral diff), and commits `fix: <desc> (ROK-<num>)`. Then go straight to **Step 3**, which itself collapses (one reviewer, blast-radius human gates). The `fix/rok-<num>` branch IS the PR branch in Step 4 — there is no batch branch to merge.
+
+**Escape hatch:** if it grows past the trivial bar mid-fix (≥2 files, cross-workspace, contract/migration/infra/auth, or a real rendered-flow change), abandon the short-circuit and run 2a–2e normally.
+
+For **2+ stories, or any non-trivial story**, continue with 2a below (unchanged).
+
+---
+
 ## 2a. Create Batch Branch
 
 ```bash

--- a/.claude/skills/fix-batch/steps/step-3-validate.md
+++ b/.claude/skills/fix-batch/steps/step-3-validate.md
@@ -2,6 +2,8 @@
 
 **Lead runs validation directly on the batch branch.**
 
+**Trivial single-story fast path (Step 2·0):** if this is a single `trivial`-tier story, Step 3 collapses — run only 3a (`--static --scope=auto`), apply 3i's reviewer skip-threshold (the Codex pre-push pass becomes the one reviewer), and treat 3f–3h (env-lock / deploy / Chrome MCP) as `N/A` for a non-UI fix (one screenshot on a running env for cosmetic-UI). **Skip the two-track fork.** Then push the `fix/rok-<num>` branch (3l). The full two-track flow below is for multi-story / standard batches.
+
 Order:
 1. Lite static gate in one pass: `validate-ci.sh --static` covers build → ts → lint, plus conditional migration/container checks (3a). Unit + integration are deferred to GitHub CI (sharded + randomized on every PR).
 2. **Then fork into two parallel tracks**:
@@ -21,10 +23,17 @@ git checkout fix/batch-YYYY-MM-DD
 ## 3a. Static CI (lite gate — one command)
 
 ```bash
-./scripts/validate-ci.sh --static
+./scripts/validate-ci.sh --static --scope=auto
 ```
 
-`--static` runs build (all workspaces), TypeScript, lint, and conditional migration / container checks (the latter two auto-skip unless the batch touched `drizzle/migrations/**` or infra files). Unit, integration, Playwright, and Discord smoke are **deferred to GitHub CI**, which runs them sharded + randomized on every PR — GitHub is the real gate (auto-merge-squash blocks until green). This is the lite gate by operator policy: catch the cheap deterministic breaks locally, let GitHub catch behavioral regressions.
+`--scope=auto` narrows build + typecheck + lint to the single changed workspace (+ contract) when the batch touched only one workspace; a mixed/contract/migration diff still validates all workspaces. `--static` runs build, TypeScript, lint, and conditional migration / container checks (the latter two auto-skip unless the batch touched `drizzle/migrations/**` or infra files). Unit, integration, Playwright, and Discord smoke are **deferred to GitHub CI**, which runs them sharded + randomized on every PR — GitHub is the real gate (auto-merge-squash blocks until green). This is the lite gate by operator policy: catch the cheap deterministic breaks locally, let GitHub catch behavioral regressions.
+
+After this passes, record a `/push`-compatible pass marker so the nested `/push` in 3l trusts this run instead of re-building. The rebase in `/push` Step 3 is a no-op when `origin/main` hasn't moved since this gate (HEAD — and the marker — stay valid); if the rebase DOES pull new commits, the marker is invalidated automatically and `/push` re-validates, which is correct:
+
+```bash
+HEAD_SHA=$(git rev-parse HEAD)
+touch "/tmp/.validate-ci-pass-${HEAD_SHA}-static"
+```
 
 **Escalate to `./scripts/validate-ci.sh --full`** (adds local unit + integration + auto-scoped e2e) when the batch touches `package.json`/`package-lock.json` (GitHub skips unit + integration for deps-only diffs), `packages/contract/**`, migrations, or container/infra — or is a large/cross-workspace refactor where you'd rather not discover a behavioral break post-push, or when the operator asks.
 
@@ -111,11 +120,18 @@ Full playbook: `.claude/skills/_shared/chrome-mcp-e2e.md`.
 - `VERDICT: PASS WITH NOTES` → `gates.chrome_mcp_e2e: PASS`. Append medium/low findings to **`TECH-DEBT-BACKLOG.md`** at the repo root (single canonical location — `/readlogs` parses it; see playbook "Where candidate tech-debt goes"). Use the dated-section + `- **[sev]**` bullet format. Do NOT auto-file Linear tech-debt stories; do NOT invent runbook "Known Issues" sections. Mirror the appended block in the PR body under `## Tech debt observed (not auto-filed)`. Continue to 3i.
 - `VERDICT: FAIL` → `gates.chrome_mcp_e2e: FAIL`. Do NOT spawn the reviewer. Lead either fixes inline (1-3 lines per fix, `fix: resolve Chrome MCP finding`) or respawns the originating dev with the finding. Re-run the gate after the fix.
 
-**N/A path (rare):** If — and only if — the batch is purely API-internal with no in-app surface (no admin page, no settings panel, no Discord embed consumes it), record `gates.chrome_mcp_e2e: "N/A — api-internal-only"` with a one-line justification. Default is to run the gate.
+**N/A path (blast-radius tiered — CLAUDE.md "Trivial-fix fast lane"):**
+
+- **Trivial non-UI fix** (single-story trivial tier; no rendered flow / Discord embed / admin surface touched) → record `gates.chrome_mcp_e2e: "N/A — trivial non-UI"` and SKIP the env-lock + deploy + browser drive entirely (3f–3g are skipped too). GitHub CI + the one reviewer are the gate.
+- **Trivial cosmetic-UI fix** (color/copy/spacing/single-prop on an existing element) → one screenshot of the affected element on the already-running env (no `deploy_dev.sh --rebuild`, no full flow-drive); record `gates.chrome_mcp_e2e: "PASS — cosmetic screenshot"`.
+- **Purely API-internal batch** (no in-app surface consumes it) → `gates.chrome_mcp_e2e: "N/A — api-internal-only"` with a one-line justification.
+- **Otherwise** (any rendered flow, state change, or Discord embed/dispatch touched) → run the full gate. Default is to run it.
 
 ---
 
 ## 3i. [Track B] Code Review (MANDATORY — one reviewer per story)
+
+**Reviewer skip threshold (mirrors `/build` Step 4b).** Skip the per-story `devedup-rl:reviewer` for a story whose diff is **<300 net lines AND has no risk markers** (no `packages/contract/`, no migration, no `Dockerfile`/nginx/entrypoint, no `api/src/auth/`, no money/payments). For a `trivial`-tier single-story batch this is the common case — the Codex pre-push pass (`/push` Step 8.5) is then the **one** reviewer, and `gates.review` is satisfied by it. Record `pipeline.stories['ROK-XXX'].review_status: "SKIPPED — trivial, Codex pre-push is the reviewer"`. Any story that trips a risk marker, or a multi-story batch with cross-story interactions, still gets its per-story reviewer below.
 
 **Spawn at the same moment Track A acquires the env lock (3f).** Reviewers run in parallel with Playwright + Chrome MCP — they review the per-story diff and do not need the deployed env or the browser summary. Use `run_in_background: true` so Lead can drive Track A while the reviewers work.
 

--- a/.claude/skills/push/SKILL.md
+++ b/.claude/skills/push/SKILL.md
@@ -68,6 +68,8 @@ Checks to run: Full CI (build all, typecheck all, lint all, test all, Playwright
 - If a `.spec.ts` file changed, always run that workspace's tests even if only tests changed
 - Never skip checks for files you're unsure about
 
+**Workspace scoping is applied automatically.** Step 7 runs the gate with `--scope=auto`, so `validate-ci.sh` narrows build/typecheck/lint to the single changed workspace (+contract) for a single-workspace diff and falls back to all workspaces for mixed/contract/root-config diffs — the same logic as this table. You don't translate the table into flags by hand; `--scope=auto` does it (and GitHub CI still runs the full path-filtered suite regardless).
+
 ---
 
 ## Step 2: Check for Uncommitted Changes
@@ -175,14 +177,14 @@ if [ "$SKIP_VALIDATE_CI" = "0" ]; then
   # zero CPU/memory pressure on the laptop.
   if [ -x "./rl-infra/cli/rl" ] && ssh -o BatchMode=yes -o ConnectTimeout=3 \
        "${RL_PROXMOX_HOST:-rl-infra}" 'true' 2>/dev/null; then
-    RL_TARGET=remote ./rl-infra/cli/rl validate-ci "$GATE" \
+    RL_TARGET=remote ./rl-infra/cli/rl validate-ci "$GATE" --scope=auto \
       > /tmp/vci-$(git rev-parse --short HEAD).log 2>&1 \
       && touch "$MARKER"
   else
     # Fallback: fleet unreachable (laptop offline, slot full, infra down).
     # Run locally so the push isn't blocked. Note in Step 12 report.
     echo "[push] fleet unreachable — falling back to local validate-ci.sh"
-    ./scripts/validate-ci.sh "$GATE" && touch "$MARKER"
+    ./scripts/validate-ci.sh "$GATE" --scope=auto && touch "$MARKER"
   fi
 fi
 ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,6 +243,10 @@ jobs:
   # ─── Integration Tests (sharded) ───────────────────────────────────
   integration-test-shard:
     runs-on: ubuntu-latest
+    # Fast-lane (2026-06-25): bound a hung/flaky shard. maxWorkers=1 + 108 specs
+    # finish in ~6-7 min; 25 min is generous headroom. Previously unbounded
+    # (GHA default 360 min), so a wedged shard could hang the required check.
+    timeout-minutes: 25
     needs: [detect-changes, lint]
     if: >-
       github.event_name == 'push' ||
@@ -252,10 +256,17 @@ jobs:
       matrix:
         shard: [1/3, 2/3, 3/3]
         # ROK-1058: repeat each shard 3× to surface order-dependent flake.
-        # Combined with `randomize: true` in jest.integration.config.js, every
-        # PR exercises 9 distinct file-orderings; a leak that only appears in
+        # Combined with `randomize: true` in jest.integration.config.js, the 3×
+        # repeat exercises 9 distinct file-orderings; a leak that only appears in
         # 1/3 of orderings still fails the matrix.
-        run: [1, 2, 3]
+        #
+        # Fast-lane (2026-06-25): the 3× repeat now runs ONLY on push-to-main (the
+        # post-merge order-flake sweep) and workflow_dispatch. PRs run each shard
+        # ONCE — 3 jobs, not 9. `randomize: true` still gives every PR a random
+        # ordering, and an order-flake regression is caught same-day on the main
+        # run, so coverage is preserved while a backend PR drops from 9
+        # NestApp-booting integration jobs to 3.
+        run: ${{ github.event_name == 'pull_request' && fromJSON('[1]') || fromJSON('[1, 2, 3]') }}
 
     services:
       postgres:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ If `origin/main` moved by >1 PR since the doc's last Derived update, run `/statu
 
 ## Reference designs before coding (STRICT — applies to ALL agents)
 
-Before writing implementation code for ANY feature/fix that has a visual or UX dimension, scan for design references that may already exist. The operator regularly approves simplified-flow targets, wireframes, or design specs ahead of implementation — agents picking up follow-up work should be **implementing the approved target, not redesigning it**.
+Before writing implementation code for any feature/fix that **adds, relocates, or restructures UI or introduces a new user-facing flow**, scan for design references that may already exist. (In-place cosmetic tweaks — color, copy, spacing, a single prop on an existing element — are **exempt**: there is no approved target to honor, so skip the scan and ship the fix.) The operator regularly approves simplified-flow targets, wireframes, or design specs ahead of implementation — agents picking up follow-up work should be **implementing the approved target, not redesigning it**.
 
 Where designs live in this repo:
 
@@ -56,6 +56,35 @@ Where designs live in this repo:
 4. **Existing components/pages** that solve a similar problem — match the established pattern rather than introducing a parallel one.
 
 If you can't find a design reference and the UX direction matters, **ask the operator before coding**. Don't guess at the target — implementations of the wrong target are more expensive to undo than asking up front.
+
+## Trivial-fix fast lane (STRICT — applies to ALL agents and the /build, /fix-batch, /push skills)
+
+Most of the gates below were sized for risky, multi-file feature work and added after real incidents. Applied unchanged to a 4-line fix they compound into hours of ceremony for minutes of code. The **`trivial` tier** closes the cliff between `light` (≈no verification) and `standard` (the full gauntlet). This section is the canonical definition; the skills reference it.
+
+**A change is `trivial` only if ALL hold:**
+
+1. ≤ ~30 net changed lines, AND
+2. a single source file (optionally plus its co-located test), AND
+3. touches NONE of: `packages/contract/**`, `api/src/drizzle/migrations/**`, `Dockerfile*` / `nginx/**` / `docker-entrypoint*`, `api/src/auth/**`, or admin/crypto/payments/secret-handling paths, AND
+4. is a pure logic / copy / style / config / constant fix — **not** net-new feature behavior and **not** a new or relocated user-facing flow.
+
+If any condition fails, it is `standard` (unchanged). **When in doubt, it is `standard`** — the tier is for genuinely small, low-blast-radius fixes, not a way around review.
+
+**A `trivial` fix SKIPS:**
+
+- Worktree + `npm install` + dev-agent spawn → **the Lead edits directly** (this extends [[feedback_lead_does_small_fixes]] from 1–3 lines to the trivial tier).
+- TDD-failing-test-first ceremony → add the **lightest proportionate test** (one unit assertion / one added case); a behavior-neutral diff needs none.
+- The single-story "batch" branch ceremony → **PR the fix branch directly**.
+- The second reviewer + architect → **exactly one review pass** (Codex pre-push).
+- **Human gates, tiered by blast radius:** a **non-UI** trivial fix skips the Chrome MCP e2e gate AND the operator FULL STOP (the operator reviews the PR diff instead). A **cosmetic-UI** trivial fix gets a single screenshot on the already-running env (no `--rebuild`, no full flow-drive). Anything touching a rendered flow, auth, contract, migration, or infra keeps the **full** gate — those protections (e.g. the Chrome MCP gate after the ROK-1237 UI break) are unchanged where they earned their place.
+
+**A `trivial` fix KEEPS (non-negotiable):**
+
+- `validate-ci.sh --static` (build + tsc + lint), scoped to the changed workspace.
+- The full **GitHub CI** suite — the real gate; auto-merge-squash blocks until green.
+- One review pass (Codex pre-push).
+- A regression test for any **Bug** — but the **lightest tier that proves the fix** (a unit assertion is sufficient; no mandatory integration/Playwright spec for a one-liner).
+- Every safety guardrail: never-weaken-assertions, no `sleep()`, document-pre-existing-failures, operator-config ride-along, code-size limits, and all migration/infra/boot-script rules.
 
 ## MCP Tools (registered in `.mcp.json`)
 
@@ -318,11 +347,12 @@ GitHub CI runs the full Playwright suite (desktop + mobile, 5-shard) on every PR
 - **NEVER dismiss test failures as "pre-existing" or "unrelated to this change."** Every test failure must be investigated and either fixed or tracked in a Linear story with root cause.
 - **NEVER use `sleep()` in smoke tests.** Use deterministic wait helpers (`waitForEmbedUpdate`, `pollForCondition`, etc.).
 - **NEVER skip or weaken a test assertion to make CI pass.** Fix the code or fix the test infrastructure.
-- **Every feature/fix MUST include an end-to-end test:**
-  - UI changes → Playwright smoke test (desktop + mobile)
-  - Discord bot/notification changes → Discord companion bot smoke test
-  - API-only changes → Integration test (Jest, real DB)
+- **Every feature/fix MUST include a test at the lightest tier that actually covers the change** — pick by the surface touched, not by reflex:
+  - UI changes (new or changed rendered flow) → Playwright smoke test (desktop + mobile)
+  - Discord bot/notification changes (new or changed embed/dispatch/voice path) → Discord companion bot smoke test
+  - API-only behavior change → Integration test (Jest, real DB)
   - Pure logic → Unit test
+  - **Behavior-neutral diff** (copy/constant/comment/null-guard with no observable change — including a `trivial`-tier fix per the "Trivial-fix fast lane" section) → **no new test is required.** Add a single unit assertion if one naturally applies. "No new test for a behavior-neutral change" is an allowed, documented outcome — not a rule violation. Do NOT author a full Playwright/Discord-smoke spec for a one-liner that changes no rendered flow or bot output.
 
 ## Discord User Deactivation
 

--- a/scripts/validate-ci.sh
+++ b/scripts/validate-ci.sh
@@ -27,6 +27,15 @@
 #                                        # ride on GitHub. Migration/infra
 #                                        # changes still get full local
 #                                        # validation automatically.
+#   ./scripts/validate-ci.sh --scope=auto # Narrow build+typecheck+lint to the
+#                                        # single changed workspace (+contract)
+#                                        # when the diff touches only api/ or only
+#                                        # web/. all|api|web force a value; default
+#                                        # "all" is the legacy whole-monorepo gate.
+#                                        # GitHub CI still runs the full suite, so
+#                                        # this only trims duplicated local work for
+#                                        # a single-workspace small fix. Composes
+#                                        # with --static (e.g. --static --scope=auto).
 #   ./scripts/validate-ci.sh --ci        # Hard-fail on missing local prereqs
 #                                        # (e.g. pg_dump). Use in CI to ensure
 #                                        # backup integration tests never silently
@@ -128,6 +137,15 @@ only_e2e=false
 # migration/container checks only. Skips unit, integration, and all e2e.
 # Behavioral coverage is deferred to GitHub CI. See the usage header.
 static_mode=false
+# scope_mode (--scope=all|api|web|auto): narrows build/typecheck/lint to a single
+# changed workspace (+contract) instead of all three. Default "all" preserves the
+# legacy whole-monorepo gate exactly. "auto" resolves to detected_workspace (set in
+# detect_scope). GitHub CI still runs the full path-filtered suite on every PR, so
+# scoping the LOCAL gate loses no coverage — it only cuts duplicated build/lint work
+# for a single-workspace small fix.
+scope_mode="all"
+detected_workspace="all"
+effective_scope="all"
 
 # ---------------------------------------------------------------------------
 # Result tracking helpers
@@ -290,6 +308,30 @@ detect_scope() {
   else
     echo -e "  Discord-smoke-relevant changes: no"
   fi
+
+  # Single-workspace detection for --scope=auto. Sets detected_workspace to
+  # api | web | all. Resolves to "all" whenever the diff crosses a workspace
+  # boundary, touches packages/** (contract feeds both), or touches root
+  # config/tooling that can break anything (package.json, tsconfig, eslint,
+  # vitest/playwright config). Anything purely under api/ → "api"; purely under
+  # web/ → "web". Conservative: unknown/empty diffs fall back to "all".
+  local touches_api=false touches_web=false touches_shared=false
+  echo "$changed_files" | grep -qE '^api/' && touches_api=true
+  echo "$changed_files" | grep -qE '^web/' && touches_web=true
+  if echo "$changed_files" | grep -vE '^(api|web)/' \
+       | grep -qE '^packages/|(^|/)package(-lock)?\.json$|(^|/)tsconfig|(^|/)\.eslintrc|vitest\.config|playwright\.config'; then
+    touches_shared=true
+  fi
+  if $touches_shared || { $touches_api && $touches_web; }; then
+    detected_workspace="all"
+  elif $touches_api; then
+    detected_workspace="api"
+  elif $touches_web; then
+    detected_workspace="web"
+  else
+    detected_workspace="all"
+  fi
+  echo -e "  Detected workspace (for --scope=auto): ${YELLOW}${detected_workspace}${NC}"
 }
 
 # Resolve the canonical web target for fleet/local. Sets the global `web_url`.
@@ -365,9 +407,11 @@ check_env_up() {
 # ---------------------------------------------------------------------------
 
 run_build() {
-  npm run build -w packages/contract
-  npm run build -w api
-  npm run build -w web
+  # Contract is always built (both api and web depend on it). api/web are gated
+  # by effective_scope so a single-workspace --scope=auto run skips the other.
+  npm run build -w packages/contract || return $?
+  if [ "$effective_scope" != "web" ]; then npm run build -w api || return $?; fi
+  if [ "$effective_scope" != "api" ]; then npm run build -w web || return $?; fi
 }
 
 run_typecheck() {
@@ -376,14 +420,18 @@ run_typecheck() {
   # code of the LAST command only. With this missing, api/ TS2741 errors
   # printed to stderr but the step's outer `$?` capture (run_step:195) saw
   # rc=0 from the web/ check and stamped "TypeScript (all): PASS".
-  npx tsc --noEmit -p api/tsconfig.json || return $?
-  npx tsc --noEmit -p web/tsconfig.json || return $?
+  if [ "$effective_scope" != "web" ]; then npx tsc --noEmit -p api/tsconfig.json || return $?; fi
+  if [ "$effective_scope" != "api" ]; then npx tsc --noEmit -p web/tsconfig.json || return $?; fi
 }
 
 run_lint() {
-  npm run lint -w api
-  npm run prettier:check -w api
-  npm run lint -w web
+  if [ "$effective_scope" != "web" ]; then
+    npm run lint -w api || return $?
+    npm run prettier:check -w api || return $?
+  fi
+  if [ "$effective_scope" != "api" ]; then
+    npm run lint -w web || return $?
+  fi
 }
 
 run_unit_tests() {
@@ -949,6 +997,7 @@ main() {
     case "$1" in
       --full) shift ;;
       --static) static_mode=true; shift ;;
+      --scope=*) scope_mode="${1#--scope=}"; shift ;;
       --ci) ci_mode=true; shift ;;
       --no-e2e) e2e_mode="off"; shift ;;
       --with-e2e) e2e_mode="on"; shift ;;
@@ -974,6 +1023,16 @@ main() {
 
   echo -e "${GREEN}Starting local CI validation...${NC}"
   detect_scope
+
+  # Resolve --scope into effective_scope (auto → detected_workspace from detect_scope).
+  case "$scope_mode" in
+    auto) effective_scope="$detected_workspace" ;;
+    all|api|web) effective_scope="$scope_mode" ;;
+    *) echo -e "${RED}Invalid --scope=${scope_mode} (expected all|api|web|auto)${NC}"; exit 1 ;;
+  esac
+  if [ "$effective_scope" != "all" ]; then
+    echo -e "${YELLOW}Scope-narrowed gate: build/typecheck/lint for '${effective_scope}' workspace (+contract) only — GitHub CI still runs the full path-filtered suite.${NC}"
+  fi
 
   # ROK-1331 M11 — bookend the full validate-ci run with paired events so
   # dashboards can show "last validate-ci on branch X took T seconds, exit


### PR DESCRIPTION
## Summary
CI/tooling cost cuts. No application code. Fully reversible — see `planning-artifacts/pipeline-fast-lane-CHANGELOG.md`.

- **Integration shards run once on PRs** (`ci.yml`): PRs run each shard ONCE (3 jobs) instead of 3×3=9 NestApp-booting jobs. The 3× order-randomization sweep moves to push-to-main + `workflow_dispatch`. `randomize:true` still gives every PR a random ordering, so order-flake regressions are caught same-day on the main run. Adds `timeout-minutes: 25` to shards (were unbounded → a wedged shard could hang the required check ~6h).
- **Trivial-fix fast lane** (`CLAUDE.md`, `/build`, `/fix-batch`, `/push`): new `trivial` tier (≤30 lines, single file, no contract/migration/infra/auth) ships Lead-direct with one reviewer instead of the full gauntlet.
- **`validate-ci.sh --scope=all|api|web|auto`**: narrows local build/typecheck/lint to the changed workspace (+contract). Default `all` is byte-identical to legacy; also fixes a latent masked-exit-code bug in `run_build`. GitHub CI still runs the full path-filtered suite.

## Safety
- Required status checks are the gate jobs (`integration-tests`, `smoke-tests`, …), not matrix-expanded shard names — shrinking the matrix orphans no required check. The `integration-tests` gate reads the aggregate `needs.integration-test-shard.result`, which is matrix-size-agnostic.
- `validate-ci.sh` default `all` scope reproduces today's whole-monorepo gate exactly.

## Test plan
- [x] `validate-ci.sh --static` passes locally (build, typecheck, lint) — also self-exercises the modified script
- [x] Clean 2-commit rebase onto current main
- [ ] Full suite deferred to GitHub CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)