### PR TITLE
chore(ci): pull CI service images from GHCR mirror — ROK-1352 step 2/2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,6 +243,11 @@ jobs:
   # ─── Integration Tests (sharded) ───────────────────────────────────
   integration-test-shard:
     runs-on: ubuntu-latest
+    # ROK-1352: read the CI service images from the GHCR mirror (private package);
+    # GITHUB_TOKEN needs packages:read to pull them via the service `credentials`.
+    permissions:
+      contents: read
+      packages: read
     # Fast-lane (2026-06-25): bound a hung/flaky shard. maxWorkers=1 + 108 specs
     # finish in ~6-7 min; 25 min is generous headroom. Previously unbounded
     # (GHA default 360 min), so a wedged shard could hang the required check.
@@ -270,7 +275,10 @@ jobs:
 
     services:
       postgres:
-        image: pgvector/pgvector:pg16
+        image: ghcr.io/sjdodge123/rl-ci-pgvector:pg16
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         env:
           POSTGRES_USER: user
           POSTGRES_PASSWORD: password
@@ -284,7 +292,10 @@ jobs:
           --health-retries 5
 
       redis:
-        image: redis:alpine
+        image: ghcr.io/sjdodge123/rl-ci-redis:alpine
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         ports:
           - 6379:6379
         options: >-
@@ -328,7 +339,7 @@ jobs:
         # and restart the postgres container in place. Default 100 is too
         # low for the shard's combined NestJS boot + parallel-query load.
         run: |
-          PG_CONTAINER=$(docker ps --filter "ancestor=pgvector/pgvector:pg16" --format "{{.ID}}" | head -1)
+          PG_CONTAINER=$(docker ps --filter "ancestor=ghcr.io/sjdodge123/rl-ci-pgvector:pg16" --format "{{.ID}}" | head -1)
           if [ -z "$PG_CONTAINER" ]; then echo "Postgres container not found"; exit 1; fi
           docker exec "$PG_CONTAINER" psql -U user -d raid_ledger_test -c "ALTER SYSTEM SET max_connections = 300;"
           docker restart "$PG_CONTAINER"
@@ -365,6 +376,10 @@ jobs:
   # Only runs when web/UI files or Playwright config changed
   smoke-test-shard:
     runs-on: ubuntu-latest
+    # ROK-1352: pull CI service images from the private GHCR mirror.
+    permissions:
+      contents: read
+      packages: read
     timeout-minutes: 20
     needs: [detect-changes, lint]
     if: >-
@@ -377,7 +392,10 @@ jobs:
 
     services:
       postgres:
-        image: pgvector/pgvector:pg16
+        image: ghcr.io/sjdodge123/rl-ci-pgvector:pg16
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         env:
           POSTGRES_USER: user
           POSTGRES_PASSWORD: password
@@ -391,7 +409,10 @@ jobs:
           --health-retries 5
 
       redis:
-        image: redis:alpine
+        image: ghcr.io/sjdodge123/rl-ci-redis:alpine
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         ports:
           - 6379:6379
         options: >-
@@ -471,7 +492,7 @@ jobs:
         # and restart the postgres container in place. Default 100 is too
         # low for the boot connection burst + parallel-query test load.
         run: |
-          PG_CONTAINER=$(docker ps --filter "ancestor=pgvector/pgvector:pg16" --format "{{.ID}}" | head -1)
+          PG_CONTAINER=$(docker ps --filter "ancestor=ghcr.io/sjdodge123/rl-ci-pgvector:pg16" --format "{{.ID}}" | head -1)
           if [ -z "$PG_CONTAINER" ]; then echo "Postgres container not found"; exit 1; fi
           docker exec "$PG_CONTAINER" psql -U user -d raid_ledger -c "ALTER SYSTEM SET max_connections = 300;"
           docker restart "$PG_CONTAINER"

--- a/.github/workflows/discord-smoke.yml
+++ b/.github/workflows/discord-smoke.yml
@@ -37,6 +37,10 @@ jobs:
 
   discord-smoke:
     runs-on: ubuntu-latest
+    # ROK-1352: pull CI service images from the private GHCR mirror.
+    permissions:
+      contents: read
+      packages: read
     needs: detect-changes
     if: >-
       github.event_name == 'push' ||
@@ -45,7 +49,10 @@ jobs:
 
     services:
       postgres:
-        image: pgvector/pgvector:pg16
+        image: ghcr.io/sjdodge123/rl-ci-pgvector:pg16
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         env:
           POSTGRES_USER: user
           POSTGRES_PASSWORD: password
@@ -59,7 +66,10 @@ jobs:
           --health-retries 5
 
       redis:
-        image: redis:alpine
+        image: ghcr.io/sjdodge123/rl-ci-redis:alpine
+        credentials:
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
         ports:
           - 6379:6379
         options: >-


### PR DESCRIPTION
## ROK-1352 — Docker Hub registry-pull flake (step 2 of 2)

Completes the fix. Step 1 (#925) added the mirror workflow and it has populated GHCR with `rl-ci-pgvector:pg16` + `rl-ci-redis:alpine`. This PR points CI's service containers at that mirror, so PRs no longer pull `pgvector`/`redis` anonymously from Docker Hub (the source of the `context deadline exceeded` pre-test failures).

### Changes
- `ci.yml` (`integration-test-shard`, `smoke-test-shard`) + `discord-smoke.yml` (`discord-smoke`): service `image:` refs → `ghcr.io/sjdodge123/rl-ci-*`.
- Each service block gets `credentials:` (username `github.actor`, password `GITHUB_TOKEN`) — the packages are **private**.
- Each of the 3 jobs gets `permissions: { contents: read, packages: read }` so the token can pull.
- The two `docker ps --filter "ancestor=…"` max_connections lines updated in lockstep with the new image ref.

### Why credentials (not public packages)
Keeps everything in-repo with no manual visibility step. Same-repo PRs (every agent PR) have `packages: read` via `GITHUB_TOKEN`; dependabot deps-only PRs skip integration/smoke via the path filter, so they never pull these images.

### Validation
**This PR's CI run is the proof** — if the GHCR pulls work, integration/smoke/discord-smoke service containers come up and the suites run green. If a pull is denied, the fix is a one-time flip of the two packages to Public (auto-merge will hold until then).

🤖 Generated with [Claude Code](https://claude.com/claude-code)