### PR TITLE
feat: private event — invite/roster-only ephemeral voice (ROK-1386)

### DIFF
--- a/api/src/discord-bot/listeners/discord-sync.listener.ts
+++ b/api/src/discord-bot/listeners/discord-sync.listener.ts
@@ -1,10 +1,15 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnApplicationShutdown } from '@nestjs/common';
 import { OnEvent } from '@nestjs/event-emitter';
 import {
   SIGNUP_EVENTS,
   type SignupEventPayload,
 } from '../discord-bot.constants';
 import { EmbedSyncQueueService } from '../queues/embed-sync.queue';
+import { EphemeralVoiceService } from '../services/ephemeral-voice.service';
+
+/** Debounce window for private-voice access re-sync — mirrors the embed-sync
+ *  coalescing window so a burst of roster edits collapses to one reconcile. */
+const VOICE_ACCESS_DEBOUNCE_MS = 2_000;
 
 /**
  * Listens for signup and event lifecycle events and enqueues
@@ -13,12 +18,20 @@ import { EmbedSyncQueueService } from '../queues/embed-sync.queue';
  * Signup events are NOT already handled by DiscordEventListener, so
  * this listener bridges the gap. Event updates are also enqueued here
  * to ensure debouncing applies uniformly.
+ *
+ * ROK-1386: also debounce-triggers EphemeralVoiceService.syncVoiceAccess so a
+ * private event's voice allow-list full-reconciles on signup AND roster/bench
+ * reassignment (the service bails fast for non-private / channel-less events).
  */
 @Injectable()
-export class DiscordSyncListener {
+export class DiscordSyncListener implements OnApplicationShutdown {
   private readonly logger = new Logger(DiscordSyncListener.name);
+  private readonly voiceAccessTimers = new Map<number, NodeJS.Timeout>();
 
-  constructor(private readonly embedSyncQueue: EmbedSyncQueueService) {}
+  constructor(
+    private readonly embedSyncQueue: EmbedSyncQueueService,
+    private readonly ephemeralVoice: EphemeralVoiceService,
+  ) {}
 
   @OnEvent(SIGNUP_EVENTS.CREATED)
   async onSignupCreated(payload: SignupEventPayload): Promise<void> {
@@ -26,6 +39,7 @@ export class DiscordSyncListener {
       `Signup created for event ${payload.eventId} (action: ${payload.action})`,
     );
     await this.embedSyncQueue.enqueue(payload.eventId, payload.action);
+    this.scheduleVoiceAccessSync(payload.eventId);
   }
 
   @OnEvent(SIGNUP_EVENTS.UPDATED)
@@ -34,6 +48,7 @@ export class DiscordSyncListener {
       `Signup updated for event ${payload.eventId} (action: ${payload.action})`,
     );
     await this.embedSyncQueue.enqueue(payload.eventId, payload.action);
+    this.scheduleVoiceAccessSync(payload.eventId);
   }
 
   @OnEvent(SIGNUP_EVENTS.DELETED)
@@ -42,5 +57,32 @@ export class DiscordSyncListener {
       `Signup deleted for event ${payload.eventId} (action: ${payload.action})`,
     );
     await this.embedSyncQueue.enqueue(payload.eventId, payload.action);
+    this.scheduleVoiceAccessSync(payload.eventId);
+  }
+
+  onApplicationShutdown(): void {
+    for (const timer of this.voiceAccessTimers.values()) clearTimeout(timer);
+    this.voiceAccessTimers.clear();
+  }
+
+  /**
+   * Debounce a private-voice access re-sync for an event. Coalesces rapid-fire
+   * roster/signup changes into a single full-reconcile (resets the timer each
+   * call, keyed by eventId).
+   */
+  private scheduleVoiceAccessSync(eventId: number): void {
+    const existing = this.voiceAccessTimers.get(eventId);
+    if (existing) clearTimeout(existing);
+    const timer = setTimeout(() => {
+      this.voiceAccessTimers.delete(eventId);
+      this.ephemeralVoice
+        .syncVoiceAccess(eventId)
+        .catch((e) =>
+          this.logger.warn(
+            `Voice access sync failed for event ${eventId}: ${e}`,
+          ),
+        );
+    }, VOICE_ACCESS_DEBOUNCE_MS);
+    this.voiceAccessTimers.set(eventId, timer);
   }
 }

--- a/api/src/discord-bot/listeners/voice-state.listener.ts
+++ b/api/src/discord-bot/listeners/voice-state.listener.ts
@@ -22,6 +22,7 @@ import { GameActivityService } from '../services/game-activity.service';
 import { UsersService } from '../../users/users.service';
 import { AdHocEventsGateway } from '../../events/ad-hoc-events.gateway';
 import { EphemeralVoiceIdleCoordinator } from '../services/ephemeral-voice-idle.coordinator';
