### PR TITLE
fix(ci-flakes): Phase 1 test-infra hardening — unblock main + isolation/timing fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,12 @@ scripts/*
 !scripts/test-plan-comments.sh
 !scripts/recover-stuck-migration.sh
 !scripts/test/
+# ROK-1286: keep the Playwright auth-cache DIRECTORY in the synced tree (so the
+# fleet Mutagen replica never deletes it mid-run) while still ignoring the JWT
+# token files written into it at runtime.
+!scripts/.auth/
+scripts/.auth/*
+!scripts/.auth/.gitkeep
 !/api/scripts/
 implementation_plan.md
 walkthrough.md

--- a/api/package.json
+++ b/api/package.json
@@ -25,7 +25,7 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "test:integration": "jest --config ./jest.integration.config.js --runInBand"
+    "test:integration": "NODE_OPTIONS=\"--max-old-space-size=4096\" jest --config ./jest.integration.config.js --runInBand"
   },
   "dependencies": {
     "@nestjs/bullmq": "^11.0.4",

--- a/api/src/common/testing/integration-helpers.ts
+++ b/api/src/common/testing/integration-helpers.ts
@@ -292,6 +292,15 @@ export async function waitFor(
 /**
  * Login as the seeded admin user and return a JWT access token.
  * Convenience helper for tests that need authenticated requests.
+ *
+ * ROK-1321: a non-200 here on sustained full-suite re-runs is the signature
+ * of a STALE TestApp handle — a sibling/global afterAll closed the server, or
+ * `seed` predates a mid-suite re-seed. In practice that is the residual socket
+ * carrier (ROK-1268) surfacing on the first bare request after a truncate, NOT
+ * a real auth break. We do NOT retry/self-heal here (that would mask the carrier
+ * on an unreproduced hypothesis — see TESTING.md flake-investigation protocol);
+ * instead the error names the lifecycle cause so the next investigator looks at
+ * the socket/teardown layer rather than chasing a phantom auth bug.
  */
 export async function loginAsAdmin(
   request: TestAgent<supertest.Test>,
@@ -303,7 +312,12 @@ export async function loginAsAdmin(
 
   if (res.status !== 200) {
     throw new Error(
-      `loginAsAdmin failed: expected 200 but got ${res.status} — ${JSON.stringify(res.body)}`,
+      `loginAsAdmin failed: expected 200 but got ${res.status} — ` +
+        `${JSON.stringify(res.body)}. A non-200 from /auth/local mid-suite ` +
+        `usually means the supertest agent/app handle was closed or re-seeded ` +
+        `(stale TestApp reference / residual socket carrier ROK-1268) — confirm ` +
+        `no nested describe calls closeTestApp(); rely on the global afterAll ` +
+        `in integration-setup.ts.`,
     );
   }
 

--- a/api/src/events/events-dashboard.dashboard.integration.spec.ts
+++ b/api/src/events/events-dashboard.dashboard.integration.spec.ts
@@ -79,6 +79,12 @@ let adminToken: string;
 
 async function setupAll() {
   testApp = await getTestApp();
+  // Defensive clean-start under `jest --randomize`: don't trust the prior spec
+  // file (random order) to have left an empty DB. Re-seed from baseline so
+  // testEmptyDashboard (and the other order-sensitive dashboard asserts) see
+  // only this file's data. Pairs with the per-test afterEach truncate to
+  // isolate every test from both prior files and prior tests. ROK CI-flake A1/#8.
+  testApp.seed = await truncateAllTables(testApp.db);
   adminToken = await loginAsAdmin(testApp.request, testApp.seed);
 }
 

--- a/api/src/game-taste/game-taste.integration.spec.ts
+++ b/api/src/game-taste/game-taste.integration.spec.ts
@@ -51,6 +51,12 @@ describe('Game Taste Vectors (ROK-1082)', () => {
 
   beforeAll(async () => {
     testApp = await getTestApp();
+    // Defensive clean-start under `jest --randomize`: don't trust the prior
+    // spec file (random order) to have left an empty DB. Re-seed from a known
+    // baseline here so this file's first test is isolated from whatever ran
+    // before it. Combined with the per-test afterEach truncate, every test is
+    // fully isolated from both prior files and prior tests. ROK CI-flake A1/#7.
+    testApp.seed = await truncateAllTables(testApp.db);
     adminToken = await loginAsAdmin(testApp.request, testApp.seed);
     memberToken = await createMemberAndLogin();
     service = testApp.app.get(GameTasteService);
@@ -374,10 +380,15 @@ describe('Game Taste Vectors (ROK-1082)', () => {
     });
 
     it('POST /games/similar returns 403 for non-admin', async () => {
+      // Self-seed a real game so the request body references a current row
+      // instead of a hardcoded sentinel id (id 1 may not exist after
+      // cross-suite truncation under --randomize). AdminGuard must reject the
+      // member BEFORE the handler runs, so the status is 403 regardless.
+      const gameId = await seedGame('Similar Guard Game');
       const res = await testApp.request
         .post('/games/similar')
         .set('Authorization', `Bearer ${memberToken}`)
-        .send({ gameId: 1, limit: 3 });
+        .send({ gameId, limit: 3 });
       expect(res.status).toBe(403);
     });
 

--- a/api/src/lineups/ai-suggestions/ai-suggestions-pregen.integration.spec.ts
+++ b/api/src/lineups/ai-suggestions/ai-suggestions-pregen.integration.spec.ts
@@ -103,6 +103,13 @@ function describePreGen() {
   beforeEach(async () => {
     await settings.set(SETTING_KEYS_AI_ENABLED, 'true');
     await settings.set(SETTING_KEYS_AI_PROVIDER, 'google');
+    // Resolve the seeded admin id BEFORE every test so the `sanity` test is
+    // order-independent under `jest --randomize`. Previously adminUserId was
+    // assigned only in afterEach, so when `sanity` was scheduled first it
+    // read `undefined` ("Expected number, Received undefined"). The admin row
+    // exists at this point (seeded in beforeAll / re-seeded by the prior
+    // afterEach truncate). ROK CI-flake A1/K1.
+    adminUserId = await resolveAdminUserId();
   });
 
   const SETTING_KEYS_AI_ENABLED = 'ai_suggestions_enabled';

--- a/api/src/lineups/lineup-auto-advance-grace.integration.spec.ts
+++ b/api/src/lineups/lineup-auto-advance-grace.integration.spec.ts
@@ -410,12 +410,16 @@ function describeGrace() {
     expect(state.pendingAdvanceAt).toBeNull();
     expect(await readStatus(lineupId)).toBe('voting');
 
-    // The orphaned BullMQ grace job, if it still exists, must no-op when
-    // it fires. We assert this by giving it a moment to wake (we kept the
-    // grace at 300s so it cannot have fired naturally yet) and verifying
-    // status hasn't moved. The job *may* be cancelled eagerly — both are
-    // acceptable behaviors. We assert the OBSERVABLE outcome (status).
-    await new Promise((r) => setTimeout(r, 200));
+    // The orphaned BullMQ grace job, if it still exists, must no-op: with
+    // grace=300s it stays parked as a `delayed` BullMQ job and cannot fire
+    // within the test, so the status cannot advance. The job *may* be
+    // cancelled eagerly — both are acceptable. Assert the OBSERVABLE outcome
+    // (status) plus that any surviving job is still parked — deterministic
+    // rather than sleeping to "give it a chance to wake".
+    const orphan = await getGraceJob(lineupId);
+    if (orphan) {
+      expect(await orphan.getState()).toBe('delayed');
+    }
     expect(await readStatus(lineupId)).toBe('voting');
   });
 
@@ -489,8 +493,10 @@ function describeGrace() {
     expect(stillPaused.pendingAdvanceAt).toBeNull();
     expect(await readStatus(lineupId)).toBe('building');
 
-    // Give any erroneous BullMQ grace job a chance to fire.
-    await new Promise((r) => setTimeout(r, 1_000));
+    // A paused lineup must NOT have an erroneous grace job queued. Assert its
+    // absence directly instead of sleeping to "let it fire": with no job
+    // scheduled nothing can flip the status, so the lineup stays 'building'.
+    expect(await getGraceJob(lineupId)).toBeFalsy();
     expect(await readStatus(lineupId)).toBe('building');
   });
 
@@ -582,8 +588,15 @@ function describeGrace() {
       (await readAdvanceState(lineupId)).autoAdvancePausedAt,
     ).not.toBeNull();
 
-    // Wait past the 50ms TTL.
-    await new Promise((r) => setTimeout(r, 200));
+    // Deterministically expire the pause cool-off: push auto_advance_paused_at
+    // far enough into the past that the 50ms TTL is guaranteed elapsed, rather
+    // than sleeping for it. This puts the row in the exact "TTL elapsed" state
+    // the next mutation must observe to re-schedule grace.
+    await writeAdvanceState(
+      lineupId,
+      'auto_advance_paused_at',
+      new Date(Date.now() - 60_000),
+    );
 
     // Top up nominations to satisfy the nomination floor (default 4).
     for (let i = 0; i < 3; i++) {
@@ -676,8 +689,16 @@ function describeGrace() {
     // where the BullMQ cancel-on-revert lost.
     await writeAdvanceState(lineupId, 'auto_advance_paused_at', new Date());
 
-    // Wait long enough that the grace job's delay would normally elapse.
-    await new Promise((r) => setTimeout(r, 2_000));
+    // Wait until the delayed grace job actually fires and the processor runs
+    // to completion (job removed on complete, or a terminal state) instead of
+    // sleeping for the 500ms delay. Once it has run we can assert it no-op'd.
+    const processed = await pollForCondition(async () => {
+      const job = await getGraceJob(lineupId);
+      if (!job) return true; // removeOnComplete → processor ran and finished
+      const state = await job.getState();
+      return state === 'completed' || state === 'failed' ? true : null;
+    }, 10_000);
+    expect(processed).toBe(true);
 
     // Status must stay 'voting' — the processor saw the pause and bailed.
     expect(await readStatus(lineupId)).toBe('voting');
@@ -938,8 +959,12 @@ function describeGrace() {
       await submitAllVotes(lineupId, [v2.token]);
 
       // The fire-and-forget call inside the toggle handler races the HTTP
-      // response; give it a brief window to flush.
-      await new Promise((r) => setTimeout(r, 200));
+      // response; poll until the gateway emit has flushed instead of sleeping
+      // for a fixed window.
+      await pollForCondition(
+        () => Promise.resolve(spy.mock.calls.length > 0 ? true : null),
+        5_000,
+      );
 
       expect(spy).toHaveBeenCalledTimes(1);
       const [emittedId, emittedAt] = spy.mock.calls[0];

--- a/api/src/lineups/standalone-poll/standalone-poll.integration.spec.ts
+++ b/api/src/lineups/standalone-poll/standalone-poll.integration.spec.ts
@@ -117,6 +117,36 @@ async function addGameInterest(userId: number, gameId: number) {
   });
 }
 
+/**
+ * Poll the notifications table until a row with the given payload subtype
+ * lands for the user, or the deadline elapses. The poll DMs from
+ * POST /scheduling-polls are dispatched fire-and-forget (the controller
+ * `void`s notifyInterestedUsers), so the row appears asynchronously after
+ * the response returns. Returns the matching row, or `undefined` on timeout
+ * (preserving `.find()` semantics for the existing `toBeDefined()` checks).
+ * Replaces fixed `setTimeout` sleeps with a deterministic wait.
+ */
+async function waitForNotification(
+  userId: number,
+  subtype: string,
+  timeoutMs = 5000,
+): Promise<typeof schema.notifications.$inferSelect | undefined> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const rows = await testApp.db
+      .select()
+      .from(schema.notifications)
+      .where(eq(schema.notifications.userId, userId));
+    const match = rows.find((n) => {
+      const payload = n.payload as Record<string, unknown> | null;
+      return payload?.subtype === subtype;
+    });
+    if (match) return match;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  return undefined;
+}
+
 // ── ROK-977 AC1: POST with valid gameId creates lineup + match ───────
 
 function describeCreatePoll() {
@@ -638,19 +668,11 @@ function describeRosterNotifications() {
       linkedEventId: event.id,
     });
 
-    // Allow fire-and-forget notifications to complete
-    await new Promise((r) => setTimeout(r, 500));
-
-    // Check notification for roster member — should have reschedule subtype
-    const notifications = await testApp.db
-      .select()
-      .from(schema.notifications)
-      .where(eq(schema.notifications.userId, rosterMember.userId));
-
-    const rescheduleNotif = notifications.find((n) => {
-      const payload = n.payload as Record<string, unknown> | null;
-      return payload?.subtype === 'event_rescheduling';
-    });
+    // Poll until the fire-and-forget reschedule notification row lands.
+    const rescheduleNotif = await waitForNotification(
+      rosterMember.userId,
+      'event_rescheduling',
+    );
 
     expect(rescheduleNotif).toBeDefined();
     expect(rescheduleNotif!.title).toMatch(/reschedul/i);
@@ -677,10 +699,14 @@ function describeInterestOnlyNotifications() {
       linkedEventId: event.id,
     });
 
-    // Allow fire-and-forget notifications to complete
-    await new Promise((r) => setTimeout(r, 500));
+    // Poll until the generic scheduling-poll notification row lands, then
+    // re-read all rows for the user to run the same shape assertions.
+    const generic = await waitForNotification(
+      interestUser.userId,
+      'standalone_scheduling_poll',
+    );
+    expect(generic).toBeDefined();
 
-    // Check notification for interest-only user — should have generic subtype
     const userNotifs = await testApp.db
       .select()
       .from(schema.notifications)
@@ -724,8 +750,15 @@ function describeNotificationDedup() {
       linkedEventId: event.id,
     });
 
-    // Allow fire-and-forget notifications to complete
-    await new Promise((r) => setTimeout(r, 500));
+    // Poll until the reschedule notification row lands (the dedup logic sends
+    // a dual roster+interest user ONLY this row), then re-read all rows to
+    // assert the exact count. Mirrors the established poll-then-exact-count
+    // idiom (lineup-deadline-transition-notify.integration.spec.ts).
+    const reschedule = await waitForNotification(
+      dualUser.userId,
+      'event_rescheduling',
+    );
+    expect(reschedule).toBeDefined();
 
     // Check notifications for dual user — should have exactly 1
     const notifications = await testApp.db

--- a/scripts/.auth/.gitkeep
+++ b/scripts/.auth/.gitkeep
@@ -1,0 +1,5 @@
+# Keeps scripts/.auth/ present in the synced tree (ROK-1286).
+# Playwright global-setup writes admin-token.json + admin.json here; the *.json
+# token files stay gitignored (see .gitignore), but the directory itself must
+# exist so the fleet's one-way Mutagen replica never deletes it mid-run and the
+# token write never ENOENTs.

--- a/scripts/auth-paths.ts
+++ b/scripts/auth-paths.ts
@@ -12,9 +12,22 @@
  * (the smoke worker would see "missing" and fall back to live login).
  *
  * Importing both paths from this module guarantees they stay in lockstep.
+ *
+ * ROK-1286: the anchor is `process.cwd()`, NOT `__dirname`. Playwright's
+ * transpile loader rewrites this file into a per-invocation temp directory, so
+ * `__dirname` resolved to a transient path that differed between
+ * `playwright-global-setup.ts` (which writes the token) and
+ * `smoke/api-helpers.ts` (which reads it). The reader would see "missing" and
+ * fall back to a live `/auth/local` login — the rate-limited fan-out that
+ * ROK-1085 introduced this cache to avoid. On the fleet's one-way Mutagen
+ * replica the temp `.auth` dir was also deleted mid-run, producing ENOENT on
+ * write. `process.cwd()` is the repo root for every `npx playwright test`
+ * invocation and matches `playwright.config.ts`'s
+ * `path.resolve('scripts/.auth/admin.json')` storageState anchor exactly, so
+ * setup, the workers, and the config all resolve the same real directory.
  */
 import path from 'node:path';
 
-export const AUTH_DIR = path.resolve(__dirname, '.auth');
+export const AUTH_DIR = path.resolve(process.cwd(), 'scripts/.auth');
 export const STORAGE_STATE_PATH = path.join(AUTH_DIR, 'admin.json');
 export const TOKEN_FILE_PATH = path.join(AUTH_DIR, 'admin-token.json');

--- a/scripts/playwright-global-setup.ts
+++ b/scripts/playwright-global-setup.ts
@@ -32,6 +32,37 @@ const BASE_URL = process.env.BASE_URL || 'http://localhost:5173';
 const ADMIN_EMAIL = 'admin@local';
 const ADMIN_PASSWORD = process.env.ADMIN_PASSWORD || 'password';
 
+/**
+ * Best-effort, idempotent archive of lineups from a previous smoke run.
+ * Scoped to the shared `smoke-w` worker-title prefix so it never touches
+ * real/demo lineups. Swallows all failures (logs + continues) so a missing
+ * DEMO_MODE endpoint or transient error can never crash global setup.
+ */
+async function archiveStaleSmokeLineups(
+    apiBase: string,
+    token: string,
+): Promise<void> {
+    try {
+        const res = await fetch(`${apiBase}/admin/test/reset-lineups`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Authorization: `Bearer ${token}`,
+            },
+            body: JSON.stringify({ titlePrefix: 'smoke-w' }),
+        });
+        if (!res.ok) {
+            console.warn(
+                `[global-setup] reset-lineups(smoke-w) → ${res.status} — continuing`,
+            );
+        }
+    } catch (err) {
+        console.warn(
+            `[global-setup] reset-lineups(smoke-w) failed: ${String(err)} — continuing`,
+        );
+    }
+}
+
 export default async function globalSetup(_config: FullConfig) {
     // Ensure .auth directory exists
     fs.mkdirSync(AUTH_DIR, { recursive: true });
@@ -73,6 +104,18 @@ export default async function globalSetup(_config: FullConfig) {
 
     if (!resetRes.ok) {
         const body = await resetRes.text();
+        // ROK-1286 (FIX 4): a 403 here means the API is NOT in DEMO_MODE, so
+        // every /admin/test/* reset endpoint is disabled. Call it out loudly —
+        // the demo/install fallback below does NOT wipe lineups, so smoke
+        // fixtures can otherwise inherit stale/absent state and flake. The real
+        // fix is running smoke with DEMO_MODE=true in CI (see CI config).
+        if (resetRes.status === 403) {
+            console.warn(
+                '[global-setup] reset-to-seed → 403: API is NOT running in DEMO_MODE; ' +
+                    'test-only reset endpoints are disabled. Smoke state may be stale/absent. ' +
+                    'Run smoke with DEMO_MODE=true. Falling back to demo/install.',
+            );
+        }
         console.warn(
             `Reset-to-seed returned ${resetRes.status}: ${body} — falling back to demo/install`,
         );
@@ -88,6 +131,16 @@ export default async function globalSetup(_config: FullConfig) {
             console.warn(`Demo data seed returned ${seedRes.status}: ${seedBody}`);
         }
     }
+
+    // ROK-1286 (FIX 2): belt-and-suspenders archive of any lineups left behind
+    // by a PREVIOUS smoke run (title prefix `smoke-w<idx>-…`). When reset-to-
+    // seed succeeds above this is a no-op (all lineups are already wiped); but
+    // when it 403s/falls back to demo/install (which does NOT wipe lineups) on
+    // a persistent DB (e.g. the fleet), stale `smoke-w*` rows would otherwise
+    // bleed across runs and hand `/lineups/banner` to a sibling's VOTING-phase
+    // lineup — deterministically breaking the Nominate-button specs. Idempotent
+    // and best-effort: a failure logs and continues so setup never crashes.
+    await archiveStaleSmokeLineups(API_BASE, access_token);
 
     // 3. Launch browser, set JWT in localStorage, save storageState
     const browser = await chromium.launch();

--- a/scripts/smoke/community-lineup.smoke.spec.ts
+++ b/scripts/smoke/community-lineup.smoke.spec.ts
@@ -206,6 +206,16 @@ test.describe('Community Lineup banner on Games page', () => {
 // ---------------------------------------------------------------------------
 
 test.describe('Nomination modal', () => {
+    // ROK-1286 (FIX 1): the Nominate button only renders while the newest
+    // lineup is in BUILDING phase. A sibling/stale VOTING-phase lineup that is
+    // newer hands `/lineups/banner` to itself (no Nominate CTA), so the click
+    // below times out — deterministic on a persistent DB, cross-worker flake in
+    // CI. Re-assert a building-phase lineup before each test, mirroring the
+    // banner/detail/responsive describes above.
+    test.beforeEach(async () => {
+        lineupId = await ensureActiveLineupInBuildingPhase(adminToken);
+    });
+
     test('opens when clicking Nominate button on banner', async ({ page }) => {
         await gotoGames(page);
         await expect(page.getByText('COMMUNITY LINEUP')).toBeVisible({ timeout: 15_000 });
@@ -481,6 +491,66 @@ test.describe('Community Lineup responsive layout', () => {
 // Voting phase (ROK-936)
 // ---------------------------------------------------------------------------
 
+/** Shared lineup-create body (per-worker title, long phase durations). */
+function newLineupBody(): Record<string, unknown> {
+    return {
+        title: lineupTitle,
+        targetDate: new Date(Date.now() + 7 * 86_400_000).toISOString(),
+        buildingDurationHours: 720,
+        votingDurationHours: 720,
+        decidedDurationHours: 720,
+    };
+}
+
+/**
+ * ROK-1286 (FIX 1, #26): resolve a lineup we can deterministically drive to
+ * voting. Reuses the banner lineup when it's already voting/building; archives
+ * THIS worker's rows and re-creates (via createLineupOrRetry, so a sibling 409
+ * is loud + retried) when the banner is in a non-advanceable state (decided) or
+ * absent because an earlier spec left everything archived.
+ */
+async function ensureVotingLineup(token: string): Promise<number> {
+    const banner = await apiGet(token, '/lineups/banner');
+    if (
+        banner &&
+        typeof banner.id === 'number' &&
+        (banner.status === 'voting' || banner.status === 'building')
+    ) {
+        return banner.id;
+    }
+    if (banner && typeof banner.id === 'number') {
+        await archiveLineup(token, banner.id);
+    }
+    const { id } = await createLineupOrRetry(token, newLineupBody(), workerPrefix);
+    return id;
+}
+
+/**
+ * Ensure `id` has nominations, advance it to voting, and gate on the server
+ * actually reporting `voting` before tests assert the leaderboard. The PATCH +
+ * its async side-effects settle out-of-band; navigating too early renders the
+ * building surface (the #26 leaderboard flake).
+ */
+async function seedAndAdvanceToVoting(token: string, id: number): Promise<void> {
+    const detail = await apiGet(token, `/lineups/${id}`);
+    if (!detail?.entries?.length) {
+        const gameIds = await fetchGameIds(token, 3);
+        for (const gid of gameIds) {
+            await apiPost(token, `/lineups/${id}/nominate`, { gameId: gid });
+        }
+    }
+    if (detail?.status !== 'voting') {
+        await apiPatch(token, `/lineups/${id}/status`, { status: 'voting' });
+    }
+    await pollForCondition(
+        async () => {
+            const d = await apiGet(token, `/lineups/${id}`);
+            return d?.status === 'voting' ? d : null;
+        },
+        { timeoutMs: 10_000, description: `/lineups/${id} reports voting` },
+    );
+}
+
 test.describe('Voting phase', () => {
     // ROK-1147: this describe reads the global /lineups/banner to find a
     // voting lineup and also archives the active lineup to assert the
@@ -494,50 +564,12 @@ test.describe('Voting phase', () => {
     let votingLineupId: number;
 
     test.beforeAll(async () => {
-        // Ensure a lineup exists and advance it to voting status
-        const banner = await apiGet(adminToken, '/lineups/banner');
-        if (banner && typeof banner.id === 'number') {
-            if (banner.status === 'voting') {
-                votingLineupId = banner.id;
-                return;
-            }
-            // Archive anything that is not building (decided, etc)
-            if (banner.status !== 'building') {
-                await archiveLineup(adminToken, banner.id);
-                const created = (await apiPost(adminToken, '/lineups', {
-                    title: lineupTitle,
-                    targetDate: new Date(Date.now() + 7 * 86_400_000).toISOString(),
-                    buildingDurationHours: 720,
-                    votingDurationHours: 720,
-                    decidedDurationHours: 720,
-                })) as { id: number };
-                votingLineupId = created.id;
-            } else {
-                votingLineupId = banner.id;
-            }
-        } else {
-            // No active lineup -- create one
-            const created = (await apiPost(adminToken, '/lineups', {
-                title: lineupTitle,
-                targetDate: new Date(Date.now() + 7 * 86_400_000).toISOString(),
-                buildingDurationHours: 720,
-                votingDurationHours: 720,
-                decidedDurationHours: 720,
-            })) as { id: number };
-            votingLineupId = created.id;
-        }
-
-        // Ensure the lineup has nominations before advancing to voting.
-        const detail = await apiGet(adminToken, `/lineups/${votingLineupId}`);
-        if (!detail?.entries?.length) {
-            const gameIds = await fetchGameIds(adminToken, 3);
-            for (const gid of gameIds) {
-                await apiPost(adminToken, `/lineups/${votingLineupId}/nominate`, { gameId: gid });
-            }
-        }
-
-        // Advance to voting (the detail page needs games to render a leaderboard)
-        await apiPatch(adminToken, `/lineups/${votingLineupId}/status`, { status: 'voting' });
+        // ROK-1286 (#26): resolve (reuse or recreate) a lineup, seed it with
+        // nominations, advance it to voting, and gate on the server reporting
+        // `voting` — so this hook always reaches voting regardless of whether an
+        // earlier spec left the prior lineup archived/decided.
+        votingLineupId = await ensureVotingLineup(adminToken);
+        await seedAndAdvanceToVoting(adminToken, votingLineupId);
     });
 
     test('leaderboard renders sorted by vote count descending', async ({ page }) => {

--- a/scripts/smoke/lineup-confirmation-pills-invitee.smoke.spec.ts
+++ b/scripts/smoke/lineup-confirmation-pills-invitee.smoke.spec.ts
@@ -181,12 +181,16 @@ test.describe('Voting phase — per-row checkmark for invitee', () => {
         await awaitProcessing(adminToken);
     });
 
-    // ROK-1297 round 5ae: mobile-only timing flake on the post-vote
-    // hero re-render. The assertion is correct (HeroNextStep IS still
-    // rendered during voting phase), but the mobile playwright project
-    // races the React Query refetch — observed 2026-05-19. Skip until
-    // we either ringfence into the flaky-lane or rewrite as part of
-    // ROK-1298 (Sv composite) which replaces HeroNextStep in voting too.
+    // LEFT SKIPPED — root cause is NOT the original mobile staleTime flake;
+    // the targeted element no longer exists. ROK-1298 rewrote the voting
+    // phase to the cycle-4 `VotingComposite` → `VotingLeaderboardV2`, whose
+    // rows are `data-testid="voting-row"` (VotingRow.tsx). The legacy
+    // `data-testid="leaderboard-row"` is no longer rendered anywhere in the
+    // voting flow (verified 2026-06-28). `data-voted` and the "You voted"
+    // ✓ marker now live on `voting-row`, not `leaderboard-row`, so this
+    // test's selectors resolve to zero elements regardless of timing.
+    // Re-enabling requires re-targeting the assertion at `voting-row`
+    // (a target change, out of scope for this flake-hardening pass).
     test.skip("invitee's voted row renders ✓ marker and data-voted='true'", async ({ page }) => {
         // Cast one vote AS THE INVITEE — the per-row checkmark depends on
         // `entry.myVote != null` for the requesting user, so the assertion
@@ -217,6 +221,15 @@ test.describe('Voting phase — per-row checkmark for invitee', () => {
         await expect(votedRow.getByLabel(/you voted/i)).toBeVisible();
     });
 
+    // LEFT SKIPPED — ROK-1323 retired the legacy HeroNextStep banner, so
+    // `data-testid="hero-next-step"` is no longer rendered on the lineup
+    // detail page (verified 2026-06-28). The voting phase now renders the
+    // cycle-4 VotingComposite JourneyHero (role="region", name "Step 2 of 4 ·
+    // Voting"); the waiting-tone hero data-tone attribute no longer exists
+    // here. The selector resolves to zero elements regardless of timing, so
+    // a wait fix cannot rescue it. Re-enabling requires re-targeting the
+    // assertion at the VotingComposite JourneyHero (a target change, out of
+    // scope for this flake-hardening pass).
     test.skip('invitee-acted: voting hero flips to waiting tone after one vote', async ({ page }) => {
         // The previous test cast one vote as the invitee. That alone
         // moves persona to `invitee-acted` and pushes the voting hero into
@@ -240,10 +253,16 @@ test.describe('Voting phase — per-row checkmark for invitee', () => {
 // ---------------------------------------------------------------------------
 
 test.describe('Mobile sticky hero — invitee', () => {
-    // ROK-1297 round 5ae: sticky-compact behaviour moved from the
-    // legacy HeroNextStep to the NominatingComposite's sticky
-    // JourneyHero. Re-target this assertion when ROK-1323 lands the
-    // legacy chrome teardown.
+    // LEFT SKIPPED — ROK-1323 HAS landed the legacy chrome teardown:
+    // `data-testid="hero-next-step"` (components/common/HeroNextStep.tsx) is
+    // no longer rendered on the lineup detail page (verified 2026-06-28 —
+    // only the type survives, imported by use-lineup-hero.ts). Sticky-compact
+    // behaviour moved to the cycle-4 composite JourneyHero (sticky header in
+    // NominatingComposite/VotingComposite). A dedicated decided-state
+    // lineupId in a local beforeAll would not help — the element does not
+    // exist to compact. Re-enabling requires re-targeting the scroll/compact
+    // assertion at that composite's sticky region (a target change, out of
+    // scope for this flake-hardening pass).
     test.skip('hero compacts after scrolling past sentinel on mobile', async ({ page }, testInfo) => {
         test.skip(
             testInfo.project.name === 'desktop',

--- a/scripts/smoke/lineup-confirmation-pills.smoke.spec.ts
+++ b/scripts/smoke/lineup-confirmation-pills.smoke.spec.ts
@@ -207,12 +207,21 @@ test.describe('Voting phase — pill variant transitions', () => {
         await expect(pill).toContainText(/1 of \d+ votes used/i);
     });
 
-    // ROK-1297 round 5af: cross-spec voting-pill flake observed during
-    // /push validate-ci 2026-05-19. Got "Voted · 2 of 3 votes used"
-    // instead of the expected "waiting on …" copy — the third vote API
-    // POST hadn't propagated to React Query's cache by the time the pill
-    // re-rendered. Not caused by ROK-1297 (no changes to ConfirmationPill
-    // or VotingLeaderboard). Documented in TECH-DEBT-BACKLOG 2026-05-19.
+    // LEFT SKIPPED — root cause is NOT the original staleTime/propagation
+    // flake (2026-05-19 note); the targeted element no longer exists.
+    // ROK-1298 rewrote the voting phase: `LineupDetailBody` now renders the
+    // cycle-4 `VotingComposite`, which shows `votes-used-pill` (VotesUsedPill,
+    // copy "{n} of {m} votes used") above `VotingLeaderboardV2` (rows are
+    // `voting-row`). `ConfirmationPill` (`data-testid="confirmation-pill"`)
+    // and its `waitingOnN` "waiting on N others" copy are no longer in the
+    // voting flow at all — ConfirmationPill only renders in NominationCard
+    // (building) and the tiebreaker BracketView/VetoView. So this test's
+    // selector + copy resolve to zero elements regardless of how long we
+    // poll; a wait fix cannot rescue it. Re-enabling requires REWRITING the
+    // assertion against `votes-used-pill` reaching "{max} of {max} votes
+    // used" (a behavior/target change, out of scope for flake-hardening).
+    // Verified 2026-06-28: confirmation-pill render sites are NominationCard,
+    // BracketView, VetoView only (no voting-phase site).
     test.skip("pill flips to waitingOnN variant after using all votes", async ({ page }) => {
         // Top up to the cap.
         for (const gid of gameIds.slice(1)) {
@@ -244,14 +253,20 @@ test.describe('Decided phase — hero schedule CTA', () => {
         await awaitProcessing(adminToken);
     });
 
-    // ROK-1297 round 5af: cross-spec fixture race — `hero-next-step`
-    // was not visible at the assertion point on desktop. The
-    // suppression in round 5ae only fires during `building`, so a
-    // `decided`-phase fixture SHOULD still render HeroNextStep. The
-    // beforeAll PATCH to `decided` may not have propagated to the
-    // React Query cache before the page loaded, or the activity-log
-    // refetch raced the assertion. Not caused by ROK-1297. Documented
-    // in TECH-DEBT-BACKLOG 2026-05-19.
+    // LEFT SKIPPED — root cause is NOT the original staleTime/propagation
+    // flake (2026-05-19 note); the targeted element no longer exists.
+    // ROK-1323 FULLY retired the legacy `HeroNextStep` banner: the only
+    // `data-testid="hero-next-step"` source (components/common/HeroNextStep
+    // .tsx) is no longer rendered on the lineup detail page — only its
+    // `HeroNextStepProps` type survives, imported by use-lineup-hero.ts
+    // (verified 2026-06-28: no JSX usage outside web/src/dev + tests, and
+    // lineup-detail-page.tsx:200 documents the retirement). The decided
+    // phase now renders `DecidedView` whose JourneyHero carries the schedule
+    // CTA. `getByTestId('hero-next-step')` therefore resolves to zero
+    // elements regardless of timing, so polling the lineup status to
+    // `decided`/abortedAt===null cannot rescue it. Re-enabling requires
+    // re-targeting the assertion at the DecidedView composite's schedule
+    // CTA (a behavior/target change, out of scope for flake-hardening).
     test.skip('hero offers schedule CTA referencing the decided game name', async ({ page }) => {
         await page.goto(`/community-lineup/${lineupId}`);
 
@@ -273,12 +288,19 @@ test.describe('Decided phase — hero schedule CTA', () => {
 // ---------------------------------------------------------------------------
 
 test.describe('Mobile sticky hero', () => {
-    // TECH-DEBT 2026-05-20 / ROK-1298: getByTestId('hero-next-step') flakes
-    // in CI on mobile — 6/6 retries failed on PR #830 even after rerun.
-    // Hero is the legacy HeroNextStep which still renders in decided state;
-    // pre-existing cross-describe lineupId state isolation issue. Passes
-    // on operator's laptop. Candidate for the test:integration:flaky
-    // ringfence lane.
+    // LEFT SKIPPED — the original diagnosis (cross-describe lineupId
+    // pollution + mobile staleTime flake) is now superseded by a hard
+    // blocker: ROK-1323 fully retired the legacy `HeroNextStep` banner, so
+    // `data-testid="hero-next-step"` is no longer rendered on the lineup
+    // detail page (verified 2026-06-28 — only the type survives; see the
+    // decided-phase test above for the full retirement note). Switching to a
+    // dedicated per-test decided-state lineupId in a local beforeAll (the
+    // suggested isolation fix) would NOT help — the element does not exist
+    // to compact. Sticky-compact behaviour moved to the cycle-4 composite
+    // JourneyHero (sticky header in VotingComposite/NominatingComposite).
+    // Re-enabling requires re-targeting the scroll/compact assertion at that
+    // composite's sticky region, not a wait/isolation fix — out of scope for
+    // flake-hardening.
     test.skip('hero compacts after scrolling past sentinel on mobile', async ({ page }, testInfo) => {
         test.skip(
             testInfo.project.name === 'desktop',

--- a/scripts/smoke/lineup-nominating-composite.smoke.spec.ts
+++ b/scripts/smoke/lineup-nominating-composite.smoke.spec.ts
@@ -132,18 +132,41 @@ test.describe('Nominating composite — Common Ground multi-row hero (ROK-1297)'
 // ---------------------------------------------------------------------------
 
 test.describe('Nominating composite — drawer interactions (ROK-1297)', () => {
-    // TECH-DEBT 2026-05-20 / ROK-1298: getByTestId('common-ground-tile')
-    // flakes on mobile project — 6/6 retries failed on PR #830 even after
-    // rerun. Other tests in this describe pass; only the drawer-navigation
-    // case is flaky. Hits a CI API startup race (saw "API failed to start
-    // within 60s" in the logs). The behavior is covered by the per-tile
-    // unit + Chrome MCP gate passes. Skip until the test:integration:flaky
-    // ringfence lands.
+    // LEFT SKIPPED — the data-load race named in the original note is now
+    // mitigated (see the GET /lineups/common-ground waitForResponse gate
+    // inside the test body), but a second, non-timing blocker remains:
+    // `common-ground-tile` CARDINALITY is non-deterministic on the mobile
+    // project. The smoke fixture creates a bare building lineup with zero
+    // ownership/taste signals, so classifyTheme buckets are sparse and —
+    // per the "renders the Common Ground hero" note above — the mobile
+    // project's per-worker prefix isolation can leave even the trending
+    // bucket empty (history: 6/6 mobile retries failed on PR #830).
+    // `getByTestId('common-ground-tile').first()` then resolves to zero
+    // elements, a DETERMINISTIC failure, not a flake. The waitForResponse
+    // guarantees the query resolved; it cannot guarantee a tile exists to
+    // click. Re-enabling requires a seeded-ownership fixture (taste
+    // vectors/ownership for the lineup's audience) so >=1 tile renders on
+    // BOTH desktop and mobile. Until then this stays skipped — re-enabling
+    // on the bare fixture would reintroduce the mobile failure. Behaviour
+    // is covered at the unit layer + Chrome MCP gate.
     test.skip('clicking a tile body navigates to /games/:id', async ({ page }) => {
         // ROK-1297 round 5y: GameResearchDrawer was replaced with a router
         // navigation to /games/:id. The tile body click should therefore
         // change the URL to /games/<n>, NOT mount a drawer overlay.
+        //
+        // Deterministic data-load gate: register the listener BEFORE the
+        // navigation so the debounced (~300ms) GET /lineups/common-ground
+        // fetch that backs the tile grid is captured, then await it. This
+        // removes the API-startup/render race where the tile grid was
+        // probed before its useQuery resolved (the original skip reason).
+        const cgResponse = page.waitForResponse(
+            (r) =>
+                /\/lineups\/common-ground(\?|$)/.test(r.url()) &&
+                r.request().method() === 'GET',
+            { timeout: 20_000 },
+        );
         await gotoNominating(page);
+        await cgResponse;
 
         await expect(page.getByTestId('game-research-drawer')).toHaveCount(0);
 

--- a/scripts/smoke/lineup-voting-composite.smoke.spec.ts
+++ b/scripts/smoke/lineup-voting-composite.smoke.spec.ts
@@ -171,12 +171,28 @@ async function gotoVoting(page: import('@playwright/test').Page): Promise<void> 
         /something went wrong/i,
         { timeout: 10_000 },
     );
-    // Hero region is the readiness gate — JourneyHero exposes
+    // Hero region is the FIRST readiness gate — JourneyHero exposes
     // role="region" with aria-labelledby pointing at the "Step 2 of 4 ·
     // Voting" badge.
     await expect(
         page.getByRole('region', { name: /step 2 of 4 · voting/i }),
     ).toBeVisible({ timeout: 20_000 });
+    // K5/F3 flake fix: the JourneyHero (in the sticky header) renders
+    // before VotingLeaderboardV2 finishes mapping its rows, so asserting a
+    // game-row locator (the "Open details for {name}" opener at AC9, or any
+    // "Vote for {name}" toggle) straight after the hero raced an
+    // empty/not-yet-rendered leaderboard on slow CI runners — the opener's
+    // own 10s `toBeVisible` exhausted all 3 attempts. Gate on the
+    // leaderboard CONTAINER and its FIRST row so every row-level locator
+    // that follows resolves against a populated list. Deterministic
+    // (waits on the actual rendered list, not a fixed delay) and aligned
+    // with the 20s hero gate above.
+    await expect(page.getByTestId('voting-leaderboard-v2')).toBeVisible({
+        timeout: 20_000,
+    });
+    await expect(page.getByTestId('voting-row').first()).toBeVisible({
+        timeout: 20_000,
+    });
 }
 
 // ─────────────────────────────────────────────────────────────────────

--- a/scripts/validate-ci.sh
+++ b/scripts/validate-ci.sh
@@ -528,13 +528,15 @@ run_integration_tests() {
       # and ts-jest mis-resolves --ignoreDeprecations to an empty value
       # (TS5103). Discovered ROK-1331 Probe 1 attempt 6 (2026-05-20).
       #
-      # NODE_OPTIONS=--max-old-space-size=3072 gives V8 a 3 GB heap ceiling
+      # NODE_OPTIONS=--max-old-space-size=4096 gives V8 a 4 GB heap ceiling
       # per shard (vs 1.4 GB default) which is ample headroom for ~25 suites
-      # per shard.
+      # per shard. Raised 3072 -> 4096 (ROK-1268): 3 GB was tripping the OOM
+      # carrier under sustained re-runs while still leaving margin on the
+      # 7 GB fleet/CI runners (one shard process runs at a time here).
       # ROK-1331 M11 — JEST_SHARD_ID + JEST_TOTAL_SHARDS feed the perf
        # reporter so jest.suite.end events carry shard labels.
        # --logHeapUsage feeds the reporter's heap_used_mb sample.
-      if (cd api && NODE_OPTIONS="--max-old-space-size=3072" \
+      if (cd api && NODE_OPTIONS="--max-old-space-size=4096" \
          JEST_SHARD_ID="${i}" JEST_TOTAL_SHARDS="${shards}" \
          npx jest --config ./jest.integration.config.js \
                   --runInBand --verbose --logHeapUsage --shard="${i}/${shards}"); then


### PR DESCRIPTION
## CI flake sweep — Phase 1 (test-infra hardening)

First of a phased sweep to make CI smooth going forward. Discovery reconciled **42 open flake entries → 7 root-cause families** (live `gh run` history + tech-debt backlog + in-code markers + Linear carriers). This PR ships the deterministic, non-masking, highest-leverage fixes. **Deep socket/OOM carrier work (ROK-1268)** and the **GHCR registry mirror (ROK-1352)** follow as separate PRs.

### What this fixes
- **🔴 main was RED** — `ai-suggestions-pregen.integration.spec.ts › sanity: admin user resolves` failed under `jest --randomize` because `adminUserId` was assigned only in `afterEach`. Now resolved in `beforeEach` (order-independent). This also unblocks the `docker-build`/deploy job.
- **Integration isolation** — `game-taste` / `events-dashboard` self-seed real ids + clean-start `beforeAll` truncate (order-independent). *Note: the observed "404" on these is the residual socket carrier (ROK-1268), not seed-bleed — hardening improves isolation; the carrier root-cause is Phase 3.*
- **Heap headroom** — `test:integration` + `validate-ci.sh` get `--max-old-space-size=4096` (was unset / 3072) to stop the unsharded full-suite OOM.
- **No more fixed sleeps** — `lineup-auto-advance-grace` + `standalone-poll` replace multi-second `setTimeout` waits with deterministic polling on the real condition (job state / notification row). Assertions unchanged.
- **Playwright smoke fixture infra** (ROK-1286) — building-phase `beforeEach` guard on the Nomination-modal describe; harden voting `beforeAll` vs archived/sibling lineups; archive stale `smoke-w*` lineups at suite start; loud warning when `reset-to-seed` 403s; `.auth` dir anchored to `cwd` (fixes fleet/Mutagen ENOENT) + committed `scripts/.auth/.gitkeep`.
- **voting-composite** — `gotoVoting` now gates on the leaderboard list (`voting-row`), fixing the keyboard-nav `toBeVisible` flake.

### Method
5 repo-aware tester agents fixed disjoint file-sets in parallel; each was adversarially reviewed (never-weaken-assertions, root-cause-not-masked, no new sleeps, no re-enabling still-flaky skips). Two `rework` verdicts (A2 masking retry, A3 lint errors) were corrected before commit.

### Deferred (tracked for next PRs)
- **Phase 2 — GHCR mirror** for the Docker Hub registry-pull flake (ROK-1352).
- **Phase 3 — deep carriers**: ROK-1268 socket/OOM instrumentation; re-target the confirmation-pill smoke tests that assert on DOM removed by ROK-1298/1323 (left skipped with precise reasons); ROK-1290/1285; Discord cold-start; CDP sleeps.
- **CI follow-up**: confirm the smoke job sets `DEMO_MODE=true` so `reset-to-seed` is authorized (warning now surfaces if missing).

### Test checklist
- [x] `validate-ci.sh --static` (build + tsc + lint) — PASS
- [ ] GitHub CI (integration ×3 randomized + Playwright 5-shard) — the real gate for these flake fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
