### PR TITLE
fix(test): cap vitest workers + raise timeouts to kill fork starvation (ROK-1285)

### DIFF
--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,7 +1,15 @@
 import '@testing-library/jest-dom/vitest';
 import * as matchers from 'vitest-axe/matchers';
+import { configure } from '@testing-library/react';
 import { expect, beforeAll, afterEach, afterAll } from 'vitest';
 import { server } from './mocks/server';
+
+// ROK-1285: raise Testing Library's async-util timeout (default 1000ms) so
+// `waitFor`/`findBy` in poll-heavy specs (e.g. use-ai-suggestions) survive
+// transient event-loop starvation during the full coverage run. Kept below
+// vitest's testTimeout (15000) so a genuinely stuck test still fails the test,
+// not the util.
+configure({ asyncUtilTimeout: 10000 });
 
 // Node 24 ships a built-in `localStorage` whose prototype shadows the jsdom
 // polyfill — the result is an empty object with no `getItem`/`setItem`. Restore

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -7,6 +7,16 @@ export default defineConfig({
         environment: 'jsdom',
         globals: true,
         setupFiles: ['./src/test/setup.ts'],
+        // ROK-1285: a full `vitest run --coverage` on a high-core dev box forks
+        // ~1 worker per core under v8 coverage, starving the event loop until
+        // unlucky specs blow the 5s testTimeout (the pool even failed to *spawn*
+        // workers — "[vitest-pool]: Failed to start forks worker"). Cap workers
+        // to half the cores (ratio scales down on low-core CI too) and give the
+        // starvation-prone async/poll specs real headroom. Not a module leak.
+        // NB: vitest 4 removed `poolOptions`; min/maxWorkers are top-level now.
+        testTimeout: 15000,
+        minWorkers: 1,
+        maxWorkers: '50%',
         coverage: {
             provider: 'v8',
             reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary (`web`)
Phase-3 CI flake sweep. A full `vitest run --coverage` on a high-core dev box (10 cores) forks ~1 worker per core under v8 coverage, starving the event loop until unlucky specs blow the 5s `testTimeout`. At the extreme the pool fails to spawn workers entirely (`[vitest-pool]: Failed to start forks worker`), with individual test files taking **350–428s**. **Not** a module/MSW leak (`server.resetHandlers()` already runs in `afterEach`).

## Root cause (reproduced, not inferred)
- Reproduced **3/15** full-coverage runs (~20%) on a 10-core box. Carriers rotate per run (`use-ai-suggestions`, `ollama-setup-card`, `AiSuggestionCard`, `ephemeral-voice-toggle`) — each passes in isolation, confirming starvation, not logic.

## Fix
- `web/vitest.config.ts`: `maxWorkers: '50%'` + `minWorkers: 1` (ratio scales down on low-core CI too), `testTimeout: 15000`.
- `web/src/test/setup.ts`: `configure({ asyncUtilTimeout: 10000 })` for poll-heavy `waitFor`/`findBy` specs.
- NB: vitest 4 removed `test.poolOptions` — `min/maxWorkers` are top-level now.

## Validation
- **0/13** full `vitest run --coverage` loops failed post-fix (vs 3/15 baseline).
- Each previously-flaky spec still green in isolation; coverage thresholds unchanged.
- `validate-ci.sh --static`: build + tsc + lint PASS.
- No assertion weakened, no `sleep()` added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)