### PR TITLE
chore(ci): mirror CI base images to GHCR — ROK-1352 step 1/2

### DIFF
--- a/.github/workflows/mirror-ci-images.yml
+++ b/.github/workflows/mirror-ci-images.yml
@@ -1,0 +1,59 @@
+name: Mirror CI base images to GHCR
+
+# ROK-1352: Docker Hub anonymous pulls of the CI service-container images
+# (pgvector, redis) intermittently fail with "context deadline exceeded" /
+# rate-limiting, red-flagging PRs before any test runs. This job mirrors the
+# pinned images into GHCR (pulled by CI via GITHUB_TOKEN, no Docker Hub limit).
+# Runs weekly + on demand; the per-PR hot path then pulls only from GHCR.
+
+on:
+  schedule:
+    - cron: '0 9 * * 1' # Mondays 09:00 UTC
+  workflow_dispatch: {}
+
+concurrency:
+  group: mirror-ci-images
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    env:
+      GHCR_NS: ghcr.io/${{ github.repository_owner }}
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Mirror images (retry-with-backoff on Docker Hub pull)
+        run: |
+          set -euo pipefail
+          mirror() {
+            local upstream="$1" dest="$2"
+            local i
+            for i in 1 2 3 4 5; do
+              if docker pull "$upstream"; then
+                docker tag "$upstream" "$dest"
+                docker push "$dest"
+                echo "mirrored $upstream -> $dest"
+                return 0
+              fi
+              echo "pull failed ($upstream) attempt $i; backing off $((i*15))s"
+              sleep $((i*15))
+            done
+            echo "FATAL: could not mirror $upstream after retries" >&2
+            return 1
+          }
+          mirror pgvector/pgvector:pg16 "$GHCR_NS/rl-ci-pgvector:pg16"
+          mirror redis:alpine          "$GHCR_NS/rl-ci-redis:alpine"
+
+      - name: Summary
+        run: |
+          echo "### Mirrored images" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`$GHCR_NS/rl-ci-pgvector:pg16\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- \`$GHCR_NS/rl-ci-redis:alpine\`" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## ROK-1352 — Docker Hub registry-pull flake (step 1 of 2)

Service-container jobs (`integration-test-shard`, `smoke-test-shard`, `discord-smoke`) intermittently fail at the **Docker image-pull step before any test runs** — `Get "https://registry-1.docker.io/v2/": context deadline exceeded` — from Docker Hub anonymous-pull rate limiting. Today the only "fix" is a manual `gh run rerun`, which breaks walk-away auto-merge.

### This PR (step 1): mirror the images to GHCR
Adds `.github/workflows/mirror-ci-images.yml` — a weekly + `workflow_dispatch` job that pulls the two pinned upstream images and pushes them to GHCR with retry-with-backoff:
- `pgvector/pgvector:pg16` → `ghcr.io/sjdodge123/rl-ci-pgvector:pg16`
- `redis:alpine` → `ghcr.io/sjdodge123/rl-ci-redis:alpine`

This decouples the per-PR hot path from Docker Hub: the rate-limited pull now happens **once a week** (with retry), not on every PR.

### Next (step 2, separate PR — held until GHCR is populated)
1. Merge this → run the mirror via `workflow_dispatch` → confirm both images in GHCR.
2. Make the two GHCR packages **public** (so service containers pull with no credentials, all PR types).
3. Swap the 6 `services.image:` refs in `ci.yml` (×4) + `discord-smoke.yml` (×2) to the GHCR mirror, and update the two `docker ps --filter "ancestor=pgvector/pgvector:pg16"` lines in lockstep.

Sequencing matters: if the swap lands before GHCR has the images, **all** service-container CI breaks — hence two PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)