+import { EphemeralVoiceService } from '../services/ephemeral-voice.service';
 import { DISCORD_BOT_EVENTS } from '../discord-bot.constants';
 import {
   DEBOUNCE_MS,
@@ -79,6 +80,9 @@ export class VoiceStateListener implements OnApplicationShutdown {
     @Optional()
     @Inject(EphemeralVoiceIdleCoordinator)
     private readonly ephemeralIdle: EphemeralVoiceIdleCoordinator | null = null,
+    @Optional()
+    @Inject(EphemeralVoiceService)
+    private readonly ephemeralVoice: EphemeralVoiceService | null = null,
   ) {}
 
   private get deps(): VoiceHandlerDeps {
@@ -227,6 +231,12 @@ export class VoiceStateListener implements OnApplicationShutdown {
     }
     if (newCh) {
       this.userChannelMap.set(userId, newCh);
+      // ROK-1386: private-event join-guard — disconnect non-allow-listed members
+      // who join (or race into) a private ephemeral channel. Only fires on this
+      // join transition, so already-connected members are never kicked on demote.
+      await this.ephemeralVoice
+        ?.enforceJoinGuard(newCh, userId)
+        .catch((e) => this.logger.warn(`Join-guard failed: ${e}`));
       // ROK-1352: rejoin cancels any pending ephemeral idle-delete.
       await this.ephemeralIdle
         ?.onChannelJoin(newCh)

--- a/api/src/discord-bot/services/ephemeral-voice.db-helpers.ts
+++ b/api/src/discord-bot/services/ephemeral-voice.db-helpers.ts
@@ -1,6 +1,7 @@
 import { eq, and, isNull, isNotNull, sql } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import * as schema from '../../drizzle/schema';
+import { computeAllowedDiscordIds } from './ephemeral-voice.private.helpers';
 
 /**
  * Fetch an event's live ephemeral voice channel id (null when none). Shared by
@@ -29,6 +30,8 @@ export interface EphemeralEventRow {
   recurrenceGroupId: string | null;
   ephemeralVoiceEnabled: boolean | null;
   ephemeralVoiceChannelId: string | null;
+  /** ROK-1386: roster-only lock on the ephemeral channel (null = open). */
+  privateVoice: boolean | null;
 }
 
 const EVENT_FIELDS = {
@@ -40,6 +43,7 @@ const EVENT_FIELDS = {
   recurrenceGroupId: schema.events.recurrenceGroupId,
   ephemeralVoiceEnabled: schema.events.ephemeralVoiceEnabled,
   ephemeralVoiceChannelId: schema.events.ephemeralVoiceChannelId,
+  privateVoice: schema.events.privateVoice,
 };
 
 /**

--- a/api/src/discord-bot/services/ephemeral-voice.db-helpers.ts
+++ b/api/src/discord-bot/services/ephemeral-voice.db-helpers.ts
@@ -1,7 +1,7 @@
 import { eq, and, isNull, isNotNull, sql } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import * as schema from '../../drizzle/schema';
-import { computeAllowedDiscordIds } from './ephemeral-voice.private.helpers';
+import type { RosterSignupRow } from './ephemeral-voice.private.helpers';
 
 /**
  * Fetch an event's live ephemeral voice channel id (null when none). Shared by
@@ -235,4 +235,30 @@ export async function findEventByEphemeralChannel(
     .where(eq(schema.events.ephemeralVoiceChannelId, channelId))
     .limit(1);
   return row ?? null;
+}
+
+/**
+ * ROK-1386: fetch every signup for an event reduced to the fields the private
+ * allow-list cares about — roster slot (LEFT JOIN roster_assignments.role, null
+ * when unallocated), attendance status, the linked member's Discord id, and the
+ * anonymous-participant fallback id. Fed straight into `computeAllowedDiscordIds`.
+ */
+export async function fetchRosterSignupRows(
+  db: PostgresJsDatabase<typeof schema>,
+  eventId: number,
+): Promise<RosterSignupRow[]> {
+  return db
+    .select({
+      assignedSlot: schema.rosterAssignments.role,
+      status: schema.eventSignups.status,
+      userDiscordId: schema.users.discordId,
+      signupDiscordUserId: schema.eventSignups.discordUserId,
+    })
+    .from(schema.eventSignups)
+    .leftJoin(
+      schema.rosterAssignments,
+      eq(schema.rosterAssignments.signupId, schema.eventSignups.id),
+    )
+    .leftJoin(schema.users, eq(schema.users.id, schema.eventSignups.userId))
+    .where(eq(schema.eventSignups.eventId, eventId));
 }

--- a/api/src/discord-bot/services/ephemeral-voice.discord-ops.spec.ts
+++ b/api/src/discord-bot/services/ephemeral-voice.discord-ops.spec.ts
@@ -1,14 +1,24 @@
 /**
- * Unit tests for the ephemeral-voice Discord ops added for the in-flight
- * name backfill: reading the current channel name, renaming a channel, and the
- * no-churn Scheduled-Event name reconcile (rename only when Discord's current
- * name differs).
+ * Unit tests for the ephemeral-voice Discord ops.
+ *
+ * Covers two independent op groups:
+ *  - name backfill (ROK ephemeral-name): reading the current channel name,
+ *    renaming a channel, and the no-churn Scheduled-Event name reconcile
+ *    (rename only when Discord's current name differs).
+ *  - private-event overwrites (ROK-1386): the full overwrite reconcile that
+ *    adds rostered members, removes stale ones, and re-asserts the base lock.
  */
+import { OverwriteType } from 'discord.js';
 import {
   getEphemeralChannelName,
   renameVoiceChannel,
   reconcileScheduledEventName,
+  applyPrivateVoiceOverwrites,
 } from './ephemeral-voice.discord-ops';
+
+jest.mock('./scheduled-event.helpers', () => ({
+  timedDiscordCall: (_label: string, fn: () => unknown) => fn(),
+}));
 
 interface FakeGuild {
   channels: {
@@ -112,5 +122,77 @@ describe('reconcileScheduledEventName (no-churn)', () => {
     );
     expect(renamed).toBe(false);
     expect(guild.scheduledEvents.edit).not.toHaveBeenCalled();
+  });
+});
+
+const BOT = 'bot-id';
+const GUILD = 'guild-id';
+
+function memberOverwrite(id: string) {
+  return { id, type: OverwriteType.Member };
+}
+
+function buildChannel(currentMemberIds: string[]) {
+  const cache = new Map<string, { id: string; type: number }>();
+  cache.set(GUILD, { id: GUILD, type: OverwriteType.Role });
+  cache.set(BOT, memberOverwrite(BOT));
+  for (const id of currentMemberIds) cache.set(id, memberOverwrite(id));
+  const po = {
+    cache,
+    edit: jest.fn().mockResolvedValue(undefined),
+    delete: jest.fn().mockResolvedValue(undefined),
+  };
+  const channel = { isVoiceBased: () => true, permissionOverwrites: po };
+  return { channel, po };
+}
+
+function buildGuild(channel: unknown) {
+  return {
+    id: GUILD,
+    channels: {
+      cache: { get: () => channel },
+      fetch: jest.fn(),
+    },
+  } as never;
+}
+
+describe('applyPrivateVoiceOverwrites — full reconcile (ROK-1386)', () => {
+  it('adds missing rostered members and removes stale ones', async () => {
+    const { channel, po } = buildChannel(['stay', 'stale']);
+    await applyPrivateVoiceOverwrites(
+      buildGuild(channel),
+      'ch1',
+      new Set(['stay', 'new']),
+      BOT,
+    );
+    // base lock re-asserted for @everyone + bot, plus the added member
+    expect(po.edit).toHaveBeenCalledWith(GUILD, {
+      Connect: false,
+      ViewChannel: true,
+    });
+    expect(po.edit).toHaveBeenCalledWith(BOT, {
+      Connect: true,
+      ViewChannel: true,
+    });
+    expect(po.edit).toHaveBeenCalledWith('new', {
+      Connect: true,
+      ViewChannel: true,
+    });
+    // stale member removed; 'stay' left untouched
+    expect(po.delete).toHaveBeenCalledTimes(1);
+    expect(po.delete).toHaveBeenCalledWith('stale');
+  });
+
+  it('is a no-op when the channel no longer exists', async () => {
+    const guild = {
+      id: GUILD,
+      channels: {
+        cache: { get: () => undefined },
+        fetch: jest.fn().mockResolvedValue(null),
+      },
+    } as never;
+    await expect(
+      applyPrivateVoiceOverwrites(guild, 'gone', new Set(['x']), BOT),
+    ).resolves.toBeUndefined();
   });
 });

--- a/api/src/discord-bot/services/ephemeral-voice.discord-ops.ts
+++ b/api/src/discord-bot/services/ephemeral-voice.discord-ops.ts
@@ -1,6 +1,7 @@
-import { ChannelType } from 'discord.js';
+import { ChannelType, OverwriteType, type OverwriteResolvable } from 'discord.js';
 import type { DiscordBotClientService } from '../discord-bot-client.service';
 import { timedDiscordCall } from './scheduled-event.helpers';
+import { reconcileMemberOverwrites } from './ephemeral-voice.private.helpers';
 
 type Guild = NonNullable<ReturnType<DiscordBotClientService['getGuild']>>;
 
@@ -10,19 +11,70 @@ type Guild = NonNullable<ReturnType<DiscordBotClientService['getGuild']>>;
  * `timedDiscordCall` so latency + timeouts are instrumented uniformly.
  */
 
-/** Create a public voice channel under `parentId` (guild root when null). */
+/**
+ * Create a voice channel under `parentId` (guild root when null). Pass
+ * `permissionOverwrites` to seed a private (roster-only) channel at creation
+ * time so it is locked before anyone can race in (ROK-1386).
+ */
 export async function createVoiceChannel(
   guild: Guild,
-  opts: { name: string; parentId: string | null },
+  opts: {
+    name: string;
+    parentId: string | null;
+    permissionOverwrites?: OverwriteResolvable[];
+  },
 ): Promise<string> {
   const channel = await timedDiscordCall('ephemeral.create', () =>
     guild.channels.create({
       name: opts.name,
       type: ChannelType.GuildVoice,
       parent: opts.parentId ?? undefined,
+      permissionOverwrites: opts.permissionOverwrites,
     }),
   );
   return channel.id;
+}
+
+/**
+ * Full-reconcile a private channel's permission overwrites against the desired
+ * allow-list (ROK-1386): re-assert the `@everyone` Connect-deny + bot allow,
+ * add overwrites for newly rostered members, and remove stale ones. No-op when
+ * the channel is gone. Safe to call repeatedly (idempotent).
+ */
+export async function applyPrivateVoiceOverwrites(
+  guild: Guild,
+  channelId: string,
+  desiredDiscordIds: Set<string>,
+  botId: string,
+): Promise<void> {
+  let channel = guild.channels.cache.get(channelId);
+  if (!channel) {
+    channel =
+      (await guild.channels.fetch(channelId).catch(() => null)) ?? undefined;
+  }
+  if (!channel || !channel.isVoiceBased()) return;
+  const po = channel.permissionOverwrites;
+  const currentMemberIds: string[] = [];
+  for (const ow of po.cache.values()) {
+    if (ow.type === OverwriteType.Member && ow.id !== botId)
+      currentMemberIds.push(ow.id);
+  }
+  const { toAdd, toRemove } = reconcileMemberOverwrites(
+    currentMemberIds,
+    desiredDiscordIds,
+  );
+  await timedDiscordCall('ephemeral.lock.base', async () => {
+    await po.edit(guild.id, { Connect: false, ViewChannel: true });
+    await po.edit(botId, { Connect: true, ViewChannel: true });
+  });
+  for (const id of toAdd) {
+    await timedDiscordCall('ephemeral.lock.add', () =>
+      po.edit(id, { Connect: true, ViewChannel: true }),
+    );
+  }
+  for (const id of toRemove) {
+    await timedDiscordCall('ephemeral.lock.remove', () => po.delete(id));
+  }
 }
 
 /** Delete a voice channel. No-op (returns false) if it's already gone. */

--- a/api/src/discord-bot/services/ephemeral-voice.discord-ops.ts
+++ b/api/src/discord-bot/services/ephemeral-voice.discord-ops.ts
@@ -1,4 +1,8 @@
-import { ChannelType, OverwriteType, type OverwriteResolvable } from 'discord.js';
+import {
+  ChannelType,
+  OverwriteType,
+  type OverwriteResolvable,
+} from 'discord.js';
 import type { DiscordBotClientService } from '../discord-bot-client.service';
 import { timedDiscordCall } from './scheduled-event.helpers';
 import { reconcileMemberOverwrites } from './ephemeral-voice.private.helpers';
@@ -75,6 +79,26 @@ export async function applyPrivateVoiceOverwrites(
   for (const id of toRemove) {
     await timedDiscordCall('ephemeral.lock.remove', () => po.delete(id));
   }
+}
+
+/**
+ * ROK-1386 join-guard: forcibly disconnect a member from voice. Used when a
+ * non-allow-listed member joins a private ephemeral channel. Force-fetches the
+ * member when not cached. Returns false (no-op) when the member is gone or not
+ * in voice. Instrumented like every other Discord call.
+ */
+export async function disconnectMember(
+  guild: Guild,
+  discordUserId: string,
+): Promise<boolean> {
+  const member =
+    guild.members.cache.get(discordUserId) ??
+    (await guild.members.fetch(discordUserId).catch(() => null));
+  if (!member?.voice?.channelId) return false;
+  await timedDiscordCall('ephemeral.guard.disconnect', () =>
+    member.voice.disconnect('Private event: not on the roster allow-list'),
+  );
+  return true;
 }
 
 /** Delete a voice channel. No-op (returns false) if it's already gone. */

--- a/api/src/discord-bot/services/ephemeral-voice.private.helpers.spec.ts
+++ b/api/src/discord-bot/services/ephemeral-voice.private.helpers.spec.ts
@@ -1,0 +1,115 @@
+import { PermissionFlagsBits } from 'discord.js';
+import {
+  computeAllowedDiscordIds,
+  buildPrivateVoiceOverwrites,
+  reconcileMemberOverwrites,
+  type RosterSignupRow,
+} from './ephemeral-voice.private.helpers';
+
+const CONNECT = PermissionFlagsBits.Connect;
+const VIEW = PermissionFlagsBits.ViewChannel;
+
+function row(over: Partial<RosterSignupRow>): RosterSignupRow {
+  return {
+    assignedSlot: 'dps',
+    status: 'signed_up',
+    userDiscordId: 'u1',
+    signupDiscordUserId: null,
+    ...over,
+  };
+}
+
+describe('computeAllowedDiscordIds (ROK-1386)', () => {
+  it('includes rostered signed_up + tentative members', () => {
+    const ids = computeAllowedDiscordIds([
+      row({ userDiscordId: 'a', status: 'signed_up' }),
+      row({ userDiscordId: 'b', status: 'tentative' }),
+    ]);
+    expect(ids).toEqual(new Set(['a', 'b']));
+  });
+
+  it('excludes benched players even when signed_up or tentative', () => {
+    const ids = computeAllowedDiscordIds([
+      row({ userDiscordId: 'a', status: 'signed_up', assignedSlot: 'bench' }),
+      row({ userDiscordId: 'b', status: 'tentative', assignedSlot: 'bench' }),
+    ]);
+    expect(ids.size).toBe(0);
+  });
+
+  it('excludes declined / roached_out / departed statuses', () => {
+    const ids = computeAllowedDiscordIds([
+      row({ userDiscordId: 'a', status: 'declined' }),
+      row({ userDiscordId: 'b', status: 'roached_out' }),
+      row({ userDiscordId: 'c', status: 'departed' }),
+    ]);
+    expect(ids.size).toBe(0);
+  });
+
+  it('falls back to signup.discordUserId when users.discordId is null', () => {
+    const ids = computeAllowedDiscordIds([
+      row({ userDiscordId: null, signupDiscordUserId: 'anon1' }),
+    ]);
+    expect(ids).toEqual(new Set(['anon1']));
+  });
+
+  it('drops rows with no resolvable discord id (unlinked members blocked)', () => {
+    const ids = computeAllowedDiscordIds([
+      row({ userDiscordId: null, signupDiscordUserId: null }),
+      row({ userDiscordId: 'ok' }),
+    ]);
+    expect(ids).toEqual(new Set(['ok']));
+  });
+});
+
+describe('buildPrivateVoiceOverwrites (ROK-1386)', () => {
+  it('denies Connect for @everyone but keeps it visible', () => {
+    const ow = buildPrivateVoiceOverwrites({
+      guildId: 'g',
+      botId: 'bot',
+      allowedDiscordIds: [],
+    });
+    const everyone = ow.find((o) => o.id === 'g')!;
+    expect(everyone.deny).toEqual([CONNECT]);
+    expect(everyone.allow).toEqual([VIEW]);
+  });
+
+  it('grants the bot Connect + ViewChannel so the deny cannot lock it out', () => {
+    const ow = buildPrivateVoiceOverwrites({
+      guildId: 'g',
+      botId: 'bot',
+      allowedDiscordIds: ['m1'],
+    });
+    const bot = ow.find((o) => o.id === 'bot')!;
+    expect(bot.allow).toEqual([CONNECT, VIEW]);
+  });
+
+  it('grants each allowed member Connect + ViewChannel', () => {
+    const ow = buildPrivateVoiceOverwrites({
+      guildId: 'g',
+      botId: 'bot',
+      allowedDiscordIds: ['m1', 'm2'],
+    });
+    expect(ow.find((o) => o.id === 'm1')!.allow).toEqual([CONNECT, VIEW]);
+    expect(ow.find((o) => o.id === 'm2')!.allow).toEqual([CONNECT, VIEW]);
+  });
+});
+
+describe('reconcileMemberOverwrites (ROK-1386)', () => {
+  it('computes ids to add and stale ids to remove', () => {
+    const { toAdd, toRemove } = reconcileMemberOverwrites(
+      ['stay', 'stale'],
+      new Set(['stay', 'new']),
+    );
+    expect(toAdd).toEqual(['new']);
+    expect(toRemove).toEqual(['stale']);
+  });
+
+  it('returns empty diffs when current already matches desired', () => {
+    const { toAdd, toRemove } = reconcileMemberOverwrites(
+      ['a', 'b'],
+      new Set(['a', 'b']),
+    );
+    expect(toAdd).toEqual([]);
+    expect(toRemove).toEqual([]);
+  });
+});

--- a/api/src/discord-bot/services/ephemeral-voice.private.helpers.ts
+++ b/api/src/discord-bot/services/ephemeral-voice.private.helpers.ts
@@ -1,0 +1,89 @@
+import { PermissionFlagsBits, type OverwriteResolvable } from 'discord.js';
+
+/**
+ * Pure helpers for private (roster-only) ephemeral voice channels (ROK-1386).
+ *
+ * Kept infrastructure-free so the allow-list rules and overwrite shape are
+ * unit-testable without a live Discord guild. The discord-side apply lives in
+ * `ephemeral-voice.discord-ops.ts`; persistence lives in the db-helpers.
+ */
+
+/** A signup row reduced to the fields the allow-list cares about. */
+export interface RosterSignupRow {
+  /** Roster slot the player was allocated to. `bench` excludes them. */
+  assignedSlot: string | null;
+  /** Attendance intent. Only `signed_up` / `tentative` are allow-listed. */
+  status: string;
+  /** Linked-member Discord id (users.discordId). Preferred. */
+  userDiscordId: string | null;
+  /** Anonymous-participant Discord id (signup.discordUserId). Fallback. */
+  signupDiscordUserId: string | null;
+}
+
+/**
+ * Resolve the rostered-only allow-list of Discord ids from signup rows.
+ *
+ * Rules: exclude benched players; include only `signed_up` / `tentative`
+ * (tentative included only when not benched); resolve `users.discordId` then
+ * `signup.discordUserId`; drop rows whose resolved id is null (unlinked members
+ * are silently blocked).
+ */
+export function computeAllowedDiscordIds(
+  rows: RosterSignupRow[],
+): Set<string> {
+  const allowed = new Set<string>();
+  for (const row of rows) {
+    if (row.assignedSlot === 'bench') continue;
+    if (row.status !== 'signed_up' && row.status !== 'tentative') continue;
+    const id = row.userDiscordId ?? row.signupDiscordUserId;
+    if (id) allowed.add(id);
+  }
+  return allowed;
+}
+
+/**
+ * Build the permission-overwrite list for a private channel: deny Connect for
+ * `@everyone` (id = guildId) while keeping it visible (ViewChannel allowed), an
+ * explicit allow for the bot so the deny can't lock it out, and Connect +
+ * ViewChannel for each allow-listed member.
+ */
+export function buildPrivateVoiceOverwrites(opts: {
+  guildId: string;
+  botId: string;
+  allowedDiscordIds: Iterable<string>;
+}): OverwriteResolvable[] {
+  const overwrites: OverwriteResolvable[] = [
+    {
+      id: opts.guildId,
+      deny: [PermissionFlagsBits.Connect],
+      allow: [PermissionFlagsBits.ViewChannel],
+    },
+    {
+      id: opts.botId,
+      allow: [PermissionFlagsBits.Connect, PermissionFlagsBits.ViewChannel],
+    },
+  ];
+  for (const id of opts.allowedDiscordIds) {
+    if (id === opts.botId || id === opts.guildId) continue;
+    overwrites.push({
+      id,
+      allow: [PermissionFlagsBits.Connect, PermissionFlagsBits.ViewChannel],
+    });
+  }
+  return overwrites;
+}
+
+/**
+ * Diff the channel's current member overwrites against the desired allow-list.
+ * Returns the ids to add (newly rostered) and remove (stale). `@everyone` and
+ * the bot are managed separately and must not be passed in `currentMemberIds`.
+ */
+export function reconcileMemberOverwrites(
+  currentMemberIds: Iterable<string>,
+  desiredIds: Set<string>,
+): { toAdd: string[]; toRemove: string[] } {
+  const current = new Set(currentMemberIds);
+  const toAdd = [...desiredIds].filter((id) => !current.has(id));
+  const toRemove = [...current].filter((id) => !desiredIds.has(id));
+  return { toAdd, toRemove };
+}

--- a/api/src/discord-bot/services/ephemeral-voice.private.helpers.ts
+++ b/api/src/discord-bot/services/ephemeral-voice.private.helpers.ts
@@ -28,9 +28,7 @@ export interface RosterSignupRow {
  * `signup.discordUserId`; drop rows whose resolved id is null (unlinked members
  * are silently blocked).
  */
-export function computeAllowedDiscordIds(
-  rows: RosterSignupRow[],
-): Set<string> {
+export function computeAllowedDiscordIds(rows: RosterSignupRow[]): Set<string> {
   const allowed = new Set<string>();
   for (const row of rows) {
     if (row.assignedSlot === 'bench') continue;

--- a/api/src/discord-bot/services/ephemeral-voice.scheduler.spec.ts
+++ b/api/src/discord-bot/services/ephemeral-voice.scheduler.spec.ts
@@ -42,6 +42,7 @@ const candidate = {
   recurrenceGroupId: null,
   ephemeralVoiceEnabled: null,
   ephemeralVoiceChannelId: 'ch-1',
+  privateVoice: null,
   discordScheduledEventId: 'se-1',
 };
 

--- a/api/src/discord-bot/services/ephemeral-voice.service.spec.ts
+++ b/api/src/discord-bot/services/ephemeral-voice.service.spec.ts
@@ -22,6 +22,7 @@ async function build(memberCount: number) {
   const client = {
     isConnected: jest.fn().mockReturnValue(true),
     getGuild: jest.fn().mockReturnValue(guild),
+    getClientId: jest.fn().mockReturnValue('bot-id'),
   };
   const scheduledEvent = { updateScheduledEvent: jest.fn() };
   const voiceAttendance = { flushToDb: jest.fn().mockResolvedValue(undefined) };
@@ -92,6 +93,7 @@ const row = {
   recurrenceGroupId: null,
   ephemeralVoiceEnabled: null,
   ephemeralVoiceChannelId: 'ch-1',
+  privateVoice: null,
 };
 
 afterEach(() => jest.restoreAllMocks());
@@ -194,5 +196,127 @@ describe('reconcileNamesForEvent — in-flight name backfill', () => {
       service.reconcileNamesForEvent({ ...reconcileRow }),
     ).resolves.toBeUndefined();
     expect(seReconcileSpy).toHaveBeenCalled();
+  });
+});
+
+const rosterRow = (over: {
+  assignedSlot?: string | null;
+  status?: string;
+  userDiscordId?: string | null;
+  signupDiscordUserId?: string | null;
+}) => ({
+  assignedSlot: over.assignedSlot ?? 'dps',
+  status: over.status ?? 'signed_up',
+  userDiscordId: over.userDiscordId ?? null,
+  signupDiscordUserId: over.signupDiscordUserId ?? null,
+});
+
+describe('syncVoiceAccess — reconcile against rostered allow-list (ROK-1386)', () => {
+  it('bails (no reconcile) when the event is not private', async () => {
+    const { service } = await build(0);
+    jest
+      .spyOn(dbHelpers, 'fetchEventForEphemeral')
+      .mockResolvedValue({ ...row, privateVoice: null });
+    const applySpy = jest
+      .spyOn(discordOps, 'applyPrivateVoiceOverwrites')
+      .mockResolvedValue(undefined);
+    await service.syncVoiceAccess(1);
+    expect(applySpy).not.toHaveBeenCalled();
+  });
+
+  it('bails when private but the channel is gone', async () => {
+    const { service } = await build(0);
+    jest.spyOn(dbHelpers, 'fetchEventForEphemeral').mockResolvedValue({
+      ...row,
+      privateVoice: true,
+      ephemeralVoiceChannelId: null,
+    });
+    const applySpy = jest
+      .spyOn(discordOps, 'applyPrivateVoiceOverwrites')
+      .mockResolvedValue(undefined);
+    await service.syncVoiceAccess(1);
+    expect(applySpy).not.toHaveBeenCalled();
+  });
+
+  it('reconciles overwrites against the rostered set (adds + removes via builder)', async () => {
+    const { service } = await build(0);
+    jest.spyOn(dbHelpers, 'fetchEventForEphemeral').mockResolvedValue({
+      ...row,
+      privateVoice: true,
+      ephemeralVoiceChannelId: 'ch-1',
+    });
+    jest.spyOn(dbHelpers, 'fetchRosterSignupRows').mockResolvedValue([
+      rosterRow({ assignedSlot: 'dps', userDiscordId: 'keep' }),
+      rosterRow({ assignedSlot: 'bench', userDiscordId: 'benched' }), // excluded
+      rosterRow({
+        assignedSlot: null,
+        status: 'tentative',
+        userDiscordId: 'tent',
+      }),
+      rosterRow({ status: 'declined', userDiscordId: 'nope' }), // excluded
+    ]);
+    const applySpy = jest
+      .spyOn(discordOps, 'applyPrivateVoiceOverwrites')
+      .mockResolvedValue(undefined);
+    await service.syncVoiceAccess(1);
+    // The full add-missing/remove-stale diff is applyPrivateVoiceOverwrites'
+    // job (covered in discord-ops.spec) — here we assert the service hands it
+    // the correctly-computed desired allow-list + bot id.
+    expect(applySpy).toHaveBeenCalledWith(
+      guild,
+      'ch-1',
+      new Set(['keep', 'tent']),
+      'bot-id',
+    );
+  });
+});
+
+describe('enforceJoinGuard — private-event voice join-guard (ROK-1386)', () => {
+  const privateEv = {
+    ...row,
+    privateVoice: true,
+    ephemeralVoiceChannelId: 'ch-1',
+  };
+
+  it('disconnects a member who is not on the allow-list', async () => {
+    const { service } = await build(0);
+    jest
+      .spyOn(dbHelpers, 'findEventByEphemeralChannel')
+      .mockResolvedValue(privateEv);
+    jest
+      .spyOn(dbHelpers, 'fetchRosterSignupRows')
+      .mockResolvedValue([rosterRow({ userDiscordId: 'allowed' })]);
+    const disconnectSpy = jest
+      .spyOn(discordOps, 'disconnectMember')
+      .mockResolvedValue(true);
+    await service.enforceJoinGuard('ch-1', 'intruder');
+    expect(disconnectSpy).toHaveBeenCalledWith(guild, 'intruder');
+  });
+
+  it('leaves an allow-listed member connected', async () => {
+    const { service } = await build(0);
+    jest
+      .spyOn(dbHelpers, 'findEventByEphemeralChannel')
+      .mockResolvedValue(privateEv);
+    jest
+      .spyOn(dbHelpers, 'fetchRosterSignupRows')
+      .mockResolvedValue([rosterRow({ userDiscordId: 'allowed' })]);
+    const disconnectSpy = jest
+      .spyOn(discordOps, 'disconnectMember')
+      .mockResolvedValue(false);
+    await service.enforceJoinGuard('ch-1', 'allowed');
+    expect(disconnectSpy).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op for a non-private channel', async () => {
+    const { service } = await build(0);
+    jest
+      .spyOn(dbHelpers, 'findEventByEphemeralChannel')
+      .mockResolvedValue({ ...row, privateVoice: null });
+    const disconnectSpy = jest
+      .spyOn(discordOps, 'disconnectMember')
+      .mockResolvedValue(true);
+    await service.enforceJoinGuard('ch-1', 'whoever');
+    expect(disconnectSpy).not.toHaveBeenCalled();
   });
 });

--- a/api/src/discord-bot/services/ephemeral-voice.service.spec.ts
+++ b/api/src/discord-bot/services/ephemeral-voice.service.spec.ts
@@ -308,6 +308,19 @@ describe('enforceJoinGuard — private-event voice join-guard (ROK-1386)', () =>
     expect(disconnectSpy).not.toHaveBeenCalled();
   });
 
+  it('never disconnects the bot itself (self-kick guard, ROK-1386 review)', async () => {
+    const { service } = await build(0);
+    jest
+      .spyOn(dbHelpers, 'findEventByEphemeralChannel')
+      .mockResolvedValue(privateEv);
+    const disconnectSpy = jest
+      .spyOn(discordOps, 'disconnectMember')
+      .mockResolvedValue(true);
+    // 'bot-id' is what the mocked getClientId() returns in build().
+    await service.enforceJoinGuard('ch-1', 'bot-id');
+    expect(disconnectSpy).not.toHaveBeenCalled();
+  });
+
   it('is a no-op for a non-private channel', async () => {
     const { service } = await build(0);
     jest

--- a/api/src/discord-bot/services/ephemeral-voice.service.ts
+++ b/api/src/discord-bot/services/ephemeral-voice.service.ts
@@ -231,6 +231,10 @@ export class EphemeralVoiceService {
   ): Promise<void> {
     const ev = await findEventByEphemeralChannel(this.db, channelId);
     if (!ev?.privateVoice || ev.ephemeralVoiceChannelId !== channelId) return;
+    // Never disconnect the bot itself — it joins to record voice attendance and
+    // will never be on the roster allow-list, so without this guard the join-
+    // guard would self-kick the bot (latent footgun, ROK-1386 review).
+    if (discordUserId === this.clientService.getClientId()) return;
     const guild = this.requireGuild();
     if (!guild) return;
     try {
@@ -300,7 +304,21 @@ export class EphemeralVoiceService {
     guildId: string,
   ): Promise<OverwriteResolvable[] | undefined> {
     const botId = this.clientService.getClientId();
-    if (!botId) return undefined;
+    if (!botId) {
+      // Fail-open: without the bot id we cannot seed roster overwrites, so the
+      // channel is created fully OPEN. The join-guard still backstops intruders,
+      // but flag the gap loudly for observability (ROK-1386 review).
+      const message =
+        'private ephemeral channel created WITHOUT overwrites — Discord client not ready; relying on join-guard';
+      this.logger.warn(`${message} (event ${ev.id})`);
+      Sentry.addBreadcrumb({
+        category: 'ephemeral-voice',
+        level: 'warning',
+        message,
+        data: { eventId: ev.id },
+      });
+      return undefined;
+    }
     const allowedDiscordIds = await this.resolveAllowedIds(ev.id);
     return buildPrivateVoiceOverwrites({ guildId, botId, allowedDiscordIds });
   }

--- a/api/src/discord-bot/services/ephemeral-voice.service.ts
+++ b/api/src/discord-bot/services/ephemeral-voice.service.ts
@@ -1,5 +1,6 @@
 import { Inject, Injectable, Logger, Optional } from '@nestjs/common';
 import * as Sentry from '@sentry/node';
+import type { OverwriteResolvable } from 'discord.js';
 import { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { DrizzleAsyncProvider } from '../../drizzle/drizzle.module';
 import * as schema from '../../drizzle/schema';
@@ -14,8 +15,10 @@ import {
 } from './scheduled-event.helpers';
 import { shouldCreateEphemeralChannel } from './ephemeral-voice.gate.helpers';
 import {
+  applyPrivateVoiceOverwrites,
   createVoiceChannel,
   deleteVoiceChannel,
+  disconnectMember,
   getChannelMemberCountFresh,
   getEphemeralChannelName,
   renameVoiceChannel,
@@ -29,7 +32,13 @@ import {
   claimEphemeralChannelId,
   clearEphemeralChannelId,
   fetchEventForEphemeral,
+  fetchRosterSignupRows,
+  findEventByEphemeralChannel,
 } from './ephemeral-voice.db-helpers';
+import {
+  buildPrivateVoiceOverwrites,
+  computeAllowedDiscordIds,
+} from './ephemeral-voice.private.helpers';
 
 type Guild = NonNullable<ReturnType<DiscordBotClientService['getGuild']>>;
 
@@ -85,9 +94,15 @@ export class EphemeralVoiceService {
         await this.settingsService.getEphemeralVoiceCategoryId();
       const data = await buildRepointData(this.db, ev);
       const name = buildEphemeralChannelName(data);
+      // ROK-1386: seed the roster-only overwrites in the same channels.create
+      // call so a private channel is locked before anyone can race in.
+      const permissionOverwrites = ev.privateVoice
+        ? await this.buildSeedOverwrites(ev, guild.id)
+        : undefined;
       const channelId = await createVoiceChannel(guild, {
         name,
         parentId: categoryId,
+        permissionOverwrites,
       });
       // Atomically claim the slot (set id only if still null). If an overlapping
       // scan already created a channel, delete the one we just made so we don't
@@ -177,6 +192,56 @@ export class EphemeralVoiceService {
     await this.reconcileSeName(guild, ev, data);
   }
 
+  /**
+   * ROK-1386: full-reconcile a private event's channel overwrites against the
+   * current rostered allow-list (adds newly rostered, removes demoted/benched).
+   * No-op unless the event is private AND has a live channel. Hooked debounced
+   * on signup/roster fan-out so bench↔roster moves re-sync; the join-guard
+   * backstops sync lag.
+   */
+  async syncVoiceAccess(eventId: number): Promise<void> {
+    const ev = await fetchEventForEphemeral(this.db, eventId);
+    if (!ev?.privateVoice || !ev.ephemeralVoiceChannelId) return;
+    const guild = this.requireGuild();
+    const botId = this.clientService.getClientId();
+    if (!guild || !botId) return;
+    try {
+      const desired = await this.resolveAllowedIds(eventId);
+      await applyPrivateVoiceOverwrites(
+        guild,
+        ev.ephemeralVoiceChannelId,
+        desired,
+        botId,
+      );
+    } catch (err) {
+      this.captureError('sync-access', eventId, err);
+    }
+  }
+
+  /**
+   * ROK-1386 join-guard: disconnect a member who joined a private ephemeral
+   * channel without being on the roster allow-list. This is the REAL
+   * enforcement — overwrites only block future connects and a create-race
+   * window exists. Block re-entry only; only ever called on join transitions,
+   * never on demotion (so already-connected members are not kicked).
+   */
+  async enforceJoinGuard(
+    channelId: string,
+    discordUserId: string,
+  ): Promise<void> {
+    const ev = await findEventByEphemeralChannel(this.db, channelId);
+    if (!ev?.privateVoice || ev.ephemeralVoiceChannelId !== channelId) return;
+    const guild = this.requireGuild();
+    if (!guild) return;
+    try {
+      const allowed = await this.resolveAllowedIds(ev.id);
+      if (allowed.has(discordUserId)) return;
+      await disconnectMember(guild, discordUserId);
+    } catch (err) {
+      this.captureError('join-guard', ev.id, err);
+    }
+  }
+
   // ─── Private helpers ──────────────────────────────────────
 
   /** Rename the channel only when its current Discord name differs (no churn). */
@@ -221,6 +286,23 @@ export class EphemeralVoiceService {
         `Ephemeral SE rename skipped for event ${ev.id}: ${err instanceof Error ? err.message : 'unknown'}`,
       );
     }
+  }
+
+  /** Resolve the rostered-only Discord-id allow-list for an event (ROK-1386). */
+  private async resolveAllowedIds(eventId: number): Promise<Set<string>> {
+    const rows = await fetchRosterSignupRows(this.db, eventId);
+    return computeAllowedDiscordIds(rows);
+  }
+
+  /** Build seed overwrites for a private channel at create time (ROK-1386). */
+  private async buildSeedOverwrites(
+    ev: EphemeralEventRow,
+    guildId: string,
+  ): Promise<OverwriteResolvable[] | undefined> {
+    const botId = this.clientService.getClientId();
+    if (!botId) return undefined;
+    const allowedDiscordIds = await this.resolveAllowedIds(ev.id);
+    return buildPrivateVoiceOverwrites({ guildId, botId, allowedDiscordIds });
   }
 
   /** Re-resolve + edit the SE channel and trigger an embed re-sync. */

--- a/api/src/drizzle/migrations/0150_nasty_pixie.sql
+++ b/api/src/drizzle/migrations/0150_nasty_pixie.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "events" ADD COLUMN "private_voice" boolean;

--- a/api/src/drizzle/migrations/meta/0150_snapshot.json
+++ b/api/src/drizzle/migrations/meta/0150_snapshot.json
@@ -1,0 +1,7783 @@
+{
+  "id": "7b8d690d-a753-4f65-b170-c637af117b47",
+  "prevId": "165c02fc-f2ff-4eda-9fe5-9b829b9837d1",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "discord_id": {
+          "name": "discord_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_id": {
+          "name": "steam_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "custom_avatar_url": {
+          "name": "custom_avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "onboarding_completed_at": {
+          "name": "onboarding_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_time_confirmed_at": {
+          "name": "game_time_confirmed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "deactivated_at": {
+          "name": "deactivated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "users_discord_id_unique": {
+          "name": "users_discord_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_id"
+          ]
+        },
+        "users_steam_id_unique": {
+          "name": "users_steam_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "steam_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "display_name_length": {
+          "name": "display_name_length",
+          "value": "\"users\".\"display_name\" IS NULL OR (LENGTH(\"users\".\"display_name\") >= 2 AND LENGTH(\"users\".\"display_name\") <= 30)"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_sessions_expires_at": {
+          "name": "idx_sessions_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_user_id_users_id_fk": {
+          "name": "sessions_user_id_users_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration": {
+          "name": "duration",
+          "type": "tsrange",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot_config": {
+          "name": "slot_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_attendees": {
+          "name": "max_attendees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_unbench": {
+          "name": "auto_unbench",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "recurrence_group_id": {
+          "name": "recurrence_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_rule": {
+          "name": "recurrence_rule",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_instances": {
+          "name": "content_instances",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_15min": {
+          "name": "reminder_15min",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_1hour": {
+          "name": "reminder_1hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_24hour": {
+          "name": "reminder_24hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "is_ad_hoc": {
+          "name": "is_ad_hoc",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ad_hoc_status": {
+          "name": "ad_hoc_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_binding_id": {
+          "name": "channel_binding_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_scheduled_event_id": {
+          "name": "discord_scheduled_event_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "extended_until": {
+          "name": "extended_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_channel_override": {
+          "name": "notification_channel_override",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rescheduling_poll_id": {
+          "name": "rescheduling_poll_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancelled_at": {
+          "name": "cancelled_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cancellation_reason": {
+          "name": "cancellation_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scheduled_event_reconcile_backoff_until": {
+          "name": "scheduled_event_reconcile_backoff_until",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ephemeral_voice_enabled": {
+          "name": "ephemeral_voice_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ephemeral_voice_channel_id": {
+          "name": "ephemeral_voice_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "private_voice": {
+          "name": "private_voice",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_events_creator_id": {
+          "name": "idx_events_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_game_id": {
+          "name": "idx_events_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_ad_hoc_binding": {
+          "name": "idx_events_ad_hoc_binding",
+          "columns": [
+            {
+              "expression": "channel_binding_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_ad_hoc",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_recurrence_group_id": {
+          "name": "idx_events_recurrence_group_id",
+          "columns": [
+            {
+              "expression": "recurrence_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_cancelled_at": {
+          "name": "idx_events_cancelled_at",
+          "columns": [
+            {
+              "expression": "cancelled_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_discord_scheduled_event_id": {
+          "name": "idx_events_discord_scheduled_event_id",
+          "columns": [
+            {
+              "expression": "discord_scheduled_event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_se_reconcile_backoff": {
+          "name": "idx_events_se_reconcile_backoff",
+          "columns": [
+            {
+              "expression": "scheduled_event_reconcile_backoff_until",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_events_ephemeral_voice_channel_id": {
+          "name": "idx_events_ephemeral_voice_channel_id",
+          "columns": [
+            {
+              "expression": "ephemeral_voice_channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"events\".\"ephemeral_voice_channel_id\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_game_id_games_id_fk": {
+          "name": "events_game_id_games_id_fk",
+          "tableFrom": "events",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_creator_id_users_id_fk": {
+          "name": "events_creator_id_users_id_fk",
+          "tableFrom": "events",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "events_channel_binding_id_channel_bindings_id_fk": {
+          "name": "events_channel_binding_id_channel_bindings_id_fk",
+          "tableFrom": "events",
+          "tableTo": "channel_bindings",
+          "columnsFrom": [
+            "channel_binding_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_types": {
+      "name": "event_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "default_player_cap": {
+          "name": "default_player_cap",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_duration_minutes": {
+          "name": "default_duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "requires_composition": {
+          "name": "requires_composition",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_event_types_game_id": {
+          "name": "idx_event_types_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_types_game_id_games_id_fk": {
+          "name": "event_types_game_id_games_id_fk",
+          "tableFrom": "event_types",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "event_types_game_slug_unique": {
+          "name": "event_types_game_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "game_id",
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games": {
+      "name": "games",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "igdb_id": {
+          "name": "igdb_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cover_url": {
+          "name": "cover_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "cached_at": {
+          "name": "cached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "aggregated_rating": {
+          "name": "aggregated_rating",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "popularity": {
+          "name": "popularity",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_modes": {
+          "name": "game_modes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "themes": {
+          "name": "themes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "platforms": {
+          "name": "platforms",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "screenshots": {
+          "name": "screenshots",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "videos": {
+          "name": "videos",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "first_release_date": {
+          "name": "first_release_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_count": {
+          "name": "player_count",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitch_game_id": {
+          "name": "twitch_game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "steam_app_id": {
+          "name": "steam_app_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "crossplay": {
+          "name": "crossplay",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hidden": {
+          "name": "hidden",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "short_name": {
+          "name": "short_name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "color_hex": {
+          "name": "color_hex",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_roles": {
+          "name": "has_roles",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "has_specs": {
+          "name": "has_specs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "itad_game_id": {
+          "name": "itad_game_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_boxart_url": {
+          "name": "itad_boxart_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_tags": {
+          "name": "itad_tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "max_characters_per_user": {
+          "name": "max_characters_per_user",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "api_namespace_prefix": {
+          "name": "api_namespace_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_current_price": {
+          "name": "itad_current_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_current_cut": {
+          "name": "itad_current_cut",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_current_shop": {
+          "name": "itad_current_shop",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_current_url": {
+          "name": "itad_current_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_lowest_price": {
+          "name": "itad_lowest_price",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_lowest_cut": {
+          "name": "itad_lowest_cut",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "itad_price_updated_at": {
+          "name": "itad_price_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "early_access": {
+          "name": "early_access",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "igdb_enrichment_status": {
+          "name": "igdb_enrichment_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'pending'"
+        },
+        "igdb_enrichment_retry_count": {
+          "name": "igdb_enrichment_retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "games_igdb_id_unique": {
+          "name": "games_igdb_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "igdb_id"
+          ]
+        },
+        "games_slug_unique": {
+          "name": "games_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        },
+        "games_itad_game_id_unique": {
+          "name": "games_itad_game_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "itad_game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_signups": {
+      "name": "event_signups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_avatar_hash": {
+          "name": "discord_avatar_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "character_id": {
+          "name": "character_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "confirmation_status": {
+          "name": "confirmation_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'signed_up'"
+        },
+        "preferred_roles": {
+          "name": "preferred_roles",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attendance_status": {
+          "name": "attendance_status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "attendance_recorded_at": {
+          "name": "attendance_recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roached_out_at": {
+          "name": "roached_out_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "running_late_at": {
+          "name": "running_late_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "late_minutes": {
+          "name": "late_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "signed_up_at": {
+          "name": "signed_up_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_event_signups_event_id": {
+          "name": "idx_event_signups_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_signups_discord_user_id": {
+          "name": "idx_event_signups_discord_user_id",
+          "columns": [
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_signups_user_id": {
+          "name": "idx_event_signups_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_signups_event_id_status": {
+          "name": "idx_event_signups_event_id_status",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_signups_event_id_events_id_fk": {
+          "name": "event_signups_event_id_events_id_fk",
+          "tableFrom": "event_signups",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_signups_user_id_users_id_fk": {
+          "name": "event_signups_user_id_users_id_fk",
+          "tableFrom": "event_signups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_signups_character_id_characters_id_fk": {
+          "name": "event_signups_character_id_characters_id_fk",
+          "tableFrom": "event_signups",
+          "tableTo": "characters",
+          "columnsFrom": [
+            "character_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_user": {
+          "name": "unique_event_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id"
+          ]
+        },
+        "unique_event_discord_user": {
+          "name": "unique_event_discord_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "discord_user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "user_or_discord": {
+          "name": "user_or_discord",
+          "value": "\"event_signups\".\"user_id\" IS NOT NULL OR \"event_signups\".\"discord_user_id\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.characters": {
+      "name": "characters",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "realm": {
+          "name": "realm",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class": {
+          "name": "class",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role_override": {
+          "name": "role_override",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_main": {
+          "name": "is_main",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "item_level": {
+          "name": "item_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "render_url": {
+          "name": "render_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "level": {
+          "name": "level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "race": {
+          "name": "race",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faction": {
+          "name": "faction",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_url": {
+          "name": "profile_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "region": {
+          "name": "region",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_variant": {
+          "name": "game_variant",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "equipment": {
+          "name": "equipment",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "talents": {
+          "name": "talents",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "professions": {
+          "name": "professions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "display_order": {
+          "name": "display_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_one_main_per_game": {
+          "name": "idx_one_main_per_game",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"characters\".\"is_main\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_characters_user_id": {
+          "name": "idx_characters_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_characters_user_id_name": {
+          "name": "idx_characters_user_id_name",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "characters_user_id_users_id_fk": {
+          "name": "characters_user_id_users_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "characters_game_id_games_id_fk": {
+          "name": "characters_game_id_games_id_fk",
+          "tableFrom": "characters",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_game_character": {
+          "name": "unique_user_game_character",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id",
+            "name",
+            "realm"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.local_credentials": {
+      "name": "local_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "local_credentials_user_id_users_id_fk": {
+          "name": "local_credentials_user_id_users_id_fk",
+          "tableFrom": "local_credentials",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "local_credentials_email_unique": {
+          "name": "local_credentials_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.availability": {
+      "name": "availability",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_range": {
+          "name": "time_range",
+          "type": "tsrange",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'available'"
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_event_id": {
+          "name": "source_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_availability_user_id": {
+          "name": "idx_availability_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "availability_user_id_users_id_fk": {
+          "name": "availability_user_id_users_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "availability_game_id_games_id_fk": {
+          "name": "availability_game_id_games_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "availability_source_event_id_events_id_fk": {
+          "name": "availability_source_event_id_events_id_fk",
+          "tableFrom": "availability",
+          "tableTo": "events",
+          "columnsFrom": [
+            "source_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.roster_assignments": {
+      "name": "roster_assignments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "signup_id": {
+          "name": "signup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "is_override": {
+          "name": "is_override",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_roster_assignments_event_id": {
+          "name": "idx_roster_assignments_event_id",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_roster_assignments_signup_id": {
+          "name": "idx_roster_assignments_signup_id",
+          "columns": [
+            {
+              "expression": "signup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "roster_assignments_event_id_events_id_fk": {
+          "name": "roster_assignments_event_id_events_id_fk",
+          "tableFrom": "roster_assignments",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "roster_assignments_signup_id_event_signups_id_fk": {
+          "name": "roster_assignments_signup_id_event_signups_id_fk",
+          "tableFrom": "roster_assignments",
+          "tableTo": "event_signups",
+          "columnsFrom": [
+            "signup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_signup": {
+          "name": "unique_event_signup",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "signup_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted_value": {
+          "name": "encrypted_value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "app_settings_key_unique": {
+          "name": "app_settings_key_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notifications_user_unread_idx": {
+          "name": "notifications_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notifications_expires_at": {
+          "name": "idx_notifications_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_user_id_users_id_fk": {
+          "name": "notifications_user_id_users_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_notification_preferences": {
+      "name": "user_notification_preferences",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "channel_prefs": {
+          "name": "channel_prefs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"slot_vacated\":{\"inApp\":true,\"push\":true,\"discord\":true},\"event_reminder\":{\"inApp\":true,\"push\":true,\"discord\":true},\"new_event\":{\"inApp\":true,\"push\":true,\"discord\":true},\"subscribed_game\":{\"inApp\":true,\"push\":true,\"discord\":true},\"achievement_unlocked\":{\"inApp\":true,\"push\":false,\"discord\":false},\"level_up\":{\"inApp\":true,\"push\":false,\"discord\":false},\"missed_event_nudge\":{\"inApp\":true,\"push\":true,\"discord\":true},\"event_rescheduled\":{\"inApp\":true,\"push\":true,\"discord\":true},\"event_delayed\":{\"inApp\":true,\"push\":true,\"discord\":true},\"bench_promoted\":{\"inApp\":true,\"push\":true,\"discord\":true},\"event_cancelled\":{\"inApp\":true,\"push\":true,\"discord\":true},\"roster_reassigned\":{\"inApp\":true,\"push\":true,\"discord\":true},\"tentative_displaced\":{\"inApp\":true,\"push\":true,\"discord\":true},\"member_returned\":{\"inApp\":true,\"push\":true,\"discord\":true},\"recruitment_reminder\":{\"inApp\":true,\"push\":true,\"discord\":true},\"role_gap_alert\":{\"inApp\":true,\"push\":true,\"discord\":true},\"lineup_steam_nudge\":{\"inApp\":true,\"push\":false,\"discord\":true},\"community_lineup\":{\"inApp\":true,\"push\":true,\"discord\":true},\"user_deactivated_discord\":{\"inApp\":true,\"push\":false,\"discord\":false},\"user_reactivated_discord\":{\"inApp\":true,\"push\":false,\"discord\":false},\"system\":{\"inApp\":true,\"push\":false,\"discord\":false}}'::jsonb"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_notification_preferences_user_id_users_id_fk": {
+          "name": "user_notification_preferences_user_id_users_id_fk",
+          "tableFrom": "user_notification_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key": {
+          "name": "key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_preference_key": {
+          "name": "unique_user_preference_key",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_time_templates": {
+      "name": "game_time_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_hour": {
+          "name": "start_hour",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_time_templates_user_id_idx": {
+          "name": "game_time_templates_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_time_templates_user_id_users_id_fk": {
+          "name": "game_time_templates_user_id_users_id_fk",
+          "tableFrom": "game_time_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_game_time_slot": {
+          "name": "unique_user_game_time_slot",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "day_of_week",
+            "start_hour"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_time_absences": {
+      "name": "game_time_absences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "start_date": {
+          "name": "start_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end_date": {
+          "name": "end_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_time_absences_user_id_idx": {
+          "name": "game_time_absences_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_time_absences_user_id_users_id_fk": {
+          "name": "game_time_absences_user_id_users_id_fk",
+          "tableFrom": "game_time_absences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_time_overrides": {
+      "name": "game_time_overrides",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hour": {
+          "name": "hour",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "game_time_overrides_user_id_idx": {
+          "name": "game_time_overrides_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_time_overrides_user_id_users_id_fk": {
+          "name": "game_time_overrides_user_id_users_id_fk",
+          "tableFrom": "game_time_overrides",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_override_date_hour": {
+          "name": "unique_user_override_date_hour",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "date",
+            "hour"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_interests": {
+      "name": "game_interests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        },
+        "playtime_forever": {
+          "name": "playtime_forever",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playtime_2weeks": {
+          "name": "playtime_2weeks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_game_interests_game_id": {
+          "name": "idx_game_interests_game_id",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_interests_user_id_users_id_fk": {
+          "name": "game_interests_user_id_users_id_fk",
+          "tableFrom": "game_interests",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_interests_game_id_games_id_fk": {
+          "name": "game_interests_game_id_games_id_fk",
+          "tableFrom": "game_interests",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_user_game_interest_source": {
+          "name": "uq_user_game_interest_source",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id",
+            "source"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_reminders_sent": {
+      "name": "event_reminders_sent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reminder_type": {
+          "name": "reminder_type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_reminders_sent_event_id_events_id_fk": {
+          "name": "event_reminders_sent_event_id_events_id_fk",
+          "tableFrom": "event_reminders_sent",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_reminders_sent_user_id_users_id_fk": {
+          "name": "event_reminders_sent_user_id_users_id_fk",
+          "tableFrom": "event_reminders_sent",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_user_reminder": {
+          "name": "unique_event_user_reminder",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id",
+            "reminder_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_templates": {
+      "name": "event_templates",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "event_templates_user_id_users_id_fk": {
+          "name": "event_templates_user_id_users_id_fk",
+          "tableFrom": "event_templates",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.plugins": {
+      "name": "plugins",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slug": {
+          "name": "slug",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "config_json": {
+          "name": "config_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "plugins_slug_unique": {
+          "name": "plugins_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.feedback": {
+      "name": "feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "page_url": {
+          "name": "page_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "github_issue_url": {
+          "name": "github_issue_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "client_logs": {
+          "name": "client_logs",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "feedback_user_id_users_id_fk": {
+          "name": "feedback_user_id_users_id_fk",
+          "tableFrom": "feedback",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pug_slots": {
+      "name": "pug_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_avatar_hash": {
+          "name": "discord_avatar_hash",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class": {
+          "name": "class",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "spec": {
+          "name": "spec",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "server_invite_url": {
+          "name": "server_invite_url",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invite_code": {
+          "name": "invite_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "unique_event_pug": {
+          "name": "unique_event_pug",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_username",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pug_slots\".\"discord_username\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "unique_invite_code": {
+          "name": "unique_invite_code",
+          "columns": [
+            {
+              "expression": "invite_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"pug_slots\".\"invite_code\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pug_slots_event_id_events_id_fk": {
+          "name": "pug_slots_event_id_events_id_fk",
+          "tableFrom": "pug_slots",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pug_slots_claimed_by_user_id_users_id_fk": {
+          "name": "pug_slots_claimed_by_user_id_users_id_fk",
+          "tableFrom": "pug_slots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "claimed_by_user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "pug_slots_created_by_users_id_fk": {
+          "name": "pug_slots_created_by_users_id_fk",
+          "tableFrom": "pug_slots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cron_jobs": {
+      "name": "cron_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "plugin_slug": {
+          "name": "plugin_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Other'"
+        },
+        "paused": {
+          "name": "paused",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "cron_jobs_name_unique": {
+          "name": "cron_jobs_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cron_job_executions": {
+      "name": "cron_job_executions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cron_job_id": {
+          "name": "cron_job_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_ms": {
+          "name": "duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cron_job_executions_job_started_idx": {
+          "name": "cron_job_executions_job_started_idx",
+          "columns": [
+            {
+              "expression": "cron_job_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cron_job_executions_cron_job_id_cron_jobs_id_fk": {
+          "name": "cron_job_executions_cron_job_id_cron_jobs_id_fk",
+          "tableFrom": "cron_job_executions",
+          "tableTo": "cron_jobs",
+          "columnsFrom": [
+            "cron_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_event_messages": {
+      "name": "discord_event_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "embed_state": {
+          "name": "embed_state",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'posted'"
+        },
+        "bump_message_id": {
+          "name": "bump_message_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bump_channel_id": {
+          "name": "bump_channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_discord_event_messages_event": {
+          "name": "idx_discord_event_messages_event",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_discord_event_messages_message": {
+          "name": "idx_discord_event_messages_message",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discord_event_messages_event_id_events_id_fk": {
+          "name": "discord_event_messages_event_id_events_id_fk",
+          "tableFrom": "discord_event_messages",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_event_channel_message": {
+          "name": "unique_event_channel_message",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "channel_id",
+            "message_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_bindings": {
+      "name": "channel_bindings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_type": {
+          "name": "channel_type",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "binding_purpose": {
+          "name": "binding_purpose",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recurrence_group_id": {
+          "name": "recurrence_group_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'{}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_bindings_guild_channel_series_unique": {
+          "name": "channel_bindings_guild_channel_series_unique",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "recurrence_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_bindings_guild": {
+          "name": "idx_channel_bindings_guild",
+          "columns": [
+            {
+              "expression": "guild_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_bindings_game": {
+          "name": "idx_channel_bindings_game",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_channel_bindings_recurrence_group": {
+          "name": "idx_channel_bindings_recurrence_group",
+          "columns": [
+            {
+              "expression": "recurrence_group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_bindings_game_id_games_id_fk": {
+          "name": "channel_bindings_game_id_games_id_fk",
+          "tableFrom": "channel_bindings",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.post_event_reminders_sent": {
+      "name": "post_event_reminders_sent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pug_slot_id": {
+          "name": "pug_slot_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "post_event_reminders_sent_event_id_events_id_fk": {
+          "name": "post_event_reminders_sent_event_id_events_id_fk",
+          "tableFrom": "post_event_reminders_sent",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "post_event_reminders_sent_pug_slot_id_pug_slots_id_fk": {
+          "name": "post_event_reminders_sent_pug_slot_id_pug_slots_id_fk",
+          "tableFrom": "post_event_reminders_sent",
+          "tableTo": "pug_slots",
+          "columnsFrom": [
+            "pug_slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_post_event_pug_reminder": {
+          "name": "unique_post_event_pug_reminder",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "pug_slot_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_plans": {
+      "name": "event_plans",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "creator_id": {
+          "name": "creator_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slot_config": {
+          "name": "slot_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_attendees": {
+          "name": "max_attendees",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_unbench": {
+          "name": "auto_unbench",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_options": {
+          "name": "poll_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_duration_hours": {
+          "name": "poll_duration_hours",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_mode": {
+          "name": "poll_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'standard'"
+        },
+        "poll_round": {
+          "name": "poll_round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "poll_channel_id": {
+          "name": "poll_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_message_id": {
+          "name": "poll_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "winning_option": {
+          "name": "winning_option",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_event_id": {
+          "name": "created_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content_instances": {
+          "name": "content_instances",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reminder_15min": {
+          "name": "reminder_15min",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_1hour": {
+          "name": "reminder_1hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reminder_24hour": {
+          "name": "reminder_24hour",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "poll_started_at": {
+          "name": "poll_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "poll_ends_at": {
+          "name": "poll_ends_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_event_plans_creator_id": {
+          "name": "idx_event_plans_creator_id",
+          "columns": [
+            {
+              "expression": "creator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_plans_status": {
+          "name": "idx_event_plans_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_plans_creator_id_users_id_fk": {
+          "name": "event_plans_creator_id_users_id_fk",
+          "tableFrom": "event_plans",
+          "tableTo": "users",
+          "columnsFrom": [
+            "creator_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_plans_game_id_games_id_fk": {
+          "name": "event_plans_game_id_games_id_fk",
+          "tableFrom": "event_plans",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "event_plans_created_event_id_events_id_fk": {
+          "name": "event_plans_created_event_id_events_id_fk",
+          "tableFrom": "event_plans",
+          "tableTo": "events",
+          "columnsFrom": [
+            "created_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_dungeon_quests": {
+      "name": "wow_classic_dungeon_quests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dungeon_instance_id": {
+          "name": "dungeon_instance_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quest_level": {
+          "name": "quest_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "required_level": {
+          "name": "required_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expansion": {
+          "name": "expansion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quest_giver_npc": {
+          "name": "quest_giver_npc",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quest_giver_zone": {
+          "name": "quest_giver_zone",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "prev_quest_id": {
+          "name": "prev_quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_quest_id": {
+          "name": "next_quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rewards_json": {
+          "name": "rewards_json",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "objectives": {
+          "name": "objectives",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "class_restriction": {
+          "name": "class_restriction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "race_restriction": {
+          "name": "race_restriction",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_inside_dungeon": {
+          "name": "starts_inside_dungeon",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "sharable": {
+          "name": "sharable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "reward_xp": {
+          "name": "reward_xp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_gold": {
+          "name": "reward_gold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reward_type": {
+          "name": "reward_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'none'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "wow_classic_dungeon_quests_quest_id_unique": {
+          "name": "wow_classic_dungeon_quests_quest_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "quest_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_boss_loot": {
+      "name": "wow_classic_boss_loot",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "boss_id": {
+          "name": "boss_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_name": {
+          "name": "item_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "slot": {
+          "name": "slot",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "quality": {
+          "name": "quality",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_level": {
+          "name": "item_level",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drop_rate": {
+          "name": "drop_rate",
+          "type": "numeric(5, 4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expansion": {
+          "name": "expansion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "class_restrictions": {
+          "name": "class_restrictions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "icon_url": {
+          "name": "icon_url",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_subclass": {
+          "name": "item_subclass",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wow_classic_boss_loot_boss_id_wow_classic_bosses_id_fk": {
+          "name": "wow_classic_boss_loot_boss_id_wow_classic_bosses_id_fk",
+          "tableFrom": "wow_classic_boss_loot",
+          "tableTo": "wow_classic_bosses",
+          "columnsFrom": [
+            "boss_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_loot_boss_item_expansion": {
+          "name": "uq_loot_boss_item_expansion",
+          "nullsNotDistinct": false,
+          "columns": [
+            "boss_id",
+            "item_id",
+            "expansion"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_bosses": {
+      "name": "wow_classic_bosses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "instance_id": {
+          "name": "instance_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expansion": {
+          "name": "expansion",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sod_modified": {
+          "name": "sod_modified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_boss_instance_name_expansion": {
+          "name": "uq_boss_instance_name_expansion",
+          "nullsNotDistinct": false,
+          "columns": [
+            "instance_id",
+            "name",
+            "expansion"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.wow_classic_quest_progress": {
+      "name": "wow_classic_quest_progress",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quest_id": {
+          "name": "quest_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "picked_up": {
+          "name": "picked_up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "wow_classic_quest_progress_event_id_events_id_fk": {
+          "name": "wow_classic_quest_progress_event_id_events_id_fk",
+          "tableFrom": "wow_classic_quest_progress",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "wow_classic_quest_progress_user_id_users_id_fk": {
+          "name": "wow_classic_quest_progress_user_id_users_id_fk",
+          "tableFrom": "wow_classic_quest_progress",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_quest_progress_event_user_quest": {
+          "name": "uq_quest_progress_event_user_quest",
+          "nullsNotDistinct": false,
+          "columns": [
+            "event_id",
+            "user_id",
+            "quest_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_activity_sessions": {
+      "name": "game_activity_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_activity_name": {
+          "name": "discord_activity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration_seconds": {
+          "name": "duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "game_activity_sessions_user_game_started_idx": {
+          "name": "game_activity_sessions_user_game_started_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "game_activity_sessions_game_started_idx": {
+          "name": "game_activity_sessions_game_started_idx",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_activity_sessions_user_id_users_id_fk": {
+          "name": "game_activity_sessions_user_id_users_id_fk",
+          "tableFrom": "game_activity_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_activity_sessions_game_id_games_id_fk": {
+          "name": "game_activity_sessions_game_id_games_id_fk",
+          "tableFrom": "game_activity_sessions",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_activity_rollups": {
+      "name": "game_activity_rollups",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period": {
+          "name": "period",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_seconds": {
+          "name": "total_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "game_activity_rollups_game_period_start_idx": {
+          "name": "game_activity_rollups_game_period_start_idx",
+          "columns": [
+            {
+              "expression": "game_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_activity_rollups_user_id_users_id_fk": {
+          "name": "game_activity_rollups_user_id_users_id_fk",
+          "tableFrom": "game_activity_rollups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_activity_rollups_game_id_games_id_fk": {
+          "name": "game_activity_rollups_game_id_games_id_fk",
+          "tableFrom": "game_activity_rollups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "game_activity_rollups_user_game_period_unique": {
+          "name": "game_activity_rollups_user_game_period_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id",
+            "period",
+            "period_start"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discord_game_mappings": {
+      "name": "discord_game_mappings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "discord_activity_name": {
+          "name": "discord_activity_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "discord_game_mappings_game_id_games_id_fk": {
+          "name": "discord_game_mappings_game_id_games_id_fk",
+          "tableFrom": "discord_game_mappings",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discord_game_mappings_discord_activity_name_unique": {
+          "name": "discord_game_mappings_discord_activity_name_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "discord_activity_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ad_hoc_participants": {
+      "name": "ad_hoc_participants",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_avatar_hash": {
+          "name": "discord_avatar_hash",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_duration_seconds": {
+          "name": "total_duration_seconds",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "ad_hoc_participants_event_discord_user_unique": {
+          "name": "ad_hoc_participants_event_discord_user_unique",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ad_hoc_participants_event": {
+          "name": "idx_ad_hoc_participants_event",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ad_hoc_participants_user": {
+          "name": "idx_ad_hoc_participants_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ad_hoc_participants_event_id_events_id_fk": {
+          "name": "ad_hoc_participants_event_id_events_id_fk",
+          "tableFrom": "ad_hoc_participants",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "ad_hoc_participants_user_id_users_id_fk": {
+          "name": "ad_hoc_participants_user_id_users_id_fk",
+          "tableFrom": "ad_hoc_participants",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.game_interest_suppressions": {
+      "name": "game_interest_suppressions",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suppressed_at": {
+          "name": "suppressed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "game_interest_suppressions_user_id_users_id_fk": {
+          "name": "game_interest_suppressions_user_id_users_id_fk",
+          "tableFrom": "game_interest_suppressions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "game_interest_suppressions_game_id_games_id_fk": {
+          "name": "game_interest_suppressions_game_id_games_id_fk",
+          "tableFrom": "game_interest_suppressions",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_user_game_suppression": {
+          "name": "uq_user_game_suppression",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.event_voice_sessions": {
+      "name": "event_voice_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "event_id": {
+          "name": "event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_user_id": {
+          "name": "discord_user_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discord_username": {
+          "name": "discord_username",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_join_at": {
+          "name": "first_join_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_leave_at": {
+          "name": "last_leave_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_duration_sec": {
+          "name": "total_duration_sec",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "segments": {
+          "name": "segments",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "classification": {
+          "name": "classification",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "event_voice_sessions_event_discord_user_unique": {
+          "name": "event_voice_sessions_event_discord_user_unique",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "discord_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_voice_sessions_event": {
+          "name": "idx_event_voice_sessions_event",
+          "columns": [
+            {
+              "expression": "event_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "event_voice_sessions_event_id_events_id_fk": {
+          "name": "event_voice_sessions_event_id_events_id_fk",
+          "tableFrom": "event_voice_sessions",
+          "tableTo": "events",
+          "columnsFrom": [
+            "event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "event_voice_sessions_user_id_users_id_fk": {
+          "name": "event_voice_sessions_user_id_users_id_fk",
+          "tableFrom": "event_voice_sessions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.enrichments": {
+      "name": "enrichments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enricher_key": {
+          "name": "enricher_key",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_enrichments_entity": {
+          "name": "idx_enrichments_entity",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_entity_enricher": {
+          "name": "unique_entity_enricher",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entity_type",
+            "entity_id",
+            "enricher_key"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ai_request_logs": {
+      "name": "ai_request_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "feature": {
+          "name": "feature",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_tokens": {
+          "name": "prompt_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completion_tokens": {
+          "name": "completion_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "success": {
+          "name": "success",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_ai_request_logs_created_at": {
+          "name": "idx_ai_request_logs_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_ai_request_logs_feature_created_at": {
+          "name": "idx_ai_request_logs_feature_created_at",
+          "columns": [
+            {
+              "expression": "feature",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ai_request_logs_user_id_users_id_fk": {
+          "name": "ai_request_logs_user_id_users_id_fk",
+          "tableFrom": "ai_request_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_entries": {
+      "name": "community_lineup_entries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nominated_by": {
+          "name": "nominated_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "carried_over_from": {
+          "name": "carried_over_from",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_entries_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_entries_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_entries",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_entries_game_id_games_id_fk": {
+          "name": "community_lineup_entries_game_id_games_id_fk",
+          "tableFrom": "community_lineup_entries",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_entries_nominated_by_users_id_fk": {
+          "name": "community_lineup_entries_nominated_by_users_id_fk",
+          "tableFrom": "community_lineup_entries",
+          "tableTo": "users",
+          "columnsFrom": [
+            "nominated_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_entries_carried_over_from_community_lineups_id_fk": {
+          "name": "community_lineup_entries_carried_over_from_community_lineups_id_fk",
+          "tableFrom": "community_lineup_entries",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "carried_over_from"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lineup_entry_game": {
+          "name": "uq_lineup_entry_game",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineup_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_invitees": {
+      "name": "community_lineup_invitees",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_invitees_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_invitees_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_invitees",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_invitees_user_id_users_id_fk": {
+          "name": "community_lineup_invitees_user_id_users_id_fk",
+          "tableFrom": "community_lineup_invitees",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lineup_invitee_user": {
+          "name": "uq_lineup_invitee_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineup_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_votes": {
+      "name": "community_lineup_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_votes_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_votes_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_votes",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_votes_user_id_users_id_fk": {
+          "name": "community_lineup_votes_user_id_users_id_fk",
+          "tableFrom": "community_lineup_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_votes_game_id_games_id_fk": {
+          "name": "community_lineup_votes_game_id_games_id_fk",
+          "tableFrom": "community_lineup_votes",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lineup_vote_user_game": {
+          "name": "uq_lineup_vote_user_game",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineup_id",
+            "user_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineups": {
+      "name": "community_lineups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'building'"
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'public'"
+        },
+        "target_date": {
+          "name": "target_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_game_id": {
+          "name": "decided_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_event_id": {
+          "name": "linked_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voting_deadline": {
+          "name": "voting_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase_deadline": {
+          "name": "phase_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auto_advance_paused_at": {
+          "name": "auto_advance_paused_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_advance_at": {
+          "name": "pending_advance_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase_duration_override": {
+          "name": "phase_duration_override",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_threshold": {
+          "name": "match_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 35
+        },
+        "max_votes_per_player": {
+          "name": "max_votes_per_player",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "default_tiebreaker_mode": {
+          "name": "default_tiebreaker_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_tiebreaker_id": {
+          "name": "active_tiebreaker_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_created_channel_id": {
+          "name": "discord_created_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "discord_created_message_id": {
+          "name": "discord_created_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "channel_override_id": {
+          "name": "channel_override_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "public_share_enabled": {
+          "name": "public_share_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "public_slug": {
+          "name": "public_slug",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "include_scheduling_phase": {
+          "name": "include_scheduling_phase",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineups_decided_game_id_games_id_fk": {
+          "name": "community_lineups_decided_game_id_games_id_fk",
+          "tableFrom": "community_lineups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "decided_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_lineups_linked_event_id_events_id_fk": {
+          "name": "community_lineups_linked_event_id_events_id_fk",
+          "tableFrom": "community_lineups",
+          "tableTo": "events",
+          "columnsFrom": [
+            "linked_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_lineups_created_by_users_id_fk": {
+          "name": "community_lineups_created_by_users_id_fk",
+          "tableFrom": "community_lineups",
+          "tableTo": "users",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_lineups_public_slug_unique": {
+          "name": "community_lineups_public_slug_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "public_slug"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_tiebreaker_bracket_matchups": {
+      "name": "community_lineup_tiebreaker_bracket_matchups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tiebreaker_id": {
+          "name": "tiebreaker_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "smallint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_a_id": {
+          "name": "game_a_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_b_id": {
+          "name": "game_b_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "winner_game_id": {
+          "name": "winner_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_bye": {
+          "name": "is_bye",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_tiebreaker_bracket_matchups_tiebreaker_id_community_lineup_tiebreakers_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_matchups_tiebreaker_id_community_lineup_tiebreakers_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_matchups",
+          "tableTo": "community_lineup_tiebreakers",
+          "columnsFrom": [
+            "tiebreaker_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_matchups_game_a_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_matchups_game_a_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_matchups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_a_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_matchups_game_b_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_matchups_game_b_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_matchups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_b_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_matchups_winner_game_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_matchups_winner_game_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_matchups",
+          "tableTo": "games",
+          "columnsFrom": [
+            "winner_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_tiebreaker_matchup_round_pos": {
+          "name": "uq_tiebreaker_matchup_round_pos",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tiebreaker_id",
+            "round",
+            "position"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_tiebreaker_bracket_votes": {
+      "name": "community_lineup_tiebreaker_bracket_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "matchup_id": {
+          "name": "matchup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_tiebreaker_bracket_votes_matchup_id_community_lineup_tiebreaker_bracket_matchups_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_votes_matchup_id_community_lineup_tiebreaker_bracket_matchups_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_votes",
+          "tableTo": "community_lineup_tiebreaker_bracket_matchups",
+          "columnsFrom": [
+            "matchup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_votes_user_id_users_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_votes_user_id_users_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_bracket_votes_game_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_bracket_votes_game_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_bracket_votes",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_tiebreaker_bracket_vote": {
+          "name": "uq_tiebreaker_bracket_vote",
+          "nullsNotDistinct": false,
+          "columns": [
+            "matchup_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_tiebreaker_vetoes": {
+      "name": "community_lineup_tiebreaker_vetoes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "tiebreaker_id": {
+          "name": "tiebreaker_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "revealed": {
+          "name": "revealed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_tiebreaker_vetoes_tiebreaker_id_community_lineup_tiebreakers_id_fk": {
+          "name": "community_lineup_tiebreaker_vetoes_tiebreaker_id_community_lineup_tiebreakers_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_vetoes",
+          "tableTo": "community_lineup_tiebreakers",
+          "columnsFrom": [
+            "tiebreaker_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_vetoes_user_id_users_id_fk": {
+          "name": "community_lineup_tiebreaker_vetoes_user_id_users_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_vetoes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreaker_vetoes_game_id_games_id_fk": {
+          "name": "community_lineup_tiebreaker_vetoes_game_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreaker_vetoes",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_tiebreaker_veto_user": {
+          "name": "uq_tiebreaker_veto_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "tiebreaker_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_tiebreakers": {
+      "name": "community_lineup_tiebreakers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "tied_game_ids": {
+          "name": "tied_game_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_vote_count": {
+          "name": "original_vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "winner_game_id": {
+          "name": "winner_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "round_deadline": {
+          "name": "round_deadline",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_tiebreakers_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_tiebreakers_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_tiebreakers",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_tiebreakers_winner_game_id_games_id_fk": {
+          "name": "community_lineup_tiebreakers_winner_game_id_games_id_fk",
+          "tableFrom": "community_lineup_tiebreakers",
+          "tableTo": "games",
+          "columnsFrom": [
+            "winner_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_match_members": {
+      "name": "community_lineup_match_members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduling_submitted_at": {
+          "name": "scheduling_submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_match_members_match_id_community_lineup_matches_id_fk": {
+          "name": "community_lineup_match_members_match_id_community_lineup_matches_id_fk",
+          "tableFrom": "community_lineup_match_members",
+          "tableTo": "community_lineup_matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_match_members_user_id_users_id_fk": {
+          "name": "community_lineup_match_members_user_id_users_id_fk",
+          "tableFrom": "community_lineup_match_members",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_match_member_user": {
+          "name": "uq_match_member_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "match_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_matches": {
+      "name": "community_lineup_matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'suggested'"
+        },
+        "threshold_met": {
+          "name": "threshold_met",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "vote_count": {
+          "name": "vote_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "vote_percentage": {
+          "name": "vote_percentage",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fit_type": {
+          "name": "fit_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linked_event_id": {
+          "name": "linked_event_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_message_id": {
+          "name": "embed_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "embed_channel_id": {
+          "name": "embed_channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_vote_threshold": {
+          "name": "min_vote_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "threshold_notified_at": {
+          "name": "threshold_notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_matches_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_matches_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_matches",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_matches_game_id_games_id_fk": {
+          "name": "community_lineup_matches_game_id_games_id_fk",
+          "tableFrom": "community_lineup_matches",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_matches_linked_event_id_events_id_fk": {
+          "name": "community_lineup_matches_linked_event_id_events_id_fk",
+          "tableFrom": "community_lineup_matches",
+          "tableTo": "events",
+          "columnsFrom": [
+            "linked_event_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lineup_match_game": {
+          "name": "uq_lineup_match_game",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineup_id",
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_schedule_slots": {
+      "name": "community_lineup_schedule_slots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "match_id": {
+          "name": "match_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "proposed_time": {
+          "name": "proposed_time",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "overlap_score": {
+          "name": "overlap_score",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_by": {
+          "name": "suggested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_schedule_slots_match_id_community_lineup_matches_id_fk": {
+          "name": "community_lineup_schedule_slots_match_id_community_lineup_matches_id_fk",
+          "tableFrom": "community_lineup_schedule_slots",
+          "tableTo": "community_lineup_matches",
+          "columnsFrom": [
+            "match_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_schedule_votes": {
+      "name": "community_lineup_schedule_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "slot_id": {
+          "name": "slot_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_schedule_votes_slot_id_community_lineup_schedule_slots_id_fk": {
+          "name": "community_lineup_schedule_votes_slot_id_community_lineup_schedule_slots_id_fk",
+          "tableFrom": "community_lineup_schedule_votes",
+          "tableTo": "community_lineup_schedule_slots",
+          "columnsFrom": [
+            "slot_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_schedule_votes_user_id_users_id_fk": {
+          "name": "community_lineup_schedule_votes_user_id_users_id_fk",
+          "tableFrom": "community_lineup_schedule_votes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_schedule_vote_user": {
+          "name": "uq_schedule_vote_user",
+          "nullsNotDistinct": false,
+          "columns": [
+            "slot_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_lineup_user_submissions": {
+      "name": "community_lineup_user_submissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nominations_submitted_at": {
+          "name": "nominations_submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "votes_submitted_at": {
+          "name": "votes_submitted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "community_lineup_user_submissions_lineup_id_community_lineups_id_fk": {
+          "name": "community_lineup_user_submissions_lineup_id_community_lineups_id_fk",
+          "tableFrom": "community_lineup_user_submissions",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "community_lineup_user_submissions_user_id_users_id_fk": {
+          "name": "community_lineup_user_submissions_user_id_users_id_fk",
+          "tableFrom": "community_lineup_user_submissions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lineup_user_submission": {
+          "name": "uq_lineup_user_submission",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineup_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.activity_log": {
+      "name": "activity_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_activity_log_entity": {
+          "name": "idx_activity_log_entity",
+          "columns": [
+            {
+              "expression": "entity_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "entity_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "activity_log_actor_id_users_id_fk": {
+          "name": "activity_log_actor_id_users_id_fk",
+          "tableFrom": "activity_log",
+          "tableTo": "users",
+          "columnsFrom": [
+            "actor_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_dedup": {
+      "name": "notification_dedup",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "dedup_key": {
+          "name": "dedup_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "uq_notification_dedup_key": {
+          "name": "uq_notification_dedup_key",
+          "columns": [
+            {
+              "expression": "dedup_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_notification_dedup_expires_at": {
+          "name": "idx_notification_dedup_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.consumed_intent_tokens": {
+      "name": "consumed_intent_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "consumed_at": {
+          "name": "consumed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_consumed_intent_tokens_consumed_at": {
+          "name": "idx_consumed_intent_tokens_consumed_at",
+          "columns": [
+            {
+              "expression": "consumed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "consumed_intent_tokens_token_hash_unique": {
+          "name": "consumed_intent_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_taste_vectors": {
+      "name": "player_taste_vectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vector": {
+          "name": "vector",
+          "type": "vector(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "intensity_metrics": {
+          "name": "intensity_metrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "archetype": {
+          "name": "archetype",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "signal_hash": {
+          "name": "signal_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "player_taste_vectors_computed_at_idx": {
+          "name": "player_taste_vectors_computed_at_idx",
+          "columns": [
+            {
+              "expression": "computed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "player_taste_vectors_user_id_users_id_fk": {
+          "name": "player_taste_vectors_user_id_users_id_fk",
+          "tableFrom": "player_taste_vectors",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "player_taste_vectors_user_id_unique": {
+          "name": "player_taste_vectors_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_intensity_snapshots": {
+      "name": "player_intensity_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week_start": {
+          "name": "week_start",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_hours": {
+          "name": "total_hours",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_breakdown": {
+          "name": "game_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unique_games": {
+          "name": "unique_games",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longest_session_hours": {
+          "name": "longest_session_hours",
+          "type": "numeric(10, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "longest_session_game_id": {
+          "name": "longest_session_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "player_intensity_snapshots_week_start_idx": {
+          "name": "player_intensity_snapshots_week_start_idx",
+          "columns": [
+            {
+              "expression": "week_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "player_intensity_snapshots_user_id_users_id_fk": {
+          "name": "player_intensity_snapshots_user_id_users_id_fk",
+          "tableFrom": "player_intensity_snapshots",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "player_intensity_snapshots_longest_session_game_id_games_id_fk": {
+          "name": "player_intensity_snapshots_longest_session_game_id_games_id_fk",
+          "tableFrom": "player_intensity_snapshots",
+          "tableTo": "games",
+          "columnsFrom": [
+            "longest_session_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_player_intensity_user_week": {
+          "name": "uq_player_intensity_user_week",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "week_start"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_co_play": {
+      "name": "player_co_play",
+      "schema": "",
+      "columns": {
+        "user_id_a": {
+          "name": "user_id_a",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id_b": {
+          "name": "user_id_b",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_count": {
+          "name": "session_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_minutes": {
+          "name": "total_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_played_at": {
+          "name": "last_played_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "games_played": {
+          "name": "games_played",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "player_co_play_user_id_a_users_id_fk": {
+          "name": "player_co_play_user_id_a_users_id_fk",
+          "tableFrom": "player_co_play",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id_a"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "player_co_play_user_id_b_users_id_fk": {
+          "name": "player_co_play_user_id_b_users_id_fk",
+          "tableFrom": "player_co_play",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id_b"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "player_co_play_user_id_a_user_id_b_pk": {
+          "name": "player_co_play_user_id_a_user_id_b_pk",
+          "columns": [
+            "user_id_a",
+            "user_id_b"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "chk_player_co_play_canonical_order": {
+          "name": "chk_player_co_play_canonical_order",
+          "value": "\"player_co_play\".\"user_id_a\" < \"player_co_play\".\"user_id_b\""
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.game_taste_vectors": {
+      "name": "game_taste_vectors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "game_id": {
+          "name": "game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vector": {
+          "name": "vector",
+          "type": "vector(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dimensions": {
+          "name": "dimensions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "signal_hash": {
+          "name": "signal_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "game_taste_vectors_computed_at_idx": {
+          "name": "game_taste_vectors_computed_at_idx",
+          "columns": [
+            {
+              "expression": "computed_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "game_taste_vectors_game_id_games_id_fk": {
+          "name": "game_taste_vectors_game_id_games_id_fk",
+          "tableFrom": "game_taste_vectors",
+          "tableTo": "games",
+          "columnsFrom": [
+            "game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "game_taste_vectors_game_id_unique": {
+          "name": "game_taste_vectors_game_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "game_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lineup_ai_suggestions": {
+      "name": "lineup_ai_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "lineup_id": {
+          "name": "lineup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voter_set_hash": {
+          "name": "voter_set_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "lineup_ai_suggestions_lineup_generated_at_idx": {
+          "name": "lineup_ai_suggestions_lineup_generated_at_idx",
+          "columns": [
+            {
+              "expression": "lineup_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "lineup_ai_suggestions_lineup_id_community_lineups_id_fk": {
+          "name": "lineup_ai_suggestions_lineup_id_community_lineups_id_fk",
+          "tableFrom": "lineup_ai_suggestions",
+          "tableTo": "community_lineups",
+          "columnsFrom": [
+            "lineup_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "uq_lineup_ai_suggestion_voter_set": {
+          "name": "uq_lineup_ai_suggestion_voter_set",
+          "nullsNotDistinct": false,
+          "columns": [
+            "lineup_id",
+            "voter_set_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discovery_category_suggestions": {
+      "name": "discovery_category_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(120)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_type": {
+          "name": "category_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "theme_vector": {
+          "name": "theme_vector",
+          "type": "vector(7)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter_criteria": {
+          "name": "filter_criteria",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::jsonb"
+        },
+        "candidate_game_ids": {
+          "name": "candidate_game_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "population_strategy": {
+          "name": "population_strategy",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1000
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "reviewed_by": {
+          "name": "reviewed_by",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "discovery_category_status_idx": {
+          "name": "discovery_category_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_category_sort_idx": {
+          "name": "discovery_category_sort_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sort_order",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"discovery_category_suggestions\".\"status\" = 'approved'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discovery_category_suggestions_reviewed_by_users_id_fk": {
+          "name": "discovery_category_suggestions_reviewed_by_users_id_fk",
+          "tableFrom": "discovery_category_suggestions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reviewed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.community_insights_snapshots": {
+      "name": "community_insights_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "snapshot_date": {
+          "name": "snapshot_date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "radar_payload": {
+          "name": "radar_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "engagement_payload": {
+          "name": "engagement_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "churn_payload": {
+          "name": "churn_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "social_graph_payload": {
+          "name": "social_graph_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "temporal_payload": {
+          "name": "temporal_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "key_insights_payload": {
+          "name": "key_insights_payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_community_insights_snapshots_created_at": {
+          "name": "idx_community_insights_snapshots_created_at",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "community_insights_snapshots_snapshot_date_unique": {
+          "name": "community_insights_snapshots_snapshot_date_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "snapshot_date"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.games_dedup_audit": {
+      "name": "games_dedup_audit",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "match_type": {
+          "name": "match_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "match_key": {
+          "name": "match_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "canonical_game_id": {
+          "name": "canonical_game_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dup_game_ids": {
+          "name": "dup_game_ids",
+          "type": "integer[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_size": {
+          "name": "group_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "downstream_counts": {
+          "name": "downstream_counts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unique_conflicts": {
+          "name": "unique_conflicts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "snapshot_at": {
+          "name": "snapshot_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "games_dedup_audit_snapshot_at_match_type_idx": {
+          "name": "games_dedup_audit_snapshot_at_match_type_idx",
+          "columns": [
+            {
+              "expression": "snapshot_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "match_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "games_dedup_audit_canonical_game_id_games_id_fk": {
+          "name": "games_dedup_audit_canonical_game_id_games_id_fk",
+          "tableFrom": "games_dedup_audit",
+          "tableTo": "games",
+          "columnsFrom": [
+            "canonical_game_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.refresh_tokens": {
+      "name": "refresh_tokens",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "rotated_at": {
+          "name": "rotated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "replaced_by": {
+          "name": "replaced_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "auth_method": {
+          "name": "auth_method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_refresh_tokens_user_id": {
+          "name": "idx_refresh_tokens_user_id",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_expires_at": {
+          "name": "idx_refresh_tokens_expires_at",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_refresh_tokens_family_id": {
+          "name": "idx_refresh_tokens_family_id",
+          "columns": [
+            {
+              "expression": "family_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "refresh_tokens_user_id_users_id_fk": {
+          "name": "refresh_tokens_user_id_users_id_fk",
+          "tableFrom": "refresh_tokens",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "refresh_tokens_token_hash_unique": {
+          "name": "refresh_tokens_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/api/src/drizzle/migrations/meta/_journal.json
+++ b/api/src/drizzle/migrations/meta/_journal.json
@@ -1051,6 +1051,13 @@
       "when": 1782700510333,
       "tag": "0149_nervous_omega_red",
       "breakpoints": true
+    },
+    {
+      "idx": 150,
+      "version": "7",
+      "when": 1782779036931,
+      "tag": "0150_nasty_pixie",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/drizzle/schema/events.ts
+++ b/api/src/drizzle/schema/events.ts
@@ -119,6 +119,9 @@ export const events = pgTable(
     /** ROK-1352: Live ephemeral voice channel ID. Set on create, cleared on
      *  destroy. Non-null marks the channel as the resolver Tier 0 target. */
     ephemeralVoiceChannelId: text('ephemeral_voice_channel_id'),
+    /** ROK-1386: Lock the ephemeral voice channel to rostered members only.
+     *  null/false = open. Only meaningful when ephemeral voice is on. */
+    privateVoice: boolean('private_voice'),
     createdAt: timestamp('created_at').defaultNow().notNull(),
     updatedAt: timestamp('updated_at').defaultNow().notNull(),
   },

--- a/api/src/events/event-create.helpers.ts
+++ b/api/src/events/event-create.helpers.ts
@@ -31,6 +31,8 @@ export function buildBaseValues(
     // admin force-ephemeral setting is on). Recurring instances each inherit
     // this base value; later series edits propagate via PATCH /events/:id/series.
     ephemeralVoiceEnabled: dto.ephemeralVoiceEnabled ?? null,
+    // ROK-1386: lock the ephemeral channel to rostered members only.
+    privateVoice: dto.privateVoice ?? null,
   };
 }
 

--- a/api/src/events/event-response-map.helpers.ts
+++ b/api/src/events/event-response-map.helpers.ts
@@ -75,6 +75,8 @@ function mapEventFields(
     // ROK-1352: ephemeral voice override + live channel id.
     ephemeralVoiceEnabled: event.ephemeralVoiceEnabled ?? null,
     ephemeralVoiceChannelId: event.ephemeralVoiceChannelId ?? null,
+    // ROK-1386: private-voice (roster-only) override.
+    privateVoice: event.privateVoice ?? null,
     createdAt: event.createdAt.toISOString(),
     updatedAt: event.updatedAt.toISOString(),
   };

--- a/api/src/events/event-update.helpers.ts
+++ b/api/src/events/event-update.helpers.ts
@@ -67,6 +67,9 @@ export function buildUpdateData(
   // which applies buildUpdateData per target) was a silent no-op.
   if (dto.ephemeralVoiceEnabled !== undefined)
     updateData.ephemeralVoiceEnabled = dto.ephemeralVoiceEnabled;
+  // ROK-1386: persist the per-event private-voice override on edit.
+  if (dto.privateVoice !== undefined)
+    updateData.privateVoice = dto.privateVoice;
   if (dto.startTime || dto.endTime) {
     updateData.duration = resolveDuration(dto, existing);
   }

--- a/packages/contract/src/events.schema.ts
+++ b/packages/contract/src/events.schema.ts
@@ -54,6 +54,9 @@ export const CreateEventSchema = z.object({
      *  unless the admin force-ephemeral setting is on. Series-wide changes
      *  propagate per-event via the ROK-429 scope flow (PATCH /events/:id/series). */
     ephemeralVoiceEnabled: z.boolean().nullable().optional(),
+    /** ROK-1386: Lock the ephemeral voice channel to rostered members only.
+     *  Only meaningful when ephemeral voice is effectively on. */
+    privateVoice: z.boolean().nullable().optional(),
 }).refine(
     (data) => new Date(data.startTime) < new Date(data.endTime),
     { message: 'Start time must be before end time', path: ['endTime'] }
@@ -81,6 +84,8 @@ export const UpdateEventSchema = z.object({
     /** ROK-1352: Per-event ephemeral-voice opt-in. Persisted on single + series
      *  edits via buildUpdateData; series scope is driven by the ROK-429 modal. */
     ephemeralVoiceEnabled: z.boolean().nullable().optional(),
+    /** ROK-1386: Lock the ephemeral voice channel to rostered members only. */
+    privateVoice: z.boolean().nullable().optional(),
 }).refine(
     (data) => {
         if (data.startTime && data.endTime) {
@@ -177,6 +182,8 @@ export const EventResponseSchema = z.object({
     ephemeralVoiceEnabled: z.boolean().nullable().optional(),
     /** ROK-1352: Live ephemeral voice channel ID (null when none). */
     ephemeralVoiceChannelId: z.string().nullable().optional(),
+    /** ROK-1386: Lock ephemeral voice to rostered members only (null = off). */
+    privateVoice: z.boolean().nullable().optional(),
     createdAt: z.string().datetime(),
     updatedAt: z.string().datetime(),
 });

--- a/web/src/components/events/create-event-form-sections.tsx
+++ b/web/src/components/events/create-event-form-sections.tsx
@@ -99,7 +99,7 @@ export function WhenSection({ form, errors, isEditMode, tzAbbr, endTimePreview, 
             <DurationSection durationMinutes={form.durationMinutes} customDuration={form.customDuration} durationError={errors.duration} onDurationMinutesChange={(v) => updateField('durationMinutes', v)} onCustomDurationChange={(v) => updateField('customDuration', v)} onDurationErrorClear={() => setErrors((prev) => ({ ...prev, duration: undefined }))} />
             {endTimePreview && <EndTimePreview endTimePreview={endTimePreview} tzAbbr={tzAbbr} durationMinutes={form.durationMinutes} />}
             {!isEditMode && <RecurrenceFields form={form} errors={errors} recurrenceCount={recurrenceCount} updateField={updateField} setErrors={setErrors} />}
-            <EphemeralVoiceToggle value={form.ephemeralVoiceEnabled} onChange={(v) => updateField('ephemeralVoiceEnabled', v)} />
+            <EphemeralVoiceToggle value={form.ephemeralVoiceEnabled} onChange={(v) => updateField('ephemeralVoiceEnabled', v)} privateValue={form.privateVoice} onPrivateChange={(v) => updateField('privateVoice', v)} />
         </FormSection>
     );
 }

--- a/web/src/components/events/create-event-form.types.ts
+++ b/web/src/components/events/create-event-form.types.ts
@@ -24,6 +24,8 @@ export interface FormState {
     reminder24hour: boolean;
     /** ROK-1352: per-event ephemeral-voice override. null = inherit series/global. */
     ephemeralVoiceEnabled: boolean | null;
+    /** ROK-1386: lock the ephemeral channel to rostered members only. null = open. */
+    privateVoice: boolean | null;
     selectedInstances: Record<string, unknown>[];
     titleIsAutoSuggested: boolean;
     descriptionIsAutoSuggested: boolean;

--- a/web/src/components/events/create-event-form.utils.ts
+++ b/web/src/components/events/create-event-form.utils.ts
@@ -27,6 +27,7 @@ function getEditModeState(editEvent: EventResponseDto, resolved: string): FormSt
         reminder1hour: editEvent.reminder1hour ?? false,
         reminder24hour: editEvent.reminder24hour ?? false,
         ephemeralVoiceEnabled: editEvent.ephemeralVoiceEnabled ?? null,
+        privateVoice: editEvent.privateVoice ?? null,
         selectedInstances: (editEvent.contentInstances as Record<string, unknown>[]) ?? [],
         titleIsAutoSuggested: false, descriptionIsAutoSuggested: false,
     };
@@ -43,7 +44,7 @@ function getDefaultState(): FormState {
         maxAttendees: '', autoUnbench: true,
         recurrenceFrequency: '', recurrenceUntil: '',
         reminder15min: true, reminder1hour: false, reminder24hour: false,
-        ephemeralVoiceEnabled: null,
+        ephemeralVoiceEnabled: null, privateVoice: null,
         selectedInstances: [], titleIsAutoSuggested: false, descriptionIsAutoSuggested: false,
     };
 }
@@ -183,5 +184,6 @@ export function buildSubmitDto(
         contentInstances: form.selectedInstances.length > 0 ? form.selectedInstances : undefined,
         reminder15min: form.reminder15min, reminder1hour: form.reminder1hour, reminder24hour: form.reminder24hour,
         ephemeralVoiceEnabled: form.ephemeralVoiceEnabled,
+        privateVoice: form.privateVoice,
     };
 }

--- a/web/src/components/events/ephemeral-voice-toggle.test.tsx
+++ b/web/src/components/events/ephemeral-voice-toggle.test.tsx
@@ -1,6 +1,8 @@
 /**
  * ROK-1352: per-event ephemeral-voice toggle — gated on the member-readable
  * system status (master flag) with a force-ephemeral on+disabled mode.
+ * ROK-1386: nested private (roster-only) checkbox, shown only when ephemeral
+ * voice is effectively on.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
@@ -13,6 +15,8 @@ vi.mock('../../hooks/use-system-status', () => ({
     useSystemStatus: () => status,
 }));
 
+const PRIVATE_LABEL = 'Private event — only rostered members can join';
+
 describe('EphemeralVoiceToggle (ROK-1352)', () => {
     beforeEach(() => {
         status.data = {};
@@ -21,14 +25,26 @@ describe('EphemeralVoiceToggle (ROK-1352)', () => {
     it('renders nothing when the master toggle is off', () => {
         status.data = { ephemeralVoiceEnabled: false };
         const { container } = render(
-            <EphemeralVoiceToggle value={null} onChange={vi.fn()} />,
+            <EphemeralVoiceToggle
+                value={null}
+                onChange={vi.fn()}
+                privateValue={null}
+                onPrivateChange={vi.fn()}
+            />,
         );
         expect(container).toBeEmptyDOMElement();
     });
 
     it('renders the toggle when the master flag is on', () => {
         status.data = { ephemeralVoiceEnabled: true };
-        render(<EphemeralVoiceToggle value={null} onChange={vi.fn()} />);
+        render(
+            <EphemeralVoiceToggle
+                value={null}
+                onChange={vi.fn()}
+                privateValue={null}
+                onPrivateChange={vi.fn()}
+            />,
+        );
         expect(
             screen.getByLabelText('Ephemeral voice channel for this event'),
         ).toBeInTheDocument();
@@ -37,7 +53,14 @@ describe('EphemeralVoiceToggle (ROK-1352)', () => {
     it('emits true when checked and null when unchecked (inherit)', () => {
         status.data = { ephemeralVoiceEnabled: true };
         const onChange = vi.fn();
-        render(<EphemeralVoiceToggle value={null} onChange={onChange} />);
+        render(
+            <EphemeralVoiceToggle
+                value={null}
+                onChange={onChange}
+                privateValue={null}
+                onPrivateChange={vi.fn()}
+            />,
+        );
         fireEvent.click(
             screen.getByLabelText('Ephemeral voice channel for this event'),
         );
@@ -46,11 +69,95 @@ describe('EphemeralVoiceToggle (ROK-1352)', () => {
 
     it('renders on + disabled when force-ephemeral is enabled', () => {
         status.data = { ephemeralVoiceEnabled: true, ephemeralVoiceForced: true };
-        render(<EphemeralVoiceToggle value={null} onChange={vi.fn()} />);
+        render(
+            <EphemeralVoiceToggle
+                value={null}
+                onChange={vi.fn()}
+                privateValue={null}
+                onPrivateChange={vi.fn()}
+            />,
+        );
         const box = screen.getByLabelText(
             'Ephemeral voice channel for this event',
         ) as HTMLInputElement;
         expect(box.checked).toBe(true);
         expect(box.disabled).toBe(true);
+    });
+});
+
+describe('EphemeralVoiceToggle — private checkbox (ROK-1386)', () => {
+    beforeEach(() => {
+        status.data = {};
+    });
+
+    it('hides the private checkbox while ephemeral voice is off', () => {
+        status.data = { ephemeralVoiceEnabled: true };
+        render(
+            <EphemeralVoiceToggle
+                value={null}
+                onChange={vi.fn()}
+                privateValue={null}
+                onPrivateChange={vi.fn()}
+            />,
+        );
+        expect(screen.queryByLabelText(PRIVATE_LABEL)).not.toBeInTheDocument();
+    });
+
+    it('shows the private checkbox when ephemeral voice is on', () => {
+        status.data = { ephemeralVoiceEnabled: true };
+        render(
+            <EphemeralVoiceToggle
+                value={true}
+                onChange={vi.fn()}
+                privateValue={null}
+                onPrivateChange={vi.fn()}
+            />,
+        );
+        expect(screen.getByLabelText(PRIVATE_LABEL)).toBeInTheDocument();
+    });
+
+    it('shows the private checkbox when force-ephemeral is enabled', () => {
+        status.data = { ephemeralVoiceEnabled: true, ephemeralVoiceForced: true };
+        render(
+            <EphemeralVoiceToggle
+                value={null}
+                onChange={vi.fn()}
+                privateValue={null}
+                onPrivateChange={vi.fn()}
+            />,
+        );
+        expect(screen.getByLabelText(PRIVATE_LABEL)).toBeInTheDocument();
+    });
+
+    it('emits true/null from the private checkbox', () => {
+        status.data = { ephemeralVoiceEnabled: true };
+        const onPrivateChange = vi.fn();
+        render(
+            <EphemeralVoiceToggle
+                value={true}
+                onChange={vi.fn()}
+                privateValue={null}
+                onPrivateChange={onPrivateChange}
+            />,
+        );
+        fireEvent.click(screen.getByLabelText(PRIVATE_LABEL));
+        expect(onPrivateChange).toHaveBeenCalledWith(true);
+    });
+
+    it('resets private to null when ephemeral voice is unchecked', () => {
+        status.data = { ephemeralVoiceEnabled: true };
+        const onPrivateChange = vi.fn();
+        render(
+            <EphemeralVoiceToggle
+                value={true}
+                onChange={vi.fn()}
+                privateValue={true}
+                onPrivateChange={onPrivateChange}
+            />,
+        );
+        fireEvent.click(
+            screen.getByLabelText('Ephemeral voice channel for this event'),
+        );
+        expect(onPrivateChange).toHaveBeenCalledWith(null);
     });
 });

--- a/web/src/components/events/ephemeral-voice-toggle.tsx
+++ b/web/src/components/events/ephemeral-voice-toggle.tsx
@@ -2,6 +2,8 @@ import { useSystemStatus } from '../../hooks/use-system-status';
 
 /**
  * ROK-1352: Per-event ephemeral-voice toggle.
+ * ROK-1386: nested "Private — only rostered members can join" checkbox, shown
+ * only when ephemeral voice is EFFECTIVELY on (checked or admin-forced).
  *
  * Reads feature availability from the member-readable system status (NOT the
  * admin-only settings API) so non-admin event creators can opt in — and so the
@@ -13,29 +15,57 @@ import { useSystemStatus } from '../../hooks/use-system-status';
 export function EphemeralVoiceToggle({
     value,
     onChange,
+    privateValue,
+    onPrivateChange,
 }: {
     value: boolean | null;
     onChange: (v: boolean | null) => void;
+    privateValue: boolean | null;
+    onPrivateChange: (v: boolean | null) => void;
 }) {
     const { data: status } = useSystemStatus();
     if (!status?.ephemeralVoiceEnabled) return null;
     const forced = status.ephemeralVoiceForced === true;
+    const effectiveOn = forced || value === true;
 
     return (
-        <label className="flex items-center gap-3 cursor-pointer">
-            <input
-                type="checkbox"
-                aria-label="Ephemeral voice channel for this event"
-                checked={forced || value === true}
-                disabled={forced}
-                onChange={(e) => onChange(e.target.checked ? true : null)}
-                className="h-4 w-4 rounded border-edge text-emerald-500 focus:ring-emerald-500 disabled:opacity-60"
-            />
-            <span className="text-sm text-foreground">
-                {forced
-                    ? 'A temporary voice channel will be created for this event (enabled by admin)'
-                    : 'Create a temporary voice channel for this event'}
-            </span>
-        </label>
+        <div className="space-y-2">
+            <label className="flex items-center gap-3 cursor-pointer">
+                <input
+                    type="checkbox"
+                    aria-label="Ephemeral voice channel for this event"
+                    checked={forced || value === true}
+                    disabled={forced}
+                    onChange={(e) => {
+                        const next = e.target.checked ? true : null;
+                        onChange(next);
+                        // Private only makes sense while ephemeral is on.
+                        if (next !== true && !forced) onPrivateChange(null);
+                    }}
+                    className="h-4 w-4 rounded border-edge text-emerald-500 focus:ring-emerald-500 disabled:opacity-60"
+                />
+                <span className="text-sm text-foreground">
+                    {forced
+                        ? 'A temporary voice channel will be created for this event (enabled by admin)'
+                        : 'Create a temporary voice channel for this event'}
+                </span>
+            </label>
+            {effectiveOn && (
+                <label className="flex items-center gap-3 cursor-pointer ml-7">
+                    <input
+                        type="checkbox"
+                        aria-label="Private event — only rostered members can join"
+                        checked={privateValue === true}
+                        onChange={(e) =>
+                            onPrivateChange(e.target.checked ? true : null)
+                        }
+                        className="h-4 w-4 rounded border-edge text-emerald-500 focus:ring-emerald-500"
+                    />
+                    <span className="text-sm text-foreground">
+                        Private — only rostered members can join
+                    </span>
+                </label>
+            )}
+        </div>
     );
 }

--- a/web/src/components/events/ephemeral-voice-toggle.tsx
+++ b/web/src/components/events/ephemeral-voice-toggle.tsx
@@ -1,6 +1,35 @@
 import { useSystemStatus } from '../../hooks/use-system-status';
 
 /**
+ * Nested "Private — only rostered members can join" checkbox (ROK-1386).
+ * Extracted so the parent toggle stays under the max-lines-per-function limit.
+ */
+function PrivateVoiceCheckbox({
+    privateValue,
+    onPrivateChange,
+}: {
+    privateValue: boolean | null;
+    onPrivateChange: (v: boolean | null) => void;
+}) {
+    return (
+        <label className="flex items-center gap-3 cursor-pointer ml-7">
+            <input
+                type="checkbox"
+                aria-label="Private event — only rostered members can join"
+                checked={privateValue === true}
+                onChange={(e) =>
+                    onPrivateChange(e.target.checked ? true : null)
+                }
+                className="h-4 w-4 rounded border-edge text-emerald-500 focus:ring-emerald-500"
+            />
+            <span className="text-sm text-foreground">
+                Private — only rostered members can join
+            </span>
+        </label>
+    );
+}
+
+/**
  * ROK-1352: Per-event ephemeral-voice toggle.
  * ROK-1386: nested "Private — only rostered members can join" checkbox, shown
  * only when ephemeral voice is EFFECTIVELY on (checked or admin-forced).
@@ -51,20 +80,10 @@ export function EphemeralVoiceToggle({
                 </span>
             </label>
             {effectiveOn && (
-                <label className="flex items-center gap-3 cursor-pointer ml-7">
-                    <input
-                        type="checkbox"
-                        aria-label="Private event — only rostered members can join"
-                        checked={privateValue === true}
-                        onChange={(e) =>
-                            onPrivateChange(e.target.checked ? true : null)
-                        }
-                        className="h-4 w-4 rounded border-edge text-emerald-500 focus:ring-emerald-500"
-                    />
-                    <span className="text-sm text-foreground">
-                        Private — only rostered members can join
-                    </span>
-                </label>
+                <PrivateVoiceCheckbox
+                    privateValue={privateValue}
+                    onPrivateChange={onPrivateChange}
+                />
             )}
         </div>
     );


### PR DESCRIPTION
## ROK-1386 — Private event: invite/roster-only ephemeral voice

A **"Private — only rostered members can join"** checkbox that appears under the existing "Create a temporary voice channel" toggle (ROK-1352). When private, only **rostered** members can join the event's ephemeral Discord voice channel, enforced by **member-level permission overwrites + a voice-state join-guard** (the approved design — no per-event role, dies with the channel, zero cleanup).

> ⚠️ **High blast radius — please review carefully.** Touches the contract, a migration, Discord voice permissions, the voice-state listener, and the event create/edit form. Auto-merge is intentionally **OFF**.

### Allow-list rules (operator-confirmed)
- Rostered sign-ups only (`assignedSlot != 'bench'` — benched excluded).
- `signed_up` + `tentative` (tentative only if not benched).
- Visible-but-locked: `@everyone` keeps `ViewChannel`, `Connect` denied; explicit bot allow so the deny can't lock the bot out.
- On demotion/removal: **block re-entry only** — never disconnect an already-connected member.
- Unlinked members (no Discord id) silently blocked.

### Dynamic roster sync
`EphemeralVoiceService.syncVoiceAccess(eventId)` **full-reconciles** the channel's member overwrites against the current rostered set (adds promoted, removes demoted/benched). Hooked **debounced** on `SIGNUP_EVENTS.{CREATED,UPDATED,DELETED}` in `discord-sync.listener` (mirrors the embed-sync coalescing window), so bench↔roster moves re-sync. The join-guard backstops any sync lag.

## Implementation

**Foundation (commit 1 — prior implementer's uncommitted work, checkpointed):**
- `packages/contract/src/events.schema.ts` — `privateVoice` on Create/Update/Response event schemas.
- `api/src/drizzle/schema/events.ts` + **migration `0150_nasty_pixie.sql`** (`ALTER TABLE events ADD COLUMN private_voice boolean`) + journal/snapshot.
- `api/src/events/event-create.helpers.ts`, `event-update.helpers.ts`, `event-response-map.helpers.ts` — persistence (mirrors `ephemeralVoiceEnabled`).
- `api/src/discord-bot/services/ephemeral-voice.db-helpers.ts` — `privateVoice` projection on `EphemeralEventRow`.
- `api/src/discord-bot/services/ephemeral-voice.discord-ops.ts` — `createVoiceChannel` overwrite support + `applyPrivateVoiceOverwrites` full-reconcile.
- `api/src/discord-bot/services/ephemeral-voice.private.helpers.ts` (+spec) — `computeAllowedDiscordIds`, `buildPrivateVoiceOverwrites`, `reconcileMemberOverwrites` + `ephemeral-voice.discord-ops.spec.ts`.

**Net-new (commit 2):**
- `ephemeral-voice.service.ts` — `syncVoiceAccess` (reconcile), `enforceJoinGuard` (disconnect non-allow-listed joiners), create-time overwrite seed, `resolveAllowedIds`/`buildSeedOverwrites` helpers.
- `ephemeral-voice.db-helpers.ts` — `fetchRosterSignupRows` (LEFT JOIN `roster_assignments` + `users`).
- `ephemeral-voice.discord-ops.ts` — `disconnectMember`.
- `discord-sync.listener.ts` — debounced `syncVoiceAccess` on signup/roster fan-out + shutdown timer cleanup.
- `voice-state.listener.ts` — join-guard hook on new-join transitions only (optional injection).
- `web/src/components/events/ephemeral-voice-toggle.tsx` — conditional private checkbox (shown only when ephemeral effectively on; resets to null when ephemeral unchecked) + form `types`/`utils`/`sections` wiring.

## Test plan
- **api unit** (`ephemeral-voice.service.spec.ts`): `syncVoiceAccess` bails for non-private/channel-less; reconciles against the correctly-computed allow-list (rostered+tentative, excludes bench/declined). `enforceJoinGuard`: disconnects non-allow-listed, leaves allow-listed, no-op for non-private. Plus existing allow-list/overwrite-builder/reconcile units.
- **web unit** (`ephemeral-voice-toggle.test.tsx`): private checkbox hidden when ephemeral off, shown when on/forced, emits true/null, resets on ephemeral uncheck.
- **Local gate:** `validate-ci.sh --static` → Build / TypeScript / Lint (0 errors) / Shell-parse / **Migration validation (151 applied clean against fresh Postgres)** all PASS.
- **Playwright (desktop + mobile): PASS** against a freshly-deployed dev env.
- Discord companion-bot smoke could not run locally (no `TEST_BOT_TOKEN` in this env) — deferred to GitHub CI which has credentials.

## Reviewer notes / risk
- Risk is concentrated in the dynamic roster-sync layer + join-guard (as flagged in the issue). Permission-overwrite + disconnect behavior is hard to exercise via the companion bot deterministically; covered by unit tests + the live Playwright form pass. A bot-level smoke for the private-join flow may be a worthwhile follow-up.
- `syncVoiceAccess`/`enforceJoinGuard` bail fast for non-private events, so the hot path for existing (non-private) ephemeral channels is unchanged.
- No orphaned overwrites after reaper delete — overwrites die with the channel (per approved design).

Closes ROK-1386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
