### PR TITLE
feat(discord): show start time on ephemeral event's Scheduled-Event name (de-dupe sidebar)

### DIFF
--- a/api/src/discord-bot/services/scheduled-event.discord-ops.ts
+++ b/api/src/discord-bot/services/scheduled-event.discord-ops.ts
@@ -9,6 +9,7 @@ import {
   MAX_SCHEDULED_EVENTS_REACHED,
   timedDiscordCall,
   buildScheduledEventName,
+  buildScheduledEventNameWithTime,
   type ScheduledEventData,
 } from './scheduled-event.helpers';
 import type { DiscordBotClientService } from '../discord-bot-client.service';
@@ -237,6 +238,24 @@ export async function resolveVoiceForEdit(
   );
 }
 
+/**
+ * Resolve the SE name for an edit. Ephemeral-voice events get the start time
+ * appended (`"<base> · Sun 9:35 PM"`) so the Discord sidebar's SE line no longer
+ * duplicates the co-located `"⏰ <base>"` channel name; non-ephemeral events keep
+ * the clean game-aware name (they sit at static channels and show their time
+ * natively in the Events tab). The repoint path re-runs this on both create and
+ * destroy of the ephemeral channel, so the suffix is added/removed as the
+ * channel comes and goes. `getTimezone` is invoked only on the ephemeral path.
+ */
+export async function resolveEditedScheduledEventName(
+  event: Pick<ScheduledEventRecord, 'ephemeralVoiceChannelId'>,
+  eventData: ScheduledEventData,
+  getTimezone: () => Promise<string | null>,
+): Promise<string> {
+  if (!event.ephemeralVoiceChannelId) return buildScheduledEventName(eventData);
+  return buildScheduledEventNameWithTime(eventData, await getTimezone());
+}
+
 /** Create a new Discord Scheduled Event via the API (ROK-755 extraction). */
 export async function tryCreateNewEvent(
   guild: Guild,
@@ -261,7 +280,12 @@ export async function tryCreateNewEvent(
   );
 }
 
