### PR TITLE
fix(test): share one ioredis base conn across BullMQ queues/workers in integration tests (ROK-1268)

### DIFF
--- a/api/src/common/testing/test-app.ts
+++ b/api/src/common/testing/test-app.ts
@@ -39,6 +39,7 @@ import * as schema from '../../drizzle/schema';
 import { AppModule } from '../../app.module';
 import { DrizzleAsyncProvider } from '../../drizzle/drizzle.module';
 import { QueueHealthService } from '../../queue/queue-health.service';
+import { closeTestSharedRedis } from '../../queue/queue.module';
 import { REDIS_CLIENT } from '../../redis/redis.module';
 import { truncateAllTables, type SeededData } from './integration-helpers';
 import { createRedisMock, type RedisMockHandle } from './redis-mock';
@@ -282,43 +283,53 @@ export async function closeTestApp(): Promise<void> {
   const instance = getInstance();
   if (!instance) return;
 
-  // ROK-1248: drain BullMQ queues before tearing down the app so worker.close()
-  // never has to await an in-flight job whose DB query would race the
-  // _appClient.end timeout cap.
   try {
-    const queueHealth = instance.app.get(QueueHealthService, { strict: false });
-    if (queueHealth) {
-      await queueHealth.awaitDrained(15_000);
+    // ROK-1248: drain BullMQ queues before tearing down the app so worker.close()
+    // never has to await an in-flight job whose DB query would race the
+    // _appClient.end timeout cap.
+    try {
+      const queueHealth = instance.app.get(QueueHealthService, {
+        strict: false,
+      });
+      if (queueHealth) {
+        await queueHealth.awaitDrained(15_000);
+      }
+    } catch {
+      // best-effort — fall through to app.close() regardless
     }
-  } catch {
-    // best-effort — fall through to app.close() regardless
+
+    // Capture the test container's port BEFORE _appClient.end() / container.stop()
+    // so the fallback destroy can scope itself to ONLY our test-DB sockets.
+    const connStr =
+      instance.container?.getConnectionUri() ?? process.env.DATABASE_URL ?? '';
+    const ourPort = extractPortFromConnectionString(connStr);
+
+    await instance.app.close();
+    if (instance._appClient) {
+      await instance._appClient.end({ timeout: 30 });
+    }
+
+    // ROK-1250 fallback guard: if anything is still bound to the test
+    // container's port AFTER the graceful end resolved, force-destroy it.
+    // The `remotePort === ourPort` filter cannot collide with redis-mock,
+    // supertest, or BullMQ sockets. On healthy runs this finds 0.
+    if (ourPort !== null) {
+      destroySocketsOnPort(ourPort);
+    }
+
+    destroyBullmqRedisSocketsIfDefault();
+
+    if (instance.container) {
+      await instance.container.stop();
+    }
+  } finally {
+    // ROK-1268: quit + clear the shared test ioredis connection so the next
+    // spec file gets a fresh one and no ::1:6379 handle leaks past teardown
+    // (would trip the ROK-1250 socket-handle audit). Runs even if app.close()
+    // above threw.
+    await closeTestSharedRedis();
+    setInstance(null);
   }
-
-  // Capture the test container's port BEFORE _appClient.end() / container.stop()
-  // so the fallback destroy can scope itself to ONLY our test-DB sockets.
-  const connStr =
-    instance.container?.getConnectionUri() ?? process.env.DATABASE_URL ?? '';
-  const ourPort = extractPortFromConnectionString(connStr);
-
-  await instance.app.close();
-  if (instance._appClient) {
-    await instance._appClient.end({ timeout: 30 });
-  }
-
-  // ROK-1250 fallback guard: if anything is still bound to the test
-  // container's port AFTER the graceful end resolved, force-destroy it.
-  // The `remotePort === ourPort` filter cannot collide with redis-mock,
-  // supertest, or BullMQ sockets. On healthy runs this finds 0.
-  if (ourPort !== null) {
-    destroySocketsOnPort(ourPort);
-  }
-
-  destroyBullmqRedisSocketsIfDefault();
-
-  if (instance.container) {
-    await instance.container.stop();
-  }
-  setInstance(null);
 }
 
 /**

--- a/api/src/queue/queue.module.ts
+++ b/api/src/queue/queue.module.ts
@@ -1,7 +1,45 @@
 import { Global, Module } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { BullModule } from '@nestjs/bullmq';
+import { Redis, type RedisOptions } from 'ioredis';
 import { QueueHealthService } from './queue-health.service';
+
+// ROK-1268: in integration tests (BULLMQ_KEY_PREFIX set) every spec boots
+// AppModule, and each of the ~15 queues + ~16 workers opened its OWN ioredis
+// base connection — ~46 sockets to redis PER spec file. Across the ~109-file
+// `--runInBand` suite that cumulative loopback churn intermittently RSTs an
+// unrelated fresh connect ("socket hang up" mid-suite). Sharing ONE base
+// connection across all queues/workers drops it to ~16 (worker BLOCKING
+// connections can't be shared). Prod leaves BULLMQ_KEY_PREFIX unset, so this
+// path never runs — the production connection config is byte-for-byte unchanged.
+let sharedTestConnection: Redis | undefined;
+
+/**
+ * Lazily create + return the single shared ioredis base connection used by
+ * every BullMQ queue/worker in the integration test env. `maxRetriesPerRequest:
+ * null` is REQUIRED — BullMQ throws at startup if a shared connection instance
+ * lacks it. The bullmq key prefix stays in the bullmq `prefix` option (never as
+ * an ioredis `keyPrefix`, which BullMQ rejects on a shared connection).
+ */
+export function getTestSharedRedis(options: RedisOptions): Redis {
+  sharedTestConnection ??= new Redis({
+    ...options,
+    maxRetriesPerRequest: null,
+  });
+  return sharedTestConnection;
+}
+
+/** Quit + clear the shared test connection. Called from `closeTestApp`. */
+export async function closeTestSharedRedis(): Promise<void> {
+  const conn = sharedTestConnection;
+  sharedTestConnection = undefined;
+  if (!conn) return;
+  try {
+    await conn.quit();
+  } catch {
+    conn.disconnect();
+  }
+}
 
 @Global()
 @Module({
@@ -24,14 +62,18 @@ import { QueueHealthService } from './queue-health.service';
         }
 
         const parsed = new URL(url);
-        return {
-          connection: {
-            host: parsed.hostname,
-            port: Number(parsed.port) || 6379,
-            ...(parsed.password ? { password: parsed.password } : {}),
-          },
-          ...prefixOpt,
+        const connection = {
+          host: parsed.hostname,
+          port: Number(parsed.port) || 6379,
+          ...(parsed.password ? { password: parsed.password } : {}),
         };
+
+        // ROK-1268: integration tests share ONE base connection (see top of
+        // file); prod (no BULLMQ_KEY_PREFIX) uses per-queue config, unchanged.
+        if (prefix) {
+          return { connection: getTestSharedRedis(connection), ...prefixOpt };
+        }
+        return { connection, ...prefixOpt };
       },
     }),
   ],


