### PR TITLE
chore(dev): durable local app_settings preservation across DB resets (stop the recurring wipe)

### DIFF
--- a/scripts/deploy_dev.sh
+++ b/scripts/deploy_dev.sh
@@ -18,6 +18,16 @@
 #
 # Worktree-safe: auto-detects worktrees, uses correct Docker volumes, copies
 # .env files from the main repo, and sources env vars for NestJS.
+#
+# Durable app_settings preservation: after each healthy deploy, the local API
+# keys (the `app_settings` table — Blizzard/IGDB/ITAD/LLM/etc.) are snapshotted
+# to ~/.raid-ledger/app-settings.local.sql — OUTSIDE the repo AND outside the
+# Docker volume. Whenever a reset (--fresh, clone-prod, a `docker volume rm`, an
+# agent running --fresh) leaves app_settings empty, the snapshot is auto-restored
+# right after migrations, BEFORE the API starts. One mechanism covers every reset
+# path, so the recurring local-keys wipe stops. (app_settings is EXCLUDED from
+# all backups by design — ROK-1279 — and is NOT seeded from env, so without this
+# snapshot every reset destroys the keys with no recovery.)
 # =============================================================================
 
 set -e
@@ -42,6 +52,17 @@ COMPOSE_FILE="$MAIN_REPO/docker-compose.yml"
 ENV_FILE="$PROJECT_DIR/.env"
 LOG_DIR="$PROJECT_DIR/.dev-logs"
 PID_FILE="$PROJECT_DIR/.dev-pids"
+
+# External app_settings snapshot — the durable preservation store. Lives in the
+# same out-of-repo, out-of-volume state dir as the env lease (env-lock.sh), so it
+# survives `--fresh`, `docker volume rm`, clone-prod, and any agent DB reset.
+# Honors RAID_LEDGER_STATE_DIR like env-lock.sh for test overrides.
+RL_STATE_DIR="${RAID_LEDGER_STATE_DIR:-$HOME/.raid-ledger}"
+APP_SETTINGS_SNAPSHOT="$RL_STATE_DIR/app-settings.local.sql"
+# Tilde form used ONLY in operator-facing messages (the actual path above is
+# fully expanded for file ops). The literal ~ is intentional display text.
+# shellcheck disable=SC2088
+APP_SETTINGS_SNAPSHOT_DISPLAY="~/.raid-ledger/app-settings.local.sql"
 
 cd "$PROJECT_DIR"
 
@@ -718,6 +739,82 @@ create_safety_backup() {
     fi
 }
 