-/** Edit all fields of an existing Discord Scheduled Event (ROK-755 extraction). */
+/**
+ * Edit all fields of an existing Discord Scheduled Event (ROK-755 extraction).
+ * `name` lets the caller substitute a pre-resolved SE name (e.g. the
+ * time-suffixed ephemeral variant); when omitted it defaults to the clean
+ * `buildScheduledEventName`.
+ */
 export async function tryEditFullEvent(
   guild: Guild,
   eventId: number,
@@ -269,12 +293,13 @@ export async function tryEditFullEvent(
   eventData: ScheduledEventData,
   description: string,
   voiceChannelId: string | null,
+  name?: string,
 ): Promise<void> {
   await timedDiscordCall(
     'scheduledEvents.edit',
     () =>
       guild.scheduledEvents.edit(seId, {
-        name: buildScheduledEventName(eventData),
+        name: name ?? buildScheduledEventName(eventData),
         scheduledStartTime: new Date(eventData.startTime),
         scheduledEndTime: new Date(eventData.endTime),
         description,

--- a/api/src/discord-bot/services/scheduled-event.helpers.spec.ts
+++ b/api/src/discord-bot/services/scheduled-event.helpers.spec.ts
@@ -1,5 +1,6 @@
 import {
   buildScheduledEventName,
+  buildScheduledEventNameWithTime,
   buildEphemeralChannelName,
   EPHEMERAL_CHANNEL_MARKER,
   MAX_SCHEDULED_EVENT_NAME_LENGTH,
@@ -104,6 +105,83 @@ describe('buildEphemeralChannelName (ROK-1352)', () => {
     );
     expect(name.length).toBe(MAX_SCHEDULED_EVENT_NAME_LENGTH);
     expect(name.startsWith(EPHEMERAL_CHANNEL_MARKER)).toBe(true);
+    expect(name.endsWith('…')).toBe(true);
+  });
+
+  it('does NOT include the start-time suffix — the channel stays the clean join target', () => {
+    const name = buildEphemeralChannelName(
+      makeEventData({
+        title: 'HELLCARD Event',
+        startTime: '2026-06-14T21:35:00.000Z',
+        game: null,
+      }),
+    );
+    expect(name).toBe(`${EPHEMERAL_CHANNEL_MARKER} HELLCARD Event`);
+    expect(name).not.toContain('·');
+    expect(name).not.toMatch(/\d{1,2}:\d{2}/);
+  });
+});
+
+describe('buildScheduledEventNameWithTime (sidebar de-dupe)', () => {
+  it('appends the start time after a middot, formatted in the given timezone', () => {
+    const name = buildScheduledEventNameWithTime(
+      makeEventData({
+        title: 'HELLCARD Event',
+        startTime: '2026-06-14T21:35:00.000Z',
+        game: null,
+      }),
+      'UTC',
+    );
+    expect(name).toBe('HELLCARD Event · Sun 9:35 PM');
+  });
+
+  it('appends the time onto a variety-night base name (with game)', () => {
+    const name = buildScheduledEventNameWithTime(
+      makeEventData({
+        title: 'Gamernight',
+        startTime: '2026-06-14T21:35:00.000Z',
+        game: { name: 'HELLCARD' },
+      }),
+      'UTC',
+    );
+    expect(name).toBe('Gamernight — HELLCARD · Sun 9:35 PM');
+  });
+
+  it('uses the bare title (no game) as the base before the time', () => {
+    const name = buildScheduledEventNameWithTime(
+      makeEventData({
+        title: 'Variety Night',
+        startTime: '2026-06-14T21:35:00.000Z',
+        game: null,
+      }),
+      'UTC',
+    );
+    expect(name).toBe('Variety Night · Sun 9:35 PM');
+  });
+
+  it('honors a non-UTC configured timezone for the displayed time', () => {
+    const name = buildScheduledEventNameWithTime(
+      makeEventData({
+        title: 'Raid',
+        startTime: '2026-06-15T01:35:00.000Z',
+        game: null,
+      }),
+      'America/New_York',
+    );
+    expect(name).toBe('Raid · Sun 9:35 PM');
+  });
+
+  it('truncates a base+time name over 100 chars to 99 + ellipsis', () => {
+    const title = 'T'.repeat(100);
+    const name = buildScheduledEventNameWithTime(
+      makeEventData({
+        title,
+        startTime: '2026-06-14T21:35:00.000Z',
+        game: null,
+      }),
+      'UTC',
+    );
+    expect(name.length).toBe(MAX_SCHEDULED_EVENT_NAME_LENGTH);
     expect(name.endsWith('…')).toBe(true);
   });
 });

--- a/api/src/discord-bot/services/scheduled-event.helpers.ts
+++ b/api/src/discord-bot/services/scheduled-event.helpers.ts
@@ -125,6 +125,49 @@ export function buildScheduledEventName(eventData: ScheduledEventData): string {
 }
 
 /**
+ * Format an event's start time for embedding in a Scheduled Event name, e.g.
+ * `"Sun 9:35 PM"`. Mirrors the en-US, hour12 display style the push-content
+ * formatter uses (`utils/push-content.ts`), but trimmed to weekday + time so it
+ * fits the SE-name cap. When a display timezone is configured it is honored
+ * (the same `getDefaultTimezone()` setting the embeds use); otherwise the host's
+ * local zone is used. The comma some locales insert between weekday and time is
+ * collapsed to a single space to match the `"Sun 9:35 PM"` target.
+ */
+export function formatStartTimeForName(
+  startTime: string,
+  timezone?: string | null,
+): string {
+  const opts: Intl.DateTimeFormatOptions = {
+    weekday: 'short',
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  };
+  if (timezone) opts.timeZone = timezone;
+  return new Date(startTime).toLocaleString('en-US', opts).replace(', ', ' ');
+}
+
+/**
+ * Build the Scheduled Event name for an ephemeral-voice event, enriched with the
+ * formatted start time (`"<base> · Sun 9:35 PM"`). Scoped to ephemeral events:
+ * their SE sits at the auto-created `"⏰ <base>"` channel, so without the time
+ * suffix the Discord sidebar shows the channel and the SE name as two identical
+ * lines. Appending the start time de-dupes the second line. The base is the
+ * unchanged `buildScheduledEventName` (game-aware); the result is truncated to
+ * the Discord 100-char cap with the same ellipsis pattern.
+ */
+export function buildScheduledEventNameWithTime(
+  eventData: ScheduledEventData,
+  timezone?: string | null,
+): string {
+  const base = buildScheduledEventName(eventData);
+  const time = formatStartTimeForName(eventData.startTime, timezone);
+  const combined = `${base} · ${time}`;
+  if (combined.length <= MAX_SCHEDULED_EVENT_NAME_LENGTH) return combined;
+  return combined.slice(0, MAX_SCHEDULED_EVENT_NAME_LENGTH - 1) + '…';
+}
+
+/**
  * ROK-1352: marker prefixed to ephemeral voice channel names so they're
  * visually distinguishable from permanent channels in the Discord channel
  * list. Native Unicode (renders wherever Discord does); '⏰' connotes the

--- a/api/src/discord-bot/services/scheduled-event.service.crud.spec.ts
+++ b/api/src/discord-bot/services/scheduled-event.service.crud.spec.ts
@@ -249,6 +249,38 @@ describe('updateScheduledEvent', () => {
     );
   });
 
+  it('appends the start time to the SE name when the event has an ephemeral voice channel', async () => {
+    const selectChain = mocks.createSelectChain([
+      {
+        discordScheduledEventId: 'discord-se-id-1',
+        ephemeralVoiceChannelId: 'ephem-vc-1',
+      },
+    ]);
+    mocks.mockDb.select.mockReturnValue(selectChain);
+    await mocks.service.updateScheduledEvent(42, baseEventData, 1, false);
+    const editArg = mocks.mockGuild.scheduledEvents.edit.mock.calls[0][1] as {
+      name: string;
+    };
+    expect(editArg.name).toMatch(/^Raid Night — World of Warcraft · /);
+    expect(editArg.name).toMatch(/\d{1,2}:\d{2}\s?(AM|PM)$/);
+  });
+
+  it('keeps the clean SE name (no time suffix) for a non-ephemeral event', async () => {
+    const selectChain = mocks.createSelectChain([
+      {
+        discordScheduledEventId: 'discord-se-id-1',
+        ephemeralVoiceChannelId: null,
+      },
+    ]);
+    mocks.mockDb.select.mockReturnValue(selectChain);
+    await mocks.service.updateScheduledEvent(42, baseEventData, 1, false);
+    const editArg = mocks.mockGuild.scheduledEvents.edit.mock.calls[0][1] as {
+      name: string;
+    };
+    expect(editArg.name).toBe('Raid Night — World of Warcraft');
+    expect(editArg.name).not.toContain('·');
+  });
+
   it('creates a new scheduled event when none exists in DB', async () => {
     const selectChain = mocks.createSelectChain([
       { discordScheduledEventId: null },

--- a/api/src/discord-bot/services/scheduled-event.service.spec-helpers.ts
+++ b/api/src/discord-bot/services/scheduled-event.service.spec-helpers.ts
@@ -141,6 +141,7 @@ function buildScheduledEventProviders(
       provide: SettingsService,
       useValue: {
         getClientUrl: jest.fn().mockResolvedValue('https://raidledger.app'),
+        getDefaultTimezone: jest.fn().mockResolvedValue('UTC'),
       },
     },
     {

--- a/api/src/discord-bot/services/scheduled-event.service.ts
+++ b/api/src/discord-bot/services/scheduled-event.service.ts
@@ -32,6 +32,7 @@ import {
   tryEditDescription,
   tryEditFullEvent,
   resolveVoiceForEdit,
+  resolveEditedScheduledEventName,
 } from './scheduled-event.discord-ops';
 import {
   createScheduledEventIdempotent,
@@ -315,6 +316,9 @@ export class ScheduledEventService {
       gameId,
       this.channelResolver,
     );
+    const name = await resolveEditedScheduledEventName(event, eventData, () =>
+      this.settingsService.getDefaultTimezone(),
+    );
     try {
       await tryEditFullEvent(
         guild,
@@ -323,6 +327,7 @@ export class ScheduledEventService {
         eventData,
         d,
         vc,
+        name,
       );
     } catch (err) {
       if (!isUnknownEventError(err)) throw err;


### PR DESCRIPTION
## Problem

For an ephemeral-voice event the Discord sidebar shows two near-identical lines: the auto-created voice **channel** (`⏰ HELLCARD Event`) and the co-located **Scheduled Event** name (`HELLCARD Event`). Root cause: `buildEphemeralChannelName` is literally `"⏰ " + buildScheduledEventName(...)`, so the channel and the SE name are the same string by construction.

## Fix

Keep line 1 (the channel) as the clean `⏰ <name>` join target, and enrich line 2 (the **Scheduled Event name**) with the event's **start time**, so it reads e.g. `HELLCARD Event · Sun 9:35 PM`.

- New `buildScheduledEventNameWithTime()` + `formatStartTimeForName()` in `scheduled-event.helpers.ts`. Reuses the existing en-US / `hour12` display style from the push-content formatter (`utils/push-content.ts`) and honors the configured display timezone via `getDefaultTimezone()` — the **same setting the embeds use** (`embed-poster.service.ts`). Respects the Discord 100-char SE-name cap with the existing slice-to-99 + `…` ellipsis pattern.
- `buildScheduledEventName` (base) and `buildEphemeralChannelName` (channel = `⏰ ` + base) are **unchanged**, so line 1 stays clean and the idempotent adopt/confirm-by-name matching is unaffected.

## Scoping — ephemeral-voice events only

The time-suffix is applied **only to ephemeral-voice events**, via the SE edit/repoint path. `tryEdit` resolves the SE name through the new free helper `resolveEditedScheduledEventName(event, eventData, getTimezone)`, which appends the time only when the event has an `ephemeralVoiceChannelId`. Non-ephemeral SEs sit at static channels and keep the clean name (their time already shows natively in the Events tab).

Both ephemeral **create** and **destroy** route through `ephemeral-voice.service.ts` `repointAndResync → updateScheduledEvent → tryEdit`, so the suffix is added when the channel is created and removed when it's destroyed (the `ephemeralVoiceChannelId` is set/cleared right before each repoint). The base SE-create path keeps the plain name — in normal operation the SE exists well before the buffer-window channel is created, so the repoint edit is always the path that carries the ephemeral name, and keeping create on the plain name preserves the idempotent adopt/confirm-by-name matching.

## Tests

- `scheduled-event.helpers.spec.ts`: with-time builder (base name + formatted time, no-game and variety-night bases), non-UTC configured timezone, truncation at the 100-char cap, and that the ephemeral **channel** name has no time suffix.
- `scheduled-event.service.crud.spec.ts`: `updateScheduledEvent` applies the time-suffixed SE name when the event has an ephemeral voice channel, and keeps the clean name (no `·`) for a non-ephemeral event.
- All 210 tests across the 20 scheduled-event / ephemeral suites pass.

## Validation

`./scripts/validate-ci.sh --static` → Build / TypeScript / Lint all **PASS** (0 errors).

## Note on CI

This touches `api/src/discord-bot/**`, so GitHub's `discord-smoke` job will run. That job has a known ROK-1347/1350 timing flake — if it flakes, it's not from this change (no embed/dispatch/voice-path behavior changed here, only the SE name string).

🤖 Generated with [Claude Code](https://claude.com/claude-code)