### PR DESCRIPTION
## Summary (`api` — test infra)
Phase-3 CI flake sweep. Every integration spec boots AppModule → **~15 queues + ~16 workers, each opening its own ioredis base connection = ~46 sockets to redis per spec file** (confirmed live via socket census). Across the ~109-file `--runInBand` suite that cumulative loopback churn intermittently RSTs an unrelated fresh connect (`socket hang up` mid-suite, rotating carrier). ROK-1250 reduced but didn't eliminate it (teardown-destroy, not connection sharing).

## Fix
- `api/src/queue/queue.module.ts`: when `BULLMQ_KEY_PREFIX` is set (integration tests only), share **one** ioredis base connection across all queues/workers via `getTestSharedRedis()`. Prod leaves `BULLMQ_KEY_PREFIX` unset → **production connection config byte-for-byte unchanged**. `maxRetriesPerRequest: null` (BullMQ requires it on a shared instance); prefix stays in the bullmq `prefix` option, never as an ioredis `keyPrefix`.
- `api/src/common/testing/test-app.ts`: `closeTestApp` quits + clears the shared connection in a **finally** (runs even if `app.close()` throws) so each spec file gets a fresh one and no `::1:6379` handle leaks past teardown.

## Validation
- **Socket census: 46 → 16 per AppModule boot** (65% cut; `:6379` was 46/49 handles baseline, i.e. 94% dominance — confirmed live post-ROK-1250).
- 4 BullMQ-touching integration specs (33 tests: `lineup-auto-advance-grace`, `ephemeral-voice`, `embed-sync`, `signups-allocation`) pass with `RL_TEST_SOCKET_HANDLE_AUDIT=true` → functionality intact **and** clean teardown (audit didn't fire).
- `tsc` + `validate-ci.sh --static` green.

## Note on the flake hit-rate
The proposed fix cuts the socket count decisively, but whether that zeroes the ~3.3% mid-suite flake is only provable by a multi-hour 0-in-100 integration-suite loop. Per operator decision, we ship on the proven socket reduction (test-gated → cannot regress prod or worsen the flake) and let the residual rate **prove itself over time in CI**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)