### PR TITLE
fix(web): scheduling-poll mobile UX — participants count + availability scroll trap

### DIFF
--- a/web/src/components/features/game-time/GridBody.tsx
+++ b/web/src/components/features/game-time/GridBody.tsx
@@ -52,10 +52,14 @@ export function GridBody({
     dayDates, nextWeekDayDates, fullDayNames, todayIndex, nextWeekSlots,
     HOURS, onDayClick, isDayAllActive, ...cellProps
 }: GridBodyProps): JSX.Element {
+    // Read-only/tap grids (e.g. the scheduling availability heatmap) must let
+    // the page scroll vertically on mobile; only the interactive drag-to-paint
+    // editor needs to capture every touch gesture (touch-action: none).
+    const { isInteractive } = cellProps;
     return (
         <div
             ref={gridRef} className="grid gap-px select-none"
-            style={{ gridTemplateColumns: '52px repeat(7, 1fr)', touchAction: 'none', background: gridLineBackground }}
+            style={{ gridTemplateColumns: '52px repeat(7, 1fr)', touchAction: isInteractive ? 'none' : 'pan-y', background: gridLineBackground }}
             onPointerUp={handlePointerUp}
             onPointerLeave={() => { handlePointerUp(); setHoveredCell(null); }}
             data-testid="game-time-grid"

--- a/web/src/components/lineups/LineupParticipantsButton.tsx
+++ b/web/src/components/lineups/LineupParticipantsButton.tsx
@@ -11,25 +11,36 @@
  * button never blocks hero render.
  */
 import { useState, type JSX } from 'react';
+import type { LineupParticipantDto } from '@raid-ledger/contract';
 import { useLineupParticipants } from '../../hooks/use-lineups';
 import { MemberAvatarGroup } from './decided/MemberAvatarGroup';
 import { LineupParticipantsModal } from './LineupParticipantsModal';
 
 interface LineupParticipantsButtonProps {
   lineupId: number;
+  /**
+   * Override the participant source. Scheduling polls pass the match's invited
+   * members — the lineup roster is just the creator there, so the roster query
+   * renders "Participants · 1". When provided, the roster query is skipped.
+   */
+  participantsOverride?: LineupParticipantDto[];
 }
 
 export function LineupParticipantsButton({
   lineupId,
+  participantsOverride,
 }: LineupParticipantsButtonProps): JSX.Element {
   const [open, setOpen] = useState(false);
-  const { data, isLoading, isError, refetch } = useLineupParticipants(lineupId);
-  const participants = data?.participants ?? [];
+  const { data, isLoading, isError, refetch } = useLineupParticipants(
+    participantsOverride ? undefined : lineupId,
+  );
+  const participants = participantsOverride ?? data?.participants ?? [];
+  const loading = participantsOverride ? false : isLoading;
   const count = participants.length;
 
   // Loading → no count yet; otherwise "Participants · N".
-  const label = isLoading ? 'Participants' : `Participants · ${count}`;
-  const accessibleName = isLoading
+  const label = loading ? 'Participants' : `Participants · ${count}`;
+  const accessibleName = loading
     ? 'Participants'
     : `Participants, ${count}`;
 
@@ -51,8 +62,8 @@ export function LineupParticipantsButton({
         isOpen={open}
         onClose={() => setOpen(false)}
         participants={participants}
-        isLoading={isLoading}
-        isError={isError}
+        isLoading={loading}
+        isError={participantsOverride ? false : isError}
         onRetry={() => void refetch()}
       />
     </>

--- a/web/src/components/lineups/cycle-4/SchedulingToolbar.tsx
+++ b/web/src/components/lineups/cycle-4/SchedulingToolbar.tsx
@@ -54,7 +54,21 @@ export function SchedulingToolbar(props: SchedulingToolbarProps): JSX.Element {
             never collides with the rightmost "Schedule" ribbon node (round 3). */}
         <JourneyHero
           {...hero}
-          action={<LineupParticipantsButton lineupId={lineupId} />}
+          action={
+            <LineupParticipantsButton
+              lineupId={lineupId}
+              participantsOverride={match.members.map((m) => ({
+                userId: m.userId,
+                displayName: m.displayName,
+                avatar: m.avatar,
+                customAvatarUrl: m.customAvatarUrl,
+                discordId: m.discordId,
+                role: 'invitee' as const,
+                status: 'waiting' as const,
+                steamLinked: false,
+              }))}
+            />
+          }
           headerAction={
             <SchedulingCancelAction
               lineupId={lineupId}


### PR DESCRIPTION
Two prod bugs on the scheduling poll (operator-reported):

## 1. "Participants · 1" miscount
`LineupParticipantsButton` always queried the **lineup roster** (`/lineups/:id/participants`) — for a standalone scheduling poll that's just the creator (1), not the poll's invited members (4). Added an optional `participantsOverride`; `SchedulingToolbar` now passes `match.members` (the real invited set, which already drives the correct "4 invited" / vote counts). The roster query is skipped (`enabled:false`) when overridden. Match-members map to the participant shape with `role:'invitee'`/`status:'waiting'` (no role/status data at the match level).

## 2. Mobile scroll trap on the availability grid
`GridBody` set `touch-action: none` unconditionally, so the **read-only** GROUP AVAILABILITY heatmap captured vertical page-scroll on touch and the user got stuck. Made it conditional on `isInteractive`: the interactive drag-to-paint editor keeps `none` (precise painting); read-only/tap grids use `pan-y` so the page scrolls vertically while taps still select a slot.

Both web-only, tsc + lint clean. GitHub Playwright (desktop + mobile) covers the lineup/scheduling flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)