+# =============================================================================
+# Durable app_settings preservation (stop the recurring local-keys wipe)
+# =============================================================================
+# app_settings holds the local API keys (Blizzard/IGDB/ITAD/LLM/etc.). They are
+# EXCLUDED from all backups (ROK-1279) and NOT seeded from env, so every DB reset
+# wiped them with no recovery. The three helpers below implement ONE durable
+# mechanism: snapshot to an external file after a healthy deploy, auto-restore
+# whenever the table is empty after migrations.
+#
+# Encryption note: app_settings values are encrypted with a key derived from the
+# local JWT_SECRET, so a restored snapshot stays valid as long as JWT_SECRET is
+# unchanged (it's stable in .env). Rotate JWT_SECRET and the restored ciphertext
+# becomes undecryptable — re-enter the keys via /admin/settings.
+
+# Count rows in public.app_settings. Emits an integer, or "error" when the table
+# isn't queryable yet (DB down / pre-migration).
+count_app_settings_rows() {
+    docker exec raid-ledger-db psql -U user -d raid_ledger -tAc \
+        "SELECT count(*) FROM app_settings" 2>/dev/null || echo "error"
+}
+
+# Dump app_settings to the external snapshot after a healthy deploy so the
+# current keys can be auto-restored after the next reset. Only writes when the
+# table has >=1 row, and writes atomically (tmp + mv) so a failed dump never
+# clobbers a good snapshot. No-op (keeps prior snapshot) on empty/unqueryable.
+snapshot_app_settings() {
+    local rows
+    rows=$(count_app_settings_rows)
+    if ! [ "$rows" -gt 0 ] 2>/dev/null; then
+        return 0
+    fi
+    mkdir -p "$RL_STATE_DIR"
+    local tmp
+    tmp=$(mktemp -t rl-app-settings.XXXXXX)
+    if docker exec raid-ledger-db pg_dump \
+            --data-only --inserts --table=public.app_settings \
+            "$DATABASE_URL" >"$tmp" 2>/dev/null \
+       && grep -qE '^INSERT INTO ' "$tmp"; then
+        mv "$tmp" "$APP_SETTINGS_SNAPSHOT"
+        print_success "app_settings snapshot saved ($rows row(s)) → $APP_SETTINGS_SNAPSHOT_DISPLAY"
+    else
+        rm -f "$tmp"
+        print_warning "app_settings snapshot skipped — kept previous snapshot if any"
+    fi
+}
+
+# Auto-restore app_settings from the external snapshot when the table is empty
+# after a reset (--fresh / clone / volume nuke). Runs BEFORE the API starts so it
+# boots reading the restored rows — no settings-cache bounce needed. Only acts on
+# a definitively-empty table; re-counts after to confirm the restore landed.
+restore_app_settings_if_empty() {
+    [ -f "$APP_SETTINGS_SNAPSHOT" ] || return 0
+    local rows
+    rows=$(count_app_settings_rows)
+    [ "$rows" = "0" ] || return 0
+    docker exec -i raid-ledger-db psql -U user -d raid_ledger \
+        <"$APP_SETTINGS_SNAPSHOT" >/dev/null 2>&1 || true
+    local restored
+    restored=$(count_app_settings_rows)
+    if [ "$restored" -gt 0 ] 2>/dev/null; then
+        print_success "app_settings empty after reset — auto-restored ${restored} row(s) from $APP_SETTINGS_SNAPSHOT_DISPLAY"
+    else
+        print_warning "app_settings auto-restore from $APP_SETTINGS_SNAPSHOT_DISPLAY failed — re-enter API keys via /admin/settings"
+    fi
+}
+
+# Warn before a --fresh wipe that app_settings (API keys) will be cleared, and
+# whether the external snapshot can auto-restore them after migrations.
+warn_fresh_app_settings() {
+    if [ -f "$APP_SETTINGS_SNAPSHOT" ]; then
+        print_warning "--fresh will wipe app_settings (API keys) — snapshot at $APP_SETTINGS_SNAPSHOT_DISPLAY will auto-restore them after migrations."
+    else
+        print_warning "--fresh will wipe app_settings (API keys) — no snapshot exists yet, so you'll re-enter keys via /admin/settings (a snapshot is saved after each healthy deploy)."
+    fi
+}
+
 start_dev() {
     local rebuild=$1
     local fresh=$2
@@ -770,8 +867,15 @@ start_dev() {
 
     # Fresh start: wipe volumes (new admin password will be auto-generated on bootstrap)
     if [ "$fresh" = "true" ]; then
+        # Tell the operator the API keys are about to go, and whether we can
+        # auto-restore them after migrations.
+        warn_fresh_app_settings
         # Create a safety backup before wiping
         create_safety_backup
+        # Refresh the external app_settings snapshot while the DB is still up, so
+        # keys entered since the last healthy deploy survive this wipe too. No-op
+        # if the DB is already down or the table is empty.
+        snapshot_app_settings
 
         print_warning "Fresh start: wiping database volume..."
         docker compose -f "$COMPOSE_FILE" down -v 2>/dev/null || true
@@ -824,6 +928,14 @@ start_dev() {
     # Validate DB has real data — if empty and not --fresh, something went wrong
     validate_db_data "$fresh"
 
+    # Durable app_settings recovery: if a reset (--fresh / clone / volume nuke)
+    # left app_settings empty, auto-restore the external snapshot NOW — after
+    # migrations rebuilt the empty table, before the API starts — so the API
+    # boots reading the restored rows and no settings-cache bounce is needed.
+    # (Placed after validate_db_data so a full-backup restore that already
+    # repopulated app_settings is left untouched — we only act on 0 rows.)
+    restore_app_settings_if_empty
+
     # Bootstrap admin — capture output so we can show credentials
     echo "Checking admin account..."
     BOOTSTRAP_OUTPUT=$(npx ts-node api/scripts/bootstrap-admin.ts 2>&1 || true)
@@ -854,7 +966,15 @@ start_dev() {
     print_success "Web starting on http://localhost:5173 (PID: $!)"
 
     # Wait for API to be healthy (with retries)
-    wait_for_api || print_warning "API may still be starting — check logs with --logs"
+    local api_healthy=true
+    wait_for_api || { print_warning "API may still be starting — check logs with --logs"; api_healthy=false; }
+
+    # Snapshot app_settings now that the deploy is healthy, so the current API
+    # keys can be auto-restored after the next DB reset. No-op if the table is
+    # empty (never clobbers a good snapshot with an empty dump).
+    if [ "$api_healthy" = true ]; then
+        snapshot_app_settings
+    fi
 
     # Re-anchor the lease PID from $$ (this script — about to exit) to the
     # long-lived API server PID. Without this, the lease appears `pid_dead`
@@ -1007,6 +1127,13 @@ while [ $# -gt 0 ]; do
             echo ""
             echo "Worktree-safe: auto-detects worktrees, copies .env from main repo,"
             echo "and always uses correct Docker volumes."
+            echo ""
+            echo "Durable app_settings preservation: local API keys (the app_settings"
+            echo "table) are snapshotted to ~/.raid-ledger/app-settings.local.sql after"
+            echo "each healthy deploy (and before a --fresh wipe), then auto-restored"
+            echo "whenever a reset (--fresh / clone / volume nuke) leaves the table empty."
+            echo "The snapshot lives outside the repo + Docker volume; keys survive as"
+            echo "long as JWT_SECRET is unchanged."
             echo ""
             echo "Examples:"
             echo "  $0 --branch rok-123     # Switch to feature branch and deploy"


### PR DESCRIPTION
## What

Add ONE durable mechanism to `scripts/deploy_dev.sh` that permanently stops the recurring local `app_settings` wipe (recurred ~a dozen times; every prior fix was a per-path band-aid that didn't hold).

## Root cause (confirmed)

`app_settings` (local API keys — Blizzard/IGDB/ITAD/LLM/etc.) is **EXCLUDED from all backups by design** (ROK-1279: `--exclude-table-data=app_settings` + secret sanitization) AND is **NOT seeded from env** (the settings service only reads CLIENT_URL/DISCORD_CALLBACK_URL/JWT_SECRET). So **every** local DB reset — `deploy_dev.sh --fresh`, clone-prod, a `docker volume rm`, an agent running `--fresh` — wiped the keys with no recovery path. `deploy_dev.sh` had **no** app_settings preservation.

## The durable fix — external snapshot + auto-restore-on-empty

An **external** auto-snapshot that lives **outside the repo AND outside the Docker volume** (`~/.raid-ledger/app-settings.local.sql` — same out-of-repo state dir as the env lease), auto-restored whenever `app_settings` is empty. One mechanism, all reset paths:

1. **`snapshot_app_settings()`** — after each healthy deploy (and again right before a `--fresh` wipe while the DB is still up), dump app_settings via `pg_dump --data-only --inserts --table=public.app_settings`. Atomic `tmp` + `mv`; only writes when `>=1` row, so a failed/empty dump never clobbers a good snapshot. This path survives `--fresh`, `docker volume rm`, and clone (outside both the repo and the volume).
2. **`restore_app_settings_if_empty()`** — right after migrations, **before the API process starts**, if app_settings has 0 rows AND the snapshot exists, restore via `psql`. The API boots reading the restored rows, so **no settings-cache bounce is needed**. Placed after `validate_db_data` so a full-backup restore that already repopulated the table is left untouched (only acts on 0 rows). Logs `app_settings empty after reset — auto-restored N row(s) ...`.
3. **`warn_fresh_app_settings()`** — on `--fresh`, warn that keys will be wiped and whether a snapshot exists to auto-restore from.

Reuses the proven SQL from `scripts/clone-prod-to-local.sh` (Step 0.5 preserve / Step 6.5 re-apply) but persists OUTSIDE `/tmp` and the repo.

## Why this is DURABLE (unlike prior per-path preserves)

Prior fixes each preserved keys for **one** reset path (e.g. clone-prod's in-flight `/tmp` preserve), so the next un-covered path (a bare `--fresh`, a volume nuke, an agent reset) re-wiped them. This is a single **external** store (survives volume + repo destruction) with a single **restore-on-empty trigger** that fires on **every** path that leaves the table empty — `--fresh`, clone, `docker volume rm`, and agent `--fresh` all funnel through the same post-migration restore. There's no per-path logic to forget.

## Encryption note

The dump is encrypted with the local `JWT_SECRET`-derived key, so the restore is valid as long as `JWT_SECRET` is unchanged (stable in `.env`). Rotate `JWT_SECRET` and the restored ciphertext becomes undecryptable — re-enter via `/admin/settings`. (Documented inline.)

## Scope / future-state note

This protects **future** state: from the next healthy deploy onward, keys are snapshotted and auto-protected forever. The **already-wiped current keys still need a one-time re-entry** via `/admin/settings` — after that first deploy snapshots them, they're protected across all future resets.

## Verification

- `bash -n scripts/deploy_dev.sh` clean.
- All 4 new helpers `<30` lines (`count_app_settings_rows` 4, `snapshot_app_settings` 20, `restore_app_settings_if_empty` 15, `warn_fresh_app_settings` 7). No new shellcheck warnings (only 2 pre-existing unrelated ones remain; shellcheck is not in CI).
- **Part A** — drove the real `snapshot_app_settings` against the live dev DB (read-only, scratch `RAID_LEDGER_STATE_DIR` override to avoid touching the operator's real snapshot): live = 2 rows → dumped exactly 2 INSERTs; `restore_app_settings_if_empty` correctly no-oped on the non-empty table.
- **Part B** — full snapshot→wipe→restore round-trip on an isolated scratch schema using the identical `pg_dump`/`psql` command shapes: 2 rows → snapshot → wipe to 0 → restore → 2 rows, data **MATCH**. Zero risk to live `public.app_settings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)