### PR TITLE
fix(web): drop redundant 'Event' from game-only event title suggestion

### DIFF
--- a/web/src/components/events/shared/game-details-section.tsx
+++ b/web/src/components/events/shared/game-details-section.tsx
@@ -52,7 +52,7 @@ function useTitleSuggestion(selectedEventType: { name?: string; defaultPlayerCap
             return `${names.join(' + ')}${suffix}`;
         }
         if (etName && gName) return `${etName} \u2014 ${gName}`;
-        if (gName) return `${gName} Event`;
+        if (gName) return gName;
         return '';
     }, [etName, etCap, gName, selectedInstances]);
 }


### PR DESCRIPTION
When creating an event with just a game selected, the title auto-fill suggested `<game> Event`. Since it's already a Discord Scheduled **Event** (and ephemeral voice channel), "Event" is redundant — the sidebar read "HELLCARD Event" twice. Now suggests just the game name (`HELLCARD`).

- Only the **suggested default** changes (`useTitleSuggestion`, `game-details-section.tsx:55`); operator-typed titles and existing events are untouched.
- Other suggestion branches (instances, event-type) already didn't append "Event".
- web tsc + lint clean; `create-event-form` suite 24/24 pass. Trivial copy/default